### PR TITLE
Add linux.do friendly link

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,10 @@ Troubleshooting:
 - [ ] Try speculative decoding with a pruned draft model.
 - [ ] Try 1M context support.
 
+## Friendly links
+
+- [linux.do](https://linux.do/)
+
 ## Acknowledgement
 
 This project builds on DeepSeek-V4-Flash model assets and the surrounding open-source PyTorch, CUDA, safetensors, and transformers ecosystem. The service/runtime organization and performance scripts in this repository are engineering work for deploying and benchmarking the standalone inference path.

--- a/README_CN.md
+++ b/README_CN.md
@@ -247,6 +247,10 @@ PYTHONPATH=$PWD python tests/test_encoding_dsv4.py
 - [ ] 尝试使用裁剪模型做投机推理。
 - [ ] 尝试 1M 上下文支持。
 
+## 友情链接
+
+- [linux.do](https://linux.do/)
+
 ## Acknowledgement
 
 本项目基于 DeepSeek-V4-Flash 模型资产，以及 PyTorch、CUDA、safetensors、transformers 等开源生态。仓库中的服务化组织、运行时整理和性能脚本主要用于部署、验证和 benchmark standalone inference 路径。


### PR DESCRIPTION
## Summary
- Add linux.do as a friendly link in the English README.
- Add linux.do as a friendly link in the Chinese README.

## Test plan
- [x] Documentation-only change; verified diff includes only README.md and README_CN.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)