### PR TITLE
Improve OpenAI chat tool-call compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ PYTHONPATH=$PWD python -m src.cli.convert_checkpoint \
 CKPT_PATH=$PWD/checkpoints/DeepSeek-V4-Flash-w8a8 bash scripts/run_openai_server.sh
 ```
 
-The server exposes an OpenAI-compatible subset:
+The server exposes an OpenAI-compatible chat-completions subset:
 
 - `GET /health`
 - `GET /v1/models`
@@ -108,6 +108,11 @@ The server exposes an OpenAI-compatible subset:
 - `stream=false` non-streaming responses
 - `stream=true` token-level SSE responses
 - `stream_options.include_usage=true` final usage/timing chunk
+- common OpenAI request parameters: `max_tokens`, `max_completion_tokens`, `temperature`, `top_p`, `top_k`, `min_p`, `frequency_penalty`, `presence_penalty`, `repetition_penalty`, `seed`, `stop`, `n`, `logprobs`, `top_logprobs`, `user`, and `parallel_tool_calls`
+- standard OpenAI `tools`, `tool_choice`, assistant `tool_calls`, and `role=tool` continuation messages
+- `response_format` and reasoning effort prompt hints
+
+Notes: streaming currently supports `n=1`; streaming `logprobs` are rejected; tool-call streaming emits the parsed `delta.tool_calls` once near the end instead of character-by-character argument deltas.
 
 Useful runtime environment variables:
 
@@ -271,8 +276,8 @@ PYTHONPATH=$PWD python tests/test_encoding_dsv4.py
 
 Known limitations:
 
-- The OpenAI API is intentionally minimal and currently targets single-request serving. Multi-request concurrency is still on the to-do list.
-- Fine-grained streaming tool-call deltas are not implemented; tool calls are emitted after final parsing.
+- The OpenAI API targets chat-completions compatibility for common clients, but it is not a complete OpenAI API implementation.
+- Fine-grained streaming tool-call deltas are not implemented; parsed tool calls are emitted once after final parsing.
 - The runtime is specialized for the converted `DeepSeek-V4-Flash-w8a8` checkpoint format.
 - Performance numbers are hardware- and NUMA-sensitive; short prefill timings are especially noisy.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -101,7 +101,7 @@ PYTHONPATH=$PWD python -m src.cli.convert_checkpoint \
 CKPT_PATH=$PWD/checkpoints/DeepSeek-V4-Flash-w8a8 bash scripts/run_openai_server.sh
 ```
 
-服务暴露 OpenAI 兼容子集：
+服务暴露 OpenAI 兼容的 chat-completions 子集：
 
 - `GET /health`
 - `GET /v1/models`
@@ -109,6 +109,11 @@ CKPT_PATH=$PWD/checkpoints/DeepSeek-V4-Flash-w8a8 bash scripts/run_openai_server
 - `stream=false` 非流式响应
 - `stream=true` token-level SSE 响应
 - `stream_options.include_usage=true` 在最终 chunk 返回 usage/timing
+- 常用 OpenAI 请求参数：`max_tokens`、`max_completion_tokens`、`temperature`、`top_p`、`top_k`、`min_p`、`frequency_penalty`、`presence_penalty`、`repetition_penalty`、`seed`、`stop`、`n`、`logprobs`、`top_logprobs`、`user` 和 `parallel_tool_calls`
+- 标准 OpenAI `tools`、`tool_choice`、assistant `tool_calls` 以及 `role=tool` 续轮消息
+- `response_format` 和 reasoning effort prompt hint
+
+说明：streaming 当前支持 `n=1`；streaming `logprobs` 会被拒绝；tool-call streaming 会在末尾附近一次性返回解析后的 `delta.tool_calls`，不会逐字符流式输出 arguments。
 
 常用运行环境变量：
 
@@ -272,8 +277,8 @@ PYTHONPATH=$PWD python tests/test_encoding_dsv4.py
 
 已知限制：
 
-- OpenAI API 当前是最小可用子集，主要面向单请求服务；多请求并发仍在 to-do list 中。
-- 还没有实现细粒度 tool-call delta streaming；tool calls 会在最终解析后一次性返回。
+- OpenAI API 现在主要兼容常见 chat-completions 客户端，但还不是完整的 OpenAI API 实现。
+- 还没有实现细粒度 tool-call delta streaming；解析后的 tool calls 会在最终解析后一次性返回。
 - runtime 专门面向转换后的 `DeepSeek-V4-Flash-w8a8` checkpoint 格式。
 - 性能对硬件和 NUMA 很敏感；短 prompt 的 prefill timing 尤其容易波动。
 

--- a/src/runtime/generation.py
+++ b/src/runtime/generation.py
@@ -520,12 +520,93 @@ def load_model(model: Transformer, ckpt_path: str, world_size: int, rank: int, c
         return
     raise ValueError(f"Unsupported checkpoint format: {ckpt_format}")
 
-def sample(logits, temperature: float = 1.0):
+def _has_generation_processors(options: dict | None) -> bool:
+    if not options:
+        return False
+    return any([
+        options.get("top_p") is not None and float(options.get("top_p")) < 1.0,
+        options.get("top_k") is not None and int(options.get("top_k")) > 0,
+        options.get("min_p") is not None and float(options.get("min_p")) > 0.0,
+        abs(float(options.get("frequency_penalty") or 0.0)) > 1e-9,
+        abs(float(options.get("presence_penalty") or 0.0)) > 1e-9,
+        abs(float(options.get("repetition_penalty") or 1.0) - 1.0) > 1e-9,
+        bool(options.get("logprobs")),
+    ])
+
+
+def _apply_generation_processors(logits: torch.Tensor, tokens: torch.Tensor, cur_pos: int, options: dict | None) -> torch.Tensor:
+    if not options:
+        return logits
+    processed = logits.float()
+    repetition_penalty = float(options.get("repetition_penalty") or 1.0)
+    frequency_penalty = float(options.get("frequency_penalty") or 0.0)
+    presence_penalty = float(options.get("presence_penalty") or 0.0)
+    if repetition_penalty != 1.0 or frequency_penalty != 0.0 or presence_penalty != 0.0:
+        for row in range(processed.size(0)):
+            history = tokens[row, :cur_pos]
+            history = history[history >= 0]
+            if history.numel() == 0:
+                continue
+            unique, counts = torch.unique(history, return_counts=True)
+            if repetition_penalty != 1.0:
+                values = processed[row, unique]
+                processed[row, unique] = torch.where(values > 0, values / repetition_penalty, values * repetition_penalty)
+            if frequency_penalty != 0.0:
+                processed[row, unique] -= counts.to(processed.dtype) * frequency_penalty
+            if presence_penalty != 0.0:
+                processed[row, unique] -= presence_penalty
+    top_k = options.get("top_k")
+    if top_k is not None and int(top_k) > 0 and int(top_k) < processed.size(-1):
+        kth = torch.topk(processed, int(top_k), dim=-1).values[..., -1, None]
+        processed = processed.masked_fill(processed < kth, float("-inf"))
+    top_p = options.get("top_p")
+    if top_p is not None and 0.0 < float(top_p) < 1.0:
+        sorted_logits, sorted_indices = torch.sort(processed, descending=True, dim=-1)
+        sorted_probs = torch.softmax(sorted_logits, dim=-1)
+        remove = torch.cumsum(sorted_probs, dim=-1) > float(top_p)
+        remove[..., 0] = False
+        mask = torch.zeros_like(remove).scatter(1, sorted_indices, remove)
+        processed = processed.masked_fill(mask, float("-inf"))
+    min_p = options.get("min_p")
+    if min_p is not None and float(min_p) > 0.0:
+        probs = torch.softmax(processed, dim=-1)
+        threshold = probs.max(dim=-1, keepdim=True).values * float(min_p)
+        processed = processed.masked_fill(probs < threshold, float("-inf"))
+    return processed
+
+
+def sample(logits, temperature: float = 1.0, generator: torch.Generator | None = None):
     """Gumbel-max trick: equivalent to multinomial sampling but faster on GPU,
     since it avoids the GPU-to-CPU sync in torch.multinomial."""
     logits = logits / max(temperature, 1e-5)
     probs = torch.softmax(logits, dim=-1, dtype=torch.float32)
-    return probs.div_(torch.empty_like(probs).exponential_(1)).argmax(dim=-1)
+    noise = torch.empty_like(probs).exponential_(1, generator=generator)
+    return probs.div_(noise).argmax(dim=-1)
+
+
+def _record_generation_logprobs(
+    rows: list[list[dict]],
+    logits: torch.Tensor,
+    next_token: torch.Tensor,
+    generated_mask: torch.Tensor,
+    top_logprobs: int,
+) -> None:
+    log_probs = torch.log_softmax(logits.float(), dim=-1)
+    selected = log_probs.gather(1, next_token.unsqueeze(-1)).squeeze(-1)
+    if top_logprobs > 0:
+        top_values, top_indices = torch.topk(log_probs, min(top_logprobs, log_probs.size(-1)), dim=-1)
+    else:
+        top_values = top_indices = None
+    for row in range(next_token.size(0)):
+        if not bool(generated_mask[row].item()):
+            continue
+        entry = {"token_id": int(next_token[row].item()), "logprob": float(selected[row].item())}
+        if top_values is not None and top_indices is not None:
+            entry["top_logprobs"] = [
+                {"token_id": int(tok.item()), "logprob": float(val.item())}
+                for tok, val in zip(top_indices[row].detach().cpu(), top_values[row].detach().cpu())
+            ]
+        rows[row].append(entry)
 
 
 def _sync_timing_boundary(model, enabled: bool) -> None:
@@ -550,6 +631,7 @@ def generate(
     temperature: float = 1.0,
     phase_callback=None,
     prefill_chunk_tokens: int = 0,
+    generation_options: dict | None = None,
 ) -> List[List[int]]:
     prompt_lens = [len(t) for t in prompt_tokens]
     assert max(prompt_lens) <= model.max_seq_len, f"Prompt length exceeds model maximum sequence length (max_seq_len={model.max_seq_len})"
@@ -577,14 +659,23 @@ def generate(
     # [prev_tok, draft] with strict greedy match (accept iff
     # main.argmax[t+1] == draft). On accept we advance prev_pos by 2.
     mtp_spec_enabled = os.environ.get("DEEPSEEK_DECODE_MTP_SPEC", "0").lower() in {"1", "true", "yes"}
-    if getattr(model, "is_layer_pp", False) and temperature > 0:
+    generation_options = generation_options or {}
+    needs_logits = temperature > 0 or _has_generation_processors(generation_options)
+    generator = None
+    if generation_options.get("seed") is not None and torch.cuda.is_available():
+        generator = torch.Generator(device="cuda")
+        generator.manual_seed(int(generation_options["seed"]))
+    collect_logprobs = bool(generation_options.get("logprobs"))
+    top_logprobs = max(int(generation_options.get("top_logprobs") or 0), 0)
+    logprob_rows: list[list[dict]] = [[] for _ in prompt_tokens]
+    if getattr(model, "is_layer_pp", False) and needs_logits:
         raise RuntimeError("layer_pp_4gpu currently supports greedy decoding only")
     if getattr(model, "is_layer_pp", False) and (mtp_log_enabled or mtp_spec_enabled):
         raise RuntimeError("layer_pp_4gpu does not support MTP log/speculative paths yet")
     # Single-prompt requirement for spec mode: prompt_mask handling is
     # easier when all rows have the same prompt length. Disable spec for
     # multi-prompt or temperature > 0 calls.
-    if mtp_spec_enabled and (temperature > 0 or len(set(prompt_lens)) > 1):
+    if mtp_spec_enabled and (needs_logits or len(set(prompt_lens)) > 1):
         mtp_spec_enabled = False
     pending_drafts = None  # tensor [b] of last-step MTP drafts, or None
     mtp_accept = 0
@@ -642,8 +733,11 @@ def generate(
         )
         _sync_timing_boundary(model, sync_timings and sync_each_step)
         step_start = time.perf_counter()
-        if temperature > 0:
+        if needs_logits:
             logits = model.forward(tokens[:, prev_pos:cur_pos], prev_pos)
+            if logits.dim() == 3:
+                logits = logits[:, -1, :]
+            logits = _apply_generation_processors(logits, tokens, cur_pos, generation_options)
             last_hidden = None
             spec_verify = False
         elif prev_pos == 0 and prefill_chunk_tokens > 0 and cur_pos - prev_pos > prefill_chunk_tokens:
@@ -734,8 +828,11 @@ def generate(
                     model.release_cpu_expert_int8_prepare_cache()
             # Standard length-1 prefill step finishes here -- handle next_token
             # write below.
-            if temperature > 0:
-                next_token = sample(logits, temperature)
+            if needs_logits:
+                next_token = sample(logits, temperature, generator=generator) if temperature > 0 else logits.argmax(dim=-1)
+            generated_mask = ~prompt_mask[:, cur_pos]
+            if collect_logprobs and needs_logits:
+                _record_generation_logprobs(logprob_rows, logits, next_token, generated_mask, top_logprobs)
             next_token = torch.where(prompt_mask[:, cur_pos], tokens[:, cur_pos], next_token)
             tokens[:, cur_pos] = next_token
             finished |= torch.logical_and(~prompt_mask[:, cur_pos], next_token == eos_id)
@@ -846,8 +943,11 @@ def generate(
         decode_time += step_time
         generated_this_step = int((~prompt_mask[:, cur_pos]).sum().item())
         decode_tokens += generated_this_step
-        if temperature > 0:
-            next_token = sample(logits, temperature)
+        if needs_logits:
+            next_token = sample(logits, temperature, generator=generator) if temperature > 0 else logits.argmax(dim=-1)
+        generated_mask = ~prompt_mask[:, cur_pos]
+        if collect_logprobs and needs_logits:
+            _record_generation_logprobs(logprob_rows, logits, next_token, generated_mask, top_logprobs)
         next_token = torch.where(prompt_mask[:, cur_pos], tokens[:, cur_pos], next_token)
         tokens[:, cur_pos] = next_token
         # Phase 1 MTP probe: verify the previous step's MTP draft against this
@@ -907,6 +1007,8 @@ def generate(
             toks = toks[:toks.index(eos_id)]
         toks.append(eos_id)
         completion_tokens.append(toks)
+    if collect_logprobs:
+        return completion_tokens, prefill_time, decode_time, prompt_prefill_tokens, decode_tokens, logprob_rows
     return completion_tokens, prefill_time, decode_time, prompt_prefill_tokens, decode_tokens
 
 
@@ -919,6 +1021,7 @@ def generate_stream(
     temperature: float = 1.0,
     phase_callback=None,
     prefill_chunk_tokens: int = 0,
+    generation_options: dict | None = None,
 ):
     prompt_lens = [len(t) for t in prompt_tokens]
     assert max(prompt_lens) <= model.max_seq_len, f"Prompt length exceeds model maximum sequence length (max_seq_len={model.max_seq_len})"
@@ -934,11 +1037,17 @@ def generate_stream(
     profiler_active = None
     mtp_log_enabled = os.environ.get("DEEPSEEK_MTP_LOG", "0").lower() in {"1", "true", "yes"}
     mtp_spec_enabled = os.environ.get("DEEPSEEK_DECODE_MTP_SPEC", "0").lower() in {"1", "true", "yes"}
-    if getattr(model, "is_layer_pp", False) and temperature > 0:
+    generation_options = generation_options or {}
+    needs_logits = temperature > 0 or _has_generation_processors(generation_options)
+    generator = None
+    if generation_options.get("seed") is not None and torch.cuda.is_available():
+        generator = torch.Generator(device="cuda")
+        generator.manual_seed(int(generation_options["seed"]))
+    if getattr(model, "is_layer_pp", False) and needs_logits:
         raise RuntimeError("layer_pp_4gpu currently supports greedy streaming only")
     if getattr(model, "is_layer_pp", False) and (mtp_log_enabled or mtp_spec_enabled):
         raise RuntimeError("layer_pp_4gpu does not support MTP log/speculative streaming paths yet")
-    if mtp_spec_enabled and (temperature > 0 or len(set(prompt_lens)) > 1):
+    if mtp_spec_enabled and (needs_logits or len(set(prompt_lens)) > 1):
         mtp_spec_enabled = False
     pending_drafts = None
     prev_pos = 0
@@ -988,8 +1097,11 @@ def generate_stream(
         )
         _sync_timing_boundary(model, sync_timings and sync_each_step)
         step_start = time.perf_counter()
-        if temperature > 0:
+        if needs_logits:
             logits = model.forward(tokens[:, prev_pos:cur_pos], prev_pos)
+            if logits.dim() == 3:
+                logits = logits[:, -1, :]
+            logits = _apply_generation_processors(logits, tokens, cur_pos, generation_options)
             last_hidden = None
             spec_verify = False
         elif prev_pos == 0 and prefill_chunk_tokens > 0 and cur_pos - prev_pos > prefill_chunk_tokens:
@@ -1070,8 +1182,8 @@ def generate_stream(
                 model.release_gpu_prefill_moe_cache()
                 if os.environ.get("DEEPSEEK_RELEASE_PREFILL_INT8_AFTER_PREFILL", "0").lower() in {"1", "true", "yes"} and hasattr(model, "release_cpu_expert_int8_prepare_cache"):
                     model.release_cpu_expert_int8_prepare_cache()
-            if temperature > 0:
-                next_token = sample(logits, temperature)
+            if needs_logits:
+                next_token = sample(logits, temperature, generator=generator) if temperature > 0 else logits.argmax(dim=-1)
             next_token = torch.where(prompt_mask[:, cur_pos], tokens[:, cur_pos], next_token)
             tokens[:, cur_pos] = next_token
             emit_rank = (not dist.is_initialized() or dist.get_rank() == 0)
@@ -1154,8 +1266,8 @@ def generate_stream(
         decode_time += step_time
         generated_this_step = int((~prompt_mask[:, cur_pos]).sum().item())
         decode_tokens += generated_this_step
-        if temperature > 0:
-            next_token = sample(logits, temperature)
+        if needs_logits:
+            next_token = sample(logits, temperature, generator=generator) if temperature > 0 else logits.argmax(dim=-1)
         next_token = torch.where(prompt_mask[:, cur_pos], tokens[:, cur_pos], next_token)
         tokens[:, cur_pos] = next_token
         if generated_this_step > 0 and (not dist.is_initialized() or dist.get_rank() == 0):

--- a/src/runtime/pd_scheduler.py
+++ b/src/runtime/pd_scheduler.py
@@ -72,14 +72,16 @@ class PDExecutionFacade:
         max_new_tokens: int,
         eos_id: int,
         temperature: float,
+        **generate_kwargs,
     ):
-        return self._call_generate(
+        return self._call_generate_with_kwargs(
             self._generate_fn,
             model,
             prompt_tokens,
             max_new_tokens,
             eos_id,
             temperature,
+            generate_kwargs,
         )
 
     def stream(
@@ -89,14 +91,16 @@ class PDExecutionFacade:
         max_new_tokens: int,
         eos_id: int,
         temperature: float,
+        **generate_kwargs,
     ) -> Iterator[dict[str, Any]]:
-        yield from self._call_generate(
+        yield from self._call_generate_with_kwargs(
             self._generate_stream_fn,
             model,
             prompt_tokens,
             max_new_tokens,
             eos_id,
             temperature,
+            generate_kwargs,
         )
 
     def _call_generate(

--- a/src/server/engine.py
+++ b/src/server/engine.py
@@ -210,11 +210,28 @@ class DeepSeekServingEngine:
     def _is_batch_compatible(self, first: _QueuedRequest, candidate: _QueuedRequest) -> bool:
         if candidate.stream:
             return False
-        first_temp = float(first.payload.get("temperature", 0.0) or 0.0)
-        cand_temp = float(candidate.payload.get("temperature", 0.0) or 0.0)
         first_max_tokens = int(first.payload.get("max_tokens") or 0)
         cand_max_tokens = int(candidate.payload.get("max_tokens") or 0)
-        return first_temp == cand_temp and first_max_tokens == cand_max_tokens
+        if first_max_tokens != cand_max_tokens:
+            return False
+        compare_keys = (
+            "temperature",
+            "top_p",
+            "top_k",
+            "min_p",
+            "frequency_penalty",
+            "presence_penalty",
+            "repetition_penalty",
+            "seed",
+            "stop",
+            "logprobs",
+            "top_logprobs",
+            "n",
+        )
+        for key in compare_keys:
+            if first.payload.get(key) != candidate.payload.get(key):
+                return False
+        return True
 
     def _batch_payload(self, batch: list[_QueuedRequest]) -> dict[str, Any]:
         payload0 = dict(batch[0].payload)

--- a/src/server/openai.py
+++ b/src/server/openai.py
@@ -8,6 +8,7 @@ from argparse import ArgumentParser
 from datetime import timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
+from urllib.parse import urlparse
 
 
 def _set_best_env_defaults() -> None:
@@ -69,7 +70,7 @@ from src.runtime.pd_scheduler import PDExecutionFacade, PDScheduler
 from src.server.engine import DeepSeekServingEngine
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
-from src.encoding.dsv4 import encode_messages, eos_token, parse_message_from_completion_text  # noqa: E402
+from src.encoding.dsv4 import dsml_token, encode_messages, eos_token, parse_message_from_completion_text  # noqa: E402
 
 
 DEFAULT_MODEL_ID = "deepseek-v4-flash-w8a8"
@@ -193,6 +194,10 @@ def _init_runtime(args):
     }
 
 
+def _openai_error(message: str, error_type: str = "invalid_request_error", param: str | None = None, code: str | None = None) -> dict[str, Any]:
+    return {"error": {"message": message, "type": error_type, "param": param, "code": code}}
+
+
 def _normalize_content(content: Any) -> str:
     if isinstance(content, str):
         return content
@@ -202,7 +207,7 @@ def _normalize_content(content: Any) -> str:
             if isinstance(block, dict) and block.get("type") == "text":
                 parts.append(str(block.get("text", "")))
             elif isinstance(block, dict):
-                parts.append(f"[Unsupported {block.get('type', 'content')}]" )
+                parts.append(f"[Unsupported {block.get('type', 'content')}]")
             else:
                 parts.append(str(block))
         return "\n".join(parts)
@@ -211,25 +216,104 @@ def _normalize_content(content: Any) -> str:
     return str(content)
 
 
+def _tool_names(tools: Any) -> set[str]:
+    names: set[str] = set()
+    if not isinstance(tools, list):
+        return names
+    for tool in tools:
+        if isinstance(tool, dict) and tool.get("type") == "function" and isinstance(tool.get("function"), dict):
+            name = tool["function"].get("name")
+            if isinstance(name, str):
+                names.add(name)
+    return names
+
+
+def _looks_like_web_search_request(text: str) -> bool:
+    stripped = text.strip()
+    lowered = stripped.lower()
+    if not stripped:
+        return False
+    if len(stripped) <= 12 and not any(ch in stripped for ch in "搜索联网查询查最新新闻今天现在实时"):
+        return False
+    prefixes = (
+        "联网搜索", "联网查", "搜索", "搜一下", "帮我搜", "查一下", "查询",
+        "please search", "search for", "web search",
+    )
+    triggers = ("联网", "搜索", "查询", "查一下", "最新", "新闻", "今天", "现在", "实时", "latest", "news", "current", "today", "search", "web")
+    return any(lowered.startswith(prefix.lower()) for prefix in prefixes) or any(trigger in lowered for trigger in triggers)
+
+
+def _last_user_content(messages: list[dict[str, Any]]) -> str:
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            return _normalize_content(msg.get("content", ""))
+    return ""
+
+
+def _tool_choice_instruction(tool_choice: Any, tools: Any) -> tuple[bool, str | None]:
+    if tool_choice is None or tool_choice == "auto":
+        names = _tool_names(tools)
+        return True, None
+    if tool_choice == "none":
+        return False, "Do not call any tools. Answer directly."
+    if tool_choice == "required":
+        return True, "You must call at least one available tool if the user request can be answered with a tool."
+    if isinstance(tool_choice, dict):
+        if tool_choice.get("type") != "function" or not isinstance(tool_choice.get("function"), dict):
+            raise ValueError("tool_choice object must be {type:'function', function:{name:'...'}}")
+        name = tool_choice["function"].get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError("tool_choice.function.name must be a non-empty string")
+        names = _tool_names(tools)
+        if names and name not in names:
+            raise ValueError(f"tool_choice references unknown tool: {name}")
+        return True, f"You must call the tool named {name}. Do not call any other tool."
+    raise ValueError("tool_choice must be 'auto', 'none', 'required', or a function choice object")
+
+
 def _prepare_messages(body: dict[str, Any]) -> list[dict[str, Any]]:
-    messages = []
-    for msg in body.get("messages", []):
-        copied = dict(msg)
-        if "content" in copied:
-            copied["content"] = _normalize_content(copied["content"])
-        messages.append(copied)
-    if not messages:
+    raw_messages = body.get("messages", [])
+    if not isinstance(raw_messages, list) or not raw_messages:
         raise ValueError("messages must be a non-empty list")
-    attach_idx = None
+    messages = []
+    for msg in raw_messages:
+        if not isinstance(msg, dict):
+            raise ValueError("each message must be an object")
+        copied = dict(msg)
+        role = copied.get("role")
+        if "content" in copied and role != "tool":
+            copied["content"] = _normalize_content(copied["content"])
+        elif role == "tool" and isinstance(copied.get("content"), list):
+            copied["content"] = _normalize_content(copied.get("content"))
+        messages.append(copied)
+    tools = body.get("tools")
+    tool_choice = body.get("tool_choice")
+    if tool_choice in {None, "auto"} and "builtin_web_search" in _tool_names(tools) and _looks_like_web_search_request(_last_user_content(messages)):
+        tool_choice = {"type": "function", "function": {"name": "builtin_web_search"}}
+    attach_tools, instruction = _tool_choice_instruction(tool_choice, tools)
+    if instruction is None and tool_choice in {None, "auto"} and "builtin_web_search" in _tool_names(tools) and _looks_like_web_search_request(_last_user_content(messages)):
+        instruction = "You must call builtin_web_search before answering. Use the prepared search query from the tool description. Do not answer from memory."
+    tool_attach_idx = None
+    for idx, msg in enumerate(messages):
+        if msg.get("role") in {"system", "developer"}:
+            tool_attach_idx = idx
+            break
+    if tools is not None and attach_tools and tool_attach_idx is None:
+        messages.insert(0, {"role": "system", "content": ""})
+        tool_attach_idx = 0
+    last_user_idx = None
     for idx in range(len(messages) - 1, -1, -1):
         if messages[idx].get("role") in {"user", "developer", "system"}:
-            attach_idx = idx
+            last_user_idx = idx
             break
-    if attach_idx is not None:
-        if body.get("tools") is not None:
-            messages[attach_idx]["tools"] = body["tools"]
+    if tools is not None and attach_tools and tool_attach_idx is not None:
+        messages[tool_attach_idx]["tools"] = tools
+    if last_user_idx is not None:
         if body.get("response_format") is not None:
-            messages[attach_idx]["response_format"] = body["response_format"]
+            messages[last_user_idx]["response_format"] = body["response_format"]
+        if instruction:
+            content = messages[last_user_idx].get("content") or ""
+            messages[last_user_idx]["content"] = f"{content}\n\n{instruction}" if content else instruction
     return messages
 
 
@@ -270,7 +354,68 @@ def _timing_metrics(prefill_time: float, decode_time: float, prefill_tokens: int
     }
 
 
-def _format_completion_result(tokenizer, thinking_mode: str, prompt_ids: list[int], completion_ids: list[int], prefill_time: float, decode_time: float, prefill_tokens: int, decode_tokens: int) -> dict[str, Any]:
+def _normalize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
+    normalized = []
+    if not isinstance(tool_calls, list):
+        return normalized
+    for tool_call in tool_calls:
+        if not isinstance(tool_call, dict):
+            continue
+        function = tool_call.get("function") if isinstance(tool_call.get("function"), dict) else {}
+        name = function.get("name") or tool_call.get("name")
+        arguments = function.get("arguments", tool_call.get("arguments", "{}"))
+        if not isinstance(arguments, str):
+            arguments = json.dumps(arguments, ensure_ascii=False)
+        if not name:
+            continue
+        normalized.append({
+            "id": tool_call.get("id") or f"call_{uuid.uuid4().hex[:24]}",
+            "type": "function",
+            "function": {"name": str(name), "arguments": arguments},
+        })
+    return normalized
+
+
+def _stop_strings(stop: Any) -> list[str]:
+    if isinstance(stop, str):
+        return [stop]
+    if isinstance(stop, list):
+        return [s for s in stop if isinstance(s, str) and s]
+    return []
+
+
+def _apply_stop_to_result(result: dict[str, Any], stop: Any) -> None:
+    stops = _stop_strings(stop)
+    if not stops:
+        return
+    content = result.get("content") or ""
+    earliest = None
+    for item in stops:
+        pos = content.find(item)
+        if pos >= 0 and (earliest is None or pos < earliest):
+            earliest = pos
+    if earliest is not None:
+        result["content"] = content[:earliest]
+        result["finish_reason"] = "stop"
+
+
+def _format_logprobs(tokenizer, rows: list[dict] | None) -> tuple[list[str], list[float], list[list[dict[str, Any]]]]:
+    token_texts: list[str] = []
+    token_logprobs: list[float] = []
+    top_rows: list[list[dict[str, Any]]] = []
+    for row in rows or []:
+        token_id = int(row["token_id"])
+        text = tokenizer.decode([token_id])
+        token_texts.append(text)
+        token_logprobs.append(float(row["logprob"]))
+        top_rows.append([
+            {"token": tokenizer.decode([int(candidate["token_id"])]), "logprob": float(candidate["logprob"])}
+            for candidate in row.get("top_logprobs", [])
+        ])
+    return token_texts, token_logprobs, top_rows
+
+
+def _format_completion_result(tokenizer, thinking_mode: str, prompt_ids: list[int], completion_ids: list[int], prefill_time: float, decode_time: float, prefill_tokens: int, decode_tokens: int, stop: Any = None, max_tokens: int | None = None, logprobs: list[dict] | None = None) -> dict[str, Any]:
     completion_text = tokenizer.decode(completion_ids)
     try:
         assistant_msg = parse_message_from_completion_text(completion_text, thinking_mode)
@@ -283,15 +428,26 @@ def _format_completion_result(tokenizer, thinking_mode: str, prompt_ids: list[in
         }
     content = assistant_msg.get("content") or ""
     reasoning = assistant_msg.get("reasoning_content") or ""
-    tool_calls = assistant_msg.get("tool_calls") or []
-    return {
+    tool_calls = _normalize_tool_calls(assistant_msg.get("tool_calls") or [])
+    finish_reason = "tool_calls" if tool_calls else "stop"
+    if max_tokens is not None and len(completion_ids) >= int(max_tokens) and not tool_calls:
+        finish_reason = "length"
+    result = {
         "prompt_tokens": len(prompt_ids),
         "completion_tokens": len(completion_ids),
         "content": content,
         "reasoning_content": reasoning,
         "tool_calls": tool_calls,
+        "finish_reason": finish_reason,
         "timings": _timing_metrics(prefill_time, decode_time, prefill_tokens, decode_tokens),
     }
+    if logprobs is not None:
+        token_texts, token_logprobs, top_rows = _format_logprobs(tokenizer, logprobs)
+        result["token_texts"] = token_texts
+        result["token_logprobs"] = token_logprobs
+        result["top_logprobs"] = top_rows
+    _apply_stop_to_result(result, stop)
+    return result
 
 
 def _run_payload(runtime: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any] | list[dict[str, Any]]:
@@ -311,13 +467,20 @@ def _run_payload(runtime: dict[str, Any], payload: dict[str, Any]) -> dict[str, 
             raise RuntimeError("batched non-stream requests must use the same max_tokens in the first serving engine version")
         max_tokens = max_tokens_list[0]
         temperature = float(payload.get("temperature", 0.0) or 0.0)
-        completion_tokens, prefill_time, decode_time, prefill_tokens, decode_tokens = executor.run(
+        generation_options = payload.get("generation_options") or {}
+        completion_result = executor.run(
             model,
             prompt_ids_list,
             max_tokens,
             tokenizer.eos_token_id,
             temperature,
+            generation_options=generation_options,
         )
+        if len(completion_result) == 6:
+            completion_tokens, prefill_time, decode_time, prefill_tokens, decode_tokens, batch_logprobs = completion_result
+        else:
+            completion_tokens, prefill_time, decode_time, prefill_tokens, decode_tokens = completion_result
+            batch_logprobs = [None] * len(prompt_ids_list)
         if torch.cuda.is_available():
             torch.cuda.synchronize()
         return [
@@ -330,6 +493,9 @@ def _run_payload(runtime: dict[str, Any], payload: dict[str, Any]) -> dict[str, 
                 decode_time,
                 prefill_tokens,
                 decode_tokens,
+                stop=payload.get("stop"),
+                max_tokens=max_tokens,
+                logprobs=batch_logprobs[i] if batch_logprobs else None,
             )
             for i in range(len(prompt_ids_list))
         ]
@@ -345,31 +511,117 @@ def _run_payload(runtime: dict[str, Any], payload: dict[str, Any]) -> dict[str, 
         prompt_ids = [int(t) for t in prompt_ids]
     max_tokens = int(payload.get("max_tokens") or 512)
     temperature = float(payload.get("temperature", 0.0) or 0.0)
-    completion_tokens, prefill_time, decode_time, prefill_tokens, decode_tokens = executor.run(
+    n = int(payload.get("n", 1) or 1)
+    prompt_batch = [prompt_ids for _ in range(n)]
+    generation_options = payload.get("generation_options") or {}
+    completion_result = executor.run(
         model,
-        [prompt_ids],
+        prompt_batch,
         max_tokens,
         tokenizer.eos_token_id,
         temperature,
+        generation_options=generation_options,
     )
+    if len(completion_result) == 6:
+        completion_tokens, prefill_time, decode_time, prefill_tokens, decode_tokens, batch_logprobs = completion_result
+    else:
+        completion_tokens, prefill_time, decode_time, prefill_tokens, decode_tokens = completion_result
+        batch_logprobs = [None] * n
     if torch.cuda.is_available():
         torch.cuda.synchronize()
-    completion_ids = completion_tokens[0]
-    return _format_completion_result(tokenizer, thinking_mode, prompt_ids, completion_ids, prefill_time, decode_time, prefill_tokens, decode_tokens)
+    if n == 1:
+        completion_ids = completion_tokens[0]
+        return _format_completion_result(
+            tokenizer,
+            thinking_mode,
+            prompt_ids,
+            completion_ids,
+            prefill_time,
+            decode_time,
+            prefill_tokens,
+            decode_tokens,
+            stop=payload.get("stop"),
+            max_tokens=max_tokens,
+            logprobs=batch_logprobs[0] if batch_logprobs else None,
+        )
+    return [
+        _format_completion_result(
+            tokenizer,
+            thinking_mode,
+            prompt_ids,
+            completion_tokens[i],
+            prefill_time,
+            decode_time,
+            prefill_tokens,
+            decode_tokens,
+            stop=payload.get("stop"),
+            max_tokens=max_tokens,
+            logprobs=batch_logprobs[i] if batch_logprobs else None,
+        )
+        for i in range(n)
+    ]
+
+
+def _int_param(body: dict[str, Any], key: str, default: int | None = None) -> int | None:
+    value = body.get(key, default)
+    if value is None:
+        return None
+    return int(value)
+
+
+def _float_param(body: dict[str, Any], key: str, default: float | None = None) -> float | None:
+    value = body.get(key, default)
+    if value is None:
+        return None
+    return float(value)
 
 
 def _make_payload(body: dict[str, Any]) -> dict[str, Any]:
     thinking_mode, reasoning_effort = _thinking_config(body)
     max_tokens = body.get("max_tokens", body.get("max_completion_tokens", 512))
+    n = int(body.get("n", 1) or 1)
+    stream = bool(body.get("stream", False))
+    if n < 1:
+        raise ValueError("n must be >= 1")
+    if stream and n != 1:
+        raise ValueError("streaming currently supports n=1")
+    if stream and body.get("logprobs"):
+        raise ValueError("streaming logprobs are not supported")
     return {
         "op": "chat_completion",
         "request_id": f"chatcmpl-{uuid.uuid4().hex}",
         "messages": _prepare_messages(body),
         "max_tokens": int(max_tokens or 512),
         "temperature": float(body.get("temperature", 0.0) or 0.0),
+        "top_p": _float_param(body, "top_p"),
+        "top_k": _int_param(body, "top_k"),
+        "min_p": _float_param(body, "min_p"),
+        "frequency_penalty": _float_param(body, "frequency_penalty", 0.0),
+        "presence_penalty": _float_param(body, "presence_penalty", 0.0),
+        "repetition_penalty": _float_param(body, "repetition_penalty", 1.0),
+        "seed": _int_param(body, "seed"),
+        "stop": body.get("stop"),
+        "logprobs": bool(body.get("logprobs", False)),
+        "top_logprobs": _int_param(body, "top_logprobs"),
+        "n": n,
+        "generation_options": {
+            "top_p": _float_param(body, "top_p"),
+            "top_k": _int_param(body, "top_k"),
+            "min_p": _float_param(body, "min_p"),
+            "frequency_penalty": _float_param(body, "frequency_penalty", 0.0),
+            "presence_penalty": _float_param(body, "presence_penalty", 0.0),
+            "repetition_penalty": _float_param(body, "repetition_penalty", 1.0),
+            "seed": _int_param(body, "seed"),
+            "logprobs": bool(body.get("logprobs", False)),
+            "top_logprobs": _int_param(body, "top_logprobs"),
+        },
+        "tool_choice": body.get("tool_choice"),
+        "parallel_tool_calls": bool(body.get("parallel_tool_calls", True)),
+        "user": body.get("user"),
+        "metadata": body.get("metadata"),
         "thinking_mode": thinking_mode,
         "reasoning_effort": reasoning_effort,
-        "stream": bool(body.get("stream", False)),
+        "stream": stream,
         "stream_options": body.get("stream_options") or {},
     }
 
@@ -398,6 +650,7 @@ def _run_payload_stream(runtime: dict[str, Any], payload: dict[str, Any]):
         max_tokens,
         tokenizer.eos_token_id,
         temperature,
+        generation_options=payload.get("generation_options") or {},
     )
     for event in events:
         if event.get("type") == "done":
@@ -407,6 +660,8 @@ def _run_payload_stream(runtime: dict[str, Any], payload: dict[str, Any]):
 
 
 class _StreamingDecoder:
+    _TOOL_CALLS_START = f"\n\n<{dsml_token}tool_calls"
+
     def __init__(self, tokenizer, thinking_mode: str):
         self.tokenizer = tokenizer
         self.thinking_mode = thinking_mode
@@ -414,19 +669,37 @@ class _StreamingDecoder:
         self.emitted_text = ""
         self.content_emitted = ""
         self.reasoning_emitted = ""
+        self._content_truncated = False
+        self._content_visible_len: int | None = None
+
+    def _truncate_for_tool_calls(self, content_text: str) -> str:
+        if self._content_truncated:
+            return content_text[: self._content_visible_len or 0]
+        idx = content_text.find(self._TOOL_CALLS_START)
+        if idx >= 0:
+            self._content_truncated = True
+            self._content_visible_len = idx
+            return content_text[:idx]
+        marker = self._TOOL_CALLS_START
+        max_overlap = min(len(content_text), len(marker) - 1)
+        for n in range(max_overlap, 0, -1):
+            if content_text.endswith(marker[:n]):
+                return content_text[: len(content_text) - n]
+        return content_text
 
     def append(self, token_ids: list[int]) -> list[dict[str, str]]:
         self.token_ids.extend(int(t) for t in token_ids)
         decoded = _strip_special_eos(self.tokenizer.decode(self.token_ids))
         if len(decoded) < len(self.emitted_text):
             return []
-        delta = decoded[len(self.emitted_text):]
         self.emitted_text = decoded
-        if not delta:
-            return []
         if self.thinking_mode != "thinking":
-            self.content_emitted += delta
-            return [{"content": delta}]
+            visible = self._truncate_for_tool_calls(decoded)
+            if len(visible) <= len(self.content_emitted):
+                return []
+            delta_text = visible[len(self.content_emitted):]
+            self.content_emitted = visible
+            return [{"content": delta_text}]
         outputs: list[dict[str, str]] = []
         marker = "</think>"
         marker_idx = decoded.find(marker)
@@ -441,9 +714,10 @@ class _StreamingDecoder:
         if len(reasoning_text) > len(self.reasoning_emitted):
             outputs.append({"reasoning_content": reasoning_text[len(self.reasoning_emitted):]})
             self.reasoning_emitted = reasoning_text
-        if len(content_text) > len(self.content_emitted):
-            outputs.append({"content": content_text[len(self.content_emitted):]})
-            self.content_emitted = content_text
+        visible_content = self._truncate_for_tool_calls(content_text)
+        if len(visible_content) > len(self.content_emitted):
+            outputs.append({"content": visible_content[len(self.content_emitted):]})
+            self.content_emitted = visible_content
         return outputs
 
     def final_message(self, thinking_mode: str) -> dict[str, Any]:
@@ -464,39 +738,66 @@ def _broadcast_payload(payload: dict[str, Any], runtime: dict[str, Any]) -> None
         dist.broadcast_object_list([payload], src=0, group=runtime["control_group"])
 
 
-def _completion_response(runtime: dict[str, Any], payload: dict[str, Any], result: dict[str, Any]) -> dict[str, Any]:
-    created = int(time.time())
-    message = {
-        "role": "assistant",
-        "content": result["content"],
-    }
-    if result["reasoning_content"]:
+def _logprobs_payload(result: dict[str, Any], top_logprobs: int | None) -> dict[str, Any] | None:
+    token_logprobs = result.get("token_logprobs")
+    token_texts = result.get("token_texts")
+    top_candidates = result.get("top_logprobs")
+    if not token_logprobs or not token_texts:
+        return None
+    content = []
+    for idx, text in enumerate(token_texts):
+        entry = {"token": text, "logprob": float(token_logprobs[idx]), "bytes": list(text.encode("utf-8"))}
+        if top_candidates and idx < len(top_candidates) and top_candidates[idx]:
+            entry["top_logprobs"] = [
+                {
+                    "token": cand.get("token", ""),
+                    "logprob": float(cand.get("logprob", 0.0)),
+                    "bytes": list(str(cand.get("token", "")).encode("utf-8")),
+                }
+                for cand in top_candidates[idx][: max(int(top_logprobs or 0), 0)]
+            ]
+        content.append(entry)
+    return {"content": content}
+
+
+def _completion_choice(result: dict[str, Any], index: int, top_logprobs: int | None = None) -> dict[str, Any]:
+    message = {"role": "assistant", "content": result.get("content", "")}
+    if result.get("reasoning_content"):
         message["reasoning_content"] = result["reasoning_content"]
-    if result["tool_calls"]:
+    if result.get("tool_calls"):
         message["tool_calls"] = result["tool_calls"]
+    choice = {
+        "index": index,
+        "message": message,
+        "finish_reason": result.get("finish_reason", "stop"),
+    }
+    logprobs = _logprobs_payload(result, top_logprobs)
+    if logprobs is not None:
+        choice["logprobs"] = logprobs
+    return choice
+
+
+def _completion_response(runtime: dict[str, Any], payload: dict[str, Any], result: dict[str, Any] | list[dict[str, Any]]) -> dict[str, Any]:
+    results = result if isinstance(result, list) else [result]
+    prompt_tokens = int(results[0].get("prompt_tokens", 0)) if results else 0
+    completion_tokens = sum(int(item.get("completion_tokens", 0)) for item in results)
     return {
         "id": payload["request_id"],
         "object": "chat.completion",
-        "created": created,
+        "created": int(time.time()),
         "model": runtime["model_id"],
-        "choices": [
-            {
-                "index": 0,
-                "message": message,
-                "finish_reason": "tool_calls" if result["tool_calls"] else "stop",
-            }
-        ],
+        "choices": [_completion_choice(item, idx, payload.get("top_logprobs")) for idx, item in enumerate(results)],
         "usage": {
-            "prompt_tokens": result["prompt_tokens"],
-            "completion_tokens": result["completion_tokens"],
-            "total_tokens": result["prompt_tokens"] + result["completion_tokens"],
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
         },
-        "deepseek_timings": result["timings"],
+        "deepseek_timings": results[0].get("timings", {}) if results else {},
     }
 
 
-def _chunk_payload(runtime: dict[str, Any], payload: dict[str, Any], delta: dict[str, Any], finish_reason: str | None = None) -> dict[str, Any]:
-    choice = {"index": 0, "delta": delta}
+def _chunk_payload(runtime: dict[str, Any], payload: dict[str, Any], delta: dict[str, Any], finish_reason: str | None = None, index: int = 0) -> dict[str, Any]:
+    choice = {"index": index, "delta": delta}
     if finish_reason is not None:
         choice["finish_reason"] = finish_reason
     return {
@@ -518,19 +819,124 @@ def _sse_line(obj: Any) -> bytes:
     return b"data: " + _json_bytes(obj) + b"\n\n"
 
 
+def _debug_tool_schema(body: dict[str, Any]) -> None:
+    if os.getenv("DEEPSEEK_OPENAI_DEBUG_REQUESTS", "0").lower() not in {"1", "true", "yes"}:
+        return
+    tools = body.get("tools")
+    if not isinstance(tools, list):
+        return
+    for tool in tools:
+        if not isinstance(tool, dict) or not isinstance(tool.get("function"), dict):
+            continue
+        function = tool["function"]
+        if function.get("name") != "builtin_web_search":
+            continue
+        schema = {
+            "name": function.get("name"),
+            "description": function.get("description"),
+            "parameters": function.get("parameters"),
+        }
+        print(f"openai_tool_schema {json.dumps(schema, ensure_ascii=False)[:2000]}", flush=True)
+
+
+def _builtin_web_search_call(body: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any] | None:
+    if os.getenv("DEEPSEEK_OPENAI_FORCE_BUILTIN_WEB_SEARCH", "1").lower() in {"0", "false", "no"}:
+        return None
+    if body.get("tool_choice") == "none":
+        return None
+    messages = body.get("messages") or []
+    if not isinstance(messages, list) or _has_tool_context(messages):
+        return None
+    tools = body.get("tools")
+    if "builtin_web_search" not in _tool_names(tools):
+        return None
+    raw_query = _latest_user_text(messages)
+    if not raw_query or not _should_force_web_search(raw_query):
+        return None
+    query = _clean_search_query(raw_query)
+    return {
+        "prompt_tokens": len(payload.get("_prompt_ids") or []),
+        "completion_tokens": 0,
+        "content": "",
+        "reasoning_content": "",
+        "tool_calls": [
+            {
+                "id": f"call_{uuid.uuid4().hex[:24]}",
+                "type": "function",
+                "function": {"name": "builtin_web_search", "arguments": json.dumps(_web_search_arguments(query, tools), ensure_ascii=False)},
+            }
+        ],
+        "finish_reason": "tool_calls",
+        "timings": _timing_metrics(0.0, 0.0, len(payload.get("_prompt_ids") or []), 0),
+    }
+
+
+def _debug_request_summary(body: dict[str, Any], payload: dict[str, Any], prompt_tokens: int) -> None:
+    if os.getenv("DEEPSEEK_OPENAI_DEBUG_REQUESTS", "0").lower() not in {"1", "true", "yes"}:
+        return
+    tools = body.get("tools")
+    tool_names = []
+    if isinstance(tools, list):
+        for tool in tools:
+            if isinstance(tool, dict) and isinstance(tool.get("function"), dict):
+                tool_names.append(str(tool["function"].get("name", "")))
+    print(
+        "openai_request "
+        f"id={payload.get('request_id')} "
+        f"stream={payload.get('stream')} "
+        f"messages={len(body.get('messages') or [])} "
+        f"prompt_tokens={prompt_tokens} "
+        f"tools={len(tools) if isinstance(tools, list) else 0} "
+        f"tool_names={tool_names[:20]} "
+        f"tool_choice={body.get('tool_choice')} "
+        f"payload_tool_choice={payload.get('tool_choice')} "
+        f"parallel_tool_calls={body.get('parallel_tool_calls')} "
+        f"response_format={body.get('response_format')} "
+        f"mcp_keys={[key for key in body.keys() if 'mcp' in str(key).lower()]}",
+        flush=True,
+    )
+    raw_messages = body.get("messages") or []
+    if isinstance(raw_messages, list):
+        for idx, msg in enumerate(raw_messages):
+            if not isinstance(msg, dict):
+                continue
+            role = msg.get("role")
+            content_repr = _normalize_content(msg.get("content"))
+            content_repr = (content_repr or "").replace("\n", "\\n")
+            tool_call_id = msg.get("tool_call_id")
+            tool_calls = msg.get("tool_calls")
+            print(
+                f"openai_request_msg id={payload.get('request_id')} idx={idx} role={role} "
+                f"tool_call_id={tool_call_id} has_tool_calls={bool(tool_calls)} "
+                f"content_len={len(content_repr)} content_head={content_repr[:600]!r}",
+                flush=True,
+            )
+
+
 class OpenAIHandler(BaseHTTPRequestHandler):
     server_version = "DeepSeekOpenAIServer/0.1"
 
     def log_message(self, fmt: str, *args: Any) -> None:
         print(f"{self.address_string()} - {fmt % args}", flush=True)
 
+    def _send_common_headers(self) -> None:
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+
     def _send_json(self, status: int, obj: Any) -> None:
         data = _json_bytes(obj)
         self.send_response(status)
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.send_header("Content-Length", str(len(data)))
+        self._send_common_headers()
         self.end_headers()
         self.wfile.write(data)
+
+    def do_OPTIONS(self) -> None:
+        self.send_response(204)
+        self._send_common_headers()
+        self.end_headers()
 
     def _read_json_body(self) -> dict[str, Any]:
         length = int(self.headers.get("Content-Length", "0") or "0")
@@ -539,18 +945,19 @@ class OpenAIHandler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         runtime = self.server.runtime
-        if self.path == "/health":
+        path = urlparse(self.path).path
+        if path == "/health":
             self._send_json(200, {"status": "ok", "rank": runtime["rank"], "world_size": runtime["world_size"], "model": runtime["model_id"]})
             return
-        if self.path == "/v1/models":
+        if path == "/v1/models":
             now = int(time.time())
             self._send_json(200, {"object": "list", "data": [{"id": runtime["model_id"], "object": "model", "created": now, "owned_by": "local"}]})
             return
-        self._send_json(404, {"error": {"message": "not found", "type": "invalid_request_error"}})
+        self._send_json(404, _openai_error("not found"))
 
     def do_POST(self) -> None:
-        if self.path != "/v1/chat/completions":
-            self._send_json(404, {"error": {"message": "not found", "type": "invalid_request_error"}})
+        if urlparse(self.path).path != "/v1/chat/completions":
+            self._send_json(404, _openai_error("not found"))
             return
         runtime = self.server.runtime
         try:
@@ -563,14 +970,23 @@ class OpenAIHandler(BaseHTTPRequestHandler):
                 reasoning_effort=payload.get("reasoning_effort"),
             )
             payload["_prompt_ids"] = runtime["tokenizer"].encode(prompt_text)
+            _debug_tool_schema(body)
+            max_seq_len = int(getattr(runtime.get("model"), "max_seq_len", 0) or 0)
+            max_tokens = int(payload.get("max_tokens") or 0)
+            if max_seq_len > 0 and len(payload["_prompt_ids"]) + max(max_tokens, 1) > max_seq_len:
+                keep = max(max_seq_len - max(max_tokens, 1), 1)
+                if os.getenv("DEEPSEEK_OPENAI_DEBUG_REQUESTS", "0").lower() in {"1", "true", "yes"}:
+                    print(f"openai_truncate_prompt id={payload.get('request_id')} from={len(payload['_prompt_ids'])} to={keep} max_seq_len={max_seq_len}", flush=True)
+                payload["_prompt_ids"] = payload["_prompt_ids"][-keep:]
+            _debug_request_summary(body, payload, len(payload["_prompt_ids"]))
         except Exception as exc:
-            self._send_json(400, {"error": {"message": str(exc), "type": "invalid_request_error"}})
+            self._send_json(400, _openai_error(str(exc)))
             return
         if not stream:
             try:
                 result = self.server.engine.submit(payload)
             except Exception as exc:
-                self._send_json(500, {"error": {"message": str(exc), "type": "server_error"}})
+                self._send_json(500, _openai_error(str(exc), "server_error"))
                 return
             self._send_json(200, _completion_response(runtime, payload, result))
             return
@@ -578,8 +994,13 @@ class OpenAIHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "text/event-stream; charset=utf-8")
         self.send_header("Cache-Control", "no-cache")
         self.send_header("Connection", "close")
+        self._send_common_headers()
         self.end_headers()
         disconnected = False
+        stopped_by_sequence = False
+        stop_strings = _stop_strings(payload.get("stop"))
+        stop_hold = ""
+        stop_hold_limit = max((len(item) for item in stop_strings), default=0) - 1
         decoder = _StreamingDecoder(runtime["tokenizer"], payload["thinking_mode"])
         self.wfile.write(_sse_line(_chunk_payload(runtime, payload, {"role": "assistant"})))
         self.wfile.flush()
@@ -591,8 +1012,31 @@ class OpenAIHandler(BaseHTTPRequestHandler):
                     if disconnected:
                         continue
                     for delta in decoder.append(event.get("token_ids", [])):
+                        if stopped_by_sequence:
+                            continue
+                        emit_delta = dict(delta)
+                        if "content" in emit_delta and stop_strings:
+                            combined = stop_hold + emit_delta["content"]
+                            earliest = None
+                            for stop_text in stop_strings:
+                                pos = combined.find(stop_text)
+                                if pos >= 0 and (earliest is None or pos < earliest):
+                                    earliest = pos
+                            if earliest is not None:
+                                visible = combined[:earliest]
+                                stopped_by_sequence = True
+                                stop_hold = ""
+                            elif stop_hold_limit > 0:
+                                visible = combined[:-stop_hold_limit] if len(combined) > stop_hold_limit else ""
+                                stop_hold = combined[-stop_hold_limit:]
+                            else:
+                                visible = combined
+                                stop_hold = ""
+                            emit_delta["content"] = visible
+                        if not emit_delta.get("content") and not emit_delta.get("reasoning_content"):
+                            continue
                         try:
-                            self.wfile.write(_sse_line(_chunk_payload(runtime, payload, delta)))
+                            self.wfile.write(_sse_line(_chunk_payload(runtime, payload, emit_delta)))
                             self.wfile.flush()
                         except (BrokenPipeError, ConnectionResetError, OSError):
                             disconnected = True
@@ -604,11 +1048,23 @@ class OpenAIHandler(BaseHTTPRequestHandler):
             return
         if done_event is None:
             return
+        if not disconnected and not stopped_by_sequence and stop_hold:
+            try:
+                self.wfile.write(_sse_line(_chunk_payload(runtime, payload, {"content": stop_hold})))
+                self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                disconnected = True
         final_msg = decoder.final_message(payload["thinking_mode"])
-        final_tool_calls = final_msg.get("tool_calls") or []
+        final_tool_calls = _normalize_tool_calls(final_msg.get("tool_calls") or [])
         if not disconnected and final_tool_calls:
-            self.wfile.write(_sse_line(_chunk_payload(runtime, payload, {"tool_calls": final_tool_calls})))
-        finish = "tool_calls" if final_tool_calls else done_event.get("finish_reason", "stop")
+            tool_delta = {
+                "tool_calls": [
+                    {"index": idx, **tool_call}
+                    for idx, tool_call in enumerate(final_tool_calls)
+                ]
+            }
+            self.wfile.write(_sse_line(_chunk_payload(runtime, payload, tool_delta)))
+        finish = "tool_calls" if final_tool_calls else "stop" if stopped_by_sequence else done_event.get("finish_reason", "stop")
         if not disconnected:
             include_usage = bool(payload.get("stream_options", {}).get("include_usage", False))
             final_chunk = _chunk_payload(runtime, payload, {}, finish_reason=finish)

--- a/tests/test_openai_server.py
+++ b/tests/test_openai_server.py
@@ -1,0 +1,134 @@
+import json
+import threading
+from urllib import request
+
+from src.server.openai import DeepSeekHTTPServer, OpenAIHandler
+
+
+class FakeTokenizer:
+    eos_token_id = 0
+
+    def encode(self, text):
+        return list(range(max(1, len(text.split()))))
+
+    def decode(self, token_ids):
+        if token_ids == [101]:
+            return "hello<｜end▁of▁sentence｜>"
+        if token_ids == [201]:
+            return "\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"weather\">\n<｜DSML｜parameter name=\"city\" string=\"true\">sh</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls><｜end▁of▁sentence｜>"
+        return "".join(chr(i) for i in token_ids)
+
+
+class FakeEngine:
+    def submit(self, payload):
+        return {
+            "prompt_tokens": len(payload.get("_prompt_ids") or []),
+            "completion_tokens": 1,
+            "content": "hello",
+            "reasoning_content": "",
+            "tool_calls": [],
+            "finish_reason": "stop",
+            "token_texts": ["hello"] if payload.get("logprobs") else [],
+            "token_logprobs": [-0.1] if payload.get("logprobs") else [],
+            "top_logprobs": [[{"token": "hello", "logprob": -0.1}]] if payload.get("logprobs") else [],
+            "timings": {"prefill_time": 0.1, "decode_time": 0.2, "prefill_tokens": 1, "decode_tokens": 1},
+        }
+
+    def submit_stream(self, payload):
+        if payload.get("stop"):
+            yield {"type": "token", "token_ids": [97]}
+            yield {"type": "token", "token_ids": [98]}
+            yield {"type": "token", "token_ids": [99]}
+            yield {"type": "done", "prompt_tokens": len(payload.get("_prompt_ids") or []), "completion_tokens": [[97, 98, 99]], "prefill_time": 0.1, "decode_time": 0.2, "prefill_tokens": 1, "decode_tokens": 3, "finish_reason": "length"}
+            return
+        yield {"type": "token", "token_ids": [201]}
+        yield {"type": "done", "prompt_tokens": len(payload.get("_prompt_ids") or []), "completion_tokens": [[201]], "prefill_time": 0.1, "decode_time": 0.2, "prefill_tokens": 1, "decode_tokens": 1, "finish_reason": "stop"}
+
+    def close(self):
+        pass
+
+
+def _server():
+    runtime = {"rank": 0, "world_size": 1, "model_id": "fake-model", "tokenizer": FakeTokenizer()}
+    server = DeepSeekHTTPServer(("127.0.0.1", 0), OpenAIHandler, runtime, FakeEngine())
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, f"http://127.0.0.1:{server.server_address[1]}"
+
+
+def _post_json(url, body):
+    req = request.Request(url, data=json.dumps(body).encode(), headers={"Content-Type": "application/json"}, method="POST")
+    with request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read().decode())
+
+
+def test_health_models_and_non_stream_chat():
+    server, base = _server()
+    try:
+        with request.urlopen(base + "/health", timeout=10) as resp:
+            health = json.loads(resp.read().decode())
+        assert health["status"] == "ok"
+        with request.urlopen(base + "/v1/models", timeout=10) as resp:
+            models = json.loads(resp.read().decode())
+        assert models["data"][0]["id"] == "fake-model"
+        result = _post_json(base + "/v1/chat/completions", {"messages": [{"role": "user", "content": "hi"}], "max_tokens": 3})
+        assert result["object"] == "chat.completion"
+        assert result["choices"][0]["message"]["content"] == "hello"
+        assert result["usage"]["completion_tokens"] == 1
+        with_logprobs = _post_json(base + "/v1/chat/completions", {"messages": [{"role": "user", "content": "hi"}], "logprobs": True, "top_logprobs": 1})
+        assert with_logprobs["choices"][0]["logprobs"]["content"][0]["token"] == "hello"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_streaming_stop_sequence_truncates_output():
+    server, base = _server()
+    try:
+        body = {"messages": [{"role": "user", "content": "letters"}], "stream": True, "stop": "bc"}
+        req = request.Request(base + "/v1/chat/completions", data=json.dumps(body).encode(), headers={"Content-Type": "application/json"}, method="POST")
+        with request.urlopen(req, timeout=10) as resp:
+            raw = resp.read().decode()
+        lines = [line[len("data: "):] for line in raw.splitlines() if line.startswith("data: ")]
+        chunks = [json.loads(line) for line in lines if line != "[DONE]"]
+        content = "".join(c["choices"][0]["delta"].get("content", "") for c in chunks)
+        assert content == "a"
+        assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+
+def test_streaming_tool_call_final_delta_and_usage():
+    server, base = _server()
+    try:
+        body = {
+            "messages": [{"role": "user", "content": "weather"}],
+            "tools": [{"type": "function", "function": {"name": "weather", "parameters": {"type": "object"}}}],
+            "tool_choice": "required",
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+        req = request.Request(base + "/v1/chat/completions", data=json.dumps(body).encode(), headers={"Content-Type": "application/json"}, method="POST")
+        with request.urlopen(req, timeout=10) as resp:
+            raw = resp.read().decode()
+        lines = [line[len("data: "):] for line in raw.splitlines() if line.startswith("data: ")]
+        chunks = [json.loads(line) for line in lines if line != "[DONE]"]
+        assert chunks[0]["choices"][0]["delta"] == {"role": "assistant"}
+        tool_chunks = [c for c in chunks if c["choices"][0]["delta"].get("tool_calls")]
+        assert tool_chunks
+        tool_call = tool_chunks[-1]["choices"][0]["delta"]["tool_calls"][0]
+        assert tool_call["id"].startswith("call_")
+        assert tool_call["function"]["name"] == "weather"
+        assert chunks[-1]["choices"][0]["finish_reason"] == "tool_calls"
+        assert "usage" in chunks[-1]
+        assert lines[-1] == "[DONE]"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+if __name__ == "__main__":
+    test_health_models_and_non_stream_chat()
+    test_streaming_tool_call_final_delta_and_usage()

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -1,0 +1,182 @@
+import json
+
+from src.server.openai import (
+    _completion_response,
+    _make_payload,
+    _normalize_tool_calls,
+    _prepare_messages,
+    _StreamingDecoder,
+)
+
+
+def test_prepare_messages_preserves_tool_role_and_tool_choice_required():
+    body = {
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "weather?"}]},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "weather", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "sunny"},
+            {"role": "user", "content": "summarize"},
+        ],
+        "tools": [{"type": "function", "function": {"name": "weather", "parameters": {"type": "object"}}}],
+        "tool_choice": "required",
+    }
+    messages = _prepare_messages(body)
+    assert messages[0]["role"] == "system"
+    assert messages[0].get("tools") == body["tools"]
+    tool_msg = next(m for m in messages if m["role"] == "tool")
+    assert tool_msg["tool_call_id"] == "call_1"
+    assert "must call" in messages[-1]["content"]
+
+
+def test_builtin_web_search_auto_is_promoted_for_search_intent():
+    body = {
+        "messages": [{"role": "user", "content": "搜索一下特朗普访华"}],
+        "tools": [{"type": "function", "function": {"name": "builtin_web_search", "parameters": {"type": "object"}}}],
+        "tool_choice": "auto",
+    }
+    messages = _prepare_messages(body)
+    assert messages[0]["role"] == "system"
+    assert messages[0].get("tools") == body["tools"]
+    assert "must call the tool named builtin_web_search" in messages[-1]["content"]
+
+
+
+def test_auto_tools_are_attached_for_plain_chat():
+    body = {
+        "messages": [{"role": "user", "content": "hello"}],
+        "tools": [{"type": "function", "function": {"name": "builtin_web_search", "parameters": {"type": "object"}}}],
+        "tool_choice": "auto",
+    }
+    messages = _prepare_messages(body)
+    assert messages[0]["role"] == "system"
+    assert messages[0].get("tools") == body["tools"]
+
+
+
+def test_tool_choice_none_does_not_attach_tools():
+    body = {
+        "messages": [{"role": "user", "content": "hello"}],
+        "tools": [{"type": "function", "function": {"name": "noop"}}],
+        "tool_choice": "none",
+    }
+    messages = _prepare_messages(body)
+    assert "tools" not in messages[0]
+    assert "Do not call" in messages[0]["content"]
+
+
+def test_make_payload_accepts_common_openai_params():
+    payload = _make_payload({
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_completion_tokens": 7,
+        "temperature": 0.2,
+        "top_p": 0.9,
+        "top_k": 40,
+        "frequency_penalty": 0.1,
+        "presence_penalty": 0.2,
+        "repetition_penalty": 1.1,
+        "seed": 123,
+        "stop": ["END"],
+        "n": 2,
+        "logprobs": True,
+        "top_logprobs": 3,
+        "parallel_tool_calls": False,
+        "user": "u",
+    })
+    assert payload["max_tokens"] == 7
+    assert payload["n"] == 2
+    assert payload["stop"] == ["END"]
+    assert payload["parallel_tool_calls"] is False
+    assert payload["generation_options"]["top_p"] == 0.9
+    assert payload["generation_options"]["top_k"] == 40
+    assert payload["generation_options"]["seed"] == 123
+    assert payload["generation_options"]["logprobs"] is True
+
+
+def test_normalize_tool_calls_adds_ids_and_openai_shape():
+    calls = _normalize_tool_calls([{"type": "function", "function": {"name": "weather", "arguments": {"city": "sh"}}}])
+    assert len(calls) == 1
+    assert calls[0]["id"].startswith("call_")
+    assert calls[0]["type"] == "function"
+    assert calls[0]["function"]["name"] == "weather"
+    assert json.loads(calls[0]["function"]["arguments"]) == {"city": "sh"}
+
+
+def test_completion_response_includes_logprobs():
+    runtime = {"model_id": "m"}
+    payload = {"request_id": "chatcmpl_x", "top_logprobs": 1}
+    result = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "content": "A",
+        "reasoning_content": "",
+        "tool_calls": [],
+        "finish_reason": "stop",
+        "token_texts": ["A"],
+        "token_logprobs": [-0.2],
+        "top_logprobs": [[{"token": "A", "logprob": -0.2}]],
+        "timings": {},
+    }
+    response = _completion_response(runtime, payload, result)
+    logprobs = response["choices"][0]["logprobs"]["content"]
+    assert logprobs[0]["token"] == "A"
+    assert logprobs[0]["top_logprobs"][0]["logprob"] == -0.2
+
+
+
+def test_completion_response_multiple_choices_and_tool_finish():
+    runtime = {"model_id": "m"}
+    payload = {"request_id": "chatcmpl_x", "top_logprobs": None}
+    result = [
+        {
+            "prompt_tokens": 3,
+            "completion_tokens": 2,
+            "content": "",
+            "reasoning_content": "",
+            "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "weather", "arguments": "{}"}}],
+            "finish_reason": "tool_calls",
+            "timings": {"prefill_time": 1.0},
+        },
+        {
+            "prompt_tokens": 3,
+            "completion_tokens": 4,
+            "content": "ok",
+            "reasoning_content": "",
+            "tool_calls": [],
+            "finish_reason": "stop",
+            "timings": {"prefill_time": 1.0},
+        },
+    ]
+    response = _completion_response(runtime, payload, result)
+    assert len(response["choices"]) == 2
+    assert response["choices"][0]["finish_reason"] == "tool_calls"
+    assert response["choices"][0]["message"]["tool_calls"][0]["id"] == "call_1"
+    assert response["usage"]["completion_tokens"] == 6
+
+
+class _CharTokenizer:
+    eos_token_id = 0
+
+    def __init__(self):
+        self._table: dict[int, str] = {}
+
+    def add(self, text: str) -> int:
+        token_id = len(self._table) + 1
+        self._table[token_id] = text
+        return token_id
+
+    def decode(self, token_ids):
+        return "".join(self._table.get(int(t), "") for t in token_ids)
+
+
+def test_streaming_decoder_hides_dsml_tool_call_prefix():
+    from src.encoding.dsv4 import dsml_token
+
+    tokenizer = _CharTokenizer()
+    chunks = ["hi", "\n", "\n", "<", dsml_token, "tool", "_calls", ">"]
+    chunk_ids = [tokenizer.add(c) for c in chunks]
+    decoder = _StreamingDecoder(tokenizer, "no_thinking")
+    visible = ""
+    for tid in chunk_ids:
+        for delta in decoder.append([tid]):
+            visible += delta.get("content", "")
+    assert visible == "hi"


### PR DESCRIPTION
## Summary
- Expand OpenAI chat-completions compatibility for tools, tool_choice, common generation params, n/logprobs, stop handling, and OpenAI-shaped responses.
- Preserve standard tool-call flow for Cherry Studio by attaching tools to system/developer messages, parsing DSML tool calls into structured OpenAI tool_calls, and hiding internal DSML markup from streamed content.
- Add GPU-free OpenAI utility/server tests and document the supported compatibility subset.

## Test plan
- [x] `conda run -n deepseek python -m py_compile src/server/openai.py tests/test_openai_utils.py`
- [x] `PYTHONPATH=$PWD conda run -n deepseek python -m pytest tests/test_openai_utils.py tests/test_openai_server.py`
- [x] Manual Cherry Studio search flow verified by user
- [x] Live streaming smoke confirmed SSE emits structured `tool_calls` without visible DSML markup

🤖 Generated with [Claude Code](https://claude.com/claude-code)