### PR TITLE
Add noncommercial license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,131 @@
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/README.md
+++ b/README.md
@@ -298,6 +298,20 @@ Troubleshooting:
 - [ ] Try speculative decoding with a pruned draft model.
 - [ ] Try 1M context support.
 
+## License
+
+This repository's code is licensed under the [PolyForm Noncommercial License 1.0.0](LICENSE).
+
+Permitted uses include personal use, academic research, education, non-commercial benchmarking, and non-commercial deployment.
+Commercial use is not permitted without separate written permission from the copyright holder, including but not limited to:
+
+- selling hosted inference services based on this code;
+- selling packaged deployments or appliances;
+- selling hardware/software bundles using this code;
+- using this code in paid consulting deliverables or commercial products.
+
+Model weights, tokenizer files, and third-party dependencies are governed by their respective licenses. This repository's code license does not grant any additional rights to DeepSeek model assets or other third-party materials.
+
 ## Friendly links
 
 - [linux.do](https://linux.do/)

--- a/README_CN.md
+++ b/README_CN.md
@@ -299,6 +299,20 @@ PYTHONPATH=$PWD python tests/test_encoding_dsv4.py
 - [ ] 尝试使用裁剪模型做投机推理。
 - [ ] 尝试 1M 上下文支持。
 
+## License
+
+本仓库代码采用 [PolyForm Noncommercial License 1.0.0](LICENSE)。
+
+允许个人使用、学术研究、教学、非商业评测和非商业部署。
+未经版权所有者另行书面授权，不允许商业使用，包括但不限于：
+
+- 基于本代码销售托管推理服务；
+- 销售打包部署方案或一体机；
+- 将本代码用于硬件/软件捆绑销售；
+- 将本代码用于付费咨询交付物或商业产品。
+
+模型权重、tokenizer 文件和第三方依赖遵循其各自许可证。本仓库代码许可证不会授予 DeepSeek 模型资产或其它第三方材料的额外权利。
+
 ## 友情链接
 
 - [linux.do](https://linux.do/)


### PR DESCRIPTION
## Summary
- Add PolyForm Noncommercial License 1.0.0 as the repository code license.
- Document that personal, academic, educational, benchmarking, and other non-commercial uses are permitted.
- Clarify that commercial services, packaged deployments, appliances, bundles, consulting deliverables, and products require separate written permission, and that model assets/dependencies keep their own licenses.

## Test plan
- [x] Documentation-only change; no runtime tests needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)