### PR TITLE
Hide streaming replacement character artifacts

### DIFF
--- a/src/server/openai.py
+++ b/src/server/openai.py
@@ -689,7 +689,7 @@ class _StreamingDecoder:
 
     def append(self, token_ids: list[int]) -> list[dict[str, str]]:
         self.token_ids.extend(int(t) for t in token_ids)
-        decoded = _strip_special_eos(self.tokenizer.decode(self.token_ids))
+        decoded = _strip_special_eos(self.tokenizer.decode(self.token_ids)).rstrip("�")
         if len(decoded) < len(self.emitted_text):
             return []
         self.emitted_text = decoded

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -180,3 +180,21 @@ def test_streaming_decoder_hides_dsml_tool_call_prefix():
         for delta in decoder.append([tid]):
             visible += delta.get("content", "")
     assert visible == "hi"
+
+
+class _ResolvingTokenizer:
+    eos_token_id = 0
+
+    def decode(self, token_ids):
+        ids = [int(t) for t in token_ids]
+        if ids == [1]:
+            return "�"
+        if ids == [1, 2]:
+            return "中"
+        return ""
+
+
+def test_streaming_decoder_holds_back_trailing_replacement_character():
+    decoder = _StreamingDecoder(_ResolvingTokenizer(), "no_thinking")
+    assert decoder.append([1]) == []
+    assert decoder.append([2]) == [{"content": "中"}]


### PR DESCRIPTION
## Summary
- Hold back trailing Unicode replacement characters during OpenAI streaming decode.
- Prevent incomplete tokenizer byte sequences from leaking as visible `�` before later tokens resolve them.
- Add a focused unit test for the resolving-tokenizer case.

## Test plan
- [x] `conda run -n deepseek python -m py_compile src/server/openai.py tests/test_openai_utils.py`
- [x] `PYTHONPATH=$PWD conda run -n deepseek python -m pytest tests/test_openai_utils.py tests/test_openai_server.py`
- [x] Manual Cherry Studio streaming retest by user

🤖 Generated with [Claude Code](https://claude.com/claude-code)