### PR TITLE
Support OpenAI reasoning effort options

### DIFF
--- a/src/encoding/dsv4.py
+++ b/src/encoding/dsv4.py
@@ -232,7 +232,7 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
         messages: Full list of messages in the conversation.
         thinking_mode: Either "chat" or "thinking".
         drop_thinking: Whether to drop reasoning content from earlier turns.
-        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
+        reasoning_effort: Optional reasoning effort level ("minimal", "low", "medium", "high", "max", or None).
 
     Returns:
         Encoded string for this message.
@@ -258,7 +258,7 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
         tool_calls = tool_calls_from_openai_format(tool_calls)
 
     # Reasoning effort prefix (only at index 0 in thinking mode with max effort)
-    assert reasoning_effort in ['max', None, 'high'], f"Invalid reasoning effort: {reasoning_effort}"
+    assert reasoning_effort in ['max', None, 'minimal', 'low', 'medium', 'high'], f"Invalid reasoning effort: {reasoning_effort}"
     if index == 0 and thinking_mode == "thinking" and reasoning_effort == 'max':
         prompt += REASONING_EFFORT_MAX
 
@@ -527,7 +527,7 @@ def encode_messages(
         drop_thinking: If True, drop reasoning_content from earlier assistant turns
                       (only keep reasoning for messages after the last user message).
         add_default_bos_token: Whether to prepend BOS token at conversation start.
-        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
+        reasoning_effort: Optional reasoning effort level ("minimal", "low", "medium", "high", "max", or None).
 
     Returns:
         The encoded prompt string.

--- a/src/server/openai.py
+++ b/src/server/openai.py
@@ -293,12 +293,12 @@ def _prepare_messages(body: dict[str, Any]) -> list[dict[str, Any]]:
 
 def _thinking_config(body: dict[str, Any]) -> tuple[str, str | None]:
     reasoning = body.get("reasoning")
-    if reasoning is None:
-        return "chat", None
-    effort = None
-    if isinstance(reasoning, dict):
+    effort = body.get("reasoning_effort")
+    if isinstance(reasoning, dict) and reasoning.get("effort") is not None:
         effort = reasoning.get("effort")
-    if effort not in {None, "high", "max"}:
+    if reasoning is None and effort is None:
+        return "chat", None
+    if effort not in {None, "minimal", "low", "medium", "high", "max"}:
         effort = None
     return "thinking", effort
 

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -1,11 +1,13 @@
 import json
 
+from src.encoding.dsv4 import REASONING_EFFORT_MAX, encode_messages
 from src.server.openai import (
     _completion_response,
     _make_payload,
     _normalize_tool_calls,
     _prepare_messages,
     _StreamingDecoder,
+    _thinking_config,
 )
 
 
@@ -102,6 +104,36 @@ def test_tool_choice_none_does_not_attach_tools():
     messages = _prepare_messages(body)
     assert "tools" not in messages[0]
     assert "Do not call" in messages[0]["content"]
+
+
+def test_thinking_config_accepts_openai_and_deepseek_effort_fields():
+    assert _thinking_config({"messages": [{"role": "user", "content": "hello"}]}) == ("chat", None)
+    assert _thinking_config({"reasoning": {"effort": "high"}}) == ("thinking", "high")
+    assert _thinking_config({"reasoning": {"effort": "max"}}) == ("thinking", "max")
+    assert _thinking_config({"reasoning_effort": "max"}) == ("thinking", "max")
+    assert _thinking_config({"reasoning": {"effort": "low"}}) == ("thinking", "low")
+
+
+def test_nested_reasoning_effort_overrides_top_level_effort():
+    assert _thinking_config({"reasoning_effort": "max", "reasoning": {"effort": "medium"}}) == ("thinking", "medium")
+
+
+def test_invalid_reasoning_effort_keeps_thinking_without_effort_prefix():
+    assert _thinking_config({"reasoning_effort": "extreme"}) == ("thinking", None)
+
+
+def test_make_payload_accepts_top_level_reasoning_effort_max():
+    payload = _make_payload({"messages": [{"role": "user", "content": "hello"}], "reasoning_effort": "max"})
+    assert payload["thinking_mode"] == "thinking"
+    assert payload["reasoning_effort"] == "max"
+
+
+def test_encode_messages_injects_prefix_only_for_reasoning_effort_max():
+    messages = [{"role": "user", "content": "hello"}]
+    max_prompt = encode_messages(messages, thinking_mode="thinking", reasoning_effort="max")
+    high_prompt = encode_messages(messages, thinking_mode="thinking", reasoning_effort="high")
+    assert REASONING_EFFORT_MAX in max_prompt
+    assert REASONING_EFFORT_MAX not in high_prompt
 
 
 def test_make_payload_accepts_common_openai_params():


### PR DESCRIPTION
## Summary
- Accept `reasoning.effort` and top-level `reasoning_effort` in the OpenAI-compatible chat endpoint.
- Allow `minimal`, `low`, `medium`, `high`, and DeepSeek's extra `max` effort value.
- Keep `max` as the only effort that injects the DeepSeek `REASONING_EFFORT_MAX` prompt prefix.

## Test plan
- [x] `PYTHONPATH=$PWD conda run -n deepseek python -m pytest tests/test_openai_utils.py -v` — 18/18 passed
- [x] `PYTHONPATH=$PWD conda run -n deepseek python -m py_compile src/server/openai.py src/encoding/dsv4.py tests/test_openai_utils.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)