### PR TITLE
Add opt-in prefix snapshot cache

### DIFF
--- a/src/runtime/generation.py
+++ b/src/runtime/generation.py
@@ -13,6 +13,7 @@ from transformers import AutoTokenizer
 from safetensors import safe_open
 
 from src.moe.shared_weights import SharedCPUMoEWeightArena
+from src.runtime.prefix_snapshot import PrefixSnapshotCache
 from src.runtime.partition_policy import (
     checkpoint_key_is_needed_for_policy,
     partition_rule_kind,
@@ -618,6 +619,27 @@ def _sync_timing_boundary(model, enabled: bool) -> None:
         dist.barrier()
 
 
+def _prefix_snapshot_settings(
+    model: Transformer,
+    prompt_tokens: List[List[int]],
+    prompt_lens: list[int],
+    prefix_snapshot_hint: dict | None,
+) -> tuple[int, list[int]]:
+    if not PrefixSnapshotCache.enabled() or len(prompt_tokens) != 1 or getattr(model, "is_layer_pp", False):
+        return 0, []
+    cache = PrefixSnapshotCache.instance()
+    restore_pos = cache.restore(model, prefix_snapshot_hint, prompt_tokens[0]) if prefix_snapshot_hint else 0
+    capture_pos = (prompt_lens[0] // cache.block) * cache.block
+    if capture_pos < cache.min_tokens:
+        return restore_pos, []
+    hinted_positions = prefix_snapshot_hint.get("capture_positions") if prefix_snapshot_hint else None
+    if hinted_positions:
+        capture_positions = [int(pos) for pos in hinted_positions if restore_pos < int(pos) <= capture_pos]
+    else:
+        capture_positions = [capture_pos] if restore_pos < capture_pos else []
+    return restore_pos, capture_positions
+
+
 def _env_flag(name: str, default: str = "0") -> bool:
     return os.getenv(name, default).lower() in {"1", "true", "yes"}
 
@@ -632,6 +654,7 @@ def generate(
     phase_callback=None,
     prefill_chunk_tokens: int = 0,
     generation_options: dict | None = None,
+    prefix_snapshot_hint: dict | None = None,
 ) -> List[List[int]]:
     prompt_lens = [len(t) for t in prompt_tokens]
     assert max(prompt_lens) <= model.max_seq_len, f"Prompt length exceeds model maximum sequence length (max_seq_len={model.max_seq_len})"
@@ -677,12 +700,26 @@ def generate(
     # multi-prompt or temperature > 0 calls.
     if mtp_spec_enabled and (needs_logits or len(set(prompt_lens)) > 1):
         mtp_spec_enabled = False
+    prefix_snapshot_start_pos, prefix_snapshot_capture_positions = _prefix_snapshot_settings(
+        model, prompt_tokens, prompt_lens, prefix_snapshot_hint
+    )
+    prefix_snapshot_pending_captures = set(prefix_snapshot_capture_positions)
+    prefix_snapshot_cache = PrefixSnapshotCache.instance() if (prefix_snapshot_pending_captures or prefix_snapshot_start_pos > 0) else None
+
+    def maybe_capture_prefix_snapshot(pos: int) -> None:
+        if prefix_snapshot_cache is None or pos not in prefix_snapshot_pending_captures:
+            return
+        if len(prompt_tokens) != 1 or pos > prompt_lens[0]:
+            return
+        prefix_snapshot_cache.capture(model, prompt_tokens[0], pos)
+        prefix_snapshot_pending_captures.discard(pos)
+
     pending_drafts = None  # tensor [b] of last-step MTP drafts, or None
     mtp_accept = 0
     mtp_total = 0
     mtp_spec_accepts = 0
     mtp_spec_rounds = 0
-    prev_pos = 0
+    prev_pos = prefix_snapshot_start_pos
     finished = torch.tensor([False] * len(prompt_tokens))
     prompt_mask = tokens != -1
     sync_timings = _env_flag("DEEPSEEK_SYNC_TIMINGS", "1" if getattr(model, "is_layer_pp", False) else "0")
@@ -695,7 +732,8 @@ def generate(
     decode_wall_start = None
     cur_pos = min(prompt_lens)
     while cur_pos < total_len:
-        phase = "prefill" if prev_pos == 0 else "decode"
+        prefill_step = prev_pos < min(prompt_lens)
+        phase = "prefill" if prefill_step else "decode"
         if phase_callback is not None:
             phase_callback(phase)
         # Bump decode index up-front so profiler enable/disable logic is uniform.
@@ -740,13 +778,26 @@ def generate(
             logits = _apply_generation_processors(logits, tokens, cur_pos, generation_options)
             last_hidden = None
             spec_verify = False
-        elif prev_pos == 0 and prefill_chunk_tokens > 0 and cur_pos - prev_pos > prefill_chunk_tokens:
-            chunk_start = prev_pos
-            while chunk_start + prefill_chunk_tokens < cur_pos:
-                chunk_end = chunk_start + prefill_chunk_tokens
-                model.forward(tokens[:, chunk_start:chunk_end], chunk_start, return_next_token=False)
-                chunk_start = chunk_end
-            next_token = model.forward(tokens[:, chunk_start:cur_pos], chunk_start, return_next_token=True)
+        elif prefill_step:
+            capture_points = sorted(pos for pos in prefix_snapshot_pending_captures if prev_pos < pos < cur_pos)
+            if prefill_chunk_tokens > 0 and cur_pos - prev_pos > prefill_chunk_tokens:
+                chunk = prefill_chunk_tokens
+                chunk_start = prev_pos
+                while chunk_start + chunk < cur_pos:
+                    chunk_end = chunk_start + chunk
+                    model.forward(tokens[:, chunk_start:chunk_end], chunk_start, return_next_token=False)
+                    maybe_capture_prefix_snapshot(chunk_end)
+                    chunk_start = chunk_end
+                next_token = model.forward(tokens[:, chunk_start:cur_pos], chunk_start, return_next_token=True)
+            elif capture_points:
+                chunk_start = prev_pos
+                for chunk_end in capture_points:
+                    model.forward(tokens[:, chunk_start:chunk_end], chunk_start, return_next_token=False)
+                    maybe_capture_prefix_snapshot(chunk_end)
+                    chunk_start = chunk_end
+                next_token = model.forward(tokens[:, chunk_start:cur_pos], chunk_start, return_next_token=True)
+            else:
+                next_token = model.forward(tokens[:, prev_pos:cur_pos], prev_pos, return_next_token=True)
             last_hidden = None
             logits = None
         elif spec_verify:
@@ -815,7 +866,7 @@ def generate(
             except Exception as exc:
                 print(f"decode profile summary failed: {exc}", flush=True)
             profiler_active = None
-        if prev_pos == 0:
+        if prefill_step:
             _sync_timing_boundary(model, sync_timings and not sync_each_step)
             step_time = time.perf_counter() - step_start
             generated_this_step = int((~prompt_mask[:, cur_pos]).sum().item())
@@ -836,6 +887,7 @@ def generate(
             next_token = torch.where(prompt_mask[:, cur_pos], tokens[:, cur_pos], next_token)
             tokens[:, cur_pos] = next_token
             finished |= torch.logical_and(~prompt_mask[:, cur_pos], next_token == eos_id)
+            maybe_capture_prefix_snapshot(cur_pos)
             prev_pos = cur_pos
             cur_pos += 1
             if finished.all():
@@ -1022,6 +1074,7 @@ def generate_stream(
     phase_callback=None,
     prefill_chunk_tokens: int = 0,
     generation_options: dict | None = None,
+    prefix_snapshot_hint: dict | None = None,
 ):
     prompt_lens = [len(t) for t in prompt_tokens]
     assert max(prompt_lens) <= model.max_seq_len, f"Prompt length exceeds model maximum sequence length (max_seq_len={model.max_seq_len})"
@@ -1049,8 +1102,22 @@ def generate_stream(
         raise RuntimeError("layer_pp_4gpu does not support MTP log/speculative streaming paths yet")
     if mtp_spec_enabled and (needs_logits or len(set(prompt_lens)) > 1):
         mtp_spec_enabled = False
+    prefix_snapshot_start_pos, prefix_snapshot_capture_positions = _prefix_snapshot_settings(
+        model, prompt_tokens, prompt_lens, prefix_snapshot_hint
+    )
+    prefix_snapshot_pending_captures = set(prefix_snapshot_capture_positions)
+    prefix_snapshot_cache = PrefixSnapshotCache.instance() if (prefix_snapshot_pending_captures or prefix_snapshot_start_pos > 0) else None
+
+    def maybe_capture_prefix_snapshot(pos: int) -> None:
+        if prefix_snapshot_cache is None or pos not in prefix_snapshot_pending_captures:
+            return
+        if len(prompt_tokens) != 1 or pos > prompt_lens[0]:
+            return
+        prefix_snapshot_cache.capture(model, prompt_tokens[0], pos)
+        prefix_snapshot_pending_captures.discard(pos)
+
     pending_drafts = None
-    prev_pos = 0
+    prev_pos = prefix_snapshot_start_pos
     finished = torch.tensor([False] * len(prompt_tokens))
     prompt_mask = tokens != -1
     sync_timings = _env_flag("DEEPSEEK_SYNC_TIMINGS", "1" if getattr(model, "is_layer_pp", False) else "0")
@@ -1063,7 +1130,8 @@ def generate_stream(
     decode_wall_start = None
     cur_pos = min(prompt_lens)
     while cur_pos < total_len:
-        phase = "prefill" if prev_pos == 0 else "decode"
+        prefill_step = prev_pos < min(prompt_lens)
+        phase = "prefill" if prefill_step else "decode"
         if phase_callback is not None:
             phase_callback(phase)
         if phase == "decode":
@@ -1104,13 +1172,26 @@ def generate_stream(
             logits = _apply_generation_processors(logits, tokens, cur_pos, generation_options)
             last_hidden = None
             spec_verify = False
-        elif prev_pos == 0 and prefill_chunk_tokens > 0 and cur_pos - prev_pos > prefill_chunk_tokens:
-            chunk_start = prev_pos
-            while chunk_start + prefill_chunk_tokens < cur_pos:
-                chunk_end = chunk_start + prefill_chunk_tokens
-                model.forward(tokens[:, chunk_start:chunk_end], chunk_start, return_next_token=False)
-                chunk_start = chunk_end
-            next_token = model.forward(tokens[:, chunk_start:cur_pos], chunk_start, return_next_token=True)
+        elif prefill_step:
+            capture_points = sorted(pos for pos in prefix_snapshot_pending_captures if prev_pos < pos < cur_pos)
+            if prefill_chunk_tokens > 0 and cur_pos - prev_pos > prefill_chunk_tokens:
+                chunk = prefill_chunk_tokens
+                chunk_start = prev_pos
+                while chunk_start + chunk < cur_pos:
+                    chunk_end = chunk_start + chunk
+                    model.forward(tokens[:, chunk_start:chunk_end], chunk_start, return_next_token=False)
+                    maybe_capture_prefix_snapshot(chunk_end)
+                    chunk_start = chunk_end
+                next_token = model.forward(tokens[:, chunk_start:cur_pos], chunk_start, return_next_token=True)
+            elif capture_points:
+                chunk_start = prev_pos
+                for chunk_end in capture_points:
+                    model.forward(tokens[:, chunk_start:chunk_end], chunk_start, return_next_token=False)
+                    maybe_capture_prefix_snapshot(chunk_end)
+                    chunk_start = chunk_end
+                next_token = model.forward(tokens[:, chunk_start:cur_pos], chunk_start, return_next_token=True)
+            else:
+                next_token = model.forward(tokens[:, prev_pos:cur_pos], prev_pos, return_next_token=True)
             last_hidden = None
             logits = None
         elif spec_verify:
@@ -1171,7 +1252,7 @@ def generate_stream(
             except Exception as exc:
                 print(f"decode profile summary failed: {exc}", flush=True)
             profiler_active = None
-        if prev_pos == 0:
+        if prefill_step:
             _sync_timing_boundary(model, sync_timings and not sync_each_step)
             step_time = time.perf_counter() - step_start
             generated_this_step = int((~prompt_mask[:, cur_pos]).sum().item())
@@ -1195,6 +1276,7 @@ def generate_stream(
                     "phase": "prefill",
                 }
             finished |= torch.logical_and(~prompt_mask[:, cur_pos], next_token == eos_id)
+            maybe_capture_prefix_snapshot(cur_pos)
             prev_pos = cur_pos
             cur_pos += 1
             if finished.all():

--- a/src/runtime/prefix_snapshot.py
+++ b/src/runtime/prefix_snapshot.py
@@ -1,0 +1,306 @@
+"""Coarse-grained KV prefix snapshot cache (fastllm-style).
+
+Stores a process-local LRU of per-layer KV state at fixed token boundaries.
+The cache is off by default.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import struct
+import threading
+import time
+from array import array
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import torch
+
+
+_DEF_BLOCK = 256
+_DEF_MAX_ENTRIES = 8
+
+
+def _env_flag(name: str, default: str = "0") -> bool:
+    return os.getenv(name, default).lower() in {"1", "true", "yes"}
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass
+class SnapshotEntry:
+    pos: int
+    token_ids: list[int]
+    buffers: dict[int, dict[str, torch.Tensor]] = field(default_factory=dict)
+    age: int = 0
+
+
+class PrefixSnapshotCache:
+    _instance: Optional["PrefixSnapshotCache"] = None
+    _instance_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._entries: OrderedDict[bytes, SnapshotEntry] = OrderedDict()
+        self._tick = 0
+        self.block = max(1, _env_int("DEEPSEEK_PREFIX_SNAPSHOT_BLOCK", _DEF_BLOCK))
+        self.max_entries = max(1, _env_int("DEEPSEEK_PREFIX_SNAPSHOT_MAX_ENTRIES", _DEF_MAX_ENTRIES))
+        self.min_tokens = max(self.block, _env_int("DEEPSEEK_PREFIX_SNAPSHOT_MIN_TOKENS", self.block))
+        self.rank = int(os.getenv("RANK", "0"))
+
+    @classmethod
+    def enabled(cls) -> bool:
+        return _env_flag("DEEPSEEK_PREFIX_SNAPSHOT")
+
+    @classmethod
+    def instance(cls) -> "PrefixSnapshotCache":
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = PrefixSnapshotCache()
+            return cls._instance
+
+    def _log(self, msg: str) -> None:
+        if self.rank == 0:
+            print(f"prefix_snapshot {msg}", flush=True)
+
+    @staticmethod
+    def _hash(token_ids: list[int], n: int) -> bytes:
+        h = hashlib.blake2b(digest_size=24)
+        h.update(struct.pack("<Q", n))
+        h.update(array("I", token_ids[:n]).tobytes())
+        return h.digest()
+
+    def lookup_hint(self, token_ids: list[int]) -> Optional[dict[str, Any]]:
+        if not token_ids:
+            return None
+        prompt_len = len(token_ids)
+        capture_pos = (prompt_len // self.block) * self.block
+        if capture_pos < self.min_tokens:
+            return None
+        restore_start = ((prompt_len - 1) // self.block) * self.block
+        match_pos = 0
+        match_key: Optional[bytes] = None
+        with self._lock:
+            n = restore_start
+            while n >= self.block:
+                key = self._hash(token_ids, n)
+                entry = self._entries.get(key)
+                if entry is not None and entry.token_ids == token_ids[:n]:
+                    self._entries.move_to_end(key)
+                    self._tick += 1
+                    entry.age = self._tick
+                    match_pos = n
+                    match_key = key
+                    break
+                n -= self.block
+        if match_pos > 0:
+            self._log(f"hit pos={match_pos} prompt_len={prompt_len} capture_pos={capture_pos}")
+        else:
+            self._log(f"miss prompt_len={prompt_len} longest_match=0 capture_pos={capture_pos}")
+        capture_all = _env_flag("DEEPSEEK_PREFIX_SNAPSHOT_CAPTURE_ALL", "0")
+        capture_positions = list(range(self.block, capture_pos + 1, self.block)) if capture_all else [capture_pos]
+        return {
+            "match_key": match_key.hex() if match_key else None,
+            "match_pos": match_pos,
+            "capture_positions": capture_positions,
+        }
+
+    def restore(self, model: Any, hint: Optional[dict[str, Any]], token_ids: list[int]) -> int:
+        if not hint:
+            return 0
+        match_key_hex = hint.get("match_key")
+        match_pos = int(hint.get("match_pos") or 0)
+        if not match_key_hex or match_pos <= 0:
+            return 0
+        try:
+            key = bytes.fromhex(match_key_hex)
+        except ValueError:
+            return 0
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None or entry.pos != match_pos or entry.pos >= len(token_ids) or entry.token_ids != token_ids[:entry.pos]:
+                return 0
+            self._entries.move_to_end(key)
+            self._tick += 1
+            entry.age = self._tick
+        self._apply_buffers(model, entry.buffers)
+        return entry.pos
+
+    def capture(self, model: Any, token_ids: list[int], pos: int) -> None:
+        if pos <= 0 or pos > len(token_ids) or pos % self.block != 0:
+            return
+        if pos < self.min_tokens:
+            return
+        key = self._hash(token_ids, pos)
+        token_prefix = list(token_ids[:pos])
+        with self._lock:
+            existing = self._entries.get(key)
+            if existing is not None and existing.token_ids == token_prefix:
+                self._entries.move_to_end(key)
+                self._tick += 1
+                existing.age = self._tick
+                return
+        buffers = self._clone_buffers(model, pos)
+        entry = SnapshotEntry(pos=pos, token_ids=token_prefix, buffers=buffers)
+        with self._lock:
+            existing = self._entries.get(key)
+            if existing is not None and existing.token_ids == token_prefix:
+                self._entries.move_to_end(key)
+                self._tick += 1
+                existing.age = self._tick
+                return
+            self._tick += 1
+            entry.age = self._tick
+            self._entries[key] = entry
+            while len(self._entries) > self.max_entries:
+                _, evicted_entry = self._entries.popitem(last=False)
+                self._log(f"evict pos={evicted_entry.pos} age={evicted_entry.age}")
+        self._log(f"capture pos={pos} prompt_len={len(token_ids)} entries={len(self._entries)}")
+
+    @staticmethod
+    def _layer_buffers(layer: Any) -> list[tuple[str, torch.Tensor]]:
+        attn = getattr(layer, "attn", None)
+        if attn is None:
+            return []
+        buffers: list[tuple[str, torch.Tensor]] = []
+        kv_cache = getattr(attn, "kv_cache", None)
+        if isinstance(kv_cache, torch.Tensor):
+            buffers.append(("kv_cache", kv_cache))
+        compressor = getattr(attn, "compressor", None)
+        if compressor is not None:
+            for name in ("kv_state", "score_state"):
+                tensor = getattr(compressor, name, None)
+                if isinstance(tensor, torch.Tensor):
+                    buffers.append((f"compressor.{name}", tensor))
+        indexer = getattr(attn, "indexer", None)
+        if indexer is not None:
+            kv_cache = getattr(indexer, "kv_cache", None)
+            if isinstance(kv_cache, torch.Tensor):
+                buffers.append(("indexer.kv_cache", kv_cache))
+            indexer_compressor = getattr(indexer, "compressor", None)
+            if indexer_compressor is not None:
+                for name in ("kv_state", "score_state"):
+                    tensor = getattr(indexer_compressor, name, None)
+                    if isinstance(tensor, torch.Tensor):
+                        buffers.append((f"indexer.compressor.{name}", tensor))
+        return buffers
+
+    @staticmethod
+    def _snapshot_view(name: str, tensor: torch.Tensor, pos: int, layer: Any) -> torch.Tensor:
+        if tensor.dim() < 2:
+            return tensor.detach().clone()
+        if name == "kv_cache":
+            attn = getattr(layer, "attn", None)
+            win = int(getattr(attn, "window_size", 0) or 0)
+            compress_ratio = int(getattr(attn, "compress_ratio", 0) or 0)
+            length = win + (pos // compress_ratio if compress_ratio > 0 else 0)
+            length = min(max(length, 0), tensor.size(1))
+            return tensor[:1, :length].detach().clone()
+        if name == "indexer.kv_cache":
+            attn = getattr(layer, "attn", None)
+            indexer = getattr(attn, "indexer", None)
+            compress_ratio = int(getattr(indexer, "compress_ratio", 0) or 0)
+            length = pos // compress_ratio if compress_ratio > 0 else tensor.size(1)
+            length = min(max(length, 0), tensor.size(1))
+            return tensor[:1, :length].detach().clone()
+        return tensor[:1].detach().clone()
+
+    def _clone_buffers(self, model: Any, pos: int) -> dict[int, dict[str, torch.Tensor]]:
+        clones: dict[int, dict[str, torch.Tensor]] = {}
+        layers = getattr(model, "layers", None)
+        if layers is None:
+            return clones
+        profile = _env_flag("DEEPSEEK_PREFIX_SNAPSHOT_PROFILE", "0")
+        timings: dict[str, float] = {}
+        sizes: dict[str, int] = {}
+        for idx, layer in enumerate(layers):
+            if layer is None:
+                continue
+            tensors = self._layer_buffers(layer)
+            if not tensors:
+                continue
+            layer_clones: dict[str, torch.Tensor] = {}
+            for name, tensor in tensors:
+                if profile and tensor.is_cuda:
+                    torch.cuda.synchronize(tensor.device)
+                t0 = time.perf_counter()
+                clone = self._snapshot_view(name, tensor, pos, layer)
+                if profile and clone.is_cuda:
+                    torch.cuda.synchronize(clone.device)
+                dt = time.perf_counter() - t0
+                layer_clones[name] = clone
+                if profile:
+                    timings[name] = timings.get(name, 0.0) + dt
+                    sizes[name] = sizes.get(name, 0) + clone.numel() * clone.element_size()
+            clones[idx] = layer_clones
+        if profile:
+            parts = [f"{name}={timings[name]:.3f}s/{sizes.get(name, 0)/1048576:.1f}MiB" for name in sorted(timings)]
+            self._log(f"capture_profile pos={pos} " + " ".join(parts))
+        return clones
+
+    @staticmethod
+    def _apply_buffers(model: Any, buffers: dict[int, dict[str, torch.Tensor]]) -> None:
+        layers = getattr(model, "layers", None)
+        if layers is None:
+            return
+        for idx, snapshot in buffers.items():
+            if idx >= len(layers):
+                continue
+            layer = layers[idx]
+            if layer is None:
+                continue
+            for name, src in snapshot.items():
+                dst = _resolve_buffer(layer, name)
+                if dst is None or dst.dim() != src.dim():
+                    continue
+                if any(src_size > dst_size for src_size, dst_size in zip(src.shape, dst.shape)):
+                    continue
+                slices = tuple(slice(0, size) for size in src.shape)
+                dst[slices].copy_(src)
+            _refresh_aliases(layer)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+
+def _resolve_buffer(layer: Any, name: str) -> Optional[torch.Tensor]:
+    attn = getattr(layer, "attn", None)
+    if attn is None:
+        return None
+    parts = name.split(".")
+    obj: Any = attn
+    for part in parts[:-1]:
+        obj = getattr(obj, part, None)
+        if obj is None:
+            return None
+    tensor = getattr(obj, parts[-1], None)
+    return tensor if isinstance(tensor, torch.Tensor) else None
+
+
+def _refresh_aliases(layer: Any) -> None:
+    attn = getattr(layer, "attn", None)
+    if attn is None:
+        return
+    compressor = getattr(attn, "compressor", None)
+    if compressor is not None and getattr(compressor, "kv_cache", None) is None:
+        win = int(getattr(attn, "window_size", 0) or 0)
+        if win > 0:
+            compressor.kv_cache = attn.kv_cache[:, win:]
+            compressor.freqs_cis = getattr(attn, "freqs_cis", None)
+    indexer = getattr(attn, "indexer", None)
+    if indexer is None:
+        return
+    if getattr(indexer, "freqs_cis", None) is None:
+        indexer.freqs_cis = getattr(attn, "freqs_cis", None)
+    indexer_compressor = getattr(indexer, "compressor", None)
+    if indexer_compressor is not None and getattr(indexer_compressor, "kv_cache", None) is None:
+        indexer_compressor.kv_cache = indexer.kv_cache
+        indexer_compressor.freqs_cis = getattr(indexer, "freqs_cis", None)

--- a/src/server/openai.py
+++ b/src/server/openai.py
@@ -65,6 +65,7 @@ from src.runtime.generation import (
     generate_stream,
     load_model,
 )
+from src.runtime.prefix_snapshot import PrefixSnapshotCache
 from src.runtime.transformer import ModelArgs, Transformer
 from src.runtime.pd_scheduler import PDExecutionFacade, PDScheduler
 from src.server.engine import DeepSeekServingEngine
@@ -449,6 +450,7 @@ def _run_payload(runtime: dict[str, Any], payload: dict[str, Any]) -> dict[str, 
             tokenizer.eos_token_id,
             temperature,
             generation_options=generation_options,
+            prefix_snapshot_hint=payload.get("_prefix_snapshot_hint"),
         )
         if len(completion_result) == 6:
             completion_tokens, prefill_time, decode_time, prefill_tokens, decode_tokens, batch_logprobs = completion_result
@@ -495,6 +497,7 @@ def _run_payload(runtime: dict[str, Any], payload: dict[str, Any]) -> dict[str, 
         tokenizer.eos_token_id,
         temperature,
         generation_options=generation_options,
+        prefix_snapshot_hint=payload.get("_prefix_snapshot_hint"),
     )
     if len(completion_result) == 6:
         completion_tokens, prefill_time, decode_time, prefill_tokens, decode_tokens, batch_logprobs = completion_result
@@ -625,6 +628,7 @@ def _run_payload_stream(runtime: dict[str, Any], payload: dict[str, Any]):
         tokenizer.eos_token_id,
         temperature,
         generation_options=payload.get("generation_options") or {},
+        prefix_snapshot_hint=payload.get("_prefix_snapshot_hint"),
     )
     for event in events:
         if event.get("type") == "done":
@@ -921,6 +925,8 @@ class OpenAIHandler(BaseHTTPRequestHandler):
                 if os.getenv("DEEPSEEK_OPENAI_DEBUG_REQUESTS", "0").lower() in {"1", "true", "yes"}:
                     print(f"openai_truncate_prompt id={payload.get('request_id')} from={len(payload['_prompt_ids'])} to={keep} max_seq_len={max_seq_len}", flush=True)
                 payload["_prompt_ids"] = payload["_prompt_ids"][-keep:]
+            if PrefixSnapshotCache.enabled() and payload["_prompt_ids"]:
+                payload["_prefix_snapshot_hint"] = PrefixSnapshotCache.instance().lookup_hint(payload["_prompt_ids"])
             _debug_request_summary(body, payload, len(payload["_prompt_ids"]))
         except Exception as exc:
             self._send_json(400, _openai_error(str(exc)))


### PR DESCRIPTION
## Summary
- Add an experimental process-local KV prefix snapshot cache guarded by `DEEPSEEK_PREFIX_SNAPSHOT=1`.
- Thread prefix snapshot hints through OpenAI serving and generation without enabling the path by default.
- Keep the current FP4 best-performance path unchanged; `scripts/run_fp4_resident_best.sh` does not set the prefix snapshot env var.

## Test plan
- [x] `conda run -n deepseek python -m py_compile src/runtime/prefix_snapshot.py src/runtime/generation.py src/server/openai.py`
- [x] `git diff --check`
- [x] Default-off FP4 long_long benchmark: prefill TPS `250.706 / 315.613 / 315.592`, no `prefix_snapshot` logs.
- [x] Prefix-on smoke benchmark: cache miss captures an entry and repeated requests hit, but remains experimental and should stay disabled for best-performance runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)