### PR TITLE
Speed up cpp_engine FP4 TP4 prefill via warp-shfl reductions and shared MoE overlap

### DIFF
--- a/cpp_engine/cuda/bf16_ops.cu
+++ b/cpp_engine/cuda/bf16_ops.cu
@@ -93,19 +93,24 @@ __global__ void gate_scores_kernel(const float* x, const uint16_t* w, const floa
     const float* token_x = x + static_cast<size_t>(token) * cols;
     float* token_original = original + static_cast<size_t>(token) * experts;
     float* token_scored = scored + static_cast<size_t>(token) * experts;
+    const int tid = threadIdx.x;
+    const int lane = tid & 31;
+    const int warp_id = tid >> 5;
+    const int num_warps = blockDim.x >> 5;
     float sum = 0.0f;
-    for (int c = threadIdx.x; c < cols; c += blockDim.x) sum += bf16_to_float(w[static_cast<size_t>(row) * cols + c]) * token_x[c];
-    extern __shared__ float scratch[];
-    scratch[threadIdx.x] = sum;
+    for (int c = tid; c < cols; c += blockDim.x) sum += bf16_to_float(w[static_cast<size_t>(row) * cols + c]) * token_x[c];
+    for (int off = 16; off > 0; off >>= 1) sum += __shfl_xor_sync(0xffffffff, sum, off);
+    __shared__ float warp_partials[32];
+    if (lane == 0) warp_partials[warp_id] = sum;
     __syncthreads();
-    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
-        if (threadIdx.x < stride) scratch[threadIdx.x] += scratch[threadIdx.x + stride];
-        __syncthreads();
-    }
-    if (threadIdx.x == 0) {
-        const float orig = sqrt_softplus(scratch[0]);
-        token_original[row] = orig;
-        token_scored[row] = orig + (bias == nullptr ? 0.0f : bias[row]);
+    if (warp_id == 0) {
+        float val = lane < num_warps ? warp_partials[lane] : 0.0f;
+        for (int off = num_warps / 2; off > 0; off >>= 1) val += __shfl_xor_sync(0xffffffff, val, off);
+        if (lane == 0) {
+            const float orig = sqrt_softplus(val);
+            token_original[row] = orig;
+            token_scored[row] = orig + (bias == nullptr ? 0.0f : bias[row]);
+        }
     }
 }
 
@@ -122,18 +127,23 @@ __global__ void gate_hash_scores_kernel(
     const int k = blockIdx.x;
     if (k >= topk) return;
     const int64_t expert = tid2eid[static_cast<size_t>(token_id) * table_topk + k];
+    const int tid = threadIdx.x;
+    const int lane = tid & 31;
+    const int warp_id = tid >> 5;
+    const int num_warps = blockDim.x >> 5;
     float sum = 0.0f;
-    for (int c = threadIdx.x; c < cols; c += blockDim.x) sum += bf16_to_float(w[static_cast<size_t>(expert) * cols + c]) * x[c];
-    extern __shared__ float scratch[];
-    scratch[threadIdx.x] = sum;
+    for (int c = tid; c < cols; c += blockDim.x) sum += bf16_to_float(w[static_cast<size_t>(expert) * cols + c]) * x[c];
+    for (int off = 16; off > 0; off >>= 1) sum += __shfl_xor_sync(0xffffffff, sum, off);
+    __shared__ float warp_partials[32];
+    if (lane == 0) warp_partials[warp_id] = sum;
     __syncthreads();
-    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
-        if (threadIdx.x < stride) scratch[threadIdx.x] += scratch[threadIdx.x + stride];
-        __syncthreads();
-    }
-    if (threadIdx.x == 0) {
-        original[k] = sqrt_softplus(scratch[0]);
-        indices[k] = expert;
+    if (warp_id == 0) {
+        float val = lane < num_warps ? warp_partials[lane] : 0.0f;
+        for (int off = num_warps / 2; off > 0; off >>= 1) val += __shfl_xor_sync(0xffffffff, val, off);
+        if (lane == 0) {
+            original[k] = sqrt_softplus(val);
+            indices[k] = expert;
+        }
     }
 }
 
@@ -161,19 +171,24 @@ __global__ void gate_hash_rows_scores_kernel(
     const int token_id = token_ids[token];
     const int64_t expert = tid2eid[static_cast<size_t>(token_id) * table_topk + k];
     const float* token_x = x + static_cast<size_t>(token) * cols;
+    const int tid = threadIdx.x;
+    const int lane = tid & 31;
+    const int warp_id = tid >> 5;
+    const int num_warps = blockDim.x >> 5;
     float sum = 0.0f;
-    for (int c = threadIdx.x; c < cols; c += blockDim.x) sum += bf16_to_float(w[static_cast<size_t>(expert) * cols + c]) * token_x[c];
-    extern __shared__ float scratch[];
-    scratch[threadIdx.x] = sum;
+    for (int c = tid; c < cols; c += blockDim.x) sum += bf16_to_float(w[static_cast<size_t>(expert) * cols + c]) * token_x[c];
+    for (int off = 16; off > 0; off >>= 1) sum += __shfl_xor_sync(0xffffffff, sum, off);
+    __shared__ float warp_partials[32];
+    if (lane == 0) warp_partials[warp_id] = sum;
     __syncthreads();
-    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
-        if (threadIdx.x < stride) scratch[threadIdx.x] += scratch[threadIdx.x + stride];
-        __syncthreads();
-    }
-    if (threadIdx.x == 0) {
-        const size_t out = static_cast<size_t>(token) * topk + k;
-        weights[out] = sqrt_softplus(scratch[0]);
-        indices[out] = expert;
+    if (warp_id == 0) {
+        float val = lane < num_warps ? warp_partials[lane] : 0.0f;
+        for (int off = num_warps / 2; off > 0; off >>= 1) val += __shfl_xor_sync(0xffffffff, val, off);
+        if (lane == 0) {
+            const size_t out = static_cast<size_t>(token) * topk + k;
+            weights[out] = sqrt_softplus(val);
+            indices[out] = expert;
+        }
     }
 }
 
@@ -266,7 +281,7 @@ bool gate_topk_bf16_cuda_with_buffers(
     void* stream) {
     if (d_x == nullptr || d_w_bf16 == nullptr || d_original == nullptr || d_scored == nullptr || d_indices == nullptr || d_weights == nullptr || experts <= 0 || cols <= 0 || topk <= 0) return false;
     auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
-    gate_scores_kernel<<<dim3(experts, 1), 256, 256 * sizeof(float), cuda_stream>>>(d_x, d_w_bf16, d_bias, d_original, d_scored, experts, cols);
+    gate_scores_kernel<<<dim3(experts, 1), 256, 0, cuda_stream>>>(d_x, d_w_bf16, d_bias, d_original, d_scored, experts, cols);
     gate_topk_finalize_kernel<<<1, 1, 0, cuda_stream>>>(d_original, d_scored, d_indices, d_weights, experts, topk, route_scale);
     return cudaGetLastError() == cudaSuccess;
 }
@@ -311,7 +326,7 @@ bool gate_hash_bf16_cuda(
     void* stream) {
     if (d_x == nullptr || d_w_bf16 == nullptr || d_tid2eid == nullptr || d_original_scratch == nullptr || d_indices == nullptr || d_weights == nullptr || token < 0 || cols <= 0 || table_topk <= 0 || topk <= 0 || topk > table_topk) return false;
     auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
-    gate_hash_scores_kernel<<<topk, 256, 256 * sizeof(float), cuda_stream>>>(d_x, d_w_bf16, d_tid2eid, d_original_scratch, d_indices, token, cols, table_topk, topk);
+    gate_hash_scores_kernel<<<topk, 256, 0, cuda_stream>>>(d_x, d_w_bf16, d_tid2eid, d_original_scratch, d_indices, token, cols, table_topk, topk);
     gate_hash_finalize_kernel<<<1, 1, 0, cuda_stream>>>(d_original_scratch, d_weights, topk, route_scale);
     return cudaGetLastError() == cudaSuccess;
 }
@@ -331,7 +346,7 @@ bool gate_hash_bf16_rows_cuda(
     void* stream) {
     if (d_x == nullptr || d_w_bf16 == nullptr || d_tid2eid == nullptr || d_token_ids == nullptr || d_indices == nullptr || d_weights == nullptr || tokens <= 0 || cols <= 0 || table_topk <= 0 || topk <= 0 || topk > table_topk) return false;
     auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
-    gate_hash_rows_scores_kernel<<<dim3(topk, tokens), 256, 256 * sizeof(float), cuda_stream>>>(d_x, d_w_bf16, d_tid2eid, d_token_ids, d_indices, d_weights, cols, table_topk, topk);
+    gate_hash_rows_scores_kernel<<<dim3(topk, tokens), 256, 0, cuda_stream>>>(d_x, d_w_bf16, d_tid2eid, d_token_ids, d_indices, d_weights, cols, table_topk, topk);
     gate_hash_rows_finalize_kernel<<<tokens, 1, 0, cuda_stream>>>(d_weights, topk, route_scale);
     return cudaGetLastError() == cudaSuccess;
 }
@@ -357,7 +372,7 @@ bool gate_topk_bf16_rows_cuda(
         return false;
     }
     auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
-    gate_scores_kernel<<<dim3(experts, tokens), 256, 256 * sizeof(float), cuda_stream>>>(d_x, d_w_bf16, d_bias, d_original, d_scored, experts, cols);
+    gate_scores_kernel<<<dim3(experts, tokens), 256, 0, cuda_stream>>>(d_x, d_w_bf16, d_bias, d_original, d_scored, experts, cols);
     gate_topk_finalize_kernel<<<tokens, 1, 0, cuda_stream>>>(d_original, d_scored, d_indices, d_weights, experts, topk, route_scale);
     const cudaError_t err = cudaGetLastError();
     cudaFree(d_original);

--- a/cpp_engine/cuda/cuda_ops.cu
+++ b/cpp_engine/cuda/cuda_ops.cu
@@ -610,24 +610,33 @@ __global__ void prefill_sparse_attention_headpair_kernel(
     for (int t = tid; t < topk; t += blockDim.x) idx_shared[t] = idx_base[t];
     __syncthreads();
 
-    for (int t = tid; t < topk; t += blockDim.x) {
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+    const int num_warps = blockDim.x >> 5;
+    for (int t = warp_id; t < topk; t += num_warps) {
         const int idx = idx_shared[t];
         float score0 = -INFINITY;
         float score1 = -INFINITY;
         if (idx >= 0 && idx < kv_len) {
+            const float* kv_ptr = kv_base + static_cast<size_t>(idx) * dim;
             float acc0 = 0.0f;
             float acc1 = 0.0f;
-            const float* kv_ptr = kv_base + static_cast<size_t>(idx) * dim;
-            for (int d = 0; d < dim; ++d) {
+            for (int d = lane; d < dim; d += 32) {
                 const float v = kv_ptr[d];
                 acc0 += q0_shared[d] * v;
                 if (has_h1) acc1 += q1_shared[d] * v;
             }
+            for (int off = 16; off > 0; off >>= 1) {
+                acc0 += __shfl_xor_sync(0xffffffff, acc0, off);
+                if (has_h1) acc1 += __shfl_xor_sync(0xffffffff, acc1, off);
+            }
             score0 = acc0 * softmax_scale;
             if (has_h1) score1 = acc1 * softmax_scale;
         }
-        scores0[t] = score0;
-        if (has_h1) scores1[t] = score1;
+        if (lane == 0) {
+            scores0[t] = score0;
+            if (has_h1) scores1[t] = score1;
+        }
     }
     __syncthreads();
 

--- a/cpp_engine/cuda/rmsnorm_rope.cu
+++ b/cpp_engine/cuda/rmsnorm_rope.cu
@@ -19,8 +19,10 @@ __global__ void rmsnorm_bf16_gamma_kernel(
     int cols,
     float eps) {
     const int row = blockIdx.x;
-    extern __shared__ float scratch[];
     const int tid = threadIdx.x;
+    const int lane = tid & 31;
+    const int warp_id = tid >> 5;
+    const int num_warps = blockDim.x >> 5;
     const float* row_x = x + static_cast<size_t>(row) * cols;
     float* row_y = y + static_cast<size_t>(row) * cols;
 
@@ -29,13 +31,18 @@ __global__ void rmsnorm_bf16_gamma_kernel(
         const float v = row_x[c];
         sum_sq += v * v;
     }
-    scratch[tid] = sum_sq;
+    for (int off = 16; off > 0; off >>= 1) sum_sq += __shfl_xor_sync(0xffffffff, sum_sq, off);
+    __shared__ float warp_partials[32];
+    if (lane == 0) warp_partials[warp_id] = sum_sq;
     __syncthreads();
-    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
-        if (tid < stride) scratch[tid] += scratch[tid + stride];
-        __syncthreads();
+    __shared__ float inv_shared;
+    if (warp_id == 0) {
+        float val = lane < num_warps ? warp_partials[lane] : 0.0f;
+        for (int off = num_warps / 2; off > 0; off >>= 1) val += __shfl_xor_sync(0xffffffff, val, off);
+        if (lane == 0) inv_shared = rsqrtf(val / static_cast<float>(cols) + eps);
     }
-    const float inv = rsqrtf(scratch[0] / static_cast<float>(cols) + eps);
+    __syncthreads();
+    const float inv = inv_shared;
 
     for (int c = tid; c < cols; c += blockDim.x) {
         row_y[c] = row_x[c] * inv * bf16_to_float(gamma[c]);
@@ -55,7 +62,7 @@ bool rmsnorm_bf16_gamma_cuda(
     if (cols <= 0) return false;
     const int threads = 256;
     auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
-    rmsnorm_bf16_gamma_kernel<<<1, threads, threads * sizeof(float), cuda_stream>>>(d_x, d_gamma_bf16, d_y, cols, eps);
+    rmsnorm_bf16_gamma_kernel<<<1, threads, 0, cuda_stream>>>(d_x, d_gamma_bf16, d_y, cols, eps);
     return cudaGetLastError() == cudaSuccess;
 }
 
@@ -71,7 +78,7 @@ bool rmsnorm_bf16_gamma_rows_cuda(
     if (rows <= 0 || cols <= 0) return false;
     const int threads = 256;
     auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
-    rmsnorm_bf16_gamma_kernel<<<rows, threads, threads * sizeof(float), cuda_stream>>>(d_x, d_gamma_bf16, d_y, cols, eps);
+    rmsnorm_bf16_gamma_kernel<<<rows, threads, 0, cuda_stream>>>(d_x, d_gamma_bf16, d_y, cols, eps);
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -1906,6 +1906,15 @@ ForwardSmokeResult run_safetensors_prompt_prefill_impl(SafeForwardContext& ctx, 
         check_cuda(cudaStreamCreateWithFlags(&prefill_moe_copy_stream, cudaStreamNonBlocking), "create prefill moe copy stream");
         check_cuda(cudaEventCreateWithFlags(&prefill_moe_stage_event, cudaEventDisableTiming), "create prefill moe stage event");
     }
+    const bool prefill_shared_overlap_enabled = env_int_or_default("DSV4_CPP_PREFILL_SHARED_OVERLAP", 1) != 0;
+    cudaStream_t prefill_shared_stream = nullptr;
+    cudaEvent_t prefill_shared_ready_event = nullptr;
+    cudaEvent_t prefill_shared_done_event = nullptr;
+    if (prefill_shared_overlap_enabled) {
+        check_cuda(cudaStreamCreateWithFlags(&prefill_shared_stream, cudaStreamNonBlocking), "create prefill shared stream");
+        check_cuda(cudaEventCreateWithFlags(&prefill_shared_ready_event, cudaEventDisableTiming), "create prefill shared ready event");
+        check_cuda(cudaEventCreateWithFlags(&prefill_shared_done_event, cudaEventDisableTiming), "create prefill shared done event");
+    }
     std::vector<int> prev_layer_active_locals;
 
     auto stage_experts_for_layer = [&](int layer_idx, const std::vector<int>& locals, cudaStream_t stream) -> int {
@@ -2243,6 +2252,18 @@ ForwardSmokeResult run_safetensors_prompt_prefill_impl(SafeForwardContext& ctx, 
         total_prefill_ffn_pre_ms += elapsed_ms(stage_t, Clock::now());
         stage_t = Clock::now();
 
+        if (prefill_shared_overlap_enabled) {
+            DeviceSharedCache& shared = ctx.shared_device_cache(li, tp_world, tp_rank, dim);
+            const int shared_inter = inter;
+            check_cuda(cudaEventRecord(prefill_shared_ready_event, nullptr), "record prefill shared ready event");
+            check_cuda(cudaStreamWaitEvent(prefill_shared_stream, prefill_shared_ready_event, 0), "prefill shared stream wait ready");
+            if (!fp8_e4m3_e8m0_matmul_cuda(d_ffn_norm_rows, shared.w1, shared.s1, d_shared_gate, token_count, shared_inter, dim, prefill_shared_stream)) throw std::runtime_error("prefill shared w1 overlap launch failed");
+            if (!fp8_e4m3_e8m0_matmul_cuda(d_ffn_norm_rows, shared.w3, shared.s3, d_shared_up, token_count, shared_inter, dim, prefill_shared_stream)) throw std::runtime_error("prefill shared w3 overlap launch failed");
+            if (!silu_mul_rows_cuda(d_shared_gate, d_shared_up, d_shared_hidden, token_count, shared_inter, prefill_shared_stream)) throw std::runtime_error("prefill shared silu overlap launch failed");
+            if (!fp8_e4m3_e8m0_matmul_cuda(d_shared_hidden, shared.w2, shared.s2, d_shared_out, token_count, dim, shared_inter, prefill_shared_stream)) throw std::runtime_error("prefill shared w2 overlap launch failed");
+            check_cuda(cudaEventRecord(prefill_shared_done_event, prefill_shared_stream), "record prefill shared done event");
+        }
+
         DeviceGateCache& gate = ctx.gate_device_cache(li);
         const bool use_gpu_hash_gate = env_int_or_default("DSV4_CPP_PREFILL_GPU_HASH_GATE", 0) != 0;
         if (static_cast<uint64_t>(li) < config.n_hash_layers && gate.tid2eid != nullptr && use_gpu_hash_gate) {
@@ -2428,7 +2449,10 @@ ForwardSmokeResult run_safetensors_prompt_prefill_impl(SafeForwardContext& ctx, 
         sync_prefill_profile("profile sync prefill reduce");
         total_prefill_reduce_ms += elapsed_ms(stage_t, Clock::now());
         stage_t = Clock::now();
-        {
+        if (prefill_shared_overlap_enabled) {
+            check_cuda(cudaStreamWaitEvent(nullptr, prefill_shared_done_event, 0), "default stream wait shared done");
+            if (!vector_accum_rows_cuda(d_shared_out, d_moe_rows, token_count, dim, 1.0f)) throw std::runtime_error("prefill shared accum overlap failed");
+        } else {
             DeviceSharedCache& shared = ctx.shared_device_cache(li, tp_world, tp_rank, dim);
             const int shared_inter = inter;
             if (!fp8_e4m3_e8m0_matmul_cuda(d_ffn_norm_rows, shared.w1, shared.s1, d_shared_gate, token_count, shared_inter, dim)) throw std::runtime_error("prefill shared w1 launch failed");
@@ -2489,6 +2513,11 @@ ForwardSmokeResult run_safetensors_prompt_prefill_impl(SafeForwardContext& ctx, 
     if (prefill_moe_copy_stream_enabled) {
         cudaEventDestroy(prefill_moe_stage_event);
         cudaStreamDestroy(prefill_moe_copy_stream);
+    }
+    if (prefill_shared_overlap_enabled) {
+        cudaEventDestroy(prefill_shared_ready_event);
+        cudaEventDestroy(prefill_shared_done_event);
+        cudaStreamDestroy(prefill_shared_stream);
     }
     return ForwardSmokeResult{last_token, dim, inter, head_rows, layer_count, top_token, top_logit, checksum};
 }

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -2130,9 +2130,16 @@ ForwardSmokeResult run_safetensors_prompt_prefill_impl(SafeForwardContext& ctx, 
             attn_t = Clock::now();
             const int window_topk = static_cast<int>(std::min<uint64_t>(static_cast<uint64_t>(token_count), std::max<uint64_t>(1, config.window_size == 0 ? 128 : config.window_size)));
             if (!build_prefill_window_indices_cuda(d_prefill_window_indices, token_count, attn_dims.window_size, window_topk)) throw std::runtime_error("prefill window indices launch failed");
+            attn_stage_sync("attn build window");
+            double attn_build_window_ms = profile_attn ? elapsed_ms(attn_t, Clock::now()) : 0.0;
+            auto attn_sparse_t = Clock::now();
             if (!prefill_sparse_attention_headpair_cuda(d_q_rows, d_kv_norm_rows, attn_cache.attn_sink, d_prefill_window_indices, d_attn_value_rows, token_count, attn_dims.heads, token_count, window_topk, attn_dims.head_dim, 1.0f / std::sqrt(static_cast<float>(attn_dims.head_dim)))) throw std::runtime_error("prefill sparse attention headpair launch failed");
+            attn_stage_sync("attn sparse kernel");
+            double attn_sparse_kernel_ms = profile_attn ? elapsed_ms(attn_sparse_t, Clock::now()) : 0.0;
+            auto attn_inv_rope_t = Clock::now();
             if (!head_rmsnorm_rope_freqs_rows_cuda(d_attn_value_rows, attn_dims.d_inv_freqs, token_count, attn_dims.heads, attn_dims.head_dim, attn_dims.rope_dim, 0, true, 0.0f)) throw std::runtime_error("prefill attn value inverse rope rows launch failed");
             attn_stage_sync("attn sparse");
+            double attn_inv_rope_ms = profile_attn ? elapsed_ms(attn_inv_rope_t, Clock::now()) : 0.0;
             double attn_sparse_ms = elapsed_ms(attn_t, Clock::now());
             attn_t = Clock::now();
             for (int g = 0; g < attn_dims.groups; ++g) {
@@ -2161,6 +2168,10 @@ ForwardSmokeResult run_safetensors_prompt_prefill_impl(SafeForwardContext& ctx, 
                           << " q_ms=" << attn_q_ms
                           << " kv_ms=" << attn_kv_ms
                           << " sparse_ms=" << attn_sparse_ms
+                          << " (window_ms=" << attn_build_window_ms
+                          << " sparse_kernel_ms=" << attn_sparse_kernel_ms
+                          << " inv_rope_ms=" << attn_inv_rope_ms
+                          << ")"
                           << " wo_ms=" << attn_wo_ms
                           << " reduce_ms=" << attn_reduce_ms << "\n";
             }

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -2238,8 +2238,7 @@ ForwardSmokeResult run_safetensors_prompt_prefill_impl(SafeForwardContext& ctx, 
         stage_t = Clock::now();
 
         if (!hc_pre_float_rows_cuda(d_h4_rows, hc_cache.ffn_fn, hc_cache.ffn_scale, hc_cache.ffn_base, d_x_rows, d_hc_post_rows, d_hc_comb_rows, token_count, dim)) throw std::runtime_error("prefill hc ffn pre rows launch failed");
-        check_cuda(cudaMemcpy(d_ffn_gamma, ffn_norm_shard.tensor_data(*ffn_norm), ffn_norm->nbytes, cudaMemcpyHostToDevice), "copy prefill ffn gamma");
-        if (!rmsnorm_bf16_gamma_rows_cuda(d_x_rows, d_ffn_gamma, d_ffn_norm_rows, token_count, dim, 1e-6f)) throw std::runtime_error("prefill ffn norm rows launch failed");
+        if (!rmsnorm_bf16_gamma_rows_cuda(d_x_rows, attn_cache.ffn_norm, d_ffn_norm_rows, token_count, dim, 1e-6f)) throw std::runtime_error("prefill ffn norm rows launch failed");
         sync_prefill_profile("profile sync prefill hc ffn pre");
         total_prefill_ffn_pre_ms += elapsed_ms(stage_t, Clock::now());
         stage_t = Clock::now();


### PR DESCRIPTION
## Summary

Five incremental cpp_engine optimizations targeting FP4 TP=4 prefill on 4×RTX 2080 Ti. Each commit preserves 4-rank token bit-parity and was measured against the prior commit; decode is unaffected or slightly improved.

- **Sparse attention score warp-cooperative reduction** (049deb5): prefill_sparse_attention_headpair score phase 19.87 → 4.76 ms/layer.
- **Reuse resident ffn_norm gamma in prefill** (4c4ca59): drops 43 per-layer H2D syncs; prefill median ~266 → ~270 tps.
- **Warp-shfl reduction in gate scores kernels** (c16d341): gate stage 645 → 615 ms (-4.7%).
- **Overlap prefill shared MoE with routed MoE + reduce** (9fbeba6): shared expert runs on a side stream during routed compute + NCCL; gated by `DSV4_CPP_PREFILL_SHARED_OVERLAP=1` (default on).
- **Warp-shfl reduction in rmsnorm_bf16_gamma kernel** (d8f288f): 7-step shared-mem tree → 1-step warp-shfl; called 300+ times per prefill.

Cumulative effect on 4×RTX 2080 Ti TP=4, 2101-token prompt + 8 new tokens:
- prefill median ≈ 272 tps (mean 270, stddev ~6.8 over 8 runs after 30 s cool-down)
- decode mean ≈ 3.71 tps (above PyTorch baseline 3.36)
- PyTorch prefill target 321 → cpp_engine now within ~15%

Prefill stage breakdown after these changes: moe 39 % (w13 22 % + w2 8 % + workspace/wait 9 %), hc_pre 24.6 %, reduce 12 %, attn 12 %, gate 8.4 %, shared 0.1 % (overlapped).

## Test plan

- [x] Build cpp_engine clean (`cmake --build build/cpp_engine -j 16`)
- [x] 4-rank TP=4 token parity: each commit verified bit-identical greedy decode across ranks 0-3
- [x] Long-prompt resident benchmark: 2101-token prompt × 8 new tokens
- [x] Decode TPS not regressed (stayed within stddev of baseline)
- [x] `DSV4_CPP_PREFILL_SHARED_OVERLAP=0` falls back to sequential shared MoE path