### PR TITLE
cpp_engine: GGUF Q2 decode (Phase 3) — TP=4 at 5.47 tps

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -111,6 +111,10 @@ add_executable(test_gguf_attn_norm_wqa tests/test_gguf_attn_norm_wqa.cpp)
 target_link_libraries(test_gguf_attn_norm_wqa PRIVATE dsv4_cpp_core)
 set_target_properties(test_gguf_attn_norm_wqa PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_gguf_attn_q_path tests/test_gguf_attn_q_path.cpp)
+target_link_libraries(test_gguf_attn_q_path PRIVATE dsv4_cpp_core)
+set_target_properties(test_gguf_attn_q_path PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_quant_gemm tests/test_quant_gemm.cpp)
 target_link_libraries(test_quant_gemm PRIVATE dsv4_cpp_core)
 set_target_properties(test_quant_gemm PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -119,6 +119,10 @@ add_executable(test_gguf_attn_kv_path tests/test_gguf_attn_kv_path.cpp)
 target_link_libraries(test_gguf_attn_kv_path PRIVATE dsv4_cpp_core)
 set_target_properties(test_gguf_attn_kv_path PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_gguf_attn_full tests/test_gguf_attn_full.cpp)
+target_link_libraries(test_gguf_attn_full PRIVATE dsv4_cpp_core)
+set_target_properties(test_gguf_attn_full PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_quant_gemm tests/test_quant_gemm.cpp)
 target_link_libraries(test_quant_gemm PRIVATE dsv4_cpp_core)
 set_target_properties(test_quant_gemm PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -115,6 +115,10 @@ add_executable(test_gguf_attn_q_path tests/test_gguf_attn_q_path.cpp)
 target_link_libraries(test_gguf_attn_q_path PRIVATE dsv4_cpp_core)
 set_target_properties(test_gguf_attn_q_path PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_gguf_attn_kv_path tests/test_gguf_attn_kv_path.cpp)
+target_link_libraries(test_gguf_attn_kv_path PRIVATE dsv4_cpp_core)
+set_target_properties(test_gguf_attn_kv_path PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_quant_gemm tests/test_quant_gemm.cpp)
 target_link_libraries(test_quant_gemm PRIVATE dsv4_cpp_core)
 set_target_properties(test_quant_gemm PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -135,6 +135,10 @@ add_executable(test_gguf_routed_moe tests/test_gguf_routed_moe.cpp)
 target_link_libraries(test_gguf_routed_moe PRIVATE dsv4_cpp_core)
 set_target_properties(test_gguf_routed_moe PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_gguf_layer0_full tests/test_gguf_layer0_full.cpp)
+target_link_libraries(test_gguf_layer0_full PRIVATE dsv4_cpp_core)
+set_target_properties(test_gguf_layer0_full PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_quant_gemm tests/test_quant_gemm.cpp)
 target_link_libraries(test_quant_gemm PRIVATE dsv4_cpp_core)
 set_target_properties(test_quant_gemm PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(dsv4_cpp_core STATIC
     src/gguf_reader.cpp
     src/safetensors_reader.cpp
     src/safetensors_model.cpp
+    src/weight_source.cpp
     src/model_config.cpp
     src/tokenizer.cpp
     src/tensor.cpp
@@ -88,6 +89,10 @@ set_target_properties(test_safetensors_reader PROPERTIES RUNTIME_OUTPUT_DIRECTOR
 add_executable(test_safetensors_model tests/test_safetensors_model.cpp)
 target_link_libraries(test_safetensors_model PRIVATE dsv4_cpp_core)
 set_target_properties(test_safetensors_model PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_weight_source tests/test_weight_source.cpp)
+target_link_libraries(test_weight_source PRIVATE dsv4_cpp_core)
+set_target_properties(test_weight_source PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(test_quant_gemm tests/test_quant_gemm.cpp)
 target_link_libraries(test_quant_gemm PRIVATE dsv4_cpp_core)

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -147,6 +147,10 @@ add_executable(test_gguf_generate tests/test_gguf_generate.cpp)
 target_link_libraries(test_gguf_generate PRIVATE dsv4_cpp_core)
 set_target_properties(test_gguf_generate PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(probe_host_register tests/probe_host_register.cpp)
+target_link_libraries(probe_host_register PRIVATE dsv4_cpp_core)
+set_target_properties(probe_host_register PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_quant_gemm tests/test_quant_gemm.cpp)
 target_link_libraries(test_quant_gemm PRIVATE dsv4_cpp_core)
 set_target_properties(test_quant_gemm PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -127,6 +127,10 @@ add_executable(test_gguf_shared_expert tests/test_gguf_shared_expert.cpp)
 target_link_libraries(test_gguf_shared_expert PRIVATE dsv4_cpp_core)
 set_target_properties(test_gguf_shared_expert PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_gguf_routed_expert tests/test_gguf_routed_expert.cpp)
+target_link_libraries(test_gguf_routed_expert PRIVATE dsv4_cpp_core)
+set_target_properties(test_gguf_routed_expert PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_quant_gemm tests/test_quant_gemm.cpp)
 target_link_libraries(test_quant_gemm PRIVATE dsv4_cpp_core)
 set_target_properties(test_quant_gemm PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -107,6 +107,10 @@ add_executable(test_gguf_min_layer_smoke tests/test_gguf_min_layer_smoke.cpp)
 target_link_libraries(test_gguf_min_layer_smoke PRIVATE dsv4_cpp_core)
 set_target_properties(test_gguf_min_layer_smoke PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_gguf_attn_norm_wqa tests/test_gguf_attn_norm_wqa.cpp)
+target_link_libraries(test_gguf_attn_norm_wqa PRIVATE dsv4_cpp_core)
+set_target_properties(test_gguf_attn_norm_wqa PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_quant_gemm tests/test_quant_gemm.cpp)
 target_link_libraries(test_quant_gemm PRIVATE dsv4_cpp_core)
 set_target_properties(test_quant_gemm PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -143,6 +143,10 @@ add_executable(test_gguf_full_forward tests/test_gguf_full_forward.cpp)
 target_link_libraries(test_gguf_full_forward PRIVATE dsv4_cpp_core)
 set_target_properties(test_gguf_full_forward PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_gguf_generate tests/test_gguf_generate.cpp)
+target_link_libraries(test_gguf_generate PRIVATE dsv4_cpp_core)
+set_target_properties(test_gguf_generate PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_quant_gemm tests/test_quant_gemm.cpp)
 target_link_libraries(test_quant_gemm PRIVATE dsv4_cpp_core)
 set_target_properties(test_quant_gemm PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -99,6 +99,10 @@ add_executable(test_q2_matvec tests/test_q2_matvec.cpp)
 target_link_libraries(test_q2_matvec PRIVATE dsv4_cpp_core)
 set_target_properties(test_q2_matvec PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_gguf_dense_smoke tests/test_gguf_dense_smoke.cpp)
+target_link_libraries(test_gguf_dense_smoke PRIVATE dsv4_cpp_core)
+set_target_properties(test_gguf_dense_smoke PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_quant_gemm tests/test_quant_gemm.cpp)
 target_link_libraries(test_quant_gemm PRIVATE dsv4_cpp_core)
 set_target_properties(test_quant_gemm PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -139,6 +139,10 @@ add_executable(test_gguf_layer0_full tests/test_gguf_layer0_full.cpp)
 target_link_libraries(test_gguf_layer0_full PRIVATE dsv4_cpp_core)
 set_target_properties(test_gguf_layer0_full PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_gguf_full_forward tests/test_gguf_full_forward.cpp)
+target_link_libraries(test_gguf_full_forward PRIVATE dsv4_cpp_core)
+set_target_properties(test_gguf_full_forward PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_quant_gemm tests/test_quant_gemm.cpp)
 target_link_libraries(test_quant_gemm PRIVATE dsv4_cpp_core)
 set_target_properties(test_quant_gemm PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -123,6 +123,10 @@ add_executable(test_gguf_attn_full tests/test_gguf_attn_full.cpp)
 target_link_libraries(test_gguf_attn_full PRIVATE dsv4_cpp_core)
 set_target_properties(test_gguf_attn_full PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_gguf_shared_expert tests/test_gguf_shared_expert.cpp)
+target_link_libraries(test_gguf_shared_expert PRIVATE dsv4_cpp_core)
+set_target_properties(test_gguf_shared_expert PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_quant_gemm tests/test_quant_gemm.cpp)
 target_link_libraries(test_quant_gemm PRIVATE dsv4_cpp_core)
 set_target_properties(test_quant_gemm PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(dsv4_cpp_core STATIC
     cuda/quant_gemm.cu
     cuda/fp4_ops.cu
     cuda/fp8_ops.cu
+    cuda/q2_ops.cu
     cuda/rmsnorm_rope.cu
 )
 
@@ -93,6 +94,10 @@ set_target_properties(test_safetensors_model PROPERTIES RUNTIME_OUTPUT_DIRECTORY
 add_executable(test_weight_source tests/test_weight_source.cpp)
 target_link_libraries(test_weight_source PRIVATE dsv4_cpp_core)
 set_target_properties(test_weight_source PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_q2_matvec tests/test_q2_matvec.cpp)
+target_link_libraries(test_q2_matvec PRIVATE dsv4_cpp_core)
+set_target_properties(test_q2_matvec PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(test_quant_gemm tests/test_quant_gemm.cpp)
 target_link_libraries(test_quant_gemm PRIVATE dsv4_cpp_core)

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -131,6 +131,10 @@ add_executable(test_gguf_routed_expert tests/test_gguf_routed_expert.cpp)
 target_link_libraries(test_gguf_routed_expert PRIVATE dsv4_cpp_core)
 set_target_properties(test_gguf_routed_expert PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_gguf_routed_moe tests/test_gguf_routed_moe.cpp)
+target_link_libraries(test_gguf_routed_moe PRIVATE dsv4_cpp_core)
+set_target_properties(test_gguf_routed_moe PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_quant_gemm tests/test_quant_gemm.cpp)
 target_link_libraries(test_quant_gemm PRIVATE dsv4_cpp_core)
 set_target_properties(test_quant_gemm PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -103,6 +103,10 @@ add_executable(test_gguf_dense_smoke tests/test_gguf_dense_smoke.cpp)
 target_link_libraries(test_gguf_dense_smoke PRIVATE dsv4_cpp_core)
 set_target_properties(test_gguf_dense_smoke PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_gguf_min_layer_smoke tests/test_gguf_min_layer_smoke.cpp)
+target_link_libraries(test_gguf_min_layer_smoke PRIVATE dsv4_cpp_core)
+set_target_properties(test_gguf_min_layer_smoke PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_quant_gemm tests/test_quant_gemm.cpp)
 target_link_libraries(test_quant_gemm PRIVATE dsv4_cpp_core)
 set_target_properties(test_quant_gemm PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/cuda/q2_ops.cu
+++ b/cpp_engine/cuda/q2_ops.cu
@@ -546,4 +546,33 @@ bool q2_moe_single_w2_q2k_cuda(
     return cudaGetLastError() == cudaSuccess;
 }
 
+// --- Generic F16 row dequant ------------------------------------------------
+// GGUF stores `token_embd.weight` and `output.weight` as F16. The layout is
+// row-major [vocab, dim] (per-token row is contiguous), matching the FP4 path's
+// BF16 embed/head layout. We provide the F16 counterpart of
+// `bf16_row_to_float_cuda` so the GGUF dense path can lift one token's
+// embedding into fp32 with a single 8 KiB H2D + a tiny kernel.
+
+__global__ void f16_row_to_float_kernel(
+    const uint16_t* matrix, float* y, int row, int cols) {
+    const int out_row = blockIdx.x;
+    const uint16_t* src = matrix + static_cast<size_t>(row + out_row) * cols;
+    float* dst = y + static_cast<size_t>(out_row) * cols;
+    for (int c = threadIdx.x; c < cols; c += blockDim.x) {
+        dst[c] = __half2float(__ushort_as_half(src[c]));
+    }
+}
+
+bool f16_row_to_float_cuda(
+    const uint16_t* d_matrix_f16,
+    float* d_y,
+    int row,
+    int cols,
+    void* stream) {
+    if (cols <= 0) return true;
+    cudaStream_t cs = static_cast<cudaStream_t>(stream);
+    f16_row_to_float_kernel<<<1, 256, 0, cs>>>(d_matrix_f16, d_y, row, cols);
+    return cudaGetLastError() == cudaSuccess;
+}
+
 }  // namespace dsv4

--- a/cpp_engine/cuda/q2_ops.cu
+++ b/cpp_engine/cuda/q2_ops.cu
@@ -1,0 +1,549 @@
+// IQ2_XXS / Q2_K single-token MoE decode kernels for cpp_engine.
+//
+// Ported from src/csrc/cuda_kernel_impl.cu (gguf_moe_single_w13_iq2_xxs_dp4a_kernel
+// and gguf_moe_single_w2_q2k_dp4a_kernel).
+//
+// Layout assumptions match the GGUF on-disk blocks:
+//   * IQ2_XXS block = 66 bytes for 256 weight elements:
+//       [0..1] f16 d, [2..9] chunk0, [10..17] chunk1, ... [58..65] chunk7
+//       each chunk: bytes 0..3 = grid_id, bytes 4..7 = packed aux uint32
+//   * Q2_K block = 84 bytes for 256 weight elements:
+//       [0..15] 16 byte scales (low4=q-scale, high4=min-scale),
+//       [16..79] 64 bytes 2-bit qs (16 groups × 16 elems),
+//       [80..81] f16 d, [82..83] f16 dmin
+//
+// The kernels follow the exact DP4A math used by the PyTorch path so a single
+// expert's compute output matches PyTorch ext kernel within float rounding.
+
+#include "cuda_ops.hpp"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <mutex>
+
+namespace dsv4 {
+
+namespace {
+
+// --- IQ2_XXS lookup table (256 × 8 bytes), expanded into signed_grid lazily. ---
+// Source: src/gguf/tensor_reader.py:_IQ2XXS_GRID.
+
+static const uint64_t kIQ2XXSGrid[256] = {
+    0x0808080808080808ULL, 0x080808080808082bULL, 0x0808080808081919ULL, 0x0808080808082b08ULL,
+    0x0808080808082b2bULL, 0x0808080808190819ULL, 0x0808080808191908ULL, 0x08080808082b0808ULL,
+    0x08080808082b082bULL, 0x08080808082b2b08ULL, 0x08080808082b2b2bULL, 0x0808080819080819ULL,
+    0x0808080819081908ULL, 0x0808080819190808ULL, 0x0808080819192b08ULL, 0x08080808192b0819ULL,
+    0x08080808192b1908ULL, 0x080808082b080808ULL, 0x080808082b08082bULL, 0x080808082b082b2bULL,
+    0x080808082b2b082bULL, 0x0808081908080819ULL, 0x0808081908081908ULL, 0x0808081908190808ULL,
+    0x0808081908191919ULL, 0x0808081919080808ULL, 0x080808192b081908ULL, 0x080808192b192b08ULL,
+    0x0808082b08080808ULL, 0x0808082b0808082bULL, 0x0808082b082b082bULL, 0x0808082b2b08082bULL,
+    0x0808190808080819ULL, 0x0808190808081908ULL, 0x0808190808190808ULL, 0x08081908082b0819ULL,
+    0x08081908082b1908ULL, 0x0808190819080808ULL, 0x080819081908082bULL, 0x0808190819082b08ULL,
+    0x08081908192b0808ULL, 0x080819082b080819ULL, 0x080819082b081908ULL, 0x080819082b190808ULL,
+    0x080819082b2b1908ULL, 0x0808191908080808ULL, 0x080819190808082bULL, 0x0808191908082b08ULL,
+    0x08081919082b0808ULL, 0x080819191908192bULL, 0x08081919192b2b19ULL, 0x080819192b080808ULL,
+    0x080819192b190819ULL, 0x0808192b08082b19ULL, 0x0808192b08190808ULL, 0x0808192b19080808ULL,
+    0x0808192b2b081908ULL, 0x0808192b2b2b1908ULL, 0x08082b0808080808ULL, 0x08082b0808081919ULL,
+    0x08082b0808082b08ULL, 0x08082b0808191908ULL, 0x08082b08082b2b08ULL, 0x08082b0819080819ULL,
+    0x08082b0819081908ULL, 0x08082b0819190808ULL, 0x08082b081919082bULL, 0x08082b082b082b08ULL,
+    0x08082b1908081908ULL, 0x08082b1919080808ULL, 0x08082b2b0808082bULL, 0x08082b2b08191908ULL,
+    0x0819080808080819ULL, 0x0819080808081908ULL, 0x0819080808190808ULL, 0x08190808082b0819ULL,
+    0x0819080819080808ULL, 0x08190808192b0808ULL, 0x081908082b081908ULL, 0x081908082b190808ULL,
+    0x081908082b191919ULL, 0x0819081908080808ULL, 0x0819081908082b08ULL, 0x08190819082b0808ULL,
+    0x0819081919190808ULL, 0x0819081919192b2bULL, 0x081908192b080808ULL, 0x0819082b082b1908ULL,
+    0x0819082b19081919ULL, 0x0819190808080808ULL, 0x0819190808082b08ULL, 0x08191908082b0808ULL,
+    0x08191908082b1919ULL, 0x0819190819082b19ULL, 0x081919082b080808ULL, 0x0819191908192b08ULL,
+    0x08191919192b082bULL, 0x0819192b08080808ULL, 0x0819192b0819192bULL, 0x08192b0808080819ULL,
+    0x08192b0808081908ULL, 0x08192b0808190808ULL, 0x08192b0819080808ULL, 0x08192b082b080819ULL,
+    0x08192b1908080808ULL, 0x08192b1908081919ULL, 0x08192b192b2b0808ULL, 0x08192b2b19190819ULL,
+    0x082b080808080808ULL, 0x082b08080808082bULL, 0x082b080808082b2bULL, 0x082b080819081908ULL,
+    0x082b0808192b0819ULL, 0x082b08082b080808ULL, 0x082b08082b08082bULL, 0x082b0819082b2b19ULL,
+    0x082b081919082b08ULL, 0x082b082b08080808ULL, 0x082b082b0808082bULL, 0x082b190808080819ULL,
+    0x082b190808081908ULL, 0x082b190808190808ULL, 0x082b190819080808ULL, 0x082b19081919192bULL,
+    0x082b191908080808ULL, 0x082b191919080819ULL, 0x082b1919192b1908ULL, 0x082b192b2b190808ULL,
+    0x082b2b0808082b08ULL, 0x082b2b08082b0808ULL, 0x082b2b082b191908ULL, 0x082b2b2b19081908ULL,
+    0x1908080808080819ULL, 0x1908080808081908ULL, 0x1908080808190808ULL, 0x1908080808192b08ULL,
+    0x19080808082b0819ULL, 0x19080808082b1908ULL, 0x1908080819080808ULL, 0x1908080819082b08ULL,
+    0x190808081919192bULL, 0x19080808192b0808ULL, 0x190808082b080819ULL, 0x190808082b081908ULL,
+    0x190808082b190808ULL, 0x1908081908080808ULL, 0x19080819082b0808ULL, 0x19080819192b0819ULL,
+    0x190808192b080808ULL, 0x190808192b081919ULL, 0x1908082b08080819ULL, 0x1908082b08190808ULL,
+    0x1908082b19082b08ULL, 0x1908082b1919192bULL, 0x1908082b192b2b08ULL, 0x1908190808080808ULL,
+    0x1908190808082b08ULL, 0x19081908082b0808ULL, 0x190819082b080808ULL, 0x190819082b192b19ULL,
+    0x190819190819082bULL, 0x19081919082b1908ULL, 0x1908192b08080808ULL, 0x19082b0808080819ULL,
+    0x19082b0808081908ULL, 0x19082b0808190808ULL, 0x19082b0819080808ULL, 0x19082b0819081919ULL,
+    0x19082b1908080808ULL, 0x19082b1919192b08ULL, 0x19082b19192b0819ULL, 0x19082b192b08082bULL,
+    0x19082b2b19081919ULL, 0x19082b2b2b190808ULL, 0x1919080808080808ULL, 0x1919080808082b08ULL,
+    0x1919080808190819ULL, 0x1919080808192b19ULL, 0x19190808082b0808ULL, 0x191908082b080808ULL,
+    0x191908082b082b08ULL, 0x1919081908081908ULL, 0x191908191908082bULL, 0x191908192b2b1908ULL,
+    0x1919082b2b190819ULL, 0x191919082b190808ULL, 0x191919082b19082bULL, 0x1919191908082b2bULL,
+    0x1919192b08080819ULL, 0x1919192b19191908ULL, 0x19192b0808080808ULL, 0x19192b0808190819ULL,
+    0x19192b0808192b19ULL, 0x19192b08192b1908ULL, 0x19192b1919080808ULL, 0x19192b2b08082b08ULL,
+    0x192b080808081908ULL, 0x192b080808190808ULL, 0x192b080819080808ULL, 0x192b0808192b2b08ULL,
+    0x192b081908080808ULL, 0x192b081919191919ULL, 0x192b082b08192b08ULL, 0x192b082b192b0808ULL,
+    0x192b190808080808ULL, 0x192b190808081919ULL, 0x192b191908190808ULL, 0x192b19190819082bULL,
+    0x192b19192b081908ULL, 0x192b2b081908082bULL, 0x2b08080808080808ULL, 0x2b0808080808082bULL,
+    0x2b08080808082b2bULL, 0x2b08080819080819ULL, 0x2b0808082b08082bULL, 0x2b08081908081908ULL,
+    0x2b08081908192b08ULL, 0x2b08081919080808ULL, 0x2b08082b08190819ULL, 0x2b08190808080819ULL,
+    0x2b08190808081908ULL, 0x2b08190808190808ULL, 0x2b08190808191919ULL, 0x2b08190819080808ULL,
+    0x2b081908192b0808ULL, 0x2b08191908080808ULL, 0x2b0819191908192bULL, 0x2b0819192b191908ULL,
+    0x2b08192b08082b19ULL, 0x2b08192b19080808ULL, 0x2b08192b192b0808ULL, 0x2b082b080808082bULL,
+    0x2b082b1908081908ULL, 0x2b082b2b08190819ULL, 0x2b19080808081908ULL, 0x2b19080808190808ULL,
+    0x2b190808082b1908ULL, 0x2b19080819080808ULL, 0x2b1908082b2b0819ULL, 0x2b1908190819192bULL,
+    0x2b1908192b080808ULL, 0x2b19082b19081919ULL, 0x2b19190808080808ULL, 0x2b191908082b082bULL,
+    0x2b19190819081908ULL, 0x2b19191919190819ULL, 0x2b192b082b080819ULL, 0x2b192b19082b0808ULL,
+    0x2b2b08080808082bULL, 0x2b2b080819190808ULL, 0x2b2b08082b081919ULL, 0x2b2b081908082b19ULL,
+    0x2b2b082b08080808ULL, 0x2b2b190808192b08ULL, 0x2b2b2b0819190808ULL, 0x2b2b2b1908081908ULL,
+};
+
+// Constants borrowed from the PyTorch kernel.
+constexpr int kQ2TileN = 8;  // output cols per thread block (mirror kGGUFQuantTileN)
+
+// signed_grid layout: [256 grid_ids][128 sign_indices][8 int8 elems] = 262144 bytes.
+// Total ~256 KiB — too large for __constant__ memory on Turing (64 KiB limit), so
+// we keep it in regular device global memory and lazily initialize once per process.
+static int8_t* g_signed_grid_device = nullptr;
+static std::once_flag g_signed_grid_init_flag;
+
+void build_signed_grid_host(int8_t* out) {
+    // out shape: [256, 128, 8] int8.
+    for (int grid_id = 0; grid_id < 256; ++grid_id) {
+        uint64_t base_value = kIQ2XXSGrid[grid_id];
+        int8_t base[8];
+        for (int b = 0; b < 8; ++b) {
+            base[b] = static_cast<int8_t>(static_cast<uint8_t>((base_value >> (8 * b)) & 0xff));
+        }
+        for (int sign_idx = 0; sign_idx < 128; ++sign_idx) {
+            // sign_mask = idx | ((popcount(idx) & 1) << 7) — extends the 7-bit sign to 8.
+            const int popcount = __builtin_popcount(sign_idx);
+            const int sign_mask = sign_idx | ((popcount & 1) << 7);
+            for (int b = 0; b < 8; ++b) {
+                const int s = (sign_mask >> b) & 1;
+                const int8_t sign = s ? -1 : 1;
+                out[(grid_id * 128 + sign_idx) * 8 + b] = static_cast<int8_t>(base[b] * sign);
+            }
+        }
+    }
+}
+
+const int8_t* signed_grid_device() {
+    std::call_once(g_signed_grid_init_flag, [] {
+        constexpr size_t bytes = 256ULL * 128 * 8;
+        int8_t* host = static_cast<int8_t*>(std::malloc(bytes));
+        if (host == nullptr) return;
+        build_signed_grid_host(host);
+        if (cudaMalloc(&g_signed_grid_device, bytes) != cudaSuccess) {
+            std::free(host);
+            g_signed_grid_device = nullptr;
+            return;
+        }
+        if (cudaMemcpy(g_signed_grid_device, host, bytes, cudaMemcpyHostToDevice) != cudaSuccess) {
+            cudaFree(g_signed_grid_device);
+            g_signed_grid_device = nullptr;
+        }
+        std::free(host);
+    });
+    return g_signed_grid_device;
+}
+
+__device__ __forceinline__ float gguf_block_scale_f16(const uint8_t* ptr) {
+    const uint16_t bits = static_cast<uint16_t>(ptr[0]) | (static_cast<uint16_t>(ptr[1]) << 8);
+    return __half2float(__ushort_as_half(bits));
+}
+
+__device__ __forceinline__ int pack_i8x4(int a, int b, int c, int d) {
+    return (a & 0xff) | ((b & 0xff) << 8) | ((c & 0xff) << 16) | ((d & 0xff) << 24);
+}
+
+// Quantize one row of fp32 activations to Q8_1 (int8 + per-32-group fp32 scale).
+__global__ void gguf_q8_1_quantize_x_32_kernel(
+    const float* __restrict__ x,
+    int8_t* __restrict__ x_q,
+    float* __restrict__ x_scale,
+    int rows,
+    int row_elems) {
+    const int row = blockIdx.x;
+    const int group = blockIdx.y;
+    const int lane = threadIdx.x;
+    if (row >= rows || group * 32 >= row_elems || lane >= 32) return;
+    const int k = group * 32 + lane;
+    const float xv = k < row_elems ? x[static_cast<int64_t>(row) * row_elems + k] : 0.0f;
+    float maxv = fabsf(xv);
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        maxv = fmaxf(maxv, __shfl_down_sync(0xffffffff, maxv, offset));
+    }
+    const float scale = __shfl_sync(0xffffffff, maxv > 0.0f ? maxv / 127.0f : 1.0e-8f, 0);
+    if (lane == 0) {
+        x_scale[row * ((row_elems + 31) / 32) + group] = scale;
+    }
+    int q = __float2int_rn(xv / scale);
+    q = max(-127, min(127, q));
+    if (k < row_elems) {
+        x_q[static_cast<int64_t>(row) * row_elems + k] = static_cast<int8_t>(q);
+    }
+}
+
+// Quantize one row of fp32 to Q8_1 with 16-element groups (post-SwiGLU hidden).
+__global__ void gguf_q8_1_quantize_hidden_16_kernel(
+    const float* __restrict__ hidden,
+    int8_t* __restrict__ hidden_q,
+    float* __restrict__ hidden_scale,
+    int routes,
+    int inter_dim) {
+    const int route = blockIdx.x;
+    const int group = blockIdx.y;
+    const int lane = threadIdx.x;
+    if (route >= routes || group * 16 >= inter_dim || lane >= 16) return;
+    const int k = group * 16 + lane;
+    const float xv = k < inter_dim ? hidden[static_cast<int64_t>(route) * inter_dim + k] : 0.0f;
+    float maxv = fabsf(xv);
+    #pragma unroll
+    for (int offset = 8; offset > 0; offset >>= 1) {
+        maxv = fmaxf(maxv, __shfl_down_sync(0xffff, maxv, offset));
+    }
+    const float scale = __shfl_sync(0xffff, maxv > 0.0f ? maxv / 127.0f : 1.0e-8f, 0);
+    if (lane == 0) {
+        hidden_scale[route * ((inter_dim + 15) / 16) + group] = scale;
+    }
+    int q = __float2int_rn(xv / scale);
+    q = max(-127, min(127, q));
+    hidden_q[static_cast<int64_t>(route) * inter_dim + k] = static_cast<int8_t>(q);
+}
+
+// Fused SwiGLU + per-route weight scale + Q8_1 quantize hidden (group=16).
+__global__ void gguf_route_swiglu_quantize_hidden_16_kernel(
+    const float* __restrict__ gate,
+    const float* __restrict__ up,
+    const float* __restrict__ route_weights,
+    int8_t* __restrict__ hidden_q,
+    float* __restrict__ hidden_scale,
+    int routes,
+    int inter_dim,
+    float swiglu_limit) {
+    const int route = blockIdx.x;
+    const int group = blockIdx.y;
+    const int lane = threadIdx.x;
+    if (route >= routes || group * 16 >= inter_dim || lane >= 16) return;
+    const int k = group * 16 + lane;
+    float g = k < inter_dim ? gate[static_cast<int64_t>(route) * inter_dim + k] : 0.0f;
+    float u = k < inter_dim ? up[static_cast<int64_t>(route) * inter_dim + k] : 0.0f;
+    if (swiglu_limit > 0.0f) {
+        u = fminf(fmaxf(u, -swiglu_limit), swiglu_limit);
+        g = fminf(g, swiglu_limit);
+    }
+    const float v = (g / (1.0f + expf(-g))) * u * route_weights[route];
+    float maxv = fabsf(v);
+    #pragma unroll
+    for (int offset = 8; offset > 0; offset >>= 1) {
+        maxv = fmaxf(maxv, __shfl_down_sync(0xffff, maxv, offset));
+    }
+    const float scale = __shfl_sync(0xffff, maxv > 0.0f ? maxv / 127.0f : 1.0e-8f, 0);
+    if (lane == 0) {
+        hidden_scale[route * ((inter_dim + 15) / 16) + group] = scale;
+    }
+    int q = __float2int_rn(v / scale);
+    q = max(-127, min(127, q));
+    if (k < inter_dim) {
+        hidden_q[static_cast<int64_t>(route) * inter_dim + k] = static_cast<int8_t>(q);
+    }
+}
+
+// IQ2_XXS W1+W3 fused MoE single-token matvec.
+// Layout: w1_blocks/w3_blocks per-expert [inter_dim, blocks_per_row*66] flat bytes.
+__global__ void gguf_moe_single_w13_iq2_xxs_dp4a_kernel(
+    const int8_t* __restrict__ x_q,
+    const float* __restrict__ x_scale,
+    const int64_t* __restrict__ route_slots,
+    const uint8_t* __restrict__ w1_blocks,
+    const uint8_t* __restrict__ w3_blocks,
+    const int8_t* __restrict__ signed_grid,
+    float* __restrict__ gate,
+    float* __restrict__ up,
+    int routes,
+    int n_experts,
+    int dim,
+    int inter_dim,
+    int blocks_per_row,
+    int x_groups) {
+    const int route = blockIdx.y;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int out_col = blockIdx.x * kQ2TileN + warp;
+    if (route >= routes || warp >= kQ2TileN) return;
+    const int expert = static_cast<int>(route_slots[route]);
+    if (expert < 0 || expert >= n_experts) return;
+
+    const uint8_t* w1_row = w1_blocks + (static_cast<int64_t>(expert) * inter_dim + out_col) * blocks_per_row * 66;
+    const uint8_t* w3_row = w3_blocks + (static_cast<int64_t>(expert) * inter_dim + out_col) * blocks_per_row * 66;
+
+    __shared__ int x_shared_q[64];
+    __shared__ float x_shared_scale[8];
+
+    float acc1 = 0.0f;
+    float acc3 = 0.0f;
+
+    for (int block_idx = 0; block_idx < blocks_per_row; ++block_idx) {
+        const int k_base = block_idx * 256;
+        const int tid = threadIdx.x;
+        if (tid < 64) {
+            const int byte_off = tid * 4;
+            int v = 0;
+            if (k_base + byte_off + 4 <= dim) {
+                v = *reinterpret_cast<const int*>(x_q + k_base + byte_off);
+            }
+            x_shared_q[tid] = v;
+        }
+        if (tid < 8) {
+            const int sg_idx = block_idx * 8 + tid;
+            x_shared_scale[tid] = sg_idx < x_groups ? x_scale[sg_idx] : 0.0f;
+        }
+        __syncthreads();
+
+        if (out_col < inter_dim) {
+            const int sub = lane >> 2;
+            const int part = lane & 3;
+            const uint8_t* w1_block = w1_row + static_cast<int64_t>(block_idx) * 66;
+            const uint8_t* w3_block = w3_row + static_cast<int64_t>(block_idx) * 66;
+            const uint8_t* chunk1 = w1_block + 2 + sub * 8;
+            const uint8_t* chunk3 = w3_block + 2 + sub * 8;
+
+            const float d1 = gguf_block_scale_f16(w1_block);
+            const float d3 = gguf_block_scale_f16(w3_block);
+
+            const uint32_t aux1 = static_cast<uint32_t>(chunk1[4]) |
+                (static_cast<uint32_t>(chunk1[5]) << 8) |
+                (static_cast<uint32_t>(chunk1[6]) << 16) |
+                (static_cast<uint32_t>(chunk1[7]) << 24);
+            const uint32_t aux3 = static_cast<uint32_t>(chunk3[4]) |
+                (static_cast<uint32_t>(chunk3[5]) << 8) |
+                (static_cast<uint32_t>(chunk3[6]) << 16) |
+                (static_cast<uint32_t>(chunk3[7]) << 24);
+
+            const int grid_id1 = chunk1[part];
+            const int grid_id3 = chunk3[part];
+            const int sign_idx1 = static_cast<int>((aux1 >> (7 * part)) & 127);
+            const int sign_idx3 = static_cast<int>((aux3 >> (7 * part)) & 127);
+
+            const float s1 = 0.125f * d1 * static_cast<float>(2 * (aux1 >> 28) + 1);
+            const float s3 = 0.125f * d3 * static_cast<float>(2 * (aux3 >> 28) + 1);
+
+            const int8_t* vals1 = signed_grid + (grid_id1 * 128 + sign_idx1) * 8;
+            const int8_t* vals3 = signed_grid + (grid_id3 * 128 + sign_idx3) * 8;
+            const int v1_p0 = *reinterpret_cast<const int*>(vals1);
+            const int v1_p1 = *reinterpret_cast<const int*>(vals1 + 4);
+            const int v3_p0 = *reinterpret_cast<const int*>(vals3);
+            const int v3_p1 = *reinterpret_cast<const int*>(vals3 + 4);
+
+            const int xq_base = sub * 8 + part * 2;
+            const int x_p0 = x_shared_q[xq_base];
+            const int x_p1 = x_shared_q[xq_base + 1];
+
+            int sumi1 = __dp4a(v1_p0, x_p0, 0);
+            sumi1 = __dp4a(v1_p1, x_p1, sumi1);
+            int sumi3 = __dp4a(v3_p0, x_p0, 0);
+            sumi3 = __dp4a(v3_p1, x_p1, sumi3);
+
+            const float xs = x_shared_scale[sub];
+            float local1 = s1 * xs * static_cast<float>(sumi1);
+            float local3 = s3 * xs * static_cast<float>(sumi3);
+
+            #pragma unroll
+            for (int offset = 16; offset > 0; offset >>= 1) {
+                local1 += __shfl_down_sync(0xffffffff, local1, offset);
+                local3 += __shfl_down_sync(0xffffffff, local3, offset);
+            }
+            if (lane == 0) {
+                acc1 += local1;
+                acc3 += local3;
+            }
+        }
+        __syncthreads();
+    }
+
+    if (lane == 0 && out_col < inter_dim) {
+        gate[static_cast<int64_t>(route) * inter_dim + out_col] = acc1;
+        up[static_cast<int64_t>(route) * inter_dim + out_col] = acc3;
+    }
+}
+
+// Q2_K W2 single-token matvec (per-route hidden -> per-token output).
+// Output is accumulated via atomicAdd onto y; caller must zero y beforehand.
+__global__ void gguf_moe_single_w2_q2k_dp4a_kernel(
+    const int8_t* __restrict__ hidden_q,
+    const float* __restrict__ hidden_scale,
+    const int64_t* __restrict__ route_slots,
+    const uint8_t* __restrict__ w2_blocks,
+    float* __restrict__ y,
+    int routes,
+    int n_experts,
+    int dim,
+    int inter_dim,
+    int w2_blocks_per_row,
+    int hidden_groups) {
+    const int route = blockIdx.y;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int out_col = blockIdx.x * kQ2TileN + warp;
+    if (route >= routes || warp >= kQ2TileN || out_col >= dim) return;
+    const int expert = static_cast<int>(route_slots[route]);
+    if (expert < 0 || expert >= n_experts) return;
+
+    const int8_t* hidden_row = hidden_q + static_cast<int64_t>(route) * inter_dim;
+    const float* hs_row = hidden_scale + static_cast<int64_t>(route) * hidden_groups;
+    const uint8_t* w2_row = w2_blocks + (static_cast<int64_t>(expert) * dim + out_col) * w2_blocks_per_row * 84;
+    float acc = 0.0f;
+
+    for (int block_idx = 0; block_idx < w2_blocks_per_row; ++block_idx) {
+        const uint8_t* block = w2_row + static_cast<int64_t>(block_idx) * 84;
+        const uint8_t* scales = block;
+        const uint8_t* qs = block + 16;
+        const float d = gguf_block_scale_f16(block + 80);
+        const float dmin = gguf_block_scale_f16(block + 82);
+        const int k_base = block_idx * 256;
+        for (int group = 0; group < 16; ++group) {
+            float local = 0.0f;
+            if (lane < 4) {
+                const int half_block = group >> 3;
+                const int group_in_half = group & 7;
+                const int shift = (group_in_half >> 1) * 2;
+                const int byte_start = half_block * 32 + (group_in_half & 1) * 16;
+                const int idx = lane * 4;
+                const int q0 = static_cast<int>((qs[byte_start + idx + 0] >> shift) & 0x03);
+                const int q1 = static_cast<int>((qs[byte_start + idx + 1] >> shift) & 0x03);
+                const int q2 = static_cast<int>((qs[byte_start + idx + 2] >> shift) & 0x03);
+                const int q3 = static_cast<int>((qs[byte_start + idx + 3] >> shift) & 0x03);
+                const int w_pack = pack_i8x4(q0, q1, q2, q3);
+                const int h_idx = k_base + group * 16 + idx;
+                const int h_pack = pack_i8x4(
+                    static_cast<int>(hidden_row[h_idx + 0]),
+                    static_cast<int>(hidden_row[h_idx + 1]),
+                    static_cast<int>(hidden_row[h_idx + 2]),
+                    static_cast<int>(hidden_row[h_idx + 3]));
+                const int dot_q = __dp4a(w_pack, h_pack, 0);
+                const int sum_h = __dp4a(0x01010101, h_pack, 0);
+                const float qscale = d * static_cast<float>(scales[group] & 0x0f);
+                const float base = dmin * static_cast<float>(scales[group] >> 4);
+                local = hs_row[block_idx * 16 + group] * (qscale * static_cast<float>(dot_q) - base * static_cast<float>(sum_h));
+            }
+            #pragma unroll
+            for (int offset = 2; offset > 0; offset >>= 1) {
+                local += __shfl_down_sync(0x0f, local, offset);
+            }
+            if (lane == 0) acc += local;
+        }
+    }
+
+    if (lane == 0) {
+        atomicAdd(y + out_col, acc);
+    }
+}
+
+inline int ceil_div(int a, int b) { return (a + b - 1) / b; }
+
+}  // namespace
+
+const int8_t* q2_signed_grid_device() {
+    return signed_grid_device();
+}
+
+bool q2_quantize_x_q8_1_cuda(
+    const float* d_x,
+    int8_t* d_x_q,
+    float* d_x_scale,
+    int rows,
+    int row_elems,
+    void* stream) {
+    if (rows <= 0 || row_elems <= 0) return true;
+    const int groups = ceil_div(row_elems, 32);
+    dim3 grid(rows, groups);
+    gguf_q8_1_quantize_x_32_kernel<<<grid, 32, 0, static_cast<cudaStream_t>(stream)>>>(
+        d_x, d_x_q, d_x_scale, rows, row_elems);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool q2_quantize_hidden_q8_1_cuda(
+    const float* d_hidden,
+    int8_t* d_hidden_q,
+    float* d_hidden_scale,
+    int routes,
+    int inter_dim,
+    void* stream) {
+    if (routes <= 0 || inter_dim <= 0) return true;
+    const int groups = ceil_div(inter_dim, 16);
+    dim3 grid(routes, groups);
+    gguf_q8_1_quantize_hidden_16_kernel<<<grid, 16, 0, static_cast<cudaStream_t>(stream)>>>(
+        d_hidden, d_hidden_q, d_hidden_scale, routes, inter_dim);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool q2_route_swiglu_quantize_hidden_q8_1_cuda(
+    const float* d_gate,
+    const float* d_up,
+    const float* d_route_weights,
+    int8_t* d_hidden_q,
+    float* d_hidden_scale,
+    int routes,
+    int inter_dim,
+    float swiglu_limit,
+    void* stream) {
+    if (routes <= 0 || inter_dim <= 0) return true;
+    const int groups = ceil_div(inter_dim, 16);
+    dim3 grid(routes, groups);
+    gguf_route_swiglu_quantize_hidden_16_kernel<<<grid, 16, 0, static_cast<cudaStream_t>(stream)>>>(
+        d_gate, d_up, d_route_weights, d_hidden_q, d_hidden_scale, routes, inter_dim, swiglu_limit);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool q2_moe_single_w13_iq2_xxs_cuda(
+    const int8_t* d_x_q,
+    const float* d_x_scale,
+    const int64_t* d_route_slots,
+    const uint8_t* d_w1_blocks,
+    const uint8_t* d_w3_blocks,
+    float* d_gate,
+    float* d_up,
+    int routes,
+    int n_experts,
+    int dim,
+    int inter_dim,
+    void* stream) {
+    if (routes <= 0 || inter_dim <= 0 || dim <= 0) return true;
+    const int blocks_per_row = dim / 256;
+    const int x_groups = ceil_div(dim, 32);
+    const int8_t* sg = signed_grid_device();
+    if (sg == nullptr) return false;
+    dim3 grid(ceil_div(inter_dim, kQ2TileN), routes);
+    dim3 block(256);
+    gguf_moe_single_w13_iq2_xxs_dp4a_kernel<<<grid, block, 0, static_cast<cudaStream_t>(stream)>>>(
+        d_x_q, d_x_scale, d_route_slots, d_w1_blocks, d_w3_blocks, sg,
+        d_gate, d_up,
+        routes, n_experts, dim, inter_dim, blocks_per_row, x_groups);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool q2_moe_single_w2_q2k_cuda(
+    const int8_t* d_hidden_q,
+    const float* d_hidden_scale,
+    const int64_t* d_route_slots,
+    const uint8_t* d_w2_blocks,
+    float* d_y,
+    int routes,
+    int n_experts,
+    int dim,
+    int inter_dim,
+    void* stream) {
+    if (routes <= 0 || inter_dim <= 0 || dim <= 0) return true;
+    const int w2_blocks_per_row = inter_dim / 256;
+    const int hidden_groups = ceil_div(inter_dim, 16);
+    dim3 grid(ceil_div(dim, kQ2TileN), routes);
+    dim3 block(256);
+    gguf_moe_single_w2_q2k_dp4a_kernel<<<grid, block, 0, static_cast<cudaStream_t>(stream)>>>(
+        d_hidden_q, d_hidden_scale, d_route_slots, d_w2_blocks, d_y,
+        routes, n_experts, dim, inter_dim, w2_blocks_per_row, hidden_groups);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+}  // namespace dsv4

--- a/cpp_engine/include/cuda_ops.hpp
+++ b/cpp_engine/include/cuda_ops.hpp
@@ -314,6 +314,15 @@ bool bf16_row_to_float_cuda(
     int cols,
     void* stream = nullptr);
 
+// GGUF embed/head are stored F16 (IEEE half), not BF16. This is the F16
+// counterpart of bf16_row_to_float_cuda for the GGUF dense path.
+bool f16_row_to_float_cuda(
+    const uint16_t* d_matrix_f16,
+    float* d_y,
+    int row,
+    int cols,
+    void* stream = nullptr);
+
 bool bf16_rows_to_float_cuda(
     const uint16_t* d_matrix_bf16,
     const int* d_rows,

--- a/cpp_engine/include/cuda_ops.hpp
+++ b/cpp_engine/include/cuda_ops.hpp
@@ -15,6 +15,74 @@ bool q8_0_matvec_cuda(
     int cols,
     void* stream = nullptr);
 
+// --- IQ2_XXS / Q2_K single-token MoE decode kernels (cuda/q2_ops.cu). ---
+
+// Returns a device pointer to the lazy-initialized signed_grid lookup table
+// (shape [256, 128, 8] int8, ~256 KiB). Returns nullptr on allocation failure.
+const int8_t* q2_signed_grid_device();
+
+// Quantize fp32 activations to Q8_1 with 32-element groups (one row per launch).
+bool q2_quantize_x_q8_1_cuda(
+    const float* d_x,
+    int8_t* d_x_q,
+    float* d_x_scale,
+    int rows,
+    int row_elems,
+    void* stream = nullptr);
+
+// Quantize fp32 hidden activations to Q8_1 with 16-element groups (post-SwiGLU).
+bool q2_quantize_hidden_q8_1_cuda(
+    const float* d_hidden,
+    int8_t* d_hidden_q,
+    float* d_hidden_scale,
+    int routes,
+    int inter_dim,
+    void* stream = nullptr);
+
+// Fused: SwiGLU(gate, up) * route_weight -> Q8_1 with 16-element groups.
+bool q2_route_swiglu_quantize_hidden_q8_1_cuda(
+    const float* d_gate,
+    const float* d_up,
+    const float* d_route_weights,
+    int8_t* d_hidden_q,
+    float* d_hidden_scale,
+    int routes,
+    int inter_dim,
+    float swiglu_limit,
+    void* stream = nullptr);
+
+// IQ2_XXS W1+W3 single-token matvec (per-route gate/up outputs).
+// d_w1_blocks/d_w3_blocks layout: per-expert [inter_dim, blocks_per_row*66] flat bytes
+// where blocks_per_row = dim / 256. Output: d_gate/d_up [routes, inter_dim].
+bool q2_moe_single_w13_iq2_xxs_cuda(
+    const int8_t* d_x_q,
+    const float* d_x_scale,
+    const int64_t* d_route_slots,
+    const uint8_t* d_w1_blocks,
+    const uint8_t* d_w3_blocks,
+    float* d_gate,
+    float* d_up,
+    int routes,
+    int n_experts,
+    int dim,
+    int inter_dim,
+    void* stream = nullptr);
+
+// Q2_K W2 single-token matvec. Accumulates onto d_y (caller must zero beforehand).
+// d_w2_blocks layout: per-expert [dim, blocks_per_row*84] flat bytes
+// where blocks_per_row = inter_dim / 256.
+bool q2_moe_single_w2_q2k_cuda(
+    const int8_t* d_hidden_q,
+    const float* d_hidden_scale,
+    const int64_t* d_route_slots,
+    const uint8_t* d_w2_blocks,
+    float* d_y,
+    int routes,
+    int n_experts,
+    int dim,
+    int inter_dim,
+    void* stream = nullptr);
+
 bool fp4_e2m1_e8m0_matvec_cuda(
     const float* d_x,
     const uint8_t* d_weight,

--- a/cpp_engine/include/dsv4_engine.hpp
+++ b/cpp_engine/include/dsv4_engine.hpp
@@ -215,4 +215,32 @@ struct GgufRoutedMoeResult {
 
 GgufRoutedMoeResult run_gguf_routed_moe_smoke(const std::string& ckpt_path, int token);
 
+// Phase 3 step: full layer-0 forward composition with residuals.
+// Embed -> save x_pre_attn -> attn_norm -> Q/KV path -> sparse attention ->
+// inverse RoPE -> grouped wo_a -> wo_b -> +x_pre_attn (residual)
+// -> save x_pre_ffn -> ffn_norm -> shared expert (Q8_0 w1/w3 + silu_mul + Q8_0 w2)
+// -> hash-gate scores via gate W -> stage top-k Q2 experts -> Q8_1 quantize x
+// -> batched IQ2_XXS w1/w3 -> SwiGLU + route_weight + Q8_1 quantize hidden
+// -> batched Q2_K w2 (atomicAdd) -> +x_pre_ffn (residual) -> x_out.
+// Validates the residual flow through one full layer (attention + FFN).
+struct GgufLayer0FullResult {
+    int dim = 0;
+    int moe_inter_dim = 0;
+    int heads = 0;
+    int head_dim = 0;
+    int n_active = 0;
+    int expert_ids[8] = {0,0,0,0,0,0,0,0};
+    float embed_rms = 0.0f;
+    float attn_out_rms = 0.0f;        // wo_b output (before residual)
+    float x_post_attn_rms = 0.0f;     // x_pre_attn + attn_out
+    float shared_out_rms = 0.0f;
+    float moe_out_rms = 0.0f;
+    float ffn_combined_rms = 0.0f;    // shared_out + moe_out (before residual)
+    float x_post_ffn_rms = 0.0f;      // x_post_attn + ffn_combined
+    float route_weights_sum = 0.0f;   // sanity: should equal route_scale (1.5)
+    float x_post_ffn_first[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+};
+
+GgufLayer0FullResult run_gguf_layer0_full_smoke(const std::string& ckpt_path, int token, int position);
+
 }  // namespace dsv4

--- a/cpp_engine/include/dsv4_engine.hpp
+++ b/cpp_engine/include/dsv4_engine.hpp
@@ -204,6 +204,10 @@ struct GgufRoutedMoeResult {
     int moe_inter_dim = 0;
     int n_active = 0;          // number of active experts (top-k)
     int expert_ids[8] = {0,0,0,0,0,0,0,0};
+    // Real route weights from sqrt_softplus(W gate · x_normed), gathered at
+    // the hash-selected expert ids, normalized to sum=1, then ×route_scale.
+    float route_weights[8] = {0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f};
+    float route_weights_sum = 0.0f; // sanity: should equal route_scale (1.5 for DSV4-Flash)
     float ffn_normed_rms = 0.0f;
     float moe_out_rms = 0.0f;
     float moe_out_first[4] = {0.0f, 0.0f, 0.0f, 0.0f};

--- a/cpp_engine/include/dsv4_engine.hpp
+++ b/cpp_engine/include/dsv4_engine.hpp
@@ -111,4 +111,20 @@ struct GgufAttnQPathResult {
 
 GgufAttnQPathResult run_gguf_attn_q_path_smoke(const std::string& ckpt_path, int token, int position);
 
+// Phase 3 step: attention KV path for layer 0. Embed -> attn_norm -> wkv Q8_0
+// projection (dim -> kv_dim) -> kv_norm RMSNorm -> head_rmsnorm_rope with
+// heads=1, head_dim=kv_dim, rope_dim. RoPE is a rotation so the final L2 norm
+// equals the post-rmsnorm L2 norm (sqrt(kv_dim) for unit-RMS output).
+struct GgufAttnKvPathResult {
+    int dim = 0;
+    int kv_dim = 0;
+    int rope_dim = 0;
+    float kv_a_rms = 0.0f;       // RMS of kv_a after wkv (before rmsnorm)
+    float kv_norm_rms = 0.0f;    // RMS of kv after rmsnorm with kv_norm gamma
+    float kv_post_rope_rms = 0.0f; // RMS of kv after RoPE; rotation preserves L2
+    float kv_first[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+};
+
+GgufAttnKvPathResult run_gguf_attn_kv_path_smoke(const std::string& ckpt_path, int token, int position);
+
 }  // namespace dsv4

--- a/cpp_engine/include/dsv4_engine.hpp
+++ b/cpp_engine/include/dsv4_engine.hpp
@@ -285,6 +285,10 @@ struct GgufDecodeResult {
 
 GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
                                           const std::vector<int>& seed_tokens,
+                                          int max_new_tokens,
+                                          const ForwardSmokeOptions& options);
+GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
+                                          const std::vector<int>& seed_tokens,
                                           int max_new_tokens);
 
 }  // namespace dsv4

--- a/cpp_engine/include/dsv4_engine.hpp
+++ b/cpp_engine/include/dsv4_engine.hpp
@@ -94,4 +94,21 @@ struct GgufAttnNormWqaResult {
 
 GgufAttnNormWqaResult run_gguf_attn_norm_wq_a_smoke(const std::string& ckpt_path, int token);
 
+// Phase 3 step: full attention Q path for layer 0. Extends the q_a smoke
+// through q_norm RMSNorm, wq_b Q8_0 projection, and head_rmsnorm_rope.
+// Output is the final per-head Q tensor ready to feed attention compute.
+struct GgufAttnQPathResult {
+    int dim = 0;
+    int q_a_dim = 0;
+    int heads = 0;
+    int head_dim = 0;
+    int rope_dim = 0;
+    float q_normed_rms = 0.0f;     // RMS of q_a after q_norm
+    float q_pre_rope_rms = 0.0f;   // RMS of q (heads*head_dim) after wq_b, before head norm/rope
+    float q_post_rope_rms = 0.0f;  // RMS of q after head_rmsnorm_rope
+    float q_first[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+};
+
+GgufAttnQPathResult run_gguf_attn_q_path_smoke(const std::string& ckpt_path, int token, int position);
+
 }  // namespace dsv4

--- a/cpp_engine/include/dsv4_engine.hpp
+++ b/cpp_engine/include/dsv4_engine.hpp
@@ -127,4 +127,31 @@ struct GgufAttnKvPathResult {
 
 GgufAttnKvPathResult run_gguf_attn_kv_path_smoke(const std::string& ckpt_path, int token, int position);
 
+// Phase 3 step: full single-token dense attention for layer 0.
+// Embed -> attn_norm -> Q-path (wq_a, q_norm, wq_b, head_rmsnorm_rope) ||
+// KV-path (wkv, kv_norm, head_rmsnorm_rope) -> single_token_sparse_attention
+// (with attn_sink) -> inverse RoPE on rope tail of each head -> grouped wo_a
+// Q8_0 (o_groups separate matvecs) -> wo_b Q8_0 (-> dim).
+// Output `attn_out` is the per-layer attention residual (length dim).
+struct GgufAttnFullResult {
+    int dim = 0;
+    int q_a_dim = 0;
+    int heads = 0;
+    int head_dim = 0;
+    int kv_dim = 0;
+    int rope_dim = 0;
+    int o_groups = 0;
+    int o_lora_rank = 0;
+    int attn_mid = 0;
+    float q_rms = 0.0f;
+    float kv_rms = 0.0f;
+    float attn_value_rms = 0.0f;       // RMS of sparse-attention output
+    float attn_value_post_inv_rms = 0.0f; // after inverse RoPE
+    float attn_mid_rms = 0.0f;
+    float attn_out_rms = 0.0f;
+    float attn_out_first[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+};
+
+GgufAttnFullResult run_gguf_attn_full_smoke(const std::string& ckpt_path, int token, int position);
+
 }  // namespace dsv4

--- a/cpp_engine/include/dsv4_engine.hpp
+++ b/cpp_engine/include/dsv4_engine.hpp
@@ -172,4 +172,24 @@ struct GgufSharedExpertResult {
 
 GgufSharedExpertResult run_gguf_shared_expert_smoke(const std::string& ckpt_path, int token);
 
+// Phase 3 step: single routed expert smoke for layer 0.
+// Embed -> ffn_norm -> q8_1 quantize -> IQ2_XXS w1/w3 matvec -> SwiGLU
+// (clamped + route-weight) -> q8_1 quantize hidden -> Q2_K w2 matvec.
+// Loads only the single expert's slice from the routed 3D GGUF tensor, so
+// the kernel sees n_experts=1 + route_slots=[0]. This wires real GGUF
+// per-expert byte offsets into the existing Q2 single-token kernels.
+struct GgufRoutedExpertResult {
+    int dim = 0;
+    int moe_inter_dim = 0;
+    int expert_id = 0;
+    float ffn_normed_rms = 0.0f;
+    float gate_rms = 0.0f;
+    float up_rms = 0.0f;
+    float hidden_rms = 0.0f; // after SwiGLU + route weight (post quantize-dequantize)
+    float route_out_rms = 0.0f;
+    float route_out_first[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+};
+
+GgufRoutedExpertResult run_gguf_routed_expert_smoke(const std::string& ckpt_path, int token, int expert_id);
+
 }  // namespace dsv4

--- a/cpp_engine/include/dsv4_engine.hpp
+++ b/cpp_engine/include/dsv4_engine.hpp
@@ -243,4 +243,26 @@ struct GgufLayer0FullResult {
 
 GgufLayer0FullResult run_gguf_layer0_full_smoke(const std::string& ckpt_path, int token, int position);
 
+// Phase 3 step: 43-layer GGUF forward + final norm + Q8_0 head + argmax.
+// Loads all dense weights resident on device, per-layer stages top-k routed
+// Q2 experts (hash-gate layers use tid2eid lookup; non-hash layers compute
+// the gate then D2H copy expert ids back to host for staging), runs the
+// layer-forward helper across all 43 layers, applies output_norm RMSNorm,
+// runs the Q8_0 head matvec, and reports the argmax token + top logit + a
+// debug checksum.
+struct GgufFullForwardResult {
+    int n_layers = 0;
+    int dim = 0;
+    int vocab = 0;
+    int top_token = 0;
+    float top_logit = 0.0f;
+    float checksum = 0.0f;       // sum of logits, like FP4 path
+    float final_x_rms = 0.0f;
+    float final_normed_rms = 0.0f;
+    float logits_rms = 0.0f;
+    float logits_first[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+};
+
+GgufFullForwardResult run_gguf_full_forward_smoke(const std::string& ckpt_path, int token, int position);
+
 }  // namespace dsv4

--- a/cpp_engine/include/dsv4_engine.hpp
+++ b/cpp_engine/include/dsv4_engine.hpp
@@ -265,4 +265,26 @@ struct GgufFullForwardResult {
 
 GgufFullForwardResult run_gguf_full_forward_smoke(const std::string& ckpt_path, int token, int position);
 
+// Phase 3 step: multi-token greedy decode smoke. Loads all dense weights once,
+// allocates a per-layer KV cache sized for the full sequence (seeds + decode),
+// then runs forward once per position. The token at position p is either the
+// seed at p (when p < seeds.size()) or the argmax from position p-1. Returns
+// the full sequence of generated tokens after the seeds, plus per-step top
+// logits and rough timing breakdown.
+struct GgufDecodeResult {
+    int n_layers = 0;
+    int dim = 0;
+    int vocab = 0;
+    std::vector<int> generated_tokens;  // length = max_new_tokens
+    std::vector<float> top_logits;      // length = seeds.size() + max_new_tokens
+    double load_seconds = 0.0;
+    double forward_seconds = 0.0;       // total time across all forward steps
+    int prompt_tokens = 0;
+    int decode_tokens = 0;
+};
+
+GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
+                                          const std::vector<int>& seed_tokens,
+                                          int max_new_tokens);
+
 }  // namespace dsv4

--- a/cpp_engine/include/dsv4_engine.hpp
+++ b/cpp_engine/include/dsv4_engine.hpp
@@ -79,4 +79,19 @@ struct GgufSmokeResult {
 
 GgufSmokeResult run_gguf_min_layer_smoke(const std::string& ckpt_path);
 
+// Phase 3 step: exercise the dense input chain for layer 0 attention's
+// q_a branch. Embed F16 lookup -> attn_norm F32->BF16 RMSNorm -> wq_a Q8_0
+// matvec. Validates the F32 norm gamma conversion path and the first
+// Q8_0 attention projection against real GGUF data.
+struct GgufAttnNormWqaResult {
+    int dim = 0;
+    int q_a_dim = 0;
+    float embed_rms = 0.0f;
+    float normed_rms = 0.0f;
+    float q_a_rms = 0.0f;
+    float q_a_first[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+};
+
+GgufAttnNormWqaResult run_gguf_attn_norm_wq_a_smoke(const std::string& ckpt_path, int token);
+
 }  // namespace dsv4

--- a/cpp_engine/include/dsv4_engine.hpp
+++ b/cpp_engine/include/dsv4_engine.hpp
@@ -192,4 +192,23 @@ struct GgufRoutedExpertResult {
 
 GgufRoutedExpertResult run_gguf_routed_expert_smoke(const std::string& ckpt_path, int token, int expert_id);
 
+// Phase 3 step: multi-active-expert routed Q2 MoE smoke for layer 0.
+// Embed -> ffn_norm -> hash-gate lookup (tid2eid for hash layers) producing
+// top-k expert ids and uniform 1/k weights -> stage top-k experts' bytes
+// (w1/w3 IQ2_XXS + w2 Q2_K) into packed device buffers -> q8_1 quantize x
+// broadcast to routes -> batched IQ2_XXS w1/w3 matvec -> SwiGLU+route_weight
+// -> Q2_K w2 matvec accumulated across routes. Output: MoE contribution
+// (length dim) summed over the top-k active experts for this token.
+struct GgufRoutedMoeResult {
+    int dim = 0;
+    int moe_inter_dim = 0;
+    int n_active = 0;          // number of active experts (top-k)
+    int expert_ids[8] = {0,0,0,0,0,0,0,0};
+    float ffn_normed_rms = 0.0f;
+    float moe_out_rms = 0.0f;
+    float moe_out_first[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+};
+
+GgufRoutedMoeResult run_gguf_routed_moe_smoke(const std::string& ckpt_path, int token);
+
 }  // namespace dsv4

--- a/cpp_engine/include/dsv4_engine.hpp
+++ b/cpp_engine/include/dsv4_engine.hpp
@@ -59,4 +59,24 @@ std::vector<ForwardSmokeResult> run_safetensors_generate_tokens(const std::strin
 std::vector<ForwardSmokeResult> run_safetensors_generate_tokens_with_options(const std::string& ckpt_dir, const std::vector<int>& seed_tokens, int layer_count, int max_new_tokens, const ForwardSmokeOptions& options);
 GenerateSmokeResult run_safetensors_generate_tokens_timed_with_options(const std::string& ckpt_dir, const std::vector<int>& seed_tokens, int layer_count, int max_new_tokens, const ForwardSmokeOptions& options);
 
+// --- GGUF Q2 forward entry points ------------------------------------------
+//
+// Sibling to the safetensors path. The full forward chain isn't wired in yet
+// (Phase 3); this initial entry point only verifies that we can construct a
+// GgufForwardContext and that the GGUF mapping table resolves the dense
+// metadata we'll need. Implementation is in dsv4_engine.cpp alongside the
+// safetensors path so future GGUF forward operators can share helpers.
+
+struct GgufSmokeResult {
+    int n_layers = 0;
+    int n_hash_layers = 0;
+    int dim = 0;
+    int moe_inter_dim = 0;
+    int n_routed_experts = 0;
+    int n_activated_experts = 0;
+    int vocab = 0;
+};
+
+GgufSmokeResult run_gguf_min_layer_smoke(const std::string& ckpt_path);
+
 }  // namespace dsv4

--- a/cpp_engine/include/dsv4_engine.hpp
+++ b/cpp_engine/include/dsv4_engine.hpp
@@ -154,4 +154,22 @@ struct GgufAttnFullResult {
 
 GgufAttnFullResult run_gguf_attn_full_smoke(const std::string& ckpt_path, int token, int position);
 
+// Phase 3 step: shared-expert FFN smoke for layer 0.
+// Embed -> ffn_norm RMSNorm -> shared w1 / w3 Q8_0 matvec -> silu_mul ->
+// shared w2 Q8_0 matvec. All three shared-expert projections are stored as
+// Q8_0 in the GGUF model. Output is the shared-expert contribution to the
+// FFN residual (length dim).
+struct GgufSharedExpertResult {
+    int dim = 0;
+    int moe_inter_dim = 0;
+    float ffn_normed_rms = 0.0f;
+    float gate_rms = 0.0f;
+    float up_rms = 0.0f;
+    float hidden_rms = 0.0f;   // after silu_mul
+    float shared_out_rms = 0.0f;
+    float shared_out_first[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+};
+
+GgufSharedExpertResult run_gguf_shared_expert_smoke(const std::string& ckpt_path, int token);
+
 }  // namespace dsv4

--- a/cpp_engine/include/gguf_reader.hpp
+++ b/cpp_engine/include/gguf_reader.hpp
@@ -60,6 +60,10 @@ public:
     std::vector<uint64_t> metadata_u64_array(const std::string& key) const;
     std::vector<double> metadata_f64_array(const std::string& key) const;
 
+    // Raw mmap base + size, exposed so callers can cudaHostRegister the
+    // entire file region for pinned async H2D out of GGUF data.
+    const uint8_t* bytes() const { return static_cast<const uint8_t*>(data_); }
+
 private:
     void parse();
     uint8_t read_u8(size_t& cursor) const;
@@ -74,8 +78,6 @@ private:
     double read_f64(size_t& cursor) const;
     std::string read_string(size_t& cursor) const;
     MetadataValue read_metadata_value(size_t& cursor, uint32_t value_type) const;
-
-    const uint8_t* bytes() const { return static_cast<const uint8_t*>(data_); }
 
     std::string path_;
     int fd_ = -1;

--- a/cpp_engine/include/weight_source.hpp
+++ b/cpp_engine/include/weight_source.hpp
@@ -1,0 +1,115 @@
+#pragma once
+
+#include "gguf_reader.hpp"
+#include "safetensors_reader.hpp"
+#include "tensor.hpp"
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace dsv4 {
+
+// Read-only view of one tensor as raw bytes plus typed metadata. Borrowed from
+// either the safetensors shard mmap or the GGUF file mmap; the caller must not
+// outlive the owning WeightSource.
+struct WeightView {
+    std::string name;          // internal canonical name, e.g. "layers.0.attn.wq_a.weight"
+    DType dtype = DType::Unknown;
+    std::vector<uint64_t> shape;
+    const uint8_t* data = nullptr;
+    uint64_t nbytes = 0;
+    bool found = false;
+};
+
+// Abstracts the difference between (multi-shard FP4 safetensors) and (single
+// GGUF Q2/Q8/BF16) checkpoints. Lifetime: same as SafeForwardContext.
+class WeightSource {
+public:
+    virtual ~WeightSource() = default;
+
+    // Returns true if the source has a tensor with the given internal name.
+    virtual bool has(const std::string& name) const = 0;
+
+    // Get the tensor by internal name. Returns a view with found=false on miss.
+    virtual WeightView get(const std::string& name) const = 0;
+
+    // Same as get() but the tensor is required; throws on miss.
+    WeightView require(const std::string& name) const;
+
+    // For 3D routed-expert tensors that pack n_experts experts into one tensor
+    // (GGUF format), return just one expert's slice. For per-expert safetensors
+    // tensors the default impl just calls get() with the per-expert name.
+    virtual WeightView get_expert(const std::string& routed_name_3d,
+                                  const std::string& per_expert_name,
+                                  int expert_id) const = 0;
+
+    // Returns the quantization "family" the source uses. Drives format-specific
+    // weight loading paths in SafeForwardContext.
+    enum class Format { Safetensors_FP4, GGUF_Q2 };
+    virtual Format format() const = 0;
+};
+
+// Wraps the existing SafeTensorsIndex + lazy SafeTensorsShard opens.
+class SafetensorsWeightSource : public WeightSource {
+public:
+    explicit SafetensorsWeightSource(const std::string& ckpt_dir);
+
+    bool has(const std::string& name) const override;
+    WeightView get(const std::string& name) const override;
+    WeightView get_expert(const std::string& routed_name_3d,
+                          const std::string& per_expert_name,
+                          int expert_id) const override;
+    Format format() const override { return Format::Safetensors_FP4; }
+
+    const SafeTensorsIndex& index() const { return index_; }
+
+private:
+    SafeTensorsShard& shard_for(const std::string& tensor_name) const;
+
+    SafeTensorsIndex index_;
+    mutable std::map<std::string, std::unique_ptr<SafeTensorsShard>> shards_;
+};
+
+// Wraps a GGUFFile and translates internal canonical names to GGUF tensor names
+// via the DSV4 mapping (mirrors src/gguf/ds4_mapping.py).
+class GGUFWeightSource : public WeightSource {
+public:
+    explicit GGUFWeightSource(const std::string& path);
+
+    bool has(const std::string& name) const override;
+    WeightView get(const std::string& name) const override;
+    WeightView get_expert(const std::string& routed_name_3d,
+                          const std::string& per_expert_name,
+                          int expert_id) const override;
+    Format format() const override { return Format::GGUF_Q2; }
+
+    const GGUFFile& file() const { return file_; }
+
+private:
+    enum class Transform {
+        Direct,
+        Transpose2D,          // [a, b] -> [b, a]
+        RoutedExpertTranspose // [a, b, n_experts] -> per-expert [b, a]
+    };
+
+    struct Mapping {
+        std::string gguf_name;
+        Transform transform = Transform::Direct;
+    };
+
+    void build_mapping(int n_layers, int n_hash_layers, int n_experts);
+
+    GGUFFile file_;
+    std::map<std::string, Mapping> by_internal_name_;
+};
+
+// Returns "ckpt_path looks like a GGUF file" (suffix-based).
+bool is_gguf_path(const std::string& path);
+
+// Convenience factory: open a SafetensorsWeightSource or GGUFWeightSource based
+// on whether the path ends in ".gguf".
+std::unique_ptr<WeightSource> open_weight_source(const std::string& path);
+
+}  // namespace dsv4

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -162,6 +162,38 @@ void all_reduce_sum_fp32_via_bf16_inplace(
 }
 #endif
 
+struct GgufReduceContext {
+    int world = 1;
+    int rank = 0;
+    int device = 0;
+    const char* id_path = nullptr;
+#ifdef DSV4_HAVE_NCCL
+    BF16AllReduceScratch* scratch = nullptr;
+#endif
+};
+
+void gguf_all_reduce_sum_fp32_inplace(float* d_values, int count, const GgufReduceContext* ctx, const char* what) {
+    if (ctx == nullptr || ctx->world <= 1) return;
+#ifdef DSV4_HAVE_NCCL
+    if (ctx->id_path == nullptr || ctx->id_path[0] == '\0') throw std::runtime_error(std::string(what) + " requires NCCL id path");
+    static const bool use_fp32_reduce = [] {
+        const char* v = std::getenv("DSV4_GGUF_REDUCE_FP32");
+        if (v == nullptr) return true;  // default fp32 for Q2 (bf16 round-trip compounds noise)
+        try { return std::stoi(v) != 0; } catch (...) { return true; }
+    }();
+    if (use_fp32_reduce) {
+        nccl_all_reduce_sum_float_inplace(ctx->world, ctx->rank, ctx->device, ctx->id_path, d_values, count);
+        return;
+    }
+    if (ctx->scratch == nullptr) throw std::runtime_error(std::string(what) + " requires BF16 reduce scratch");
+    all_reduce_sum_fp32_via_bf16_inplace(ctx->world, ctx->rank, ctx->device, ctx->id_path, d_values, count, *ctx->scratch);
+#else
+    (void)d_values;
+    (void)count;
+    throw std::runtime_error(std::string(what) + " requires DSV4_HAVE_NCCL");
+#endif
+}
+
 struct WoAInt8Host {
     std::vector<int8_t> weight;
     std::vector<float> scale;
@@ -217,10 +249,37 @@ std::vector<uint8_t> slice_cols_u8(const uint8_t* src, int rows, int cols, int c
     return out;
 }
 
+size_t q8_0_row_bytes(int cols) {
+    return static_cast<size_t>((cols + 31) / 32) * 34;
+}
+
+std::vector<uint8_t> slice_q8_0_rows(const uint8_t* src, int row_start, int rows, int cols) {
+    const size_t row_bytes = q8_0_row_bytes(cols);
+    std::vector<uint8_t> out(static_cast<size_t>(rows) * row_bytes);
+    std::memcpy(out.data(), src + static_cast<size_t>(row_start) * row_bytes, out.size());
+    return out;
+}
+
+std::vector<uint8_t> slice_q8_0_cols(const uint8_t* src, int rows, int cols, int col_start, int col_count) {
+    if ((col_start % 32) != 0 || (col_count % 32) != 0) {
+        throw std::runtime_error("Q8_0 column slices must align to 32 columns");
+    }
+    const int src_blocks = (cols + 31) / 32;
+    const int dst_blocks = (col_count + 31) / 32;
+    std::vector<uint8_t> out(static_cast<size_t>(rows) * static_cast<size_t>(dst_blocks) * 34);
+    for (int r = 0; r < rows; ++r) {
+        const uint8_t* src_row = src + static_cast<size_t>(r) * static_cast<size_t>(src_blocks) * 34 + static_cast<size_t>(col_start / 32) * 34;
+        uint8_t* dst_row = out.data() + static_cast<size_t>(r) * static_cast<size_t>(dst_blocks) * 34;
+        std::memcpy(dst_row, src_row, static_cast<size_t>(dst_blocks) * 34);
+    }
+    return out;
+}
+
 struct RoutedExpert {
     int id = 0;
     float weight = 0.0f;
 };
+
 
 struct HcPreResult {
     std::vector<float> x;
@@ -3620,7 +3679,8 @@ struct GgufLayerScratch {
 void gguf_layer_forward_attn_to_gate(const GgufLayerDeviceWeights& w,
                                      GgufLayerScratch& s,
                                      const GgufLayerDims& d,
-                                     int position) {
+                                     int position,
+                                     const GgufReduceContext* reduce_ctx) {
     // ===== Attention =====
     check_cuda(cudaMemcpy(s.d_x_pre_attn, s.d_x, d.dim * sizeof(float),
                           cudaMemcpyDeviceToDevice), "save x_pre_attn");
@@ -3675,6 +3735,7 @@ void gguf_layer_forward_attn_to_gate(const GgufLayerDeviceWeights& w,
     }
     if (!q8_0_matvec_cuda(s.d_attn_mid, w.d_wo_b, s.d_attn_out, d.dim, d.attn_mid))
         throw std::runtime_error("wo_b failed");
+    gguf_all_reduce_sum_fp32_inplace(s.d_attn_out, d.dim, reduce_ctx, "GGUF attention all-reduce");
     // Attention residual.
     if (!vector_add_cuda(s.d_x_pre_attn, s.d_attn_out, s.d_x, d.dim))
         throw std::runtime_error("attn residual add failed");
@@ -3722,7 +3783,8 @@ void gguf_layer_forward_attn_to_gate(const GgufLayerDeviceWeights& w,
 // into w.d_routed_w1/w2/w3 before this call.
 void gguf_layer_forward_moe(const GgufLayerDeviceWeights& w,
                             GgufLayerScratch& s,
-                            const GgufLayerDims& d) {
+                            const GgufLayerDims& d,
+                            const GgufReduceContext* reduce_ctx) {
     const int routes = d.topk;
 
     check_cuda(cudaMemset(s.d_moe_out, 0, d.dim * sizeof(float)), "zero moe_out");
@@ -3746,6 +3808,8 @@ void gguf_layer_forward_moe(const GgufLayerDeviceWeights& w,
                                     d.dim, d.moe_inter))
         throw std::runtime_error("q2 w2 q2k failed");
 
+    gguf_all_reduce_sum_fp32_inplace(s.d_moe_out, d.dim, reduce_ctx, "GGUF MoE all-reduce");
+
     if (!vector_add_cuda(s.d_shared_out, s.d_moe_out, s.d_ffn_combined, d.dim))
         throw std::runtime_error("ffn combined add failed");
     if (!vector_add_cuda(s.d_x_pre_ffn, s.d_ffn_combined, s.d_x, d.dim))
@@ -3760,8 +3824,8 @@ void gguf_layer_forward(const GgufLayerDeviceWeights& w,
                         const GgufLayerDims& d,
                         int /*token*/,
                         int position) {
-    gguf_layer_forward_attn_to_gate(w, s, d, position);
-    gguf_layer_forward_moe(w, s, d);
+    gguf_layer_forward_attn_to_gate(w, s, d, position, nullptr);
+    gguf_layer_forward_moe(w, s, d, nullptr);
 }
 
 }  // namespace
@@ -5725,7 +5789,7 @@ GgufFullForwardResult run_gguf_full_forward_smoke(const std::string& ckpt_path,
         }
 
         // Phase A: attention + ffn_norm + shared + gate.
-        gguf_layer_forward_attn_to_gate(lw, ls, ld, position);
+        gguf_layer_forward_attn_to_gate(lw, ls, ld, position, nullptr);
 
         // Read gate's chosen expert ids, then stage those experts H2D.
         check_cuda(cudaMemcpy(h_gate_indices.data(), d_gate_indices, topk * sizeof(int64_t),
@@ -5752,7 +5816,7 @@ GgufFullForwardResult run_gguf_full_forward_smoke(const std::string& ckpt_path,
         }
 
         // Phase B: routed MoE + FFN residual.
-        gguf_layer_forward_moe(lw, ls, ld);
+        gguf_layer_forward_moe(lw, ls, ld, nullptr);
     }
 
     // ===== final norm + head =====
@@ -5820,13 +5884,20 @@ GgufFullForwardResult run_gguf_full_forward_smoke(const std::string& ckpt_path,
 
 GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
                                           const std::vector<int>& seed_tokens,
-                                          int max_new_tokens) {
+                                          int max_new_tokens,
+                                          const ForwardSmokeOptions& options) {
     if (!is_gguf_path(ckpt_path))
         throw std::runtime_error("run_gguf_generate_smoke: not a GGUF path: " + ckpt_path);
     if (seed_tokens.empty()) throw std::runtime_error("seed_tokens must be non-empty");
     if (max_new_tokens < 0) throw std::runtime_error("max_new_tokens must be >= 0");
 
     auto t_load_start = std::chrono::steady_clock::now();
+    const int tp_world = std::max(1, options.tp_world);
+    const int tp_rank = std::max(0, options.tp_rank);
+    const int tp_device = options.device >= 0 ? options.device : tp_rank;
+    if (tp_rank >= tp_world) throw std::runtime_error("run_gguf_generate_smoke: invalid TP rank");
+    if (tp_world > 1 && options.nccl_id_path.empty())
+        throw std::runtime_error("run_gguf_generate_smoke: TP requires --nccl-id-path");
     GgufForwardContext ctx(ckpt_path);
     GGUFWeightSource& gws = *ctx.weight_source;
 
@@ -5853,31 +5924,47 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
     const int n_layers = static_cast<int>(ctx.config.n_layers);
     const int n_hash = static_cast<int>(ctx.config.n_hash_layers);
     const int dim = static_cast<int>(ctx.config.dim);
-    const int heads = static_cast<int>(ctx.config.n_heads);
+    const int global_heads = static_cast<int>(ctx.config.n_heads);
     const int n_experts = static_cast<int>(ctx.config.n_routed_experts);
     const int topk = static_cast<int>(ctx.config.n_activated_experts);
     const int rope_dim = static_cast<int>(ctx.config.rope_dim);
-    const int o_groups = static_cast<int>(ctx.config.o_groups);
+    const int global_o_groups = static_cast<int>(ctx.config.o_groups);
     const int o_lora_rank = static_cast<int>(ctx.config.o_lora_rank);
     const int moe_inter = static_cast<int>(ctx.config.moe_inter_dim);
     if (topk <= 0 || topk > 8) throw std::runtime_error("topk out of supported range");
+    if ((global_heads % tp_world) != 0 || (global_o_groups % tp_world) != 0)
+        throw std::runtime_error("GGUF TP requires heads and o_groups divisible by tp_world");
 
     WeightView wq_a0 = gws.require("layers.0.attn.wq_a.weight");
     WeightView wq_b0 = gws.require("layers.0.attn.wq_b.weight");
     WeightView wkv0 = gws.require("layers.0.attn.wkv.weight");
     const int q_a_dim = static_cast<int>(wq_a0.shape[1]);
-    const int q_full = static_cast<int>(wq_b0.shape[1]);
-    if (q_full % heads != 0) throw std::runtime_error("wq_b cols % heads");
-    const int head_dim = q_full / heads;
+    const int global_q_full = static_cast<int>(wq_b0.shape[1]);
+    if (global_q_full % global_heads != 0) throw std::runtime_error("wq_b cols % heads");
+    const int head_dim = global_q_full / global_heads;
+    const int heads = global_heads / tp_world;
+    const int q_full = heads * head_dim;
     const int kv_dim = static_cast<int>(wkv0.shape[1]);
-    if (q_full % o_groups != 0) throw std::runtime_error("q_full % o_groups");
+    const int o_groups = global_o_groups / tp_world;
+    if (global_q_full % global_o_groups != 0) throw std::runtime_error("q_full % o_groups");
     const int group_in_dim = q_full / o_groups;
     const int attn_mid = o_groups * o_lora_rank;
+    const int local_head_start = tp_rank * heads;
+    const int local_q_row_start = local_head_start * head_dim;
+    const int local_group_start = tp_rank * o_groups;
+    const int local_wo_a_row_start = local_group_start * o_lora_rank;
 
     WeightView embed = gws.require("embed.weight");
     if (embed.dtype != DType::F16 || embed.shape.size() != 2 || static_cast<int>(embed.shape[0]) != dim)
         throw std::runtime_error("embed shape/dtype mismatch");
     const int vocab = static_cast<int>(embed.shape[1]);
+    if (vocab % tp_world != 0) throw std::runtime_error("GGUF TP requires vocab divisible by tp_world");
+    const int local_vocab = vocab / tp_world;
+    const int local_vocab_start = tp_rank * local_vocab;
+    const int experts_per_rank = tp_world > 1 ? n_experts / tp_world : n_experts;
+    if ((n_experts % tp_world) != 0) throw std::runtime_error("GGUF TP requires experts divisible by tp_world");
+    const int expert_start = tp_rank * experts_per_rank;
+    const int expert_end = tp_world > 1 ? expert_start + experts_per_rank : n_experts;
     for (int t : seed_tokens) if (t < 0 || t >= vocab)
         throw std::runtime_error("seed token id out of vocab range");
 
@@ -5932,7 +6019,7 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
         d_q_gamma[L] = upload_bf16_from_f32(gws.require(lp + ".attn.q_norm.weight").data, q_a_dim);
         d_kv_gamma[L] = upload_bf16_from_f32(gws.require(lp + ".attn.kv_norm.weight").data, kv_dim);
         d_ffn_gamma[L] = upload_bf16_from_f32(gws.require(lp + ".ffn_norm.weight").data, dim);
-        d_attn_sink[L] = upload_f32(gws.require(lp + ".attn.attn_sink").data, heads);
+        d_attn_sink[L] = upload_f32(reinterpret_cast<const float*>(gws.require(lp + ".attn.attn_sink").data) + local_head_start, heads);
         WeightView wq_a = gws.require(lp + ".attn.wq_a.weight");
         WeightView wq_b = gws.require(lp + ".attn.wq_b.weight");
         WeightView wkv = gws.require(lp + ".attn.wkv.weight");
@@ -5942,11 +6029,15 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
         WeightView shared_w2 = gws.require(lp + ".ffn.shared_experts.w2.weight");
         WeightView shared_w3 = gws.require(lp + ".ffn.shared_experts.w3.weight");
         WeightView gate_w = gws.require(lp + ".ffn.gate.weight");
+        auto wq_b_local = slice_q8_0_rows(wq_b.data, local_q_row_start, q_full, q_a_dim);
+        auto wo_a_local = slice_q8_0_rows(wo_a.data, local_wo_a_row_start, attn_mid, group_in_dim);
+        auto wo_b_local = slice_q8_0_cols(wo_b.data, dim, global_o_groups * o_lora_rank,
+                                          local_wo_a_row_start, attn_mid);
         d_wq_a[L] = upload_u8(wq_a.data, wq_a.nbytes);
-        d_wq_b[L] = upload_u8(wq_b.data, wq_b.nbytes);
+        d_wq_b[L] = upload_u8(wq_b_local.data(), wq_b_local.size());
         d_wkv[L] = upload_u8(wkv.data, wkv.nbytes);
-        d_wo_a[L] = upload_u8(wo_a.data, wo_a.nbytes);
-        d_wo_b[L] = upload_u8(wo_b.data, wo_b.nbytes);
+        d_wo_a[L] = upload_u8(wo_a_local.data(), wo_a_local.size());
+        d_wo_b[L] = upload_u8(wo_b_local.data(), wo_b_local.size());
         d_shared_w1[L] = upload_u8(shared_w1.data, shared_w1.nbytes);
         d_shared_w2[L] = upload_u8(shared_w2.data, shared_w2.nbytes);
         d_shared_w3[L] = upload_u8(shared_w3.data, shared_w3.nbytes);
@@ -5974,7 +6065,8 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
         static_cast<int>(head.shape[1]) != vocab)
         throw std::runtime_error("head.weight shape/dtype (expected Q8_0 [dim, vocab])");
     uint16_t* d_final_norm_gamma = upload_bf16_from_f32(final_norm.data, dim);
-    uint8_t* d_head = upload_u8(head.data, head.nbytes);
+    auto head_local = slice_q8_0_rows(head.data, local_vocab_start, local_vocab, dim);
+    uint8_t* d_head = upload_u8(head_local.data(), head_local.size());
 
     // ===== routed expert staging buffers (reused per layer per step) =====
     auto first_w1 = gws.get_expert("layers.0.ffn.experts.routed.w1",
@@ -6086,13 +6178,20 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
     check_cuda(cudaMalloc(&d_gate_indices, topk * sizeof(int64_t)), "alloc d_gate_indices");
     check_cuda(cudaMalloc(&d_tid2eid_i64, topk * sizeof(int64_t)), "alloc d_tid2eid_i64");
     check_cuda(cudaMalloc(&d_embed_row_f16, dim * sizeof(uint16_t)), "alloc d_embed_row_f16");
-    check_cuda(cudaMalloc(&d_logits, vocab * sizeof(float)), "alloc d_logits");
+    check_cuda(cudaMalloc(&d_logits, local_vocab * sizeof(float)), "alloc d_logits");
 
-    std::vector<int64_t> h_route_slots(topk);
-    for (int k = 0; k < topk; ++k) h_route_slots[k] = k;
-    check_cuda(cudaMemcpy(d_route_slots, h_route_slots.data(),
-                          topk * sizeof(int64_t), cudaMemcpyHostToDevice),
-               "copy d_route_slots");
+#ifdef DSV4_HAVE_NCCL
+    BF16AllReduceScratch bf16_reduce_scratch;
+#endif
+    GgufReduceContext reduce_ctx;
+    reduce_ctx.world = tp_world;
+    reduce_ctx.rank = tp_rank;
+    reduce_ctx.device = tp_device;
+    reduce_ctx.id_path = options.nccl_id_path.empty() ? nullptr : options.nccl_id_path.c_str();
+#ifdef DSV4_HAVE_NCCL
+    reduce_ctx.scratch = &bf16_reduce_scratch;
+#endif
+    const GgufReduceContext* reduce_ctx_ptr = (tp_world > 1) ? &reduce_ctx : nullptr;
 
     GgufLayerDims ld;
     ld.dim = dim; ld.q_a_dim = q_a_dim; ld.heads = heads; ld.head_dim = head_dim;
@@ -6127,7 +6226,8 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
 
     // ===== per-step forward (embed + 43 layers + final norm + head + argmax) =====
     std::vector<int64_t> h_gate_indices(topk);
-    std::vector<float> h_logits(vocab);
+    std::vector<int64_t> h_route_slots(topk);
+    std::vector<float> h_logits(local_vocab);
     auto run_step = [&](int token, int position) -> std::pair<int, float> {
         const uint16_t* host_embed_row =
             reinterpret_cast<const uint16_t*>(embed.data) +
@@ -6161,7 +6261,7 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
                 lw.d_tid2eid_i64 = nullptr;
                 lw.d_gate_bias_f32 = d_gate_bias[L];
             }
-            gguf_layer_forward_attn_to_gate(lw, ls, ld, position);
+            gguf_layer_forward_attn_to_gate(lw, ls, ld, position, reduce_ctx_ptr);
             check_cuda(cudaMemcpy(h_gate_indices.data(), d_gate_indices, topk * sizeof(int64_t),
                                   cudaMemcpyDeviceToHost), "copy gate indices");
             const std::string lp = "layers." + std::to_string(L);
@@ -6172,6 +6272,9 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
                 const int eid = static_cast<int>(h_gate_indices[k]);
                 if (eid < 0 || eid >= n_experts)
                     throw std::runtime_error("gate produced out-of-range expert id");
+                const bool is_local = (eid >= expert_start && eid < expert_end);
+                h_route_slots[k] = is_local ? static_cast<int64_t>(k) : -1;
+                if (!is_local) continue;
                 auto wv1 = gws.get_expert(w1_name, w1_name, eid);
                 auto wv2 = gws.get_expert(w2_name, w2_name, eid);
                 auto wv3 = gws.get_expert(w3_name, w3_name, eid);
@@ -6184,20 +6287,35 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
                 check_cuda(cudaMemcpyAsync(d_routed_w3 + per_w3_bytes * k, wv3.data, per_w3_bytes,
                                       cudaMemcpyHostToDevice, 0), "stage routed_w3");
             }
-            gguf_layer_forward_moe(lw, ls, ld);
+            check_cuda(cudaMemcpyAsync(d_route_slots, h_route_slots.data(),
+                                       topk * sizeof(int64_t),
+                                       cudaMemcpyHostToDevice, 0),
+                       "copy d_route_slots");
+            gguf_layer_forward_moe(lw, ls, ld, reduce_ctx_ptr);
         }
         if (!rmsnorm_bf16_gamma_cuda(d_x, d_final_norm_gamma, d_x_normed, dim, 1e-6f))
             throw std::runtime_error("final norm failed");
-        if (!q8_0_matvec_cuda(d_x_normed, d_head, d_logits, vocab, dim))
+        if (!q8_0_matvec_cuda(d_x_normed, d_head, d_logits, local_vocab, dim))
             throw std::runtime_error("head matvec failed");
         check_cuda(cudaDeviceSynchronize(), "sync after head");
-        check_cuda(cudaMemcpy(h_logits.data(), d_logits, vocab * sizeof(float),
+        check_cuda(cudaMemcpy(h_logits.data(), d_logits, local_vocab * sizeof(float),
                               cudaMemcpyDeviceToHost), "copy logits");
-        int top_t = 0;
-        float top_l = -INFINITY;
-        for (int i = 0; i < vocab; ++i) {
-            if (h_logits[i] > top_l) { top_l = h_logits[i]; top_t = i; }
+        int local_t = 0;
+        float local_l = -INFINITY;
+        for (int i = 0; i < local_vocab; ++i) {
+            if (h_logits[i] > local_l) { local_l = h_logits[i]; local_t = i; }
         }
+        int top_t = local_t + local_vocab_start;
+        float top_l = local_l;
+#ifdef DSV4_HAVE_NCCL
+        if (tp_world > 1 && !options.nccl_id_path.empty()) {
+            TpTopResult global = nccl_global_top1(tp_world, tp_rank, tp_device,
+                                                   options.nccl_id_path.c_str(),
+                                                   top_t, top_l);
+            top_t = global.token;
+            top_l = global.logit;
+        }
+#endif
         return {top_t, top_l};
     };
 
@@ -6260,7 +6378,11 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
     return r;
 }
 
-// --- PersistentEngine implementation ---------------------------------------
+GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
+                                          const std::vector<int>& seed_tokens,
+                                          int max_new_tokens) {
+    return run_gguf_generate_smoke(ckpt_path, seed_tokens, max_new_tokens, ForwardSmokeOptions{});
+}
 
 struct PersistentEngine::State {
     std::unique_ptr<SafeForwardContext> ctx;

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -3508,6 +3508,223 @@ float device_vector_rms(const float* d_x, int n) {
     return n > 0 ? static_cast<float>(std::sqrt(s / n)) : 0.0f;
 }
 
+// ---- Per-layer GGUF forward helper -----------------------------------------
+//
+// Inputs:
+//   - GgufLayerDeviceWeights: all dense weights already staged on device
+//     (attention Q8_0 + norms BF16 + shared experts Q8_0 + gate W BF16 + EITHER
+//     tid2eid_i64 [topk] for hash layers OR exp_probs_b bias F32 [n_experts]
+//     for non-hash) + top-k routed Q2 experts packed into 3 device buffers.
+//   - GgufLayerScratch: pre-allocated activation + staging buffers.
+//   - GgufLayerDims: dim/heads/etc.
+//   - token: used by hash gate's tid2eid lookup; ignored otherwise.
+//   - position: for RoPE.
+// In-place: reads s.d_x [dim], writes back s.d_x [dim] after both residuals.
+// For non-hash layers, the chosen expert ids land in s.d_gate_indices.
+
+struct GgufLayerDeviceWeights {
+    const uint16_t* d_attn_gamma = nullptr;
+    const uint16_t* d_q_gamma = nullptr;
+    const uint16_t* d_kv_gamma = nullptr;
+    const uint8_t* d_wq_a = nullptr;
+    const uint8_t* d_wq_b = nullptr;
+    const uint8_t* d_wkv = nullptr;
+    const uint8_t* d_wo_a = nullptr;
+    const uint8_t* d_wo_b = nullptr;
+    const float* d_attn_sink = nullptr;
+
+    const uint16_t* d_ffn_gamma = nullptr;
+    const uint8_t* d_shared_w1 = nullptr;
+    const uint8_t* d_shared_w2 = nullptr;
+    const uint8_t* d_shared_w3 = nullptr;
+
+    const uint16_t* d_gate_w_bf16 = nullptr;
+    bool is_hash = false;
+    const int64_t* d_tid2eid_i64 = nullptr;  // hash only: [topk] for this token
+    const float* d_gate_bias_f32 = nullptr;  // non-hash only: [n_experts]
+
+    const uint8_t* d_routed_w1 = nullptr;
+    const uint8_t* d_routed_w2 = nullptr;
+    const uint8_t* d_routed_w3 = nullptr;
+};
+
+struct GgufLayerDims {
+    int dim = 0;
+    int q_a_dim = 0;
+    int heads = 0;
+    int head_dim = 0;
+    int q_full = 0;          // heads * head_dim
+    int kv_dim = 0;
+    int rope_dim = 0;
+    int o_groups = 0;
+    int o_lora_rank = 0;
+    int group_in_dim = 0;
+    int attn_mid = 0;
+    int moe_inter = 0;
+    int n_experts = 0;
+    int topk = 0;
+    float rope_theta = 0.0f;
+    float swiglu_limit = 0.0f;
+    float route_scale = 0.0f;
+};
+
+struct GgufLayerScratch {
+    // hidden state (read at entry, written at exit)
+    float* d_x = nullptr;
+    // attention scratch
+    float* d_x_pre_attn = nullptr;
+    float* d_x_normed = nullptr;
+    float* d_q_a = nullptr;
+    float* d_q_normed = nullptr;
+    float* d_q = nullptr;
+    float* d_kv_a = nullptr;
+    float* d_kv = nullptr;
+    float* d_attn_value = nullptr;
+    float* d_attn_mid = nullptr;
+    float* d_attn_out = nullptr;
+    // FFN scratch
+    float* d_x_pre_ffn = nullptr;
+    float* d_x_normed_ffn = nullptr;
+    float* d_shared_gate = nullptr;
+    float* d_shared_up = nullptr;
+    float* d_shared_hidden = nullptr;
+    float* d_shared_out = nullptr;
+    float* d_moe_out = nullptr;
+    float* d_ffn_combined = nullptr;
+    // routed MoE staging
+    int8_t* d_x_q = nullptr;
+    float* d_x_scale = nullptr;
+    int64_t* d_route_slots = nullptr;     // [topk] = {0,1,..k-1}
+    float* d_route_weights = nullptr;     // [topk]
+    float* d_route_gate = nullptr;        // [topk, moe_inter]
+    float* d_route_up = nullptr;          // [topk, moe_inter]
+    int8_t* d_route_hidden_q = nullptr;   // [topk, moe_inter]
+    float* d_route_hidden_scale = nullptr; // [topk, hidden_groups]
+    // gate scratch
+    float* d_gate_scores_scratch = nullptr; // hash:[topk]; non-hash:[n_experts]
+    float* d_gate_scored_scratch = nullptr; // non-hash only: [n_experts]
+    int64_t* d_gate_indices = nullptr;    // [topk]
+};
+
+void gguf_layer_forward(const GgufLayerDeviceWeights& w,
+                        GgufLayerScratch& s,
+                        const GgufLayerDims& d,
+                        int token,
+                        int position) {
+    const int routes = d.topk;
+
+    // ===== Attention =====
+    check_cuda(cudaMemcpy(s.d_x_pre_attn, s.d_x, d.dim * sizeof(float),
+                          cudaMemcpyDeviceToDevice), "save x_pre_attn");
+    if (!rmsnorm_bf16_gamma_cuda(s.d_x, w.d_attn_gamma, s.d_x_normed, d.dim, 1e-6f))
+        throw std::runtime_error("attn_norm failed");
+    if (!q8_0_matvec_cuda(s.d_x_normed, w.d_wq_a, s.d_q_a, d.q_a_dim, d.dim))
+        throw std::runtime_error("wq_a failed");
+    if (!rmsnorm_bf16_gamma_cuda(s.d_q_a, w.d_q_gamma, s.d_q_normed, d.q_a_dim, 1e-6f))
+        throw std::runtime_error("q_norm failed");
+    if (!q8_0_matvec_cuda(s.d_q_normed, w.d_wq_b, s.d_q, d.q_full, d.q_a_dim))
+        throw std::runtime_error("wq_b failed");
+    if (!head_rmsnorm_rope_cuda(s.d_q, d.heads, d.head_dim, d.rope_dim, position,
+                                d.rope_theta, false, 1e-6f))
+        throw std::runtime_error("q head rope failed");
+    if (!q8_0_matvec_cuda(s.d_x_normed, w.d_wkv, s.d_kv_a, d.kv_dim, d.dim))
+        throw std::runtime_error("wkv failed");
+    if (!rmsnorm_bf16_gamma_cuda(s.d_kv_a, w.d_kv_gamma, s.d_kv, d.kv_dim, 1e-6f))
+        throw std::runtime_error("kv_norm failed");
+    if (!head_rmsnorm_rope_cuda(s.d_kv, /*heads=*/1, d.kv_dim, d.rope_dim, position,
+                                d.rope_theta, false, 0.0f))
+        throw std::runtime_error("kv head rope failed");
+    const float scale = 1.0f / std::sqrt(static_cast<float>(d.head_dim));
+    if (!single_token_sparse_attention_cuda(s.d_q, s.d_kv, w.d_attn_sink,
+                                            s.d_attn_value, d.heads, d.head_dim, scale))
+        throw std::runtime_error("sparse_attention failed");
+    if (!head_rmsnorm_rope_cuda(s.d_attn_value, d.heads, d.head_dim, d.rope_dim,
+                                position, d.rope_theta, /*inverse=*/true, 0.0f))
+        throw std::runtime_error("inverse rope failed");
+    const size_t group_w_bytes =
+        static_cast<size_t>(d.o_lora_rank) *
+        static_cast<size_t>((d.group_in_dim + 31) / 32) * 34;
+    for (int g = 0; g < d.o_groups; ++g) {
+        const float* group_x = s.d_attn_value + static_cast<size_t>(g) * d.group_in_dim;
+        const uint8_t* group_w = w.d_wo_a + static_cast<size_t>(g) * group_w_bytes;
+        float* group_y = s.d_attn_mid + static_cast<size_t>(g) * d.o_lora_rank;
+        if (!q8_0_matvec_cuda(group_x, group_w, group_y, d.o_lora_rank, d.group_in_dim))
+            throw std::runtime_error("wo_a group matvec failed");
+    }
+    if (!q8_0_matvec_cuda(s.d_attn_mid, w.d_wo_b, s.d_attn_out, d.dim, d.attn_mid))
+        throw std::runtime_error("wo_b failed");
+    // Attention residual.
+    if (!vector_add_cuda(s.d_x_pre_attn, s.d_attn_out, s.d_x, d.dim))
+        throw std::runtime_error("attn residual add failed");
+
+    // ===== FFN =====
+    check_cuda(cudaMemcpy(s.d_x_pre_ffn, s.d_x, d.dim * sizeof(float),
+                          cudaMemcpyDeviceToDevice), "save x_pre_ffn");
+    if (!rmsnorm_bf16_gamma_cuda(s.d_x, w.d_ffn_gamma, s.d_x_normed_ffn, d.dim, 1e-6f))
+        throw std::runtime_error("ffn_norm failed");
+
+    // Shared expert (Q8_0 w1/w3 + silu_mul + Q8_0 w2).
+    if (!q8_0_matvec_cuda(s.d_x_normed_ffn, w.d_shared_w1, s.d_shared_gate,
+                          d.moe_inter, d.dim))
+        throw std::runtime_error("shared w1 failed");
+    if (!q8_0_matvec_cuda(s.d_x_normed_ffn, w.d_shared_w3, s.d_shared_up,
+                          d.moe_inter, d.dim))
+        throw std::runtime_error("shared w3 failed");
+    if (!silu_mul_cuda(s.d_shared_gate, s.d_shared_up, s.d_shared_hidden, d.moe_inter))
+        throw std::runtime_error("shared silu_mul failed");
+    if (!q8_0_matvec_cuda(s.d_shared_hidden, w.d_shared_w2, s.d_shared_out,
+                          d.dim, d.moe_inter))
+        throw std::runtime_error("shared w2 failed");
+
+    // Gate scoring → route weights + indices.
+    if (w.is_hash) {
+        // tid2eid lookup happens inside kernel; we pre-staged the per-token slice.
+        if (!gate_hash_bf16_cuda(s.d_x_normed_ffn, w.d_gate_w_bf16, w.d_tid2eid_i64,
+                                 s.d_gate_scores_scratch, s.d_gate_indices,
+                                 s.d_route_weights,
+                                 /*token=*/0, /*cols=*/d.dim,
+                                 /*table_topk=*/d.topk, /*topk=*/d.topk,
+                                 d.route_scale))
+            throw std::runtime_error("gate_hash_bf16_cuda failed");
+    } else {
+        if (!gate_topk_bf16_cuda_with_buffers(
+                s.d_x_normed_ffn, w.d_gate_w_bf16, w.d_gate_bias_f32,
+                s.d_gate_scores_scratch, s.d_gate_scored_scratch,
+                s.d_gate_indices, s.d_route_weights,
+                d.n_experts, d.dim, d.topk, d.route_scale))
+            throw std::runtime_error("gate_topk_bf16_cuda failed");
+    }
+
+    // Routed Q2 MoE: q8_1 x → IQ2_XXS w13 → SwiGLU + route_weight + q8_1 hidden
+    // → Q2_K w2 (atomicAdd across routes).
+    check_cuda(cudaMemset(s.d_moe_out, 0, d.dim * sizeof(float)), "zero moe_out");
+    if (!q2_quantize_x_q8_1_cuda(s.d_x_normed_ffn, s.d_x_q, s.d_x_scale,
+                                  /*routes=*/1, d.dim))
+        throw std::runtime_error("q2_quantize_x_q8_1 failed");
+    if (!q2_moe_single_w13_iq2_xxs_cuda(s.d_x_q, s.d_x_scale, s.d_route_slots,
+                                         w.d_routed_w1, w.d_routed_w3,
+                                         s.d_route_gate, s.d_route_up,
+                                         routes, /*n_experts=*/routes,
+                                         d.dim, d.moe_inter))
+        throw std::runtime_error("q2 w13 iq2_xxs failed");
+    if (!q2_route_swiglu_quantize_hidden_q8_1_cuda(
+            s.d_route_gate, s.d_route_up, s.d_route_weights,
+            s.d_route_hidden_q, s.d_route_hidden_scale,
+            routes, d.moe_inter, d.swiglu_limit))
+        throw std::runtime_error("q2 swiglu + quantize failed");
+    if (!q2_moe_single_w2_q2k_cuda(s.d_route_hidden_q, s.d_route_hidden_scale,
+                                    s.d_route_slots, w.d_routed_w2, s.d_moe_out,
+                                    routes, /*n_experts=*/routes,
+                                    d.dim, d.moe_inter))
+        throw std::runtime_error("q2 w2 q2k failed");
+
+    // FFN residual: x = x_pre_ffn + (shared_out + moe_out).
+    if (!vector_add_cuda(s.d_shared_out, s.d_moe_out, s.d_ffn_combined, d.dim))
+        throw std::runtime_error("ffn combined add failed");
+    if (!vector_add_cuda(s.d_x_pre_ffn, s.d_ffn_combined, s.d_x, d.dim))
+        throw std::runtime_error("ffn residual add failed");
+}
+
 }  // namespace
 
 GgufAttnNormWqaResult run_gguf_attn_norm_wq_a_smoke(const std::string& ckpt_path, int token) {
@@ -4963,150 +5180,86 @@ GgufLayer0FullResult run_gguf_layer0_full_smoke(const std::string& ckpt_path,
 
     // ===== compute =====
 
-    // 1. Embed.
+    // 1. Embed (runs once before the first layer's forward).
     if (!f16_row_to_float_cuda(d_row_f16, d_x, /*row=*/0, dim)) {
         throw std::runtime_error("f16 embed failed");
     }
-    // Save x_pre_attn = d_x for attention residual.
-    check_cuda(cudaMemcpy(d_x_pre_attn, d_x, dim * sizeof(float),
-                          cudaMemcpyDeviceToDevice), "save x_pre_attn");
 
-    // 2. Attention.
-    if (!rmsnorm_bf16_gamma_cuda(d_x, d_attn_gamma, d_x_normed, dim, 1e-6f)) {
-        throw std::runtime_error("attn_norm failed");
-    }
-    // Q-path.
-    if (!q8_0_matvec_cuda(d_x_normed, d_wq_a, d_q_a, q_a_dim, dim)) {
-        throw std::runtime_error("wq_a failed");
-    }
-    if (!rmsnorm_bf16_gamma_cuda(d_q_a, d_q_gamma, d_q_normed, q_a_dim, 1e-6f)) {
-        throw std::runtime_error("q_norm failed");
-    }
-    if (!q8_0_matvec_cuda(d_q_normed, d_wq_b, d_q, q_full, q_a_dim)) {
-        throw std::runtime_error("wq_b failed");
-    }
-    if (!head_rmsnorm_rope_cuda(d_q, heads, head_dim, rope_dim, position,
-                                static_cast<float>(ctx.config.rope_theta),
-                                false, 1e-6f)) {
-        throw std::runtime_error("q head rope failed");
-    }
-    // KV-path.
-    if (!q8_0_matvec_cuda(d_x_normed, d_wkv, d_kv_a, kv_dim, dim)) {
-        throw std::runtime_error("wkv failed");
-    }
-    if (!rmsnorm_bf16_gamma_cuda(d_kv_a, d_kv_gamma, d_kv, kv_dim, 1e-6f)) {
-        throw std::runtime_error("kv_norm failed");
-    }
-    if (!head_rmsnorm_rope_cuda(d_kv, /*heads=*/1, kv_dim, rope_dim, position,
-                                static_cast<float>(ctx.config.rope_theta),
-                                false, 0.0f)) {
-        throw std::runtime_error("kv head rope failed");
-    }
-    // Sparse attention.
-    const float scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
-    if (!single_token_sparse_attention_cuda(d_q, d_kv, d_attn_sink, d_attn_value,
-                                            heads, head_dim, scale)) {
-        throw std::runtime_error("single_token_sparse_attention failed");
-    }
-    // Inverse RoPE on V tail.
-    if (!head_rmsnorm_rope_cuda(d_attn_value, heads, head_dim, rope_dim, position,
-                                static_cast<float>(ctx.config.rope_theta),
-                                /*inverse=*/true, 0.0f)) {
-        throw std::runtime_error("inverse rope failed");
-    }
-    // Grouped wo_a.
-    const size_t group_w_bytes =
-        static_cast<size_t>(o_lora_rank) *
-        static_cast<size_t>((group_in_dim + 31) / 32) * 34;
-    for (int g = 0; g < o_groups; ++g) {
-        const float* group_x = d_attn_value + static_cast<size_t>(g) * group_in_dim;
-        const uint8_t* group_w = d_wo_a + static_cast<size_t>(g) * group_w_bytes;
-        float* group_y = d_attn_mid + static_cast<size_t>(g) * o_lora_rank;
-        if (!q8_0_matvec_cuda(group_x, group_w, group_y, o_lora_rank, group_in_dim)) {
-            throw std::runtime_error("wo_a group matvec failed");
-        }
-    }
-    if (!q8_0_matvec_cuda(d_attn_mid, d_wo_b, d_attn_out, dim, attn_mid)) {
-        throw std::runtime_error("wo_b failed");
-    }
+    // 2-9. Per-layer forward via shared helper (attention + FFN + residuals).
+    GgufLayerDeviceWeights lw;
+    lw.d_attn_gamma = d_attn_gamma;
+    lw.d_q_gamma = d_q_gamma;
+    lw.d_kv_gamma = d_kv_gamma;
+    lw.d_wq_a = d_wq_a;
+    lw.d_wq_b = d_wq_b;
+    lw.d_wkv = d_wkv;
+    lw.d_wo_a = d_wo_a;
+    lw.d_wo_b = d_wo_b;
+    lw.d_attn_sink = d_attn_sink;
+    lw.d_ffn_gamma = d_ffn_gamma;
+    lw.d_shared_w1 = d_shared_w1;
+    lw.d_shared_w2 = d_shared_w2;
+    lw.d_shared_w3 = d_shared_w3;
+    lw.d_gate_w_bf16 = d_gate_w_bf16;
+    lw.is_hash = true;
+    lw.d_tid2eid_i64 = d_tid2eid_i64;
+    lw.d_gate_bias_f32 = nullptr;
+    lw.d_routed_w1 = d_routed_w1;
+    lw.d_routed_w2 = d_routed_w2;
+    lw.d_routed_w3 = d_routed_w3;
 
-    // 3. Attention residual: d_x = d_x_pre_attn + d_attn_out.
-    if (!vector_add_cuda(d_x_pre_attn, d_attn_out, d_x, dim)) {
-        throw std::runtime_error("attn residual add failed");
-    }
-    // Save x_pre_ffn = d_x for FFN residual.
-    check_cuda(cudaMemcpy(d_x_pre_ffn, d_x, dim * sizeof(float),
-                          cudaMemcpyDeviceToDevice), "save x_pre_ffn");
+    GgufLayerDims ld;
+    ld.dim = dim;
+    ld.q_a_dim = q_a_dim;
+    ld.heads = heads;
+    ld.head_dim = head_dim;
+    ld.q_full = q_full;
+    ld.kv_dim = kv_dim;
+    ld.rope_dim = rope_dim;
+    ld.o_groups = o_groups;
+    ld.o_lora_rank = o_lora_rank;
+    ld.group_in_dim = group_in_dim;
+    ld.attn_mid = attn_mid;
+    ld.moe_inter = moe_inter;
+    ld.n_experts = n_experts;
+    ld.topk = topk;
+    ld.rope_theta = static_cast<float>(ctx.config.rope_theta);
+    ld.swiglu_limit = static_cast<float>(ctx.config.swiglu_limit);
+    ld.route_scale = static_cast<float>(ctx.config.route_scale);
 
-    // 4. FFN norm.
-    if (!rmsnorm_bf16_gamma_cuda(d_x, d_ffn_gamma, d_x_normed_ffn, dim, 1e-6f)) {
-        throw std::runtime_error("ffn_norm failed");
-    }
+    GgufLayerScratch ls;
+    ls.d_x = d_x;
+    ls.d_x_pre_attn = d_x_pre_attn;
+    ls.d_x_normed = d_x_normed;
+    ls.d_q_a = d_q_a;
+    ls.d_q_normed = d_q_normed;
+    ls.d_q = d_q;
+    ls.d_kv_a = d_kv_a;
+    ls.d_kv = d_kv;
+    ls.d_attn_value = d_attn_value;
+    ls.d_attn_mid = d_attn_mid;
+    ls.d_attn_out = d_attn_out;
+    ls.d_x_pre_ffn = d_x_pre_ffn;
+    ls.d_x_normed_ffn = d_x_normed_ffn;
+    ls.d_shared_gate = d_shared_gate;
+    ls.d_shared_up = d_shared_up;
+    ls.d_shared_hidden = d_shared_hidden;
+    ls.d_shared_out = d_shared_out;
+    ls.d_moe_out = d_moe_out;
+    ls.d_ffn_combined = d_ffn_combined;
+    ls.d_x_q = d_x_q;
+    ls.d_x_scale = d_x_scale;
+    ls.d_route_slots = d_route_slots;
+    ls.d_route_weights = d_route_weights;
+    ls.d_route_gate = d_route_gate;
+    ls.d_route_up = d_route_up;
+    ls.d_route_hidden_q = d_route_hidden_q;
+    ls.d_route_hidden_scale = d_route_hidden_scale;
+    ls.d_gate_scores_scratch = d_gate_scores_scratch;
+    ls.d_gate_scored_scratch = nullptr;  // hash gate path doesn't need this
+    ls.d_gate_indices = d_gate_indices;
 
-    // 5. Shared expert (Q8_0 w1/w3 + silu_mul + Q8_0 w2).
-    if (!q8_0_matvec_cuda(d_x_normed_ffn, d_shared_w1, d_shared_gate,
-                          moe_inter, dim)) {
-        throw std::runtime_error("shared w1 failed");
-    }
-    if (!q8_0_matvec_cuda(d_x_normed_ffn, d_shared_w3, d_shared_up,
-                          moe_inter, dim)) {
-        throw std::runtime_error("shared w3 failed");
-    }
-    const float swiglu_limit = static_cast<float>(ctx.config.swiglu_limit);
-    if (!silu_mul_cuda(d_shared_gate, d_shared_up, d_shared_hidden,
-                       moe_inter)) {
-        throw std::runtime_error("shared silu_mul failed");
-    }
-    if (!q8_0_matvec_cuda(d_shared_hidden, d_shared_w2, d_shared_out,
-                          dim, moe_inter)) {
-        throw std::runtime_error("shared w2 failed");
-    }
-
-    // 6. Hash-gate route weights.
-    const float route_scale = static_cast<float>(ctx.config.route_scale);
-    if (!gate_hash_bf16_cuda(d_x_normed_ffn, d_gate_w_bf16, d_tid2eid_i64,
-                             d_gate_scores_scratch, d_gate_indices,
-                             d_route_weights,
-                             /*token=*/0, /*cols=*/dim,
-                             /*table_topk=*/topk, /*topk=*/topk,
-                             route_scale)) {
-        throw std::runtime_error("gate_hash_bf16_cuda failed");
-    }
-
-    // 7. Routed MoE (Q2): q8_1 x -> IQ2_XXS w1/w3 -> SwiGLU + route_weight ->
-    // q8_1 hidden -> Q2_K w2 (atomicAdd across routes).
-    if (!q2_quantize_x_q8_1_cuda(d_x_normed_ffn, d_x_q, d_x_scale,
-                                  /*routes=*/1, dim)) {
-        throw std::runtime_error("q2_quantize_x_q8_1 failed");
-    }
-    if (!q2_moe_single_w13_iq2_xxs_cuda(d_x_q, d_x_scale, d_route_slots,
-                                         d_routed_w1, d_routed_w3,
-                                         d_route_gate, d_route_up,
-                                         routes, /*n_experts=*/routes,
-                                         dim, moe_inter)) {
-        throw std::runtime_error("q2 w13 iq2_xxs failed");
-    }
-    if (!q2_route_swiglu_quantize_hidden_q8_1_cuda(
-            d_route_gate, d_route_up, d_route_weights,
-            d_route_hidden_q, d_route_hidden_scale,
-            routes, moe_inter, swiglu_limit)) {
-        throw std::runtime_error("q2 swiglu + quantize failed");
-    }
-    if (!q2_moe_single_w2_q2k_cuda(d_route_hidden_q, d_route_hidden_scale,
-                                    d_route_slots, d_routed_w2, d_moe_out,
-                                    routes, /*n_experts=*/routes,
-                                    dim, moe_inter)) {
-        throw std::runtime_error("q2 w2 q2k failed");
-    }
-
-    // 8. FFN combined: d_ffn_combined = d_shared_out + d_moe_out.
-    if (!vector_add_cuda(d_shared_out, d_moe_out, d_ffn_combined, dim)) {
-        throw std::runtime_error("ffn combined add failed");
-    }
-    // 9. FFN residual: d_x = d_x_pre_ffn + d_ffn_combined.
-    if (!vector_add_cuda(d_x_pre_ffn, d_ffn_combined, d_x, dim)) {
-        throw std::runtime_error("ffn residual add failed");
-    }
+    gguf_layer_forward(lw, ls, ld, token, position);
     check_cuda(cudaDeviceSynchronize(), "sync after layer-0 forward");
 
     GgufLayer0FullResult r;

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -7,6 +7,7 @@
 #include "sampler.hpp"
 #include "tokenizer.hpp"
 #include "tp_comm.hpp"
+#include "weight_source.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -36,6 +37,21 @@ const SafeTensorInfo* require_tensor(const SafeTensorsShard& shard, const std::s
     const auto* info = shard.find_tensor(name);
     if (info == nullptr) throw std::runtime_error("missing tensor: " + name);
     return info;
+}
+
+// Guards the safetensors-only forward path against GGUF checkpoints. Returns
+// `dir` unchanged for the common safetensors case so it can be chained into
+// SafeForwardContext::ckpt_dir's initializer. GGUF dense forward is not yet
+// wired into SafeForwardContext; we surface that here instead of crashing on
+// model.safetensors.index.json open.
+const std::string& check_safetensors_path(const std::string& dir) {
+    if (is_gguf_path(dir)) {
+        throw std::runtime_error(
+            "cpp_engine: safetensors entry point received a GGUF path '" + dir +
+            "'. GGUF Q2 dense forward is not yet wired up — use the FP4 "
+            "safetensors directory for now.");
+    }
+    return dir;
 }
 
 struct Fp4Handle {
@@ -833,7 +849,7 @@ struct DeviceGateCache {
 
 struct SafeForwardContext {
     explicit SafeForwardContext(const std::string& dir)
-        : ckpt_dir(dir),
+        : ckpt_dir(check_safetensors_path(dir)),
           index(dir),
           config(ModelConfig::from_hf_config(dir)),
           embed_shard(index.shard_path(require_shard_name(index, "embed.weight"))),

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -3829,6 +3829,263 @@ GgufAttnKvPathResult run_gguf_attn_kv_path_smoke(const std::string& ckpt_path,
     return r;
 }
 
+GgufAttnFullResult run_gguf_attn_full_smoke(const std::string& ckpt_path,
+                                             int token,
+                                             int position) {
+    if (!is_gguf_path(ckpt_path)) {
+        throw std::runtime_error("run_gguf_attn_full_smoke: not a GGUF path: " + ckpt_path);
+    }
+    if (token < 0) throw std::runtime_error("token must be >= 0");
+    if (position < 0) throw std::runtime_error("position must be >= 0");
+
+    GgufForwardContext ctx(ckpt_path);
+    WeightSource& ws = *ctx.weight_source;
+
+    // ----- weights -----
+    WeightView embed = ws.require("embed.weight");
+    WeightView attn_norm = ws.require("layers.0.attn_norm.weight");
+    WeightView wq_a = ws.require("layers.0.attn.wq_a.weight");
+    WeightView q_norm = ws.require("layers.0.attn.q_norm.weight");
+    WeightView wq_b = ws.require("layers.0.attn.wq_b.weight");
+    WeightView wkv = ws.require("layers.0.attn.wkv.weight");
+    WeightView kv_norm = ws.require("layers.0.attn.kv_norm.weight");
+    WeightView attn_sink = ws.require("layers.0.attn.attn_sink");
+    WeightView wo_a = ws.require("layers.0.attn.wo_a.weight");
+    WeightView wo_b = ws.require("layers.0.attn.wo_b.weight");
+
+    if (embed.dtype != DType::F16) throw std::runtime_error("embed dtype");
+    if (attn_norm.dtype != DType::F32) throw std::runtime_error("attn_norm dtype");
+    if (q_norm.dtype != DType::F32) throw std::runtime_error("q_norm dtype");
+    if (kv_norm.dtype != DType::F32) throw std::runtime_error("kv_norm dtype");
+    if (attn_sink.dtype != DType::F32) throw std::runtime_error("attn_sink dtype");
+    if (wq_a.dtype != DType::Q8_0 || wq_b.dtype != DType::Q8_0 ||
+        wkv.dtype != DType::Q8_0 || wo_a.dtype != DType::Q8_0 ||
+        wo_b.dtype != DType::Q8_0) {
+        throw std::runtime_error("attention projections must be Q8_0");
+    }
+
+    const int dim = static_cast<int>(embed.shape[0]);
+    const int q_a_dim = static_cast<int>(wq_a.shape[1]);
+    const int heads = static_cast<int>(ctx.config.n_heads);
+    const int q_full = static_cast<int>(wq_b.shape[1]);
+    if (q_full % heads != 0) throw std::runtime_error("wq_b cols % heads != 0");
+    const int head_dim = q_full / heads;
+    const int kv_dim = static_cast<int>(wkv.shape[1]);
+    const int rope_dim = static_cast<int>(ctx.config.rope_dim);
+    if (kv_dim != head_dim) {
+        throw std::runtime_error("expected kv_dim == head_dim for single KV head");
+    }
+    const int o_groups = static_cast<int>(ctx.config.o_groups);
+    const int o_lora_rank = static_cast<int>(ctx.config.o_lora_rank);
+    if (o_groups <= 0 || o_lora_rank <= 0) {
+        throw std::runtime_error("o_groups / o_lora_rank not set");
+    }
+    if (q_full % o_groups != 0) {
+        throw std::runtime_error("q_full not divisible by o_groups");
+    }
+    const int group_in_dim = q_full / o_groups;            // 32768 / 8 = 4096
+    const int attn_mid = o_groups * o_lora_rank;            // 8 * 1024 = 8192
+    if (static_cast<int>(wo_a.shape[0]) != group_in_dim ||
+        static_cast<int>(wo_a.shape[1]) != attn_mid) {
+        throw std::runtime_error("wo_a shape mismatch with o_groups/o_lora_rank");
+    }
+    if (static_cast<int>(wo_b.shape[0]) != attn_mid ||
+        static_cast<int>(wo_b.shape[1]) != dim) {
+        throw std::runtime_error("wo_b shape mismatch");
+    }
+    if (static_cast<int>(attn_sink.shape[0]) != heads) {
+        throw std::runtime_error("attn_sink length != heads");
+    }
+
+    // ----- upload all weights / norms -----
+    auto upload_u8 = [](const void* src, size_t bytes) {
+        uint8_t* d = nullptr;
+        check_cuda(cudaMalloc(&d, bytes), "alloc");
+        check_cuda(cudaMemcpy(d, src, bytes, cudaMemcpyHostToDevice), "copy");
+        return d;
+    };
+    auto upload_f32 = [](const void* src, size_t n) {
+        float* d = nullptr;
+        check_cuda(cudaMalloc(&d, n * sizeof(float)), "alloc f32");
+        check_cuda(cudaMemcpy(d, src, n * sizeof(float), cudaMemcpyHostToDevice), "copy f32");
+        return d;
+    };
+    auto upload_bf16_from_f32 = [&](const void* src, size_t n) {
+        auto bf = f32_to_bf16_host(reinterpret_cast<const float*>(src), n);
+        uint16_t* d = nullptr;
+        check_cuda(cudaMalloc(&d, n * sizeof(uint16_t)), "alloc bf16");
+        check_cuda(cudaMemcpy(d, bf.data(), n * sizeof(uint16_t), cudaMemcpyHostToDevice),
+                   "copy bf16");
+        return d;
+    };
+
+    const uint16_t* host_row =
+        reinterpret_cast<const uint16_t*>(embed.data) +
+        static_cast<size_t>(token) * dim;
+    uint16_t* d_row_f16 = nullptr;
+    check_cuda(cudaMalloc(&d_row_f16, dim * sizeof(uint16_t)), "alloc d_row_f16");
+    check_cuda(cudaMemcpy(d_row_f16, host_row, dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy embed row");
+
+    uint16_t* d_attn_gamma = upload_bf16_from_f32(attn_norm.data, dim);
+    uint16_t* d_q_gamma = upload_bf16_from_f32(q_norm.data, q_a_dim);
+    uint16_t* d_kv_gamma = upload_bf16_from_f32(kv_norm.data, kv_dim);
+
+    uint8_t* d_wq_a = upload_u8(wq_a.data, wq_a.nbytes);
+    uint8_t* d_wq_b = upload_u8(wq_b.data, wq_b.nbytes);
+    uint8_t* d_wkv = upload_u8(wkv.data, wkv.nbytes);
+    uint8_t* d_wo_a = upload_u8(wo_a.data, wo_a.nbytes);
+    uint8_t* d_wo_b = upload_u8(wo_b.data, wo_b.nbytes);
+    float* d_attn_sink = upload_f32(attn_sink.data, heads);
+
+    // ----- activation buffers -----
+    float* d_x = nullptr;
+    float* d_x_normed = nullptr;
+    float* d_q_a = nullptr;
+    float* d_q_normed = nullptr;
+    float* d_q = nullptr;
+    float* d_kv_a = nullptr;
+    float* d_kv = nullptr;
+    float* d_attn_value = nullptr;
+    float* d_attn_mid = nullptr;
+    float* d_attn_out = nullptr;
+    check_cuda(cudaMalloc(&d_x, dim * sizeof(float)), "alloc d_x");
+    check_cuda(cudaMalloc(&d_x_normed, dim * sizeof(float)), "alloc d_x_normed");
+    check_cuda(cudaMalloc(&d_q_a, q_a_dim * sizeof(float)), "alloc d_q_a");
+    check_cuda(cudaMalloc(&d_q_normed, q_a_dim * sizeof(float)), "alloc d_q_normed");
+    check_cuda(cudaMalloc(&d_q, q_full * sizeof(float)), "alloc d_q");
+    check_cuda(cudaMalloc(&d_kv_a, kv_dim * sizeof(float)), "alloc d_kv_a");
+    check_cuda(cudaMalloc(&d_kv, kv_dim * sizeof(float)), "alloc d_kv");
+    check_cuda(cudaMalloc(&d_attn_value, q_full * sizeof(float)), "alloc d_attn_value");
+    check_cuda(cudaMalloc(&d_attn_mid, attn_mid * sizeof(float)), "alloc d_attn_mid");
+    check_cuda(cudaMalloc(&d_attn_out, dim * sizeof(float)), "alloc d_attn_out");
+
+    // ----- compute -----
+    if (!f16_row_to_float_cuda(d_row_f16, d_x, /*row=*/0, dim)) {
+        throw std::runtime_error("f16 embed failed");
+    }
+    if (!rmsnorm_bf16_gamma_cuda(d_x, d_attn_gamma, d_x_normed, dim, 1e-6f)) {
+        throw std::runtime_error("attn_norm failed");
+    }
+
+    // Q path
+    if (!q8_0_matvec_cuda(d_x_normed, d_wq_a, d_q_a, q_a_dim, dim)) {
+        throw std::runtime_error("wq_a failed");
+    }
+    if (!rmsnorm_bf16_gamma_cuda(d_q_a, d_q_gamma, d_q_normed, q_a_dim, 1e-6f)) {
+        throw std::runtime_error("q_norm failed");
+    }
+    if (!q8_0_matvec_cuda(d_q_normed, d_wq_b, d_q, q_full, q_a_dim)) {
+        throw std::runtime_error("wq_b failed");
+    }
+    if (!head_rmsnorm_rope_cuda(d_q, heads, head_dim, rope_dim,
+                                position,
+                                static_cast<float>(ctx.config.rope_theta),
+                                false, 1e-6f)) {
+        throw std::runtime_error("q head rope failed");
+    }
+
+    // KV path
+    if (!q8_0_matvec_cuda(d_x_normed, d_wkv, d_kv_a, kv_dim, dim)) {
+        throw std::runtime_error("wkv failed");
+    }
+    if (!rmsnorm_bf16_gamma_cuda(d_kv_a, d_kv_gamma, d_kv, kv_dim, 1e-6f)) {
+        throw std::runtime_error("kv_norm failed");
+    }
+    if (!head_rmsnorm_rope_cuda(d_kv, /*heads=*/1, kv_dim, rope_dim,
+                                position,
+                                static_cast<float>(ctx.config.rope_theta),
+                                false, 0.0f)) {
+        throw std::runtime_error("kv head rope failed");
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync after q/kv");
+
+    GgufAttnFullResult r;
+    r.dim = dim;
+    r.q_a_dim = q_a_dim;
+    r.heads = heads;
+    r.head_dim = head_dim;
+    r.kv_dim = kv_dim;
+    r.rope_dim = rope_dim;
+    r.o_groups = o_groups;
+    r.o_lora_rank = o_lora_rank;
+    r.attn_mid = attn_mid;
+    r.q_rms = device_vector_rms(d_q, q_full);
+    r.kv_rms = device_vector_rms(d_kv, kv_dim);
+
+    // Sparse single-token attention against the (single) current KV vector.
+    const float scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+    if (!single_token_sparse_attention_cuda(d_q, d_kv, d_attn_sink, d_attn_value,
+                                            heads, head_dim, scale)) {
+        throw std::runtime_error("single_token_sparse_attention failed");
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync after attn");
+    r.attn_value_rms = device_vector_rms(d_attn_value, q_full);
+
+    // Inverse RoPE on the rope-tail of each head (V was rope-rotated as part of
+    // KV; undo it before output projection so subsequent layers see consistent
+    // representations). do_rmsnorm=false (just inverse rope).
+    if (!head_rmsnorm_rope_cuda(d_attn_value, heads, head_dim, rope_dim,
+                                position,
+                                static_cast<float>(ctx.config.rope_theta),
+                                /*inverse=*/true, 0.0f)) {
+        throw std::runtime_error("inverse rope failed");
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync after inverse rope");
+    r.attn_value_post_inv_rms = device_vector_rms(d_attn_value, q_full);
+
+    // Grouped wo_a: per-group matvec [group_in_dim] -> [o_lora_rank].
+    // wo_a Q8_0 is laid out [output=attn_mid, input=group_in_dim] row-major,
+    // so group g occupies rows [g*o_lora_rank, (g+1)*o_lora_rank) which is a
+    // contiguous byte range of o_lora_rank * (group_in_dim/32) * 34 bytes.
+    const size_t group_w_bytes =
+        static_cast<size_t>(o_lora_rank) *
+        static_cast<size_t>((group_in_dim + 31) / 32) * 34;
+    for (int g = 0; g < o_groups; ++g) {
+        const float* group_x = d_attn_value + static_cast<size_t>(g) * group_in_dim;
+        const uint8_t* group_w = d_wo_a + static_cast<size_t>(g) * group_w_bytes;
+        float* group_y = d_attn_mid + static_cast<size_t>(g) * o_lora_rank;
+        if (!q8_0_matvec_cuda(group_x, group_w, group_y, o_lora_rank, group_in_dim)) {
+            throw std::runtime_error("wo_a group matvec failed");
+        }
+    }
+
+    // wo_b: [attn_mid] -> [dim]
+    if (!q8_0_matvec_cuda(d_attn_mid, d_wo_b, d_attn_out, dim, attn_mid)) {
+        throw std::runtime_error("wo_b failed");
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync after wo_b");
+
+    r.attn_mid_rms = device_vector_rms(d_attn_mid, attn_mid);
+    r.attn_out_rms = device_vector_rms(d_attn_out, dim);
+    std::vector<float> first(4);
+    check_cuda(cudaMemcpy(first.data(), d_attn_out, 4 * sizeof(float),
+                          cudaMemcpyDeviceToHost), "copy attn_out first");
+    for (int i = 0; i < 4; ++i) r.attn_out_first[i] = first[i];
+
+    cudaFree(d_row_f16);
+    cudaFree(d_attn_gamma);
+    cudaFree(d_q_gamma);
+    cudaFree(d_kv_gamma);
+    cudaFree(d_wq_a);
+    cudaFree(d_wq_b);
+    cudaFree(d_wkv);
+    cudaFree(d_wo_a);
+    cudaFree(d_wo_b);
+    cudaFree(d_attn_sink);
+    cudaFree(d_x);
+    cudaFree(d_x_normed);
+    cudaFree(d_q_a);
+    cudaFree(d_q_normed);
+    cudaFree(d_q);
+    cudaFree(d_kv_a);
+    cudaFree(d_kv);
+    cudaFree(d_attn_value);
+    cudaFree(d_attn_mid);
+    cudaFree(d_attn_out);
+    return r;
+}
+
 // --- PersistentEngine implementation ---------------------------------------
 
 struct PersistentEngine::State {

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -3710,6 +3710,125 @@ GgufAttnQPathResult run_gguf_attn_q_path_smoke(const std::string& ckpt_path,
     return r;
 }
 
+GgufAttnKvPathResult run_gguf_attn_kv_path_smoke(const std::string& ckpt_path,
+                                                  int token,
+                                                  int position) {
+    if (!is_gguf_path(ckpt_path)) {
+        throw std::runtime_error("run_gguf_attn_kv_path_smoke: not a GGUF path: " + ckpt_path);
+    }
+    if (token < 0) throw std::runtime_error("token must be >= 0");
+    if (position < 0) throw std::runtime_error("position must be >= 0");
+
+    GgufForwardContext ctx(ckpt_path);
+    WeightSource& ws = *ctx.weight_source;
+
+    WeightView embed = ws.require("embed.weight");
+    WeightView attn_norm = ws.require("layers.0.attn_norm.weight");
+    WeightView wkv = ws.require("layers.0.attn.wkv.weight");
+    WeightView kv_norm = ws.require("layers.0.attn.kv_norm.weight");
+
+    if (embed.dtype != DType::F16) throw std::runtime_error("embed dtype");
+    if (attn_norm.dtype != DType::F32) throw std::runtime_error("attn_norm dtype");
+    if (kv_norm.dtype != DType::F32) throw std::runtime_error("kv_norm dtype");
+    if (wkv.dtype != DType::Q8_0) throw std::runtime_error("wkv dtype");
+
+    const int dim = static_cast<int>(embed.shape[0]);
+    // wkv stored [dim, kv_dim] with cols fastest varying.
+    if (static_cast<int>(wkv.shape[0]) != dim) {
+        throw std::runtime_error("wkv inner dim != dim");
+    }
+    const int kv_dim = static_cast<int>(wkv.shape[1]);
+    if (static_cast<int>(kv_norm.shape[0]) != kv_dim) {
+        throw std::runtime_error("kv_norm gamma length != kv_dim");
+    }
+    const int rope_dim = static_cast<int>(ctx.config.rope_dim);
+    if (rope_dim <= 0 || rope_dim > kv_dim) {
+        throw std::runtime_error("rope_dim out of range");
+    }
+
+    // ----- Embed -----
+    const uint16_t* host_row =
+        reinterpret_cast<const uint16_t*>(embed.data) +
+        static_cast<size_t>(token) * dim;
+    uint16_t* d_row_f16 = nullptr;
+    float* d_x = nullptr;
+    check_cuda(cudaMalloc(&d_row_f16, dim * sizeof(uint16_t)), "alloc d_row_f16");
+    check_cuda(cudaMalloc(&d_x, dim * sizeof(float)), "alloc d_x");
+    check_cuda(cudaMemcpy(d_row_f16, host_row, dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy embed row");
+    if (!f16_row_to_float_cuda(d_row_f16, d_x, /*row=*/0, dim)) {
+        throw std::runtime_error("f16_row_to_float_cuda failed");
+    }
+
+    // ----- attn_norm gamma -----
+    auto attn_bf16 = f32_to_bf16_host(reinterpret_cast<const float*>(attn_norm.data), dim);
+    uint16_t* d_attn_gamma = nullptr;
+    check_cuda(cudaMalloc(&d_attn_gamma, dim * sizeof(uint16_t)), "alloc d_attn_gamma");
+    check_cuda(cudaMemcpy(d_attn_gamma, attn_bf16.data(), dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy attn_gamma");
+    float* d_x_normed = nullptr;
+    check_cuda(cudaMalloc(&d_x_normed, dim * sizeof(float)), "alloc d_x_normed");
+    if (!rmsnorm_bf16_gamma_cuda(d_x, d_attn_gamma, d_x_normed, dim, 1e-6f)) {
+        throw std::runtime_error("rmsnorm attn failed");
+    }
+
+    // ----- wkv: dim -> kv_dim -----
+    uint8_t* d_wkv = nullptr;
+    check_cuda(cudaMalloc(&d_wkv, wkv.nbytes), "alloc d_wkv");
+    check_cuda(cudaMemcpy(d_wkv, wkv.data, wkv.nbytes, cudaMemcpyHostToDevice), "copy wkv");
+    float* d_kv_a = nullptr;
+    check_cuda(cudaMalloc(&d_kv_a, kv_dim * sizeof(float)), "alloc d_kv_a");
+    if (!q8_0_matvec_cuda(d_x_normed, d_wkv, d_kv_a, kv_dim, dim)) {
+        throw std::runtime_error("q8_0 wkv failed");
+    }
+
+    // ----- kv_norm RMSNorm (full kv_dim gamma) -----
+    auto kv_bf16 = f32_to_bf16_host(reinterpret_cast<const float*>(kv_norm.data), kv_dim);
+    uint16_t* d_kv_gamma = nullptr;
+    check_cuda(cudaMalloc(&d_kv_gamma, kv_dim * sizeof(uint16_t)), "alloc d_kv_gamma");
+    check_cuda(cudaMemcpy(d_kv_gamma, kv_bf16.data(), kv_dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy kv_gamma");
+    float* d_kv = nullptr;
+    check_cuda(cudaMalloc(&d_kv, kv_dim * sizeof(float)), "alloc d_kv");
+    if (!rmsnorm_bf16_gamma_cuda(d_kv_a, d_kv_gamma, d_kv, kv_dim, 1e-6f)) {
+        throw std::runtime_error("rmsnorm kv failed");
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync after kv rmsnorm");
+
+    GgufAttnKvPathResult r;
+    r.dim = dim;
+    r.kv_dim = kv_dim;
+    r.rope_dim = rope_dim;
+    r.kv_a_rms = device_vector_rms(d_kv_a, kv_dim);
+    r.kv_norm_rms = device_vector_rms(d_kv, kv_dim);
+
+    // ----- RoPE on the last rope_dim elements (heads=1, head_dim=kv_dim) -----
+    // Pass do_rmsnorm=false because rmsnorm was already done with gamma above.
+    if (!head_rmsnorm_rope_cuda(d_kv, /*heads=*/1, kv_dim, rope_dim,
+                                position,
+                                static_cast<float>(ctx.config.rope_theta),
+                                false, 0.0f)) {
+        throw std::runtime_error("head_rmsnorm_rope kv failed");
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync after kv rope");
+
+    r.kv_post_rope_rms = device_vector_rms(d_kv, kv_dim);
+    std::vector<float> first(4);
+    check_cuda(cudaMemcpy(first.data(), d_kv, 4 * sizeof(float), cudaMemcpyDeviceToHost),
+               "copy kv first");
+    for (int i = 0; i < 4; ++i) r.kv_first[i] = first[i];
+
+    cudaFree(d_row_f16);
+    cudaFree(d_x);
+    cudaFree(d_attn_gamma);
+    cudaFree(d_x_normed);
+    cudaFree(d_wkv);
+    cudaFree(d_kv_a);
+    cudaFree(d_kv_gamma);
+    cudaFree(d_kv);
+    return r;
+}
+
 // --- PersistentEngine implementation ---------------------------------------
 
 struct PersistentEngine::State {

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -3572,6 +3572,144 @@ GgufAttnNormWqaResult run_gguf_attn_norm_wq_a_smoke(const std::string& ckpt_path
     return r;
 }
 
+GgufAttnQPathResult run_gguf_attn_q_path_smoke(const std::string& ckpt_path,
+                                                int token,
+                                                int position) {
+    if (!is_gguf_path(ckpt_path)) {
+        throw std::runtime_error("run_gguf_attn_q_path_smoke: not a GGUF path: " + ckpt_path);
+    }
+    if (token < 0) throw std::runtime_error("token must be >= 0");
+    if (position < 0) throw std::runtime_error("position must be >= 0");
+
+    GgufForwardContext ctx(ckpt_path);
+    WeightSource& ws = *ctx.weight_source;
+
+    WeightView embed = ws.require("embed.weight");
+    WeightView attn_norm = ws.require("layers.0.attn_norm.weight");
+    WeightView wq_a = ws.require("layers.0.attn.wq_a.weight");
+    WeightView q_norm = ws.require("layers.0.attn.q_norm.weight");
+    WeightView wq_b = ws.require("layers.0.attn.wq_b.weight");
+
+    if (embed.dtype != DType::F16) throw std::runtime_error("embed dtype");
+    if (attn_norm.dtype != DType::F32) throw std::runtime_error("attn_norm dtype");
+    if (q_norm.dtype != DType::F32) throw std::runtime_error("q_norm dtype");
+    if (wq_a.dtype != DType::Q8_0) throw std::runtime_error("wq_a dtype");
+    if (wq_b.dtype != DType::Q8_0) throw std::runtime_error("wq_b dtype");
+
+    const int dim = static_cast<int>(embed.shape[0]);
+    const int q_a_dim = static_cast<int>(wq_a.shape[1]);
+    // wq_b is stored [q_a_dim, heads*head_dim] in GGUF (cols fastest).
+    if (static_cast<int>(wq_b.shape[0]) != q_a_dim) {
+        throw std::runtime_error("wq_b inner dim != q_a_dim");
+    }
+    const int q_full = static_cast<int>(wq_b.shape[1]);
+    const int heads = static_cast<int>(ctx.config.n_heads);
+    if (heads <= 0) throw std::runtime_error("n_heads not set");
+    if (q_full % heads != 0) {
+        throw std::runtime_error("wq_b output cols not divisible by n_heads");
+    }
+    const int head_dim = q_full / heads;
+    const int rope_dim = static_cast<int>(ctx.config.rope_dim);
+    if (rope_dim <= 0 || rope_dim > head_dim) {
+        throw std::runtime_error("rope_dim out of range");
+    }
+
+    // ----- Embed -----
+    const uint16_t* host_row =
+        reinterpret_cast<const uint16_t*>(embed.data) +
+        static_cast<size_t>(token) * dim;
+    uint16_t* d_row_f16 = nullptr;
+    float* d_x = nullptr;
+    check_cuda(cudaMalloc(&d_row_f16, dim * sizeof(uint16_t)), "alloc d_row_f16");
+    check_cuda(cudaMalloc(&d_x, dim * sizeof(float)), "alloc d_x");
+    check_cuda(cudaMemcpy(d_row_f16, host_row, dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy embed row");
+    if (!f16_row_to_float_cuda(d_row_f16, d_x, /*row=*/0, dim)) {
+        throw std::runtime_error("f16_row_to_float_cuda failed");
+    }
+
+    // ----- attn_norm gamma -----
+    auto attn_bf16 = f32_to_bf16_host(reinterpret_cast<const float*>(attn_norm.data), dim);
+    uint16_t* d_attn_gamma = nullptr;
+    check_cuda(cudaMalloc(&d_attn_gamma, dim * sizeof(uint16_t)), "alloc d_attn_gamma");
+    check_cuda(cudaMemcpy(d_attn_gamma, attn_bf16.data(), dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy attn_gamma");
+    float* d_x_normed = nullptr;
+    check_cuda(cudaMalloc(&d_x_normed, dim * sizeof(float)), "alloc d_x_normed");
+    if (!rmsnorm_bf16_gamma_cuda(d_x, d_attn_gamma, d_x_normed, dim, 1e-6f)) {
+        throw std::runtime_error("rmsnorm attn failed");
+    }
+
+    // ----- wq_a -----
+    uint8_t* d_wq_a = nullptr;
+    check_cuda(cudaMalloc(&d_wq_a, wq_a.nbytes), "alloc d_wq_a");
+    check_cuda(cudaMemcpy(d_wq_a, wq_a.data, wq_a.nbytes, cudaMemcpyHostToDevice), "copy wq_a");
+    float* d_q_a = nullptr;
+    check_cuda(cudaMalloc(&d_q_a, q_a_dim * sizeof(float)), "alloc d_q_a");
+    if (!q8_0_matvec_cuda(d_x_normed, d_wq_a, d_q_a, q_a_dim, dim)) {
+        throw std::runtime_error("q8_0 wq_a failed");
+    }
+
+    // ----- q_norm gamma -----
+    auto q_bf16 = f32_to_bf16_host(reinterpret_cast<const float*>(q_norm.data), q_a_dim);
+    uint16_t* d_q_gamma = nullptr;
+    check_cuda(cudaMalloc(&d_q_gamma, q_a_dim * sizeof(uint16_t)), "alloc d_q_gamma");
+    check_cuda(cudaMemcpy(d_q_gamma, q_bf16.data(), q_a_dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy q_gamma");
+    float* d_q_normed = nullptr;
+    check_cuda(cudaMalloc(&d_q_normed, q_a_dim * sizeof(float)), "alloc d_q_normed");
+    if (!rmsnorm_bf16_gamma_cuda(d_q_a, d_q_gamma, d_q_normed, q_a_dim, 1e-6f)) {
+        throw std::runtime_error("rmsnorm q failed");
+    }
+
+    // ----- wq_b -> q[heads*head_dim] -----
+    uint8_t* d_wq_b = nullptr;
+    check_cuda(cudaMalloc(&d_wq_b, wq_b.nbytes), "alloc d_wq_b");
+    check_cuda(cudaMemcpy(d_wq_b, wq_b.data, wq_b.nbytes, cudaMemcpyHostToDevice), "copy wq_b");
+    float* d_q = nullptr;
+    check_cuda(cudaMalloc(&d_q, q_full * sizeof(float)), "alloc d_q");
+    if (!q8_0_matvec_cuda(d_q_normed, d_wq_b, d_q, q_full, q_a_dim)) {
+        throw std::runtime_error("q8_0 wq_b failed");
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync after wq_b");
+
+    GgufAttnQPathResult r;
+    r.dim = dim;
+    r.q_a_dim = q_a_dim;
+    r.heads = heads;
+    r.head_dim = head_dim;
+    r.rope_dim = rope_dim;
+    r.q_normed_rms = device_vector_rms(d_q_normed, q_a_dim);
+    r.q_pre_rope_rms = device_vector_rms(d_q, q_full);
+
+    // ----- head-wise RMSNorm + RoPE -----
+    if (!head_rmsnorm_rope_cuda(d_q, heads, head_dim, rope_dim,
+                                position,
+                                static_cast<float>(ctx.config.rope_theta),
+                                false, 1e-6f)) {
+        throw std::runtime_error("head_rmsnorm_rope failed");
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync after head rope");
+
+    r.q_post_rope_rms = device_vector_rms(d_q, q_full);
+    std::vector<float> first(4);
+    check_cuda(cudaMemcpy(first.data(), d_q, 4 * sizeof(float), cudaMemcpyDeviceToHost),
+               "copy q first");
+    for (int i = 0; i < 4; ++i) r.q_first[i] = first[i];
+
+    cudaFree(d_row_f16);
+    cudaFree(d_x);
+    cudaFree(d_attn_gamma);
+    cudaFree(d_x_normed);
+    cudaFree(d_wq_a);
+    cudaFree(d_q_a);
+    cudaFree(d_q_gamma);
+    cudaFree(d_q_normed);
+    cudaFree(d_wq_b);
+    cudaFree(d_q);
+    return r;
+}
+
 // --- PersistentEngine implementation ---------------------------------------
 
 struct PersistentEngine::State {

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -3464,6 +3464,41 @@ std::vector<uint16_t> f32_to_bf16_host(const float* src, size_t n) {
     return out;
 }
 
+// F16 (IEEE binary16) -> BF16 via F32 intermediate. F16 has 10-bit mantissa,
+// BF16 has 7-bit mantissa, so this drops 3 bits of fraction. Used for staging
+// GGUF F16 weights into the existing BF16 matvec kernels (e.g., gate scoring).
+std::vector<uint16_t> f16_to_bf16_host(const uint16_t* src, size_t n) {
+    std::vector<uint16_t> out(n);
+    for (size_t i = 0; i < n; ++i) {
+        const uint16_t h = src[i];
+        const uint32_t sign = static_cast<uint32_t>(h & 0x8000u) << 16;
+        const uint32_t exp16 = (h >> 10) & 0x1Fu;
+        const uint32_t man16 = h & 0x3FFu;
+        uint32_t f32_bits;
+        if (exp16 == 0) {
+            if (man16 == 0) {
+                f32_bits = sign;
+            } else {
+                // Subnormal F16 -> normalized F32: shift mantissa until top bit is set.
+                uint32_t m = man16;
+                int e = -1;
+                while ((m & 0x400u) == 0) { m <<= 1; --e; }
+                m &= 0x3FFu;
+                const uint32_t exp32 = static_cast<uint32_t>(127 - 15 + e);
+                f32_bits = sign | (exp32 << 23) | (m << 13);
+            }
+        } else if (exp16 == 0x1Fu) {
+            // Inf or NaN.
+            f32_bits = sign | (0xFFu << 23) | (man16 << 13);
+        } else {
+            const uint32_t exp32 = exp16 + (127 - 15);
+            f32_bits = sign | (exp32 << 23) | (man16 << 13);
+        }
+        out[i] = static_cast<uint16_t>(f32_bits >> 16);
+    }
+    return out;
+}
+
 float device_vector_rms(const float* d_x, int n) {
     std::vector<float> h(n);
     check_cuda(cudaMemcpy(h.data(), d_x, n * sizeof(float), cudaMemcpyDeviceToHost),
@@ -4532,11 +4567,60 @@ GgufRoutedMoeResult run_gguf_routed_moe_smoke(const std::string& ckpt_path, int 
     // Staged expert buffer holds K experts back-to-back; slots index 0..K-1.
     std::vector<int64_t> h_slots(routes);
     for (int k = 0; k < routes; ++k) h_slots[k] = k;
-    std::vector<float> h_weights(routes, 1.0f / static_cast<float>(routes));
     check_cuda(cudaMemcpy(d_route_slots, h_slots.data(), routes * sizeof(int64_t),
                           cudaMemcpyHostToDevice), "copy slots");
-    check_cuda(cudaMemcpy(d_route_weights, h_weights.data(), routes * sizeof(float),
-                          cudaMemcpyHostToDevice), "copy weights");
+
+    // ----- Hash-gate route weights: gate W matvec → sqrt_softplus → gather →
+    // normalize → ×route_scale. PyTorch reference at runtime/transformer.py:1682
+    // computes the same gather+normalize for hash layers (where indices come
+    // from tid2eid). Gate W is stored F16 in this GGUF; convert to BF16 once
+    // and reuse the existing gate_hash_bf16_cuda kernel pair. -----
+    WeightView gate_w = gws.require("layers.0.ffn.gate.weight");
+    if (gate_w.dtype != DType::F16) {
+        throw std::runtime_error("gate.weight dtype expected F16");
+    }
+    // Native GGUF shape [dim, n_experts]; bf16_matvec_cuda treats the bytes
+    // as [n_experts, dim] row-major which matches the logical layout because
+    // dim is the fast (innermost) GGUF dimension.
+    const int n_experts = static_cast<int>(ctx.config.n_routed_experts);
+    if (static_cast<int>(gate_w.shape[0]) != dim ||
+        static_cast<int>(gate_w.shape[1]) != n_experts) {
+        throw std::runtime_error("gate.weight shape mismatch");
+    }
+    auto gate_w_bf16 = f16_to_bf16_host(
+        reinterpret_cast<const uint16_t*>(gate_w.data),
+        static_cast<size_t>(dim) * static_cast<size_t>(n_experts));
+    uint16_t* d_gate_w_bf16 = nullptr;
+    int64_t* d_tid2eid_i64 = nullptr;
+    float* d_gate_scores_scratch = nullptr;
+    int64_t* d_gate_indices = nullptr;
+    check_cuda(cudaMalloc(&d_gate_w_bf16, gate_w_bf16.size() * sizeof(uint16_t)),
+               "alloc d_gate_w_bf16");
+    check_cuda(cudaMemcpy(d_gate_w_bf16, gate_w_bf16.data(),
+                          gate_w_bf16.size() * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy gate_w_bf16");
+    // Stage just the per-token tid2eid slice as int64[topk]; kernel will
+    // index it with token=0, table_topk=topk so it reads positions [0..topk).
+    std::vector<int64_t> h_tid2eid_slice(topk);
+    for (int k = 0; k < topk; ++k) h_tid2eid_slice[k] = h_expert_ids[k];
+    check_cuda(cudaMalloc(&d_tid2eid_i64, topk * sizeof(int64_t)),
+               "alloc d_tid2eid_i64");
+    check_cuda(cudaMemcpy(d_tid2eid_i64, h_tid2eid_slice.data(),
+                          topk * sizeof(int64_t), cudaMemcpyHostToDevice),
+               "copy d_tid2eid_i64");
+    check_cuda(cudaMalloc(&d_gate_scores_scratch, topk * sizeof(float)),
+               "alloc d_gate_scores_scratch");
+    check_cuda(cudaMalloc(&d_gate_indices, topk * sizeof(int64_t)),
+               "alloc d_gate_indices");
+    const float route_scale = static_cast<float>(ctx.config.route_scale);
+    if (!gate_hash_bf16_cuda(d_x_normed, d_gate_w_bf16, d_tid2eid_i64,
+                             d_gate_scores_scratch, d_gate_indices,
+                             d_route_weights,
+                             /*token=*/0, /*cols=*/dim,
+                             /*table_topk=*/topk, /*topk=*/topk,
+                             route_scale)) {
+        throw std::runtime_error("gate_hash_bf16_cuda failed");
+    }
 
     // ----- Quantize x once (the w13 kernel reads x_q without per-route stride) -----
     if (!q2_quantize_x_q8_1_cuda(d_x_normed, d_x_q, d_x_scale, /*routes=*/1, dim)) {
@@ -4579,6 +4663,15 @@ GgufRoutedMoeResult run_gguf_routed_moe_smoke(const std::string& ckpt_path, int 
     check_cuda(cudaMemcpy(first.data(), d_y, 4 * sizeof(float),
                           cudaMemcpyDeviceToHost), "copy moe_out first");
     for (int i = 0; i < 4; ++i) r.moe_out_first[i] = first[i];
+    std::vector<float> h_rw(topk);
+    check_cuda(cudaMemcpy(h_rw.data(), d_route_weights, topk * sizeof(float),
+                          cudaMemcpyDeviceToHost), "copy route_weights");
+    float sum = 0.0f;
+    for (int k = 0; k < topk; ++k) {
+        r.route_weights[k] = h_rw[k];
+        sum += h_rw[k];
+    }
+    r.route_weights_sum = sum;
 
     cudaFree(d_row_f16);
     cudaFree(d_x);
@@ -4596,6 +4689,10 @@ GgufRoutedMoeResult run_gguf_routed_moe_smoke(const std::string& ckpt_path, int 
     cudaFree(d_hidden_q);
     cudaFree(d_hidden_scale);
     cudaFree(d_y);
+    cudaFree(d_gate_w_bf16);
+    cudaFree(d_tid2eid_i64);
+    cudaFree(d_gate_scores_scratch);
+    cudaFree(d_gate_indices);
     return r;
 }
 

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -4696,6 +4696,496 @@ GgufRoutedMoeResult run_gguf_routed_moe_smoke(const std::string& ckpt_path, int 
     return r;
 }
 
+GgufLayer0FullResult run_gguf_layer0_full_smoke(const std::string& ckpt_path,
+                                                 int token,
+                                                 int position) {
+    if (!is_gguf_path(ckpt_path)) {
+        throw std::runtime_error("run_gguf_layer0_full_smoke: not a GGUF path: " + ckpt_path);
+    }
+    if (token < 0) throw std::runtime_error("token must be >= 0");
+    if (position < 0) throw std::runtime_error("position must be >= 0");
+
+    GgufForwardContext ctx(ckpt_path);
+    GGUFWeightSource& gws = *ctx.weight_source;
+
+    // ----- attention weights -----
+    WeightView embed = gws.require("embed.weight");
+    WeightView attn_norm = gws.require("layers.0.attn_norm.weight");
+    WeightView wq_a = gws.require("layers.0.attn.wq_a.weight");
+    WeightView q_norm = gws.require("layers.0.attn.q_norm.weight");
+    WeightView wq_b = gws.require("layers.0.attn.wq_b.weight");
+    WeightView wkv = gws.require("layers.0.attn.wkv.weight");
+    WeightView kv_norm = gws.require("layers.0.attn.kv_norm.weight");
+    WeightView attn_sink = gws.require("layers.0.attn.attn_sink");
+    WeightView wo_a = gws.require("layers.0.attn.wo_a.weight");
+    WeightView wo_b = gws.require("layers.0.attn.wo_b.weight");
+    // ----- FFN weights -----
+    WeightView ffn_norm = gws.require("layers.0.ffn_norm.weight");
+    WeightView shared_w1 = gws.require("layers.0.ffn.shared_experts.w1.weight");
+    WeightView shared_w2 = gws.require("layers.0.ffn.shared_experts.w2.weight");
+    WeightView shared_w3 = gws.require("layers.0.ffn.shared_experts.w3.weight");
+    WeightView gate_w = gws.require("layers.0.ffn.gate.weight");
+    WeightView tid2eid = gws.require("layers.0.ffn.gate.tid2eid");
+
+    if (embed.dtype != DType::F16) throw std::runtime_error("embed dtype");
+    if (attn_norm.dtype != DType::F32 || q_norm.dtype != DType::F32 ||
+        kv_norm.dtype != DType::F32 || ffn_norm.dtype != DType::F32 ||
+        attn_sink.dtype != DType::F32) {
+        throw std::runtime_error("norm/sink dtypes must be F32");
+    }
+    if (wq_a.dtype != DType::Q8_0 || wq_b.dtype != DType::Q8_0 ||
+        wkv.dtype != DType::Q8_0 || wo_a.dtype != DType::Q8_0 ||
+        wo_b.dtype != DType::Q8_0) {
+        throw std::runtime_error("attention projections must be Q8_0");
+    }
+    if (shared_w1.dtype != DType::Q8_0 || shared_w2.dtype != DType::Q8_0 ||
+        shared_w3.dtype != DType::Q8_0) {
+        throw std::runtime_error("shared expert weights must be Q8_0");
+    }
+    if (gate_w.dtype != DType::F16) {
+        throw std::runtime_error("gate.weight dtype expected F16");
+    }
+
+    // ----- dimensions -----
+    const int dim = static_cast<int>(embed.shape[0]);
+    const int q_a_dim = static_cast<int>(wq_a.shape[1]);
+    const int heads = static_cast<int>(ctx.config.n_heads);
+    const int q_full = static_cast<int>(wq_b.shape[1]);
+    if (q_full % heads != 0) throw std::runtime_error("wq_b cols % heads != 0");
+    const int head_dim = q_full / heads;
+    const int kv_dim = static_cast<int>(wkv.shape[1]);
+    const int rope_dim = static_cast<int>(ctx.config.rope_dim);
+    if (kv_dim != head_dim) throw std::runtime_error("expected kv_dim == head_dim");
+    const int o_groups = static_cast<int>(ctx.config.o_groups);
+    const int o_lora_rank = static_cast<int>(ctx.config.o_lora_rank);
+    if (q_full % o_groups != 0) throw std::runtime_error("q_full % o_groups");
+    const int group_in_dim = q_full / o_groups;
+    const int attn_mid = o_groups * o_lora_rank;
+    const int moe_inter = static_cast<int>(ctx.config.moe_inter_dim);
+    const int n_experts = static_cast<int>(ctx.config.n_routed_experts);
+    const int topk = static_cast<int>(ctx.config.n_activated_experts);
+    const int vocab = static_cast<int>(embed.shape[1]);
+    if (token >= vocab) throw std::runtime_error("token id out of vocab range");
+    if (topk <= 0 || topk > 8) throw std::runtime_error("topk out of supported range");
+    if (tid2eid.nbytes < static_cast<uint64_t>(token + 1) * topk * sizeof(int32_t)) {
+        throw std::runtime_error("tid2eid too small for requested token");
+    }
+
+    // tid2eid hash gate row for this token.
+    const int32_t* token_eids =
+        reinterpret_cast<const int32_t*>(tid2eid.data) +
+        static_cast<size_t>(token) * topk;
+    int h_expert_ids[8] = {0};
+    for (int k = 0; k < topk; ++k) h_expert_ids[k] = token_eids[k];
+
+    // ----- upload helpers -----
+    auto upload_u8 = [](const void* src, size_t bytes) {
+        uint8_t* d = nullptr;
+        check_cuda(cudaMalloc(&d, bytes), "alloc");
+        check_cuda(cudaMemcpy(d, src, bytes, cudaMemcpyHostToDevice), "copy");
+        return d;
+    };
+    auto upload_f32 = [](const void* src, size_t n) {
+        float* d = nullptr;
+        check_cuda(cudaMalloc(&d, n * sizeof(float)), "alloc f32");
+        check_cuda(cudaMemcpy(d, src, n * sizeof(float), cudaMemcpyHostToDevice), "copy f32");
+        return d;
+    };
+    auto upload_bf16_from_f32 = [&](const void* src, size_t n) {
+        auto bf = f32_to_bf16_host(reinterpret_cast<const float*>(src), n);
+        uint16_t* d = nullptr;
+        check_cuda(cudaMalloc(&d, n * sizeof(uint16_t)), "alloc bf16");
+        check_cuda(cudaMemcpy(d, bf.data(), n * sizeof(uint16_t), cudaMemcpyHostToDevice),
+                   "copy bf16");
+        return d;
+    };
+
+    // Embed row.
+    const uint16_t* host_row =
+        reinterpret_cast<const uint16_t*>(embed.data) +
+        static_cast<size_t>(token) * dim;
+    uint16_t* d_row_f16 = nullptr;
+    check_cuda(cudaMalloc(&d_row_f16, dim * sizeof(uint16_t)), "alloc d_row_f16");
+    check_cuda(cudaMemcpy(d_row_f16, host_row, dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy embed row");
+
+    // Attention norm gammas.
+    uint16_t* d_attn_gamma = upload_bf16_from_f32(attn_norm.data, dim);
+    uint16_t* d_q_gamma = upload_bf16_from_f32(q_norm.data, q_a_dim);
+    uint16_t* d_kv_gamma = upload_bf16_from_f32(kv_norm.data, kv_dim);
+    uint16_t* d_ffn_gamma = upload_bf16_from_f32(ffn_norm.data, dim);
+    // Attention Q8_0 weights.
+    uint8_t* d_wq_a = upload_u8(wq_a.data, wq_a.nbytes);
+    uint8_t* d_wq_b = upload_u8(wq_b.data, wq_b.nbytes);
+    uint8_t* d_wkv = upload_u8(wkv.data, wkv.nbytes);
+    uint8_t* d_wo_a = upload_u8(wo_a.data, wo_a.nbytes);
+    uint8_t* d_wo_b = upload_u8(wo_b.data, wo_b.nbytes);
+    float* d_attn_sink = upload_f32(attn_sink.data, heads);
+    // Shared expert Q8_0 weights.
+    uint8_t* d_shared_w1 = upload_u8(shared_w1.data, shared_w1.nbytes);
+    uint8_t* d_shared_w2 = upload_u8(shared_w2.data, shared_w2.nbytes);
+    uint8_t* d_shared_w3 = upload_u8(shared_w3.data, shared_w3.nbytes);
+    // Gate W (F16 -> BF16).
+    auto gate_w_bf16 = f16_to_bf16_host(
+        reinterpret_cast<const uint16_t*>(gate_w.data),
+        static_cast<size_t>(dim) * static_cast<size_t>(n_experts));
+    uint16_t* d_gate_w_bf16 = nullptr;
+    check_cuda(cudaMalloc(&d_gate_w_bf16, gate_w_bf16.size() * sizeof(uint16_t)),
+               "alloc d_gate_w_bf16");
+    check_cuda(cudaMemcpy(d_gate_w_bf16, gate_w_bf16.data(),
+                          gate_w_bf16.size() * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy gate_w_bf16");
+
+    // Stage top-k routed experts.
+    auto first_w1 = gws.get_expert("layers.0.ffn.experts.routed.w1",
+                                    "layers.0.ffn.experts.routed.w1", 0);
+    auto first_w2 = gws.get_expert("layers.0.ffn.experts.routed.w2",
+                                    "layers.0.ffn.experts.routed.w2", 0);
+    auto first_w3 = gws.get_expert("layers.0.ffn.experts.routed.w3",
+                                    "layers.0.ffn.experts.routed.w3", 0);
+    if (!first_w1.found || !first_w2.found || !first_w3.found) {
+        throw std::runtime_error("get_expert(0) failed");
+    }
+    const uint64_t per_w1_bytes = first_w1.nbytes;
+    const uint64_t per_w2_bytes = first_w2.nbytes;
+    const uint64_t per_w3_bytes = first_w3.nbytes;
+    uint8_t* d_routed_w1 = nullptr;
+    uint8_t* d_routed_w2 = nullptr;
+    uint8_t* d_routed_w3 = nullptr;
+    check_cuda(cudaMalloc(&d_routed_w1, per_w1_bytes * topk), "alloc routed_w1");
+    check_cuda(cudaMalloc(&d_routed_w2, per_w2_bytes * topk), "alloc routed_w2");
+    check_cuda(cudaMalloc(&d_routed_w3, per_w3_bytes * topk), "alloc routed_w3");
+    for (int k = 0; k < topk; ++k) {
+        const int eid = h_expert_ids[k];
+        auto wv1 = gws.get_expert("layers.0.ffn.experts.routed.w1",
+                                   "layers.0.ffn.experts.routed.w1", eid);
+        auto wv2 = gws.get_expert("layers.0.ffn.experts.routed.w2",
+                                   "layers.0.ffn.experts.routed.w2", eid);
+        auto wv3 = gws.get_expert("layers.0.ffn.experts.routed.w3",
+                                   "layers.0.ffn.experts.routed.w3", eid);
+        if (!wv1.found || !wv2.found || !wv3.found) {
+            throw std::runtime_error("get_expert failed for active expert");
+        }
+        check_cuda(cudaMemcpy(d_routed_w1 + per_w1_bytes * k, wv1.data, per_w1_bytes,
+                              cudaMemcpyHostToDevice), "stage routed_w1");
+        check_cuda(cudaMemcpy(d_routed_w2 + per_w2_bytes * k, wv2.data, per_w2_bytes,
+                              cudaMemcpyHostToDevice), "stage routed_w2");
+        check_cuda(cudaMemcpy(d_routed_w3 + per_w3_bytes * k, wv3.data, per_w3_bytes,
+                              cudaMemcpyHostToDevice), "stage routed_w3");
+    }
+
+    // tid2eid slice + scratch for gate scoring.
+    std::vector<int64_t> h_tid2eid_slice(topk);
+    for (int k = 0; k < topk; ++k) h_tid2eid_slice[k] = h_expert_ids[k];
+    int64_t* d_tid2eid_i64 = nullptr;
+    float* d_gate_scores_scratch = nullptr;
+    int64_t* d_gate_indices = nullptr;
+    check_cuda(cudaMalloc(&d_tid2eid_i64, topk * sizeof(int64_t)), "alloc d_tid2eid_i64");
+    check_cuda(cudaMemcpy(d_tid2eid_i64, h_tid2eid_slice.data(),
+                          topk * sizeof(int64_t), cudaMemcpyHostToDevice),
+               "copy d_tid2eid_i64");
+    check_cuda(cudaMalloc(&d_gate_scores_scratch, topk * sizeof(float)),
+               "alloc d_gate_scores_scratch");
+    check_cuda(cudaMalloc(&d_gate_indices, topk * sizeof(int64_t)),
+               "alloc d_gate_indices");
+
+    // ----- activation buffers -----
+    float* d_x = nullptr;            // working hidden state (residual-updated)
+    float* d_x_pre_attn = nullptr;   // saved before attn_norm for residual
+    float* d_x_normed = nullptr;
+    float* d_q_a = nullptr;
+    float* d_q_normed = nullptr;
+    float* d_q = nullptr;
+    float* d_kv_a = nullptr;
+    float* d_kv = nullptr;
+    float* d_attn_value = nullptr;
+    float* d_attn_mid = nullptr;
+    float* d_attn_out = nullptr;
+    float* d_x_pre_ffn = nullptr;    // saved after attn residual for FFN residual
+    float* d_x_normed_ffn = nullptr;
+    float* d_shared_gate = nullptr;
+    float* d_shared_up = nullptr;
+    float* d_shared_hidden = nullptr;
+    float* d_shared_out = nullptr;
+    float* d_moe_out = nullptr;
+    float* d_ffn_combined = nullptr;
+    check_cuda(cudaMalloc(&d_x, dim * sizeof(float)), "alloc d_x");
+    check_cuda(cudaMalloc(&d_x_pre_attn, dim * sizeof(float)), "alloc d_x_pre_attn");
+    check_cuda(cudaMalloc(&d_x_normed, dim * sizeof(float)), "alloc d_x_normed");
+    check_cuda(cudaMalloc(&d_q_a, q_a_dim * sizeof(float)), "alloc d_q_a");
+    check_cuda(cudaMalloc(&d_q_normed, q_a_dim * sizeof(float)), "alloc d_q_normed");
+    check_cuda(cudaMalloc(&d_q, q_full * sizeof(float)), "alloc d_q");
+    check_cuda(cudaMalloc(&d_kv_a, kv_dim * sizeof(float)), "alloc d_kv_a");
+    check_cuda(cudaMalloc(&d_kv, kv_dim * sizeof(float)), "alloc d_kv");
+    check_cuda(cudaMalloc(&d_attn_value, q_full * sizeof(float)), "alloc d_attn_value");
+    check_cuda(cudaMalloc(&d_attn_mid, attn_mid * sizeof(float)), "alloc d_attn_mid");
+    check_cuda(cudaMalloc(&d_attn_out, dim * sizeof(float)), "alloc d_attn_out");
+    check_cuda(cudaMalloc(&d_x_pre_ffn, dim * sizeof(float)), "alloc d_x_pre_ffn");
+    check_cuda(cudaMalloc(&d_x_normed_ffn, dim * sizeof(float)), "alloc d_x_normed_ffn");
+    check_cuda(cudaMalloc(&d_shared_gate, moe_inter * sizeof(float)), "alloc d_shared_gate");
+    check_cuda(cudaMalloc(&d_shared_up, moe_inter * sizeof(float)), "alloc d_shared_up");
+    check_cuda(cudaMalloc(&d_shared_hidden, moe_inter * sizeof(float)), "alloc d_shared_hidden");
+    check_cuda(cudaMalloc(&d_shared_out, dim * sizeof(float)), "alloc d_shared_out");
+    check_cuda(cudaMalloc(&d_moe_out, dim * sizeof(float)), "alloc d_moe_out");
+    check_cuda(cudaMalloc(&d_ffn_combined, dim * sizeof(float)), "alloc d_ffn_combined");
+    check_cuda(cudaMemset(d_moe_out, 0, dim * sizeof(float)), "zero d_moe_out");
+
+    // Routed MoE staging buffers.
+    const int routes = topk;
+    const int x_groups = (dim + 31) / 32;
+    const int hidden_groups = (moe_inter + 15) / 16;
+    int8_t* d_x_q = nullptr;
+    float* d_x_scale = nullptr;
+    int64_t* d_route_slots = nullptr;
+    float* d_route_weights = nullptr;
+    float* d_route_gate = nullptr;
+    float* d_route_up = nullptr;
+    int8_t* d_route_hidden_q = nullptr;
+    float* d_route_hidden_scale = nullptr;
+    check_cuda(cudaMalloc(&d_x_q, dim), "alloc d_x_q");
+    check_cuda(cudaMalloc(&d_x_scale, x_groups * sizeof(float)), "alloc d_x_scale");
+    check_cuda(cudaMalloc(&d_route_slots, routes * sizeof(int64_t)), "alloc d_route_slots");
+    check_cuda(cudaMalloc(&d_route_weights, routes * sizeof(float)), "alloc d_route_weights");
+    check_cuda(cudaMalloc(&d_route_gate, static_cast<size_t>(routes) * moe_inter * sizeof(float)),
+               "alloc d_route_gate");
+    check_cuda(cudaMalloc(&d_route_up, static_cast<size_t>(routes) * moe_inter * sizeof(float)),
+               "alloc d_route_up");
+    check_cuda(cudaMalloc(&d_route_hidden_q, static_cast<size_t>(routes) * moe_inter),
+               "alloc d_route_hidden_q");
+    check_cuda(cudaMalloc(&d_route_hidden_scale,
+                          static_cast<size_t>(routes) * hidden_groups * sizeof(float)),
+               "alloc d_route_hidden_scale");
+    std::vector<int64_t> h_route_slots(routes);
+    for (int k = 0; k < routes; ++k) h_route_slots[k] = k;
+    check_cuda(cudaMemcpy(d_route_slots, h_route_slots.data(),
+                          routes * sizeof(int64_t), cudaMemcpyHostToDevice),
+               "copy d_route_slots");
+
+    // ===== compute =====
+
+    // 1. Embed.
+    if (!f16_row_to_float_cuda(d_row_f16, d_x, /*row=*/0, dim)) {
+        throw std::runtime_error("f16 embed failed");
+    }
+    // Save x_pre_attn = d_x for attention residual.
+    check_cuda(cudaMemcpy(d_x_pre_attn, d_x, dim * sizeof(float),
+                          cudaMemcpyDeviceToDevice), "save x_pre_attn");
+
+    // 2. Attention.
+    if (!rmsnorm_bf16_gamma_cuda(d_x, d_attn_gamma, d_x_normed, dim, 1e-6f)) {
+        throw std::runtime_error("attn_norm failed");
+    }
+    // Q-path.
+    if (!q8_0_matvec_cuda(d_x_normed, d_wq_a, d_q_a, q_a_dim, dim)) {
+        throw std::runtime_error("wq_a failed");
+    }
+    if (!rmsnorm_bf16_gamma_cuda(d_q_a, d_q_gamma, d_q_normed, q_a_dim, 1e-6f)) {
+        throw std::runtime_error("q_norm failed");
+    }
+    if (!q8_0_matvec_cuda(d_q_normed, d_wq_b, d_q, q_full, q_a_dim)) {
+        throw std::runtime_error("wq_b failed");
+    }
+    if (!head_rmsnorm_rope_cuda(d_q, heads, head_dim, rope_dim, position,
+                                static_cast<float>(ctx.config.rope_theta),
+                                false, 1e-6f)) {
+        throw std::runtime_error("q head rope failed");
+    }
+    // KV-path.
+    if (!q8_0_matvec_cuda(d_x_normed, d_wkv, d_kv_a, kv_dim, dim)) {
+        throw std::runtime_error("wkv failed");
+    }
+    if (!rmsnorm_bf16_gamma_cuda(d_kv_a, d_kv_gamma, d_kv, kv_dim, 1e-6f)) {
+        throw std::runtime_error("kv_norm failed");
+    }
+    if (!head_rmsnorm_rope_cuda(d_kv, /*heads=*/1, kv_dim, rope_dim, position,
+                                static_cast<float>(ctx.config.rope_theta),
+                                false, 0.0f)) {
+        throw std::runtime_error("kv head rope failed");
+    }
+    // Sparse attention.
+    const float scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+    if (!single_token_sparse_attention_cuda(d_q, d_kv, d_attn_sink, d_attn_value,
+                                            heads, head_dim, scale)) {
+        throw std::runtime_error("single_token_sparse_attention failed");
+    }
+    // Inverse RoPE on V tail.
+    if (!head_rmsnorm_rope_cuda(d_attn_value, heads, head_dim, rope_dim, position,
+                                static_cast<float>(ctx.config.rope_theta),
+                                /*inverse=*/true, 0.0f)) {
+        throw std::runtime_error("inverse rope failed");
+    }
+    // Grouped wo_a.
+    const size_t group_w_bytes =
+        static_cast<size_t>(o_lora_rank) *
+        static_cast<size_t>((group_in_dim + 31) / 32) * 34;
+    for (int g = 0; g < o_groups; ++g) {
+        const float* group_x = d_attn_value + static_cast<size_t>(g) * group_in_dim;
+        const uint8_t* group_w = d_wo_a + static_cast<size_t>(g) * group_w_bytes;
+        float* group_y = d_attn_mid + static_cast<size_t>(g) * o_lora_rank;
+        if (!q8_0_matvec_cuda(group_x, group_w, group_y, o_lora_rank, group_in_dim)) {
+            throw std::runtime_error("wo_a group matvec failed");
+        }
+    }
+    if (!q8_0_matvec_cuda(d_attn_mid, d_wo_b, d_attn_out, dim, attn_mid)) {
+        throw std::runtime_error("wo_b failed");
+    }
+
+    // 3. Attention residual: d_x = d_x_pre_attn + d_attn_out.
+    if (!vector_add_cuda(d_x_pre_attn, d_attn_out, d_x, dim)) {
+        throw std::runtime_error("attn residual add failed");
+    }
+    // Save x_pre_ffn = d_x for FFN residual.
+    check_cuda(cudaMemcpy(d_x_pre_ffn, d_x, dim * sizeof(float),
+                          cudaMemcpyDeviceToDevice), "save x_pre_ffn");
+
+    // 4. FFN norm.
+    if (!rmsnorm_bf16_gamma_cuda(d_x, d_ffn_gamma, d_x_normed_ffn, dim, 1e-6f)) {
+        throw std::runtime_error("ffn_norm failed");
+    }
+
+    // 5. Shared expert (Q8_0 w1/w3 + silu_mul + Q8_0 w2).
+    if (!q8_0_matvec_cuda(d_x_normed_ffn, d_shared_w1, d_shared_gate,
+                          moe_inter, dim)) {
+        throw std::runtime_error("shared w1 failed");
+    }
+    if (!q8_0_matvec_cuda(d_x_normed_ffn, d_shared_w3, d_shared_up,
+                          moe_inter, dim)) {
+        throw std::runtime_error("shared w3 failed");
+    }
+    const float swiglu_limit = static_cast<float>(ctx.config.swiglu_limit);
+    if (!silu_mul_cuda(d_shared_gate, d_shared_up, d_shared_hidden,
+                       moe_inter)) {
+        throw std::runtime_error("shared silu_mul failed");
+    }
+    if (!q8_0_matvec_cuda(d_shared_hidden, d_shared_w2, d_shared_out,
+                          dim, moe_inter)) {
+        throw std::runtime_error("shared w2 failed");
+    }
+
+    // 6. Hash-gate route weights.
+    const float route_scale = static_cast<float>(ctx.config.route_scale);
+    if (!gate_hash_bf16_cuda(d_x_normed_ffn, d_gate_w_bf16, d_tid2eid_i64,
+                             d_gate_scores_scratch, d_gate_indices,
+                             d_route_weights,
+                             /*token=*/0, /*cols=*/dim,
+                             /*table_topk=*/topk, /*topk=*/topk,
+                             route_scale)) {
+        throw std::runtime_error("gate_hash_bf16_cuda failed");
+    }
+
+    // 7. Routed MoE (Q2): q8_1 x -> IQ2_XXS w1/w3 -> SwiGLU + route_weight ->
+    // q8_1 hidden -> Q2_K w2 (atomicAdd across routes).
+    if (!q2_quantize_x_q8_1_cuda(d_x_normed_ffn, d_x_q, d_x_scale,
+                                  /*routes=*/1, dim)) {
+        throw std::runtime_error("q2_quantize_x_q8_1 failed");
+    }
+    if (!q2_moe_single_w13_iq2_xxs_cuda(d_x_q, d_x_scale, d_route_slots,
+                                         d_routed_w1, d_routed_w3,
+                                         d_route_gate, d_route_up,
+                                         routes, /*n_experts=*/routes,
+                                         dim, moe_inter)) {
+        throw std::runtime_error("q2 w13 iq2_xxs failed");
+    }
+    if (!q2_route_swiglu_quantize_hidden_q8_1_cuda(
+            d_route_gate, d_route_up, d_route_weights,
+            d_route_hidden_q, d_route_hidden_scale,
+            routes, moe_inter, swiglu_limit)) {
+        throw std::runtime_error("q2 swiglu + quantize failed");
+    }
+    if (!q2_moe_single_w2_q2k_cuda(d_route_hidden_q, d_route_hidden_scale,
+                                    d_route_slots, d_routed_w2, d_moe_out,
+                                    routes, /*n_experts=*/routes,
+                                    dim, moe_inter)) {
+        throw std::runtime_error("q2 w2 q2k failed");
+    }
+
+    // 8. FFN combined: d_ffn_combined = d_shared_out + d_moe_out.
+    if (!vector_add_cuda(d_shared_out, d_moe_out, d_ffn_combined, dim)) {
+        throw std::runtime_error("ffn combined add failed");
+    }
+    // 9. FFN residual: d_x = d_x_pre_ffn + d_ffn_combined.
+    if (!vector_add_cuda(d_x_pre_ffn, d_ffn_combined, d_x, dim)) {
+        throw std::runtime_error("ffn residual add failed");
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync after layer-0 forward");
+
+    GgufLayer0FullResult r;
+    r.dim = dim;
+    r.moe_inter_dim = moe_inter;
+    r.heads = heads;
+    r.head_dim = head_dim;
+    r.n_active = topk;
+    for (int k = 0; k < topk; ++k) r.expert_ids[k] = h_expert_ids[k];
+    r.embed_rms = device_vector_rms(d_x_pre_attn, dim);
+    r.attn_out_rms = device_vector_rms(d_attn_out, dim);
+    // Reuse d_x_normed as scratch — overwrite ok, we're done with it.
+    r.x_post_attn_rms = device_vector_rms(d_x_pre_ffn, dim);
+    r.shared_out_rms = device_vector_rms(d_shared_out, dim);
+    r.moe_out_rms = device_vector_rms(d_moe_out, dim);
+    r.ffn_combined_rms = device_vector_rms(d_ffn_combined, dim);
+    r.x_post_ffn_rms = device_vector_rms(d_x, dim);
+    std::vector<float> first(4);
+    check_cuda(cudaMemcpy(first.data(), d_x, 4 * sizeof(float),
+                          cudaMemcpyDeviceToHost), "copy x_post_ffn first");
+    for (int i = 0; i < 4; ++i) r.x_post_ffn_first[i] = first[i];
+    std::vector<float> h_rw(topk);
+    check_cuda(cudaMemcpy(h_rw.data(), d_route_weights, topk * sizeof(float),
+                          cudaMemcpyDeviceToHost), "copy route_weights");
+    float sum = 0.0f;
+    for (int k = 0; k < topk; ++k) sum += h_rw[k];
+    r.route_weights_sum = sum;
+
+    cudaFree(d_row_f16);
+    cudaFree(d_attn_gamma);
+    cudaFree(d_q_gamma);
+    cudaFree(d_kv_gamma);
+    cudaFree(d_ffn_gamma);
+    cudaFree(d_wq_a);
+    cudaFree(d_wq_b);
+    cudaFree(d_wkv);
+    cudaFree(d_wo_a);
+    cudaFree(d_wo_b);
+    cudaFree(d_attn_sink);
+    cudaFree(d_shared_w1);
+    cudaFree(d_shared_w2);
+    cudaFree(d_shared_w3);
+    cudaFree(d_gate_w_bf16);
+    cudaFree(d_routed_w1);
+    cudaFree(d_routed_w2);
+    cudaFree(d_routed_w3);
+    cudaFree(d_tid2eid_i64);
+    cudaFree(d_gate_scores_scratch);
+    cudaFree(d_gate_indices);
+    cudaFree(d_x);
+    cudaFree(d_x_pre_attn);
+    cudaFree(d_x_normed);
+    cudaFree(d_q_a);
+    cudaFree(d_q_normed);
+    cudaFree(d_q);
+    cudaFree(d_kv_a);
+    cudaFree(d_kv);
+    cudaFree(d_attn_value);
+    cudaFree(d_attn_mid);
+    cudaFree(d_attn_out);
+    cudaFree(d_x_pre_ffn);
+    cudaFree(d_x_normed_ffn);
+    cudaFree(d_shared_gate);
+    cudaFree(d_shared_up);
+    cudaFree(d_shared_hidden);
+    cudaFree(d_shared_out);
+    cudaFree(d_moe_out);
+    cudaFree(d_ffn_combined);
+    cudaFree(d_x_q);
+    cudaFree(d_x_scale);
+    cudaFree(d_route_slots);
+    cudaFree(d_route_weights);
+    cudaFree(d_route_gate);
+    cudaFree(d_route_up);
+    cudaFree(d_route_hidden_q);
+    cudaFree(d_route_hidden_scale);
+    return r;
+}
+
 // --- PersistentEngine implementation ---------------------------------------
 
 struct PersistentEngine::State {

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -3604,6 +3604,13 @@ struct GgufLayerScratch {
     float* d_gate_scores_scratch = nullptr; // hash:[topk]; non-hash:[n_experts]
     float* d_gate_scored_scratch = nullptr; // non-hash only: [n_experts]
     int64_t* d_gate_indices = nullptr;    // [topk]
+    // Per-layer KV cache [cache_capacity, head_dim] float. If non-null, the
+    // attention helper writes the current step's kv_norm into slot `position`
+    // and runs cached_single_token_attention on the [0..cache_len) prefix.
+    // If null, falls back to single_token_sparse_attention on d_kv only
+    // (legacy path used by the layer-0 smoke).
+    float* d_kv_cache = nullptr;
+    int cache_capacity = 0;
 };
 
 // Phase 1: attention residual + ffn_norm + shared expert + gate scoring.
@@ -3636,9 +3643,23 @@ void gguf_layer_forward_attn_to_gate(const GgufLayerDeviceWeights& w,
                                 d.rope_theta, false, 0.0f))
         throw std::runtime_error("kv head rope failed");
     const float scale = 1.0f / std::sqrt(static_cast<float>(d.head_dim));
-    if (!single_token_sparse_attention_cuda(s.d_q, s.d_kv, w.d_attn_sink,
-                                            s.d_attn_value, d.heads, d.head_dim, scale))
-        throw std::runtime_error("sparse_attention failed");
+    if (s.d_kv_cache != nullptr) {
+        if (position < 0 || position >= s.cache_capacity)
+            throw std::runtime_error("position out of KV cache capacity");
+        // Write current step's MLA latent K/V into the per-layer cache at slot
+        // `position`, then run cached attention over [0..position] + attn_sink.
+        check_cuda(cudaMemcpy(s.d_kv_cache + static_cast<size_t>(position) * d.kv_dim,
+                              s.d_kv, static_cast<size_t>(d.kv_dim) * sizeof(float),
+                              cudaMemcpyDeviceToDevice), "write kv to cache");
+        if (!cached_single_token_attention_cuda(s.d_q, s.d_kv_cache, w.d_attn_sink,
+                                                s.d_attn_value, d.heads, d.head_dim,
+                                                position + 1, scale))
+            throw std::runtime_error("cached attention failed");
+    } else {
+        if (!single_token_sparse_attention_cuda(s.d_q, s.d_kv, w.d_attn_sink,
+                                                s.d_attn_value, d.heads, d.head_dim, scale))
+            throw std::runtime_error("sparse_attention failed");
+    }
     if (!head_rmsnorm_rope_cuda(s.d_attn_value, d.heads, d.head_dim, d.rope_dim,
                                 position, d.rope_theta, /*inverse=*/true, 0.0f))
         throw std::runtime_error("inverse rope failed");
@@ -5530,6 +5551,24 @@ GgufFullForwardResult run_gguf_full_forward_smoke(const std::string& ckpt_path,
     check_cuda(cudaMalloc(&d_routed_w2, per_w2_bytes * topk), "alloc routed_w2");
     check_cuda(cudaMalloc(&d_routed_w3, per_w3_bytes * topk), "alloc routed_w3");
 
+    // ===== per-layer KV cache buffers (sized for this smoke's single step) =====
+    // Cache capacity = position + 1: enough to write the current step's KV into
+    // slot `position` and run cached attention over [0..position]. At
+    // position=0 this is equivalent to the legacy single_token_sparse_attention
+    // path and exercises the cached_single_token_attention helper end-to-end.
+    const int cache_capacity = position + 1;
+    std::vector<float*> d_kv_cache(n_layers, nullptr);
+    for (int L = 0; L < n_layers; ++L) {
+        check_cuda(cudaMalloc(&d_kv_cache[L],
+                              static_cast<size_t>(cache_capacity) *
+                                  static_cast<size_t>(kv_dim) * sizeof(float)),
+                   "alloc d_kv_cache");
+        check_cuda(cudaMemset(d_kv_cache[L], 0,
+                              static_cast<size_t>(cache_capacity) *
+                                  static_cast<size_t>(kv_dim) * sizeof(float)),
+                   "memset d_kv_cache");
+    }
+
     // ===== activation + scratch buffers (allocated once, reused per layer) =====
     const int x_groups = (dim + 31) / 32;
     const int hidden_groups = (moe_inter + 15) / 16;
@@ -5668,6 +5707,9 @@ GgufFullForwardResult run_gguf_full_forward_smoke(const std::string& ckpt_path,
         lw.is_hash = is_hash;
         lw.d_routed_w1 = d_routed_w1; lw.d_routed_w2 = d_routed_w2; lw.d_routed_w3 = d_routed_w3;
 
+        ls.d_kv_cache = d_kv_cache[L];
+        ls.cache_capacity = cache_capacity;
+
         if (is_hash) {
             // Upload per-token tid2eid row, converted to int64 (kernel expects i64).
             const int32_t* row = h_tid2eid_table[L] + static_cast<size_t>(token) * topk;
@@ -5759,6 +5801,7 @@ GgufFullForwardResult run_gguf_full_forward_smoke(const std::string& ckpt_path,
     free_vec_u16(d_gate_w); free_vec_f32(d_gate_bias);
     cudaFree(d_final_norm_gamma); cudaFree(d_head);
     cudaFree(d_routed_w1); cudaFree(d_routed_w2); cudaFree(d_routed_w3);
+    free_vec_f32(d_kv_cache);
     cudaFree(d_x); cudaFree(d_x_pre_attn); cudaFree(d_x_normed);
     cudaFree(d_q_a); cudaFree(d_q_normed); cudaFree(d_q);
     cudaFree(d_kv_a); cudaFree(d_kv); cudaFree(d_attn_value);

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -6180,6 +6180,22 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
     check_cuda(cudaMalloc(&d_embed_row_f16, dim * sizeof(uint16_t)), "alloc d_embed_row_f16");
     check_cuda(cudaMalloc(&d_logits, local_vocab * sizeof(float)), "alloc d_logits");
 
+    // Dedicated copy stream for staging (H2D for routed Q2 experts). Currently
+    // neutral in wall-time (staging is on the critical path between gate D2H
+    // and MoE compute; nothing on default stream can overlap with it within a
+    // layer) but kept so future cross-step prefetch can issue early stages on
+    // copy_stream while the prior step's MoE drains on default.
+    const bool moe_copy_stream_enabled =
+        env_int_or_default("DSV4_GGUF_MOE_COPY_STREAM", 1) != 0;
+    cudaStream_t gguf_moe_copy_stream = nullptr;
+    cudaEvent_t gguf_moe_stage_event = nullptr;
+    if (moe_copy_stream_enabled) {
+        check_cuda(cudaStreamCreateWithFlags(&gguf_moe_copy_stream, cudaStreamNonBlocking),
+                   "create gguf moe copy stream");
+        check_cuda(cudaEventCreateWithFlags(&gguf_moe_stage_event, cudaEventDisableTiming),
+                   "create gguf moe stage event");
+    }
+
 #ifdef DSV4_HAVE_NCCL
     BF16AllReduceScratch bf16_reduce_scratch;
 #endif
@@ -6225,10 +6241,19 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
     auto t_load_end = std::chrono::steady_clock::now();
 
     // ===== per-step forward (embed + 43 layers + final norm + head + argmax) =====
+    const bool profile_gguf = env_int_or_default("DSV4_GGUF_PROFILE", 0) != 0;
+    double prof_attn_ms = 0.0, prof_stage_ms = 0.0, prof_moe_ms = 0.0;
+    double prof_embed_ms = 0.0, prof_head_ms = 0.0;
+    int prof_steps = 0;
+    auto sync_now = [&]() {
+        if (profile_gguf) check_cuda(cudaDeviceSynchronize(), "profile sync");
+        return std::chrono::steady_clock::now();
+    };
     std::vector<int64_t> h_gate_indices(topk);
     std::vector<int64_t> h_route_slots(topk);
     std::vector<float> h_logits(local_vocab);
     auto run_step = [&](int token, int position) -> std::pair<int, float> {
+        auto t_embed_start = sync_now();
         const uint16_t* host_embed_row =
             reinterpret_cast<const uint16_t*>(embed.data) +
             static_cast<size_t>(token) * dim;
@@ -6236,7 +6261,10 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
                               cudaMemcpyHostToDevice), "copy embed row");
         if (!f16_row_to_float_cuda(d_embed_row_f16, d_x, /*row=*/0, dim))
             throw std::runtime_error("f16 embed failed");
+        auto t_embed_end = sync_now();
+        if (profile_gguf) prof_embed_ms += elapsed_ms(t_embed_start, t_embed_end);
         for (int L = 0; L < n_layers; ++L) {
+            auto t_layer_start = sync_now();
             const bool is_hash = (L < n_hash);
             GgufLayerDeviceWeights lw;
             lw.d_attn_gamma = d_attn_gamma[L]; lw.d_q_gamma = d_q_gamma[L]; lw.d_kv_gamma = d_kv_gamma[L];
@@ -6264,6 +6292,8 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
             gguf_layer_forward_attn_to_gate(lw, ls, ld, position, reduce_ctx_ptr);
             check_cuda(cudaMemcpy(h_gate_indices.data(), d_gate_indices, topk * sizeof(int64_t),
                                   cudaMemcpyDeviceToHost), "copy gate indices");
+            auto t_attn_end = std::chrono::steady_clock::now();
+            if (profile_gguf) prof_attn_ms += elapsed_ms(t_layer_start, t_attn_end);
             const std::string lp = "layers." + std::to_string(L);
             const std::string w1_name = lp + ".ffn.experts.routed.w1";
             const std::string w2_name = lp + ".ffn.experts.routed.w2";
@@ -6281,18 +6311,29 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
                 if (!wv1.found || !wv2.found || !wv3.found)
                     throw std::runtime_error("get_expert failed during decode staging");
                 check_cuda(cudaMemcpyAsync(d_routed_w1 + per_w1_bytes * k, wv1.data, per_w1_bytes,
-                                      cudaMemcpyHostToDevice, 0), "stage routed_w1");
+                                      cudaMemcpyHostToDevice, gguf_moe_copy_stream), "stage routed_w1");
                 check_cuda(cudaMemcpyAsync(d_routed_w2 + per_w2_bytes * k, wv2.data, per_w2_bytes,
-                                      cudaMemcpyHostToDevice, 0), "stage routed_w2");
+                                      cudaMemcpyHostToDevice, gguf_moe_copy_stream), "stage routed_w2");
                 check_cuda(cudaMemcpyAsync(d_routed_w3 + per_w3_bytes * k, wv3.data, per_w3_bytes,
-                                      cudaMemcpyHostToDevice, 0), "stage routed_w3");
+                                      cudaMemcpyHostToDevice, gguf_moe_copy_stream), "stage routed_w3");
             }
             check_cuda(cudaMemcpyAsync(d_route_slots, h_route_slots.data(),
                                        topk * sizeof(int64_t),
-                                       cudaMemcpyHostToDevice, 0),
+                                       cudaMemcpyHostToDevice, gguf_moe_copy_stream),
                        "copy d_route_slots");
+            if (moe_copy_stream_enabled) {
+                check_cuda(cudaEventRecord(gguf_moe_stage_event, gguf_moe_copy_stream),
+                           "record gguf moe stage event");
+                check_cuda(cudaStreamWaitEvent(nullptr, gguf_moe_stage_event, 0),
+                           "default stream wait stage event");
+            }
+            auto t_stage_end = sync_now();
+            if (profile_gguf) prof_stage_ms += elapsed_ms(t_attn_end, t_stage_end);
             gguf_layer_forward_moe(lw, ls, ld, reduce_ctx_ptr);
+            auto t_moe_end = sync_now();
+            if (profile_gguf) prof_moe_ms += elapsed_ms(t_stage_end, t_moe_end);
         }
+        auto t_head_start = sync_now();
         if (!rmsnorm_bf16_gamma_cuda(d_x, d_final_norm_gamma, d_x_normed, dim, 1e-6f))
             throw std::runtime_error("final norm failed");
         if (!q8_0_matvec_cuda(d_x_normed, d_head, d_logits, local_vocab, dim))
@@ -6316,6 +6357,11 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
             top_l = global.logit;
         }
 #endif
+        if (profile_gguf) {
+            auto t_head_end = std::chrono::steady_clock::now();
+            prof_head_ms += elapsed_ms(t_head_start, t_head_end);
+            ++prof_steps;
+        }
         return {top_t, top_l};
     };
 
@@ -6348,6 +6394,18 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
     r.load_seconds = std::chrono::duration<double>(t_load_end - t_load_start).count();
     r.forward_seconds = std::chrono::duration<double>(t_forward_end - t_forward_start).count();
 
+    if (profile_gguf && prof_steps > 0 && tp_rank == 0) {
+        const double inv = 1.0 / static_cast<double>(prof_steps);
+        const double per_layer_attn = prof_attn_ms * inv / static_cast<double>(n_layers);
+        const double per_layer_stage = prof_stage_ms * inv / static_cast<double>(n_layers);
+        const double per_layer_moe = prof_moe_ms * inv / static_cast<double>(n_layers);
+        const double per_step_total = (prof_embed_ms + prof_attn_ms + prof_stage_ms + prof_moe_ms + prof_head_ms) * inv;
+        std::printf("[gguf_profile steps=%d n_layers=%d] per_step: embed=%.2f attn+gate=%.2f stage=%.2f moe=%.2f head=%.2f total=%.2f ms; per_layer: attn+gate=%.3f stage=%.3f moe=%.3f ms\n",
+                    prof_steps, n_layers,
+                    prof_embed_ms * inv, prof_attn_ms * inv, prof_stage_ms * inv, prof_moe_ms * inv, prof_head_ms * inv,
+                    per_step_total, per_layer_attn, per_layer_stage, per_layer_moe);
+    }
+
     // ===== cleanup =====
     auto free_vec_u8 = [](std::vector<uint8_t*>& v) { for (auto* p : v) cudaFree(p); };
     auto free_vec_u16 = [](std::vector<uint16_t*>& v) { for (auto* p : v) cudaFree(p); };
@@ -6374,6 +6432,10 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
     cudaFree(d_route_hidden_q); cudaFree(d_route_hidden_scale);
     cudaFree(d_gate_scores_scratch); cudaFree(d_gate_scored_scratch); cudaFree(d_gate_indices);
     cudaFree(d_tid2eid_i64); cudaFree(d_embed_row_f16); cudaFree(d_logits);
+    if (moe_copy_stream_enabled) {
+        cudaEventDestroy(gguf_moe_stage_event);
+        cudaStreamDestroy(gguf_moe_copy_stream);
+    }
     if (gguf_registered) cudaHostUnregister(gguf_base);
     return r;
 }

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -3448,6 +3448,130 @@ GgufSmokeResult run_gguf_min_layer_smoke(const std::string& ckpt_path) {
     return r;
 }
 
+namespace {
+
+// Convert host F32 array to BF16 by truncating the low 16 bits of the IEEE
+// 754 binary32 representation. Matches the round-down-to-bf16 convention
+// used by the safetensors loader's BF16 norm gammas, so the GGUF F32-gamma
+// path produces RMSNorm output bit-equivalent to a BF16-gamma checkpoint.
+std::vector<uint16_t> f32_to_bf16_host(const float* src, size_t n) {
+    std::vector<uint16_t> out(n);
+    for (size_t i = 0; i < n; ++i) {
+        uint32_t bits;
+        std::memcpy(&bits, &src[i], sizeof(bits));
+        out[i] = static_cast<uint16_t>(bits >> 16);
+    }
+    return out;
+}
+
+float device_vector_rms(const float* d_x, int n) {
+    std::vector<float> h(n);
+    check_cuda(cudaMemcpy(h.data(), d_x, n * sizeof(float), cudaMemcpyDeviceToHost),
+               "device_vector_rms memcpy");
+    double s = 0.0;
+    for (float v : h) s += static_cast<double>(v) * static_cast<double>(v);
+    return n > 0 ? static_cast<float>(std::sqrt(s / n)) : 0.0f;
+}
+
+}  // namespace
+
+GgufAttnNormWqaResult run_gguf_attn_norm_wq_a_smoke(const std::string& ckpt_path, int token) {
+    if (!is_gguf_path(ckpt_path)) {
+        throw std::runtime_error("run_gguf_attn_norm_wq_a_smoke: not a GGUF path: " + ckpt_path);
+    }
+    if (token < 0) {
+        throw std::runtime_error("run_gguf_attn_norm_wq_a_smoke: token must be >= 0");
+    }
+    GgufForwardContext ctx(ckpt_path);
+    WeightSource& ws = *ctx.weight_source;
+
+    WeightView embed = ws.require("embed.weight");
+    WeightView attn_norm = ws.require("layers.0.attn_norm.weight");
+    WeightView wq_a = ws.require("layers.0.attn.wq_a.weight");
+
+    if (embed.dtype != DType::F16 || embed.shape.size() != 2) {
+        throw std::runtime_error("embed.weight is not 2D F16");
+    }
+    if (attn_norm.dtype != DType::F32 || attn_norm.shape.size() != 1) {
+        throw std::runtime_error("layers.0.attn_norm.weight is not 1D F32");
+    }
+    if (wq_a.dtype != DType::Q8_0 || wq_a.shape.size() != 2) {
+        throw std::runtime_error("layers.0.attn.wq_a.weight is not 2D Q8_0");
+    }
+
+    const int dim = static_cast<int>(embed.shape[0]);
+    const int vocab = static_cast<int>(embed.shape[1]);
+    if (token >= vocab) throw std::runtime_error("token id out of vocab range");
+    if (static_cast<int>(attn_norm.shape[0]) != dim) {
+        throw std::runtime_error("attn_norm shape mismatch with dim");
+    }
+    // GGUF wq_a shape [cols=dim, rows=q_a_dim] with cols fastest varying.
+    if (static_cast<int>(wq_a.shape[0]) != dim) {
+        throw std::runtime_error("wq_a inner dim != dim");
+    }
+    const int q_a_dim = static_cast<int>(wq_a.shape[1]);
+
+    // 1. Upload one token's F16 embedding row and dequantize to fp32.
+    const uint16_t* host_embed_row =
+        reinterpret_cast<const uint16_t*>(embed.data) +
+        static_cast<size_t>(token) * dim;
+    uint16_t* d_row_f16 = nullptr;
+    float* d_x = nullptr;
+    check_cuda(cudaMalloc(&d_row_f16, dim * sizeof(uint16_t)), "alloc d_row_f16");
+    check_cuda(cudaMalloc(&d_x, dim * sizeof(float)), "alloc d_x");
+    check_cuda(cudaMemcpy(d_row_f16, host_embed_row, dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy embed row");
+    if (!f16_row_to_float_cuda(d_row_f16, d_x, /*row=*/0, dim)) {
+        throw std::runtime_error("f16_row_to_float_cuda failed");
+    }
+
+    // 2. Convert attn_norm F32 gamma to BF16 (host-side) and upload.
+    auto bf16 = f32_to_bf16_host(reinterpret_cast<const float*>(attn_norm.data), dim);
+    uint16_t* d_attn_gamma = nullptr;
+    check_cuda(cudaMalloc(&d_attn_gamma, dim * sizeof(uint16_t)), "alloc d_attn_gamma");
+    check_cuda(cudaMemcpy(d_attn_gamma, bf16.data(), dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy attn_norm gamma");
+
+    // 3. RMSNorm.
+    float* d_x_normed = nullptr;
+    check_cuda(cudaMalloc(&d_x_normed, dim * sizeof(float)), "alloc d_x_normed");
+    if (!rmsnorm_bf16_gamma_cuda(d_x, d_attn_gamma, d_x_normed, dim, 1e-6f)) {
+        throw std::runtime_error("rmsnorm_bf16_gamma_cuda failed");
+    }
+
+    // 4. Upload wq_a Q8_0 blocks and run matvec.
+    uint8_t* d_wq_a = nullptr;
+    check_cuda(cudaMalloc(&d_wq_a, wq_a.nbytes), "alloc d_wq_a");
+    check_cuda(cudaMemcpy(d_wq_a, wq_a.data, wq_a.nbytes, cudaMemcpyHostToDevice),
+               "copy wq_a");
+    float* d_q_a = nullptr;
+    check_cuda(cudaMalloc(&d_q_a, q_a_dim * sizeof(float)), "alloc d_q_a");
+    if (!q8_0_matvec_cuda(d_x_normed, d_wq_a, d_q_a, q_a_dim, dim)) {
+        throw std::runtime_error("q8_0_matvec_cuda failed");
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync after wq_a");
+
+    // 5. Collect diagnostics.
+    GgufAttnNormWqaResult r;
+    r.dim = dim;
+    r.q_a_dim = q_a_dim;
+    r.embed_rms = device_vector_rms(d_x, dim);
+    r.normed_rms = device_vector_rms(d_x_normed, dim);
+    r.q_a_rms = device_vector_rms(d_q_a, q_a_dim);
+    std::vector<float> first(4);
+    check_cuda(cudaMemcpy(first.data(), d_q_a, 4 * sizeof(float),
+                          cudaMemcpyDeviceToHost), "copy q_a first");
+    for (int i = 0; i < 4; ++i) r.q_a_first[i] = first[i];
+
+    cudaFree(d_row_f16);
+    cudaFree(d_x);
+    cudaFree(d_attn_gamma);
+    cudaFree(d_x_normed);
+    cudaFree(d_wq_a);
+    cudaFree(d_q_a);
+    return r;
+}
+
 // --- PersistentEngine implementation ---------------------------------------
 
 struct PersistentEngine::State {

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -3406,6 +3406,48 @@ ForwardSmokeResult run_safetensors_token_forward_with_options(const std::string&
     return run_safetensors_token_forward_impl(ctx, token, layer_count, position);
 }
 
+// --- GGUF Q2 forward path (Phase 3, work in progress) ---------------------
+
+namespace {
+
+// Parallels SafeForwardContext for the GGUF Q2 path. Currently a minimal
+// shell that owns the GGUF mmap + WeightSource + ModelConfig; per-layer
+// caches and forward state will be added as dense/MoE operators are wired
+// in. Lives in the anonymous namespace because external callers go through
+// the run_gguf_* entry points.
+struct GgufForwardContext {
+    std::string ckpt_path;
+    std::unique_ptr<GGUFWeightSource> weight_source;
+    ModelConfig config;
+
+    explicit GgufForwardContext(const std::string& path)
+        : ckpt_path(path),
+          weight_source(std::make_unique<GGUFWeightSource>(path)),
+          config(ModelConfig::from_gguf(weight_source->file())) {}
+};
+
+}  // namespace
+
+GgufSmokeResult run_gguf_min_layer_smoke(const std::string& ckpt_path) {
+    if (!is_gguf_path(ckpt_path)) {
+        throw std::runtime_error("run_gguf_min_layer_smoke: not a GGUF path: " + ckpt_path);
+    }
+    GgufForwardContext ctx(ckpt_path);
+    WeightView embed = ctx.weight_source->require("embed.weight");
+    if (embed.shape.size() != 2) {
+        throw std::runtime_error("gguf embed.weight rank != 2");
+    }
+    GgufSmokeResult r;
+    r.n_layers = static_cast<int>(ctx.config.n_layers);
+    r.n_hash_layers = static_cast<int>(ctx.config.n_hash_layers);
+    r.dim = static_cast<int>(ctx.config.dim);
+    r.moe_inter_dim = static_cast<int>(ctx.config.moe_inter_dim);
+    r.n_routed_experts = static_cast<int>(ctx.config.n_routed_experts);
+    r.n_activated_experts = static_cast<int>(ctx.config.n_activated_experts);
+    r.vocab = static_cast<int>(embed.shape[1]);
+    return r;
+}
+
 // --- PersistentEngine implementation ---------------------------------------
 
 struct PersistentEngine::State {

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -4210,6 +4210,188 @@ GgufSharedExpertResult run_gguf_shared_expert_smoke(const std::string& ckpt_path
     return r;
 }
 
+GgufRoutedExpertResult run_gguf_routed_expert_smoke(const std::string& ckpt_path,
+                                                     int token,
+                                                     int expert_id) {
+    if (!is_gguf_path(ckpt_path)) {
+        throw std::runtime_error("run_gguf_routed_expert_smoke: not a GGUF path: " + ckpt_path);
+    }
+    if (token < 0) throw std::runtime_error("token must be >= 0");
+    if (expert_id < 0) throw std::runtime_error("expert_id must be >= 0");
+
+    GgufForwardContext ctx(ckpt_path);
+    GGUFWeightSource& gws = *ctx.weight_source;
+
+    WeightView embed = gws.require("embed.weight");
+    WeightView ffn_norm = gws.require("layers.0.ffn_norm.weight");
+    // Per-expert slices from the routed 3D tensors. expert_id must be
+    // < n_routed_experts; the GGUFWeightSource computes the byte offset by
+    // dividing the total tensor bytes by n_experts.
+    WeightView w1 = gws.get_expert("layers.0.ffn.experts.routed.w1",
+                                    "layers.0.ffn.experts.routed.w1", expert_id);
+    WeightView w2 = gws.get_expert("layers.0.ffn.experts.routed.w2",
+                                    "layers.0.ffn.experts.routed.w2", expert_id);
+    WeightView w3 = gws.get_expert("layers.0.ffn.experts.routed.w3",
+                                    "layers.0.ffn.experts.routed.w3", expert_id);
+
+    if (!w1.found || !w2.found || !w3.found) {
+        throw std::runtime_error("routed expert slice not found (check expert_id)");
+    }
+    if (embed.dtype != DType::F16) throw std::runtime_error("embed dtype");
+    if (ffn_norm.dtype != DType::F32) throw std::runtime_error("ffn_norm dtype");
+    if (w1.dtype != DType::IQ2_XXS || w3.dtype != DType::IQ2_XXS) {
+        throw std::runtime_error("routed w1/w3 must be IQ2_XXS");
+    }
+    if (w2.dtype != DType::Q2_K) {
+        throw std::runtime_error("routed w2 must be Q2_K");
+    }
+
+    const int dim = static_cast<int>(embed.shape[0]);
+    const int moe_inter = static_cast<int>(ctx.config.moe_inter_dim);
+    if (dim <= 0 || moe_inter <= 0) {
+        throw std::runtime_error("invalid dim / moe_inter");
+    }
+
+    // ----- Embed → ffn_norm -----
+    const uint16_t* host_row =
+        reinterpret_cast<const uint16_t*>(embed.data) +
+        static_cast<size_t>(token) * dim;
+    uint16_t* d_row_f16 = nullptr;
+    float* d_x = nullptr;
+    check_cuda(cudaMalloc(&d_row_f16, dim * sizeof(uint16_t)), "alloc d_row_f16");
+    check_cuda(cudaMalloc(&d_x, dim * sizeof(float)), "alloc d_x");
+    check_cuda(cudaMemcpy(d_row_f16, host_row, dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy embed row");
+    if (!f16_row_to_float_cuda(d_row_f16, d_x, /*row=*/0, dim)) {
+        throw std::runtime_error("f16 embed failed");
+    }
+
+    auto ffn_bf16 = f32_to_bf16_host(reinterpret_cast<const float*>(ffn_norm.data), dim);
+    uint16_t* d_ffn_gamma = nullptr;
+    check_cuda(cudaMalloc(&d_ffn_gamma, dim * sizeof(uint16_t)), "alloc d_ffn_gamma");
+    check_cuda(cudaMemcpy(d_ffn_gamma, ffn_bf16.data(), dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy ffn_gamma");
+    float* d_x_normed = nullptr;
+    check_cuda(cudaMalloc(&d_x_normed, dim * sizeof(float)), "alloc d_x_normed");
+    if (!rmsnorm_bf16_gamma_cuda(d_x, d_ffn_gamma, d_x_normed, dim, 1e-6f)) {
+        throw std::runtime_error("ffn_norm failed");
+    }
+
+    // ----- Routed Q2 expert chain -----
+    // Single route, single-expert buffer view (n_experts=1 + slot=0).
+    const int routes = 1;
+    const int x_groups = (dim + 31) / 32;
+    const int hidden_groups = (moe_inter + 15) / 16;
+    const int64_t h_route_slot = 0;
+    const float h_route_weight = 1.0f;
+
+    int8_t* d_x_q = nullptr;
+    float* d_x_scale = nullptr;
+    uint8_t* d_w1 = nullptr;
+    uint8_t* d_w2 = nullptr;
+    uint8_t* d_w3 = nullptr;
+    int64_t* d_route_slots = nullptr;
+    float* d_route_weights = nullptr;
+    float* d_gate = nullptr;
+    float* d_up = nullptr;
+    int8_t* d_hidden_q = nullptr;
+    float* d_hidden_scale = nullptr;
+    float* d_y = nullptr;
+
+    check_cuda(cudaMalloc(&d_x_q, dim), "alloc d_x_q");
+    check_cuda(cudaMalloc(&d_x_scale, x_groups * sizeof(float)), "alloc d_x_scale");
+    check_cuda(cudaMalloc(&d_w1, w1.nbytes), "alloc d_w1");
+    check_cuda(cudaMalloc(&d_w2, w2.nbytes), "alloc d_w2");
+    check_cuda(cudaMalloc(&d_w3, w3.nbytes), "alloc d_w3");
+    check_cuda(cudaMalloc(&d_route_slots, sizeof(int64_t)), "alloc d_route_slots");
+    check_cuda(cudaMalloc(&d_route_weights, sizeof(float)), "alloc d_route_weights");
+    check_cuda(cudaMalloc(&d_gate, moe_inter * sizeof(float)), "alloc d_gate");
+    check_cuda(cudaMalloc(&d_up, moe_inter * sizeof(float)), "alloc d_up");
+    check_cuda(cudaMalloc(&d_hidden_q, moe_inter), "alloc d_hidden_q");
+    check_cuda(cudaMalloc(&d_hidden_scale, hidden_groups * sizeof(float)),
+               "alloc d_hidden_scale");
+    check_cuda(cudaMalloc(&d_y, dim * sizeof(float)), "alloc d_y");
+
+    check_cuda(cudaMemcpy(d_w1, w1.data, w1.nbytes, cudaMemcpyHostToDevice), "copy w1");
+    check_cuda(cudaMemcpy(d_w2, w2.data, w2.nbytes, cudaMemcpyHostToDevice), "copy w2");
+    check_cuda(cudaMemcpy(d_w3, w3.data, w3.nbytes, cudaMemcpyHostToDevice), "copy w3");
+    check_cuda(cudaMemcpy(d_route_slots, &h_route_slot, sizeof(int64_t),
+                          cudaMemcpyHostToDevice), "copy route_slots");
+    check_cuda(cudaMemcpy(d_route_weights, &h_route_weight, sizeof(float),
+                          cudaMemcpyHostToDevice), "copy route_weights");
+    check_cuda(cudaMemset(d_y, 0, dim * sizeof(float)), "zero d_y");
+
+    if (!q2_quantize_x_q8_1_cuda(d_x_normed, d_x_q, d_x_scale, routes, dim)) {
+        throw std::runtime_error("q2_quantize_x_q8_1 failed");
+    }
+    const int kernel_n_experts = 1;
+    if (!q2_moe_single_w13_iq2_xxs_cuda(d_x_q, d_x_scale, d_route_slots,
+                                         d_w1, d_w3, d_gate, d_up,
+                                         routes, kernel_n_experts, dim, moe_inter)) {
+        throw std::runtime_error("q2 w13 iq2_xxs failed");
+    }
+    const float swiglu_limit = static_cast<float>(ctx.config.swiglu_limit);
+    if (!q2_route_swiglu_quantize_hidden_q8_1_cuda(d_gate, d_up, d_route_weights,
+                                                   d_hidden_q, d_hidden_scale,
+                                                   routes, moe_inter, swiglu_limit)) {
+        throw std::runtime_error("q2 swiglu + quantize failed");
+    }
+    if (!q2_moe_single_w2_q2k_cuda(d_hidden_q, d_hidden_scale, d_route_slots,
+                                    d_w2, d_y, routes, kernel_n_experts,
+                                    dim, moe_inter)) {
+        throw std::runtime_error("q2 w2 q2k failed");
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync after routed expert");
+
+    GgufRoutedExpertResult r;
+    r.dim = dim;
+    r.moe_inter_dim = moe_inter;
+    r.expert_id = expert_id;
+    r.ffn_normed_rms = device_vector_rms(d_x_normed, dim);
+    r.gate_rms = device_vector_rms(d_gate, moe_inter);
+    r.up_rms = device_vector_rms(d_up, moe_inter);
+    // Reconstruct hidden RMS from the Q8_1 representation: hidden_q is int8
+    // grouped by 16 with per-group fp32 scale (`hidden_scale`). RMS of the
+    // dequantized hidden = sqrt(mean(sum_g hidden_q[g] * scale[g])^2 / N).
+    {
+        std::vector<int8_t> hq(moe_inter);
+        std::vector<float> hs(hidden_groups);
+        check_cuda(cudaMemcpy(hq.data(), d_hidden_q, moe_inter, cudaMemcpyDeviceToHost),
+                   "copy hidden_q");
+        check_cuda(cudaMemcpy(hs.data(), d_hidden_scale, hidden_groups * sizeof(float),
+                              cudaMemcpyDeviceToHost), "copy hidden_scale");
+        double s = 0.0;
+        for (int i = 0; i < moe_inter; ++i) {
+            const float v = static_cast<float>(hq[i]) * hs[i / 16];
+            s += static_cast<double>(v) * static_cast<double>(v);
+        }
+        r.hidden_rms = static_cast<float>(std::sqrt(s / moe_inter));
+    }
+    r.route_out_rms = device_vector_rms(d_y, dim);
+    std::vector<float> first(4);
+    check_cuda(cudaMemcpy(first.data(), d_y, 4 * sizeof(float),
+                          cudaMemcpyDeviceToHost), "copy route_out first");
+    for (int i = 0; i < 4; ++i) r.route_out_first[i] = first[i];
+
+    cudaFree(d_row_f16);
+    cudaFree(d_x);
+    cudaFree(d_ffn_gamma);
+    cudaFree(d_x_normed);
+    cudaFree(d_x_q);
+    cudaFree(d_x_scale);
+    cudaFree(d_w1);
+    cudaFree(d_w2);
+    cudaFree(d_w3);
+    cudaFree(d_route_slots);
+    cudaFree(d_route_weights);
+    cudaFree(d_gate);
+    cudaFree(d_up);
+    cudaFree(d_hidden_q);
+    cudaFree(d_hidden_scale);
+    cudaFree(d_y);
+    return r;
+}
+
 // --- PersistentEngine implementation ---------------------------------------
 
 struct PersistentEngine::State {

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -6277,6 +6277,11 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
             lw.is_hash = is_hash;
             lw.d_routed_w1 = d_routed_w1; lw.d_routed_w2 = d_routed_w2; lw.d_routed_w3 = d_routed_w3;
             ls.d_kv_cache = d_kv_cache[L];
+            const std::string lp = "layers." + std::to_string(L);
+            const std::string w1_name = lp + ".ffn.experts.routed.w1";
+            const std::string w2_name = lp + ".ffn.experts.routed.w2";
+            const std::string w3_name = lp + ".ffn.experts.routed.w3";
+            bool hash_prestaged = false;
             if (is_hash) {
                 const int32_t* row = h_tid2eid_table[L] + static_cast<size_t>(token) * topk;
                 int64_t h_slice[8];
@@ -6285,45 +6290,77 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
                                       cudaMemcpyHostToDevice), "copy tid2eid slice");
                 lw.d_tid2eid_i64 = d_tid2eid_i64;
                 lw.d_gate_bias_f32 = nullptr;
+                // Hash-layer expert ids come straight from the deterministic
+                // tid2eid table -- no dependency on the gate matvec. Pre-stage
+                // the routed experts on copy_stream NOW so the H2D overlaps
+                // with attention compute on the default stream below.
+                if (moe_copy_stream_enabled) {
+                    for (int k = 0; k < topk; ++k) {
+                        const int eid = static_cast<int>(h_slice[k]);
+                        if (eid < 0 || eid >= n_experts)
+                            throw std::runtime_error("hash table produced out-of-range expert id");
+                        const bool is_local = (eid >= expert_start && eid < expert_end);
+                        h_route_slots[k] = is_local ? static_cast<int64_t>(k) : -1;
+                        if (!is_local) continue;
+                        auto wv1 = gws.get_expert(w1_name, w1_name, eid);
+                        auto wv2 = gws.get_expert(w2_name, w2_name, eid);
+                        auto wv3 = gws.get_expert(w3_name, w3_name, eid);
+                        if (!wv1.found || !wv2.found || !wv3.found)
+                            throw std::runtime_error("get_expert failed during hash prestaging");
+                        check_cuda(cudaMemcpyAsync(d_routed_w1 + per_w1_bytes * k, wv1.data, per_w1_bytes,
+                                              cudaMemcpyHostToDevice, gguf_moe_copy_stream), "prestage routed_w1");
+                        check_cuda(cudaMemcpyAsync(d_routed_w2 + per_w2_bytes * k, wv2.data, per_w2_bytes,
+                                              cudaMemcpyHostToDevice, gguf_moe_copy_stream), "prestage routed_w2");
+                        check_cuda(cudaMemcpyAsync(d_routed_w3 + per_w3_bytes * k, wv3.data, per_w3_bytes,
+                                              cudaMemcpyHostToDevice, gguf_moe_copy_stream), "prestage routed_w3");
+                    }
+                    check_cuda(cudaMemcpyAsync(d_route_slots, h_route_slots.data(),
+                                               topk * sizeof(int64_t),
+                                               cudaMemcpyHostToDevice, gguf_moe_copy_stream),
+                               "prestage d_route_slots");
+                    check_cuda(cudaEventRecord(gguf_moe_stage_event, gguf_moe_copy_stream),
+                               "record gguf moe stage event (hash prestage)");
+                    hash_prestaged = true;
+                }
             } else {
                 lw.d_tid2eid_i64 = nullptr;
                 lw.d_gate_bias_f32 = d_gate_bias[L];
             }
             gguf_layer_forward_attn_to_gate(lw, ls, ld, position, reduce_ctx_ptr);
-            check_cuda(cudaMemcpy(h_gate_indices.data(), d_gate_indices, topk * sizeof(int64_t),
-                                  cudaMemcpyDeviceToHost), "copy gate indices");
             auto t_attn_end = std::chrono::steady_clock::now();
             if (profile_gguf) prof_attn_ms += elapsed_ms(t_layer_start, t_attn_end);
-            const std::string lp = "layers." + std::to_string(L);
-            const std::string w1_name = lp + ".ffn.experts.routed.w1";
-            const std::string w2_name = lp + ".ffn.experts.routed.w2";
-            const std::string w3_name = lp + ".ffn.experts.routed.w3";
-            for (int k = 0; k < topk; ++k) {
-                const int eid = static_cast<int>(h_gate_indices[k]);
-                if (eid < 0 || eid >= n_experts)
-                    throw std::runtime_error("gate produced out-of-range expert id");
-                const bool is_local = (eid >= expert_start && eid < expert_end);
-                h_route_slots[k] = is_local ? static_cast<int64_t>(k) : -1;
-                if (!is_local) continue;
-                auto wv1 = gws.get_expert(w1_name, w1_name, eid);
-                auto wv2 = gws.get_expert(w2_name, w2_name, eid);
-                auto wv3 = gws.get_expert(w3_name, w3_name, eid);
-                if (!wv1.found || !wv2.found || !wv3.found)
-                    throw std::runtime_error("get_expert failed during decode staging");
-                check_cuda(cudaMemcpyAsync(d_routed_w1 + per_w1_bytes * k, wv1.data, per_w1_bytes,
-                                      cudaMemcpyHostToDevice, gguf_moe_copy_stream), "stage routed_w1");
-                check_cuda(cudaMemcpyAsync(d_routed_w2 + per_w2_bytes * k, wv2.data, per_w2_bytes,
-                                      cudaMemcpyHostToDevice, gguf_moe_copy_stream), "stage routed_w2");
-                check_cuda(cudaMemcpyAsync(d_routed_w3 + per_w3_bytes * k, wv3.data, per_w3_bytes,
-                                      cudaMemcpyHostToDevice, gguf_moe_copy_stream), "stage routed_w3");
+            if (!hash_prestaged) {
+                check_cuda(cudaMemcpy(h_gate_indices.data(), d_gate_indices, topk * sizeof(int64_t),
+                                      cudaMemcpyDeviceToHost), "copy gate indices");
+                for (int k = 0; k < topk; ++k) {
+                    const int eid = static_cast<int>(h_gate_indices[k]);
+                    if (eid < 0 || eid >= n_experts)
+                        throw std::runtime_error("gate produced out-of-range expert id");
+                    const bool is_local = (eid >= expert_start && eid < expert_end);
+                    h_route_slots[k] = is_local ? static_cast<int64_t>(k) : -1;
+                    if (!is_local) continue;
+                    auto wv1 = gws.get_expert(w1_name, w1_name, eid);
+                    auto wv2 = gws.get_expert(w2_name, w2_name, eid);
+                    auto wv3 = gws.get_expert(w3_name, w3_name, eid);
+                    if (!wv1.found || !wv2.found || !wv3.found)
+                        throw std::runtime_error("get_expert failed during decode staging");
+                    check_cuda(cudaMemcpyAsync(d_routed_w1 + per_w1_bytes * k, wv1.data, per_w1_bytes,
+                                          cudaMemcpyHostToDevice, gguf_moe_copy_stream), "stage routed_w1");
+                    check_cuda(cudaMemcpyAsync(d_routed_w2 + per_w2_bytes * k, wv2.data, per_w2_bytes,
+                                          cudaMemcpyHostToDevice, gguf_moe_copy_stream), "stage routed_w2");
+                    check_cuda(cudaMemcpyAsync(d_routed_w3 + per_w3_bytes * k, wv3.data, per_w3_bytes,
+                                          cudaMemcpyHostToDevice, gguf_moe_copy_stream), "stage routed_w3");
+                }
+                check_cuda(cudaMemcpyAsync(d_route_slots, h_route_slots.data(),
+                                           topk * sizeof(int64_t),
+                                           cudaMemcpyHostToDevice, gguf_moe_copy_stream),
+                           "copy d_route_slots");
+                if (moe_copy_stream_enabled) {
+                    check_cuda(cudaEventRecord(gguf_moe_stage_event, gguf_moe_copy_stream),
+                               "record gguf moe stage event");
+                }
             }
-            check_cuda(cudaMemcpyAsync(d_route_slots, h_route_slots.data(),
-                                       topk * sizeof(int64_t),
-                                       cudaMemcpyHostToDevice, gguf_moe_copy_stream),
-                       "copy d_route_slots");
             if (moe_copy_stream_enabled) {
-                check_cuda(cudaEventRecord(gguf_moe_stage_event, gguf_moe_copy_stream),
-                           "record gguf moe stage event");
                 check_cuda(cudaStreamWaitEvent(nullptr, gguf_moe_stage_event, 0),
                            "default stream wait stage event");
             }

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -4086,6 +4086,130 @@ GgufAttnFullResult run_gguf_attn_full_smoke(const std::string& ckpt_path,
     return r;
 }
 
+GgufSharedExpertResult run_gguf_shared_expert_smoke(const std::string& ckpt_path,
+                                                     int token) {
+    if (!is_gguf_path(ckpt_path)) {
+        throw std::runtime_error("run_gguf_shared_expert_smoke: not a GGUF path: " + ckpt_path);
+    }
+    if (token < 0) throw std::runtime_error("token must be >= 0");
+
+    GgufForwardContext ctx(ckpt_path);
+    WeightSource& ws = *ctx.weight_source;
+
+    WeightView embed = ws.require("embed.weight");
+    WeightView ffn_norm = ws.require("layers.0.ffn_norm.weight");
+    WeightView w1 = ws.require("layers.0.ffn.shared_experts.w1.weight");
+    WeightView w2 = ws.require("layers.0.ffn.shared_experts.w2.weight");
+    WeightView w3 = ws.require("layers.0.ffn.shared_experts.w3.weight");
+
+    if (embed.dtype != DType::F16) throw std::runtime_error("embed dtype");
+    if (ffn_norm.dtype != DType::F32) throw std::runtime_error("ffn_norm dtype");
+    if (w1.dtype != DType::Q8_0 || w2.dtype != DType::Q8_0 || w3.dtype != DType::Q8_0) {
+        throw std::runtime_error("shared expert projections must be Q8_0");
+    }
+
+    const int dim = static_cast<int>(embed.shape[0]);
+    const int moe_inter = static_cast<int>(ctx.config.moe_inter_dim);
+    if (static_cast<int>(w1.shape[0]) != dim ||
+        static_cast<int>(w1.shape[1]) != moe_inter) {
+        throw std::runtime_error("shared w1 shape mismatch");
+    }
+    if (static_cast<int>(w3.shape[0]) != dim ||
+        static_cast<int>(w3.shape[1]) != moe_inter) {
+        throw std::runtime_error("shared w3 shape mismatch");
+    }
+    if (static_cast<int>(w2.shape[0]) != moe_inter ||
+        static_cast<int>(w2.shape[1]) != dim) {
+        throw std::runtime_error("shared w2 shape mismatch");
+    }
+
+    // ----- Embed -----
+    const uint16_t* host_row =
+        reinterpret_cast<const uint16_t*>(embed.data) +
+        static_cast<size_t>(token) * dim;
+    uint16_t* d_row_f16 = nullptr;
+    float* d_x = nullptr;
+    check_cuda(cudaMalloc(&d_row_f16, dim * sizeof(uint16_t)), "alloc d_row_f16");
+    check_cuda(cudaMalloc(&d_x, dim * sizeof(float)), "alloc d_x");
+    check_cuda(cudaMemcpy(d_row_f16, host_row, dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy embed row");
+    if (!f16_row_to_float_cuda(d_row_f16, d_x, /*row=*/0, dim)) {
+        throw std::runtime_error("f16_row_to_float_cuda failed");
+    }
+
+    // ----- ffn_norm -----
+    auto ffn_bf16 = f32_to_bf16_host(reinterpret_cast<const float*>(ffn_norm.data), dim);
+    uint16_t* d_ffn_gamma = nullptr;
+    check_cuda(cudaMalloc(&d_ffn_gamma, dim * sizeof(uint16_t)), "alloc d_ffn_gamma");
+    check_cuda(cudaMemcpy(d_ffn_gamma, ffn_bf16.data(), dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy ffn_gamma");
+    float* d_x_normed = nullptr;
+    check_cuda(cudaMalloc(&d_x_normed, dim * sizeof(float)), "alloc d_x_normed");
+    if (!rmsnorm_bf16_gamma_cuda(d_x, d_ffn_gamma, d_x_normed, dim, 1e-6f)) {
+        throw std::runtime_error("ffn_norm failed");
+    }
+
+    // ----- Shared expert chain: silu(w1(x)) * w3(x), then w2 -----
+    uint8_t* d_w1 = nullptr;
+    uint8_t* d_w2 = nullptr;
+    uint8_t* d_w3 = nullptr;
+    check_cuda(cudaMalloc(&d_w1, w1.nbytes), "alloc d_w1");
+    check_cuda(cudaMalloc(&d_w2, w2.nbytes), "alloc d_w2");
+    check_cuda(cudaMalloc(&d_w3, w3.nbytes), "alloc d_w3");
+    check_cuda(cudaMemcpy(d_w1, w1.data, w1.nbytes, cudaMemcpyHostToDevice), "copy w1");
+    check_cuda(cudaMemcpy(d_w2, w2.data, w2.nbytes, cudaMemcpyHostToDevice), "copy w2");
+    check_cuda(cudaMemcpy(d_w3, w3.data, w3.nbytes, cudaMemcpyHostToDevice), "copy w3");
+
+    float* d_gate = nullptr;
+    float* d_up = nullptr;
+    float* d_hidden = nullptr;
+    float* d_shared_out = nullptr;
+    check_cuda(cudaMalloc(&d_gate, moe_inter * sizeof(float)), "alloc d_gate");
+    check_cuda(cudaMalloc(&d_up, moe_inter * sizeof(float)), "alloc d_up");
+    check_cuda(cudaMalloc(&d_hidden, moe_inter * sizeof(float)), "alloc d_hidden");
+    check_cuda(cudaMalloc(&d_shared_out, dim * sizeof(float)), "alloc d_shared_out");
+
+    if (!q8_0_matvec_cuda(d_x_normed, d_w1, d_gate, moe_inter, dim)) {
+        throw std::runtime_error("shared w1 failed");
+    }
+    if (!q8_0_matvec_cuda(d_x_normed, d_w3, d_up, moe_inter, dim)) {
+        throw std::runtime_error("shared w3 failed");
+    }
+    if (!silu_mul_cuda(d_gate, d_up, d_hidden, moe_inter)) {
+        throw std::runtime_error("silu_mul failed");
+    }
+    if (!q8_0_matvec_cuda(d_hidden, d_w2, d_shared_out, dim, moe_inter)) {
+        throw std::runtime_error("shared w2 failed");
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync after shared expert");
+
+    GgufSharedExpertResult r;
+    r.dim = dim;
+    r.moe_inter_dim = moe_inter;
+    r.ffn_normed_rms = device_vector_rms(d_x_normed, dim);
+    r.gate_rms = device_vector_rms(d_gate, moe_inter);
+    r.up_rms = device_vector_rms(d_up, moe_inter);
+    r.hidden_rms = device_vector_rms(d_hidden, moe_inter);
+    r.shared_out_rms = device_vector_rms(d_shared_out, dim);
+    std::vector<float> first(4);
+    check_cuda(cudaMemcpy(first.data(), d_shared_out, 4 * sizeof(float),
+                          cudaMemcpyDeviceToHost), "copy shared_out first");
+    for (int i = 0; i < 4; ++i) r.shared_out_first[i] = first[i];
+
+    cudaFree(d_row_f16);
+    cudaFree(d_x);
+    cudaFree(d_ffn_gamma);
+    cudaFree(d_x_normed);
+    cudaFree(d_w1);
+    cudaFree(d_w2);
+    cudaFree(d_w3);
+    cudaFree(d_gate);
+    cudaFree(d_up);
+    cudaFree(d_hidden);
+    cudaFree(d_shared_out);
+    return r;
+}
+
 // --- PersistentEngine implementation ---------------------------------------
 
 struct PersistentEngine::State {

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -5818,6 +5818,428 @@ GgufFullForwardResult run_gguf_full_forward_smoke(const std::string& ckpt_path,
     return r;
 }
 
+GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
+                                          const std::vector<int>& seed_tokens,
+                                          int max_new_tokens) {
+    if (!is_gguf_path(ckpt_path))
+        throw std::runtime_error("run_gguf_generate_smoke: not a GGUF path: " + ckpt_path);
+    if (seed_tokens.empty()) throw std::runtime_error("seed_tokens must be non-empty");
+    if (max_new_tokens < 0) throw std::runtime_error("max_new_tokens must be >= 0");
+
+    auto t_load_start = std::chrono::steady_clock::now();
+    GgufForwardContext ctx(ckpt_path);
+    GGUFWeightSource& gws = *ctx.weight_source;
+
+    // ===== model dims =====
+    const int n_layers = static_cast<int>(ctx.config.n_layers);
+    const int n_hash = static_cast<int>(ctx.config.n_hash_layers);
+    const int dim = static_cast<int>(ctx.config.dim);
+    const int heads = static_cast<int>(ctx.config.n_heads);
+    const int n_experts = static_cast<int>(ctx.config.n_routed_experts);
+    const int topk = static_cast<int>(ctx.config.n_activated_experts);
+    const int rope_dim = static_cast<int>(ctx.config.rope_dim);
+    const int o_groups = static_cast<int>(ctx.config.o_groups);
+    const int o_lora_rank = static_cast<int>(ctx.config.o_lora_rank);
+    const int moe_inter = static_cast<int>(ctx.config.moe_inter_dim);
+    if (topk <= 0 || topk > 8) throw std::runtime_error("topk out of supported range");
+
+    WeightView wq_a0 = gws.require("layers.0.attn.wq_a.weight");
+    WeightView wq_b0 = gws.require("layers.0.attn.wq_b.weight");
+    WeightView wkv0 = gws.require("layers.0.attn.wkv.weight");
+    const int q_a_dim = static_cast<int>(wq_a0.shape[1]);
+    const int q_full = static_cast<int>(wq_b0.shape[1]);
+    if (q_full % heads != 0) throw std::runtime_error("wq_b cols % heads");
+    const int head_dim = q_full / heads;
+    const int kv_dim = static_cast<int>(wkv0.shape[1]);
+    if (q_full % o_groups != 0) throw std::runtime_error("q_full % o_groups");
+    const int group_in_dim = q_full / o_groups;
+    const int attn_mid = o_groups * o_lora_rank;
+
+    WeightView embed = gws.require("embed.weight");
+    if (embed.dtype != DType::F16 || embed.shape.size() != 2 || static_cast<int>(embed.shape[0]) != dim)
+        throw std::runtime_error("embed shape/dtype mismatch");
+    const int vocab = static_cast<int>(embed.shape[1]);
+    for (int t : seed_tokens) if (t < 0 || t >= vocab)
+        throw std::runtime_error("seed token id out of vocab range");
+
+    auto upload_u8 = [](const void* src, size_t bytes) {
+        uint8_t* d = nullptr;
+        check_cuda(cudaMalloc(&d, bytes), "alloc u8");
+        check_cuda(cudaMemcpy(d, src, bytes, cudaMemcpyHostToDevice), "copy u8");
+        return d;
+    };
+    auto upload_f32 = [](const void* src, size_t n) {
+        float* d = nullptr;
+        check_cuda(cudaMalloc(&d, n * sizeof(float)), "alloc f32");
+        check_cuda(cudaMemcpy(d, src, n * sizeof(float), cudaMemcpyHostToDevice), "copy f32");
+        return d;
+    };
+    auto upload_bf16_from_f32 = [&](const void* src, size_t n) {
+        auto bf = f32_to_bf16_host(reinterpret_cast<const float*>(src), n);
+        uint16_t* d = nullptr;
+        check_cuda(cudaMalloc(&d, n * sizeof(uint16_t)), "alloc bf16");
+        check_cuda(cudaMemcpy(d, bf.data(), n * sizeof(uint16_t), cudaMemcpyHostToDevice), "copy bf16");
+        return d;
+    };
+    auto upload_bf16_from_f16 = [&](const void* src, size_t n) {
+        auto bf = f16_to_bf16_host(reinterpret_cast<const uint16_t*>(src), n);
+        uint16_t* d = nullptr;
+        check_cuda(cudaMalloc(&d, n * sizeof(uint16_t)), "alloc bf16-from-f16");
+        check_cuda(cudaMemcpy(d, bf.data(), n * sizeof(uint16_t), cudaMemcpyHostToDevice), "copy bf16-from-f16");
+        return d;
+    };
+
+    // ===== per-layer dense weights resident on device =====
+    std::vector<uint16_t*> d_attn_gamma(n_layers, nullptr);
+    std::vector<uint16_t*> d_q_gamma(n_layers, nullptr);
+    std::vector<uint16_t*> d_kv_gamma(n_layers, nullptr);
+    std::vector<uint16_t*> d_ffn_gamma(n_layers, nullptr);
+    std::vector<float*> d_attn_sink(n_layers, nullptr);
+    std::vector<uint8_t*> d_wq_a(n_layers, nullptr);
+    std::vector<uint8_t*> d_wq_b(n_layers, nullptr);
+    std::vector<uint8_t*> d_wkv(n_layers, nullptr);
+    std::vector<uint8_t*> d_wo_a(n_layers, nullptr);
+    std::vector<uint8_t*> d_wo_b(n_layers, nullptr);
+    std::vector<uint8_t*> d_shared_w1(n_layers, nullptr);
+    std::vector<uint8_t*> d_shared_w2(n_layers, nullptr);
+    std::vector<uint8_t*> d_shared_w3(n_layers, nullptr);
+    std::vector<uint16_t*> d_gate_w(n_layers, nullptr);
+    std::vector<float*> d_gate_bias(n_layers, nullptr);
+    std::vector<const int32_t*> h_tid2eid_table(n_layers, nullptr);
+
+    for (int L = 0; L < n_layers; ++L) {
+        const std::string lp = "layers." + std::to_string(L);
+        d_attn_gamma[L] = upload_bf16_from_f32(gws.require(lp + ".attn_norm.weight").data, dim);
+        d_q_gamma[L] = upload_bf16_from_f32(gws.require(lp + ".attn.q_norm.weight").data, q_a_dim);
+        d_kv_gamma[L] = upload_bf16_from_f32(gws.require(lp + ".attn.kv_norm.weight").data, kv_dim);
+        d_ffn_gamma[L] = upload_bf16_from_f32(gws.require(lp + ".ffn_norm.weight").data, dim);
+        d_attn_sink[L] = upload_f32(gws.require(lp + ".attn.attn_sink").data, heads);
+        WeightView wq_a = gws.require(lp + ".attn.wq_a.weight");
+        WeightView wq_b = gws.require(lp + ".attn.wq_b.weight");
+        WeightView wkv = gws.require(lp + ".attn.wkv.weight");
+        WeightView wo_a = gws.require(lp + ".attn.wo_a.weight");
+        WeightView wo_b = gws.require(lp + ".attn.wo_b.weight");
+        WeightView shared_w1 = gws.require(lp + ".ffn.shared_experts.w1.weight");
+        WeightView shared_w2 = gws.require(lp + ".ffn.shared_experts.w2.weight");
+        WeightView shared_w3 = gws.require(lp + ".ffn.shared_experts.w3.weight");
+        WeightView gate_w = gws.require(lp + ".ffn.gate.weight");
+        d_wq_a[L] = upload_u8(wq_a.data, wq_a.nbytes);
+        d_wq_b[L] = upload_u8(wq_b.data, wq_b.nbytes);
+        d_wkv[L] = upload_u8(wkv.data, wkv.nbytes);
+        d_wo_a[L] = upload_u8(wo_a.data, wo_a.nbytes);
+        d_wo_b[L] = upload_u8(wo_b.data, wo_b.nbytes);
+        d_shared_w1[L] = upload_u8(shared_w1.data, shared_w1.nbytes);
+        d_shared_w2[L] = upload_u8(shared_w2.data, shared_w2.nbytes);
+        d_shared_w3[L] = upload_u8(shared_w3.data, shared_w3.nbytes);
+        d_gate_w[L] = upload_bf16_from_f16(gate_w.data,
+                                            static_cast<size_t>(dim) * static_cast<size_t>(n_experts));
+        if (L < n_hash) {
+            WeightView tid2eid = gws.require(lp + ".ffn.gate.tid2eid");
+            if (tid2eid.nbytes < static_cast<uint64_t>(vocab) * topk * sizeof(int32_t))
+                throw std::runtime_error("tid2eid table truncated");
+            h_tid2eid_table[L] = reinterpret_cast<const int32_t*>(tid2eid.data);
+        } else {
+            WeightView bias = gws.require(lp + ".ffn.gate.bias");
+            if (bias.dtype != DType::F32 || bias.shape.size() != 1 ||
+                static_cast<int>(bias.shape[0]) != n_experts)
+                throw std::runtime_error("exp_probs_b.bias shape/dtype");
+            d_gate_bias[L] = upload_f32(bias.data, n_experts);
+        }
+    }
+
+    WeightView final_norm = gws.require("norm.weight");
+    WeightView head = gws.require("head.weight");
+    if (final_norm.dtype != DType::F32 || static_cast<int>(final_norm.shape[0]) != dim)
+        throw std::runtime_error("norm.weight shape/dtype");
+    if (head.dtype != DType::Q8_0 || static_cast<int>(head.shape[0]) != dim ||
+        static_cast<int>(head.shape[1]) != vocab)
+        throw std::runtime_error("head.weight shape/dtype (expected Q8_0 [dim, vocab])");
+    uint16_t* d_final_norm_gamma = upload_bf16_from_f32(final_norm.data, dim);
+    uint8_t* d_head = upload_u8(head.data, head.nbytes);
+
+    // ===== routed expert staging buffers (reused per layer per step) =====
+    auto first_w1 = gws.get_expert("layers.0.ffn.experts.routed.w1",
+                                    "layers.0.ffn.experts.routed.w1", 0);
+    auto first_w2 = gws.get_expert("layers.0.ffn.experts.routed.w2",
+                                    "layers.0.ffn.experts.routed.w2", 0);
+    auto first_w3 = gws.get_expert("layers.0.ffn.experts.routed.w3",
+                                    "layers.0.ffn.experts.routed.w3", 0);
+    if (!first_w1.found || !first_w2.found || !first_w3.found)
+        throw std::runtime_error("get_expert(0) failed");
+    const uint64_t per_w1_bytes = first_w1.nbytes;
+    const uint64_t per_w2_bytes = first_w2.nbytes;
+    const uint64_t per_w3_bytes = first_w3.nbytes;
+    uint8_t* d_routed_w1 = nullptr;
+    uint8_t* d_routed_w2 = nullptr;
+    uint8_t* d_routed_w3 = nullptr;
+    check_cuda(cudaMalloc(&d_routed_w1, per_w1_bytes * topk), "alloc routed_w1");
+    check_cuda(cudaMalloc(&d_routed_w2, per_w2_bytes * topk), "alloc routed_w2");
+    check_cuda(cudaMalloc(&d_routed_w3, per_w3_bytes * topk), "alloc routed_w3");
+
+    // ===== per-layer KV cache sized for full sequence =====
+    const int total_positions = static_cast<int>(seed_tokens.size()) + max_new_tokens;
+    const int cache_capacity = std::max(1, total_positions);
+    std::vector<float*> d_kv_cache(n_layers, nullptr);
+    for (int L = 0; L < n_layers; ++L) {
+        check_cuda(cudaMalloc(&d_kv_cache[L],
+                              static_cast<size_t>(cache_capacity) *
+                                  static_cast<size_t>(kv_dim) * sizeof(float)),
+                   "alloc d_kv_cache");
+        check_cuda(cudaMemset(d_kv_cache[L], 0,
+                              static_cast<size_t>(cache_capacity) *
+                                  static_cast<size_t>(kv_dim) * sizeof(float)),
+                   "memset d_kv_cache");
+    }
+
+    // ===== activation + scratch buffers (one set, reused per step + per layer) =====
+    const int x_groups = (dim + 31) / 32;
+    const int hidden_groups = (moe_inter + 15) / 16;
+    const int gate_scratch_n = std::max(topk, n_experts);
+    float* d_x = nullptr;
+    float* d_x_pre_attn = nullptr;
+    float* d_x_normed = nullptr;
+    float* d_q_a = nullptr;
+    float* d_q_normed = nullptr;
+    float* d_q = nullptr;
+    float* d_kv_a = nullptr;
+    float* d_kv = nullptr;
+    float* d_attn_value = nullptr;
+    float* d_attn_mid = nullptr;
+    float* d_attn_out = nullptr;
+    float* d_x_pre_ffn = nullptr;
+    float* d_x_normed_ffn = nullptr;
+    float* d_shared_gate = nullptr;
+    float* d_shared_up = nullptr;
+    float* d_shared_hidden = nullptr;
+    float* d_shared_out = nullptr;
+    float* d_moe_out = nullptr;
+    float* d_ffn_combined = nullptr;
+    int8_t* d_x_q = nullptr;
+    float* d_x_scale = nullptr;
+    int64_t* d_route_slots = nullptr;
+    float* d_route_weights = nullptr;
+    float* d_route_gate = nullptr;
+    float* d_route_up = nullptr;
+    int8_t* d_route_hidden_q = nullptr;
+    float* d_route_hidden_scale = nullptr;
+    float* d_gate_scores_scratch = nullptr;
+    float* d_gate_scored_scratch = nullptr;
+    int64_t* d_gate_indices = nullptr;
+    int64_t* d_tid2eid_i64 = nullptr;
+    uint16_t* d_embed_row_f16 = nullptr;
+    float* d_logits = nullptr;
+    check_cuda(cudaMalloc(&d_x, dim * sizeof(float)), "alloc d_x");
+    check_cuda(cudaMalloc(&d_x_pre_attn, dim * sizeof(float)), "alloc d_x_pre_attn");
+    check_cuda(cudaMalloc(&d_x_normed, dim * sizeof(float)), "alloc d_x_normed");
+    check_cuda(cudaMalloc(&d_q_a, q_a_dim * sizeof(float)), "alloc d_q_a");
+    check_cuda(cudaMalloc(&d_q_normed, q_a_dim * sizeof(float)), "alloc d_q_normed");
+    check_cuda(cudaMalloc(&d_q, q_full * sizeof(float)), "alloc d_q");
+    check_cuda(cudaMalloc(&d_kv_a, kv_dim * sizeof(float)), "alloc d_kv_a");
+    check_cuda(cudaMalloc(&d_kv, kv_dim * sizeof(float)), "alloc d_kv");
+    check_cuda(cudaMalloc(&d_attn_value, q_full * sizeof(float)), "alloc d_attn_value");
+    check_cuda(cudaMalloc(&d_attn_mid, attn_mid * sizeof(float)), "alloc d_attn_mid");
+    check_cuda(cudaMalloc(&d_attn_out, dim * sizeof(float)), "alloc d_attn_out");
+    check_cuda(cudaMalloc(&d_x_pre_ffn, dim * sizeof(float)), "alloc d_x_pre_ffn");
+    check_cuda(cudaMalloc(&d_x_normed_ffn, dim * sizeof(float)), "alloc d_x_normed_ffn");
+    check_cuda(cudaMalloc(&d_shared_gate, moe_inter * sizeof(float)), "alloc d_shared_gate");
+    check_cuda(cudaMalloc(&d_shared_up, moe_inter * sizeof(float)), "alloc d_shared_up");
+    check_cuda(cudaMalloc(&d_shared_hidden, moe_inter * sizeof(float)), "alloc d_shared_hidden");
+    check_cuda(cudaMalloc(&d_shared_out, dim * sizeof(float)), "alloc d_shared_out");
+    check_cuda(cudaMalloc(&d_moe_out, dim * sizeof(float)), "alloc d_moe_out");
+    check_cuda(cudaMalloc(&d_ffn_combined, dim * sizeof(float)), "alloc d_ffn_combined");
+    check_cuda(cudaMalloc(&d_x_q, dim), "alloc d_x_q");
+    check_cuda(cudaMalloc(&d_x_scale, x_groups * sizeof(float)), "alloc d_x_scale");
+    check_cuda(cudaMalloc(&d_route_slots, topk * sizeof(int64_t)), "alloc d_route_slots");
+    check_cuda(cudaMalloc(&d_route_weights, topk * sizeof(float)), "alloc d_route_weights");
+    check_cuda(cudaMalloc(&d_route_gate, static_cast<size_t>(topk) * moe_inter * sizeof(float)),
+               "alloc d_route_gate");
+    check_cuda(cudaMalloc(&d_route_up, static_cast<size_t>(topk) * moe_inter * sizeof(float)),
+               "alloc d_route_up");
+    check_cuda(cudaMalloc(&d_route_hidden_q, static_cast<size_t>(topk) * moe_inter),
+               "alloc d_route_hidden_q");
+    check_cuda(cudaMalloc(&d_route_hidden_scale,
+                          static_cast<size_t>(topk) * hidden_groups * sizeof(float)),
+               "alloc d_route_hidden_scale");
+    check_cuda(cudaMalloc(&d_gate_scores_scratch, gate_scratch_n * sizeof(float)),
+               "alloc d_gate_scores_scratch");
+    check_cuda(cudaMalloc(&d_gate_scored_scratch, n_experts * sizeof(float)),
+               "alloc d_gate_scored_scratch");
+    check_cuda(cudaMalloc(&d_gate_indices, topk * sizeof(int64_t)), "alloc d_gate_indices");
+    check_cuda(cudaMalloc(&d_tid2eid_i64, topk * sizeof(int64_t)), "alloc d_tid2eid_i64");
+    check_cuda(cudaMalloc(&d_embed_row_f16, dim * sizeof(uint16_t)), "alloc d_embed_row_f16");
+    check_cuda(cudaMalloc(&d_logits, vocab * sizeof(float)), "alloc d_logits");
+
+    std::vector<int64_t> h_route_slots(topk);
+    for (int k = 0; k < topk; ++k) h_route_slots[k] = k;
+    check_cuda(cudaMemcpy(d_route_slots, h_route_slots.data(),
+                          topk * sizeof(int64_t), cudaMemcpyHostToDevice),
+               "copy d_route_slots");
+
+    GgufLayerDims ld;
+    ld.dim = dim; ld.q_a_dim = q_a_dim; ld.heads = heads; ld.head_dim = head_dim;
+    ld.q_full = q_full; ld.kv_dim = kv_dim; ld.rope_dim = rope_dim;
+    ld.o_groups = o_groups; ld.o_lora_rank = o_lora_rank; ld.group_in_dim = group_in_dim;
+    ld.attn_mid = attn_mid; ld.moe_inter = moe_inter;
+    ld.n_experts = n_experts; ld.topk = topk;
+    ld.rope_theta = static_cast<float>(ctx.config.rope_theta);
+    ld.swiglu_limit = static_cast<float>(ctx.config.swiglu_limit);
+    ld.route_scale = static_cast<float>(ctx.config.route_scale);
+
+    GgufLayerScratch ls;
+    ls.d_x = d_x;
+    ls.d_x_pre_attn = d_x_pre_attn; ls.d_x_normed = d_x_normed;
+    ls.d_q_a = d_q_a; ls.d_q_normed = d_q_normed; ls.d_q = d_q;
+    ls.d_kv_a = d_kv_a; ls.d_kv = d_kv;
+    ls.d_attn_value = d_attn_value; ls.d_attn_mid = d_attn_mid; ls.d_attn_out = d_attn_out;
+    ls.d_x_pre_ffn = d_x_pre_ffn; ls.d_x_normed_ffn = d_x_normed_ffn;
+    ls.d_shared_gate = d_shared_gate; ls.d_shared_up = d_shared_up;
+    ls.d_shared_hidden = d_shared_hidden; ls.d_shared_out = d_shared_out;
+    ls.d_moe_out = d_moe_out; ls.d_ffn_combined = d_ffn_combined;
+    ls.d_x_q = d_x_q; ls.d_x_scale = d_x_scale;
+    ls.d_route_slots = d_route_slots; ls.d_route_weights = d_route_weights;
+    ls.d_route_gate = d_route_gate; ls.d_route_up = d_route_up;
+    ls.d_route_hidden_q = d_route_hidden_q; ls.d_route_hidden_scale = d_route_hidden_scale;
+    ls.d_gate_scores_scratch = d_gate_scores_scratch;
+    ls.d_gate_scored_scratch = d_gate_scored_scratch;
+    ls.d_gate_indices = d_gate_indices;
+    ls.cache_capacity = cache_capacity;
+
+    auto t_load_end = std::chrono::steady_clock::now();
+
+    // ===== per-step forward (embed + 43 layers + final norm + head + argmax) =====
+    std::vector<int64_t> h_gate_indices(topk);
+    std::vector<float> h_logits(vocab);
+    auto run_step = [&](int token, int position) -> std::pair<int, float> {
+        const uint16_t* host_embed_row =
+            reinterpret_cast<const uint16_t*>(embed.data) +
+            static_cast<size_t>(token) * dim;
+        check_cuda(cudaMemcpy(d_embed_row_f16, host_embed_row, dim * sizeof(uint16_t),
+                              cudaMemcpyHostToDevice), "copy embed row");
+        if (!f16_row_to_float_cuda(d_embed_row_f16, d_x, /*row=*/0, dim))
+            throw std::runtime_error("f16 embed failed");
+        for (int L = 0; L < n_layers; ++L) {
+            const bool is_hash = (L < n_hash);
+            GgufLayerDeviceWeights lw;
+            lw.d_attn_gamma = d_attn_gamma[L]; lw.d_q_gamma = d_q_gamma[L]; lw.d_kv_gamma = d_kv_gamma[L];
+            lw.d_wq_a = d_wq_a[L]; lw.d_wq_b = d_wq_b[L]; lw.d_wkv = d_wkv[L];
+            lw.d_wo_a = d_wo_a[L]; lw.d_wo_b = d_wo_b[L];
+            lw.d_attn_sink = d_attn_sink[L];
+            lw.d_ffn_gamma = d_ffn_gamma[L];
+            lw.d_shared_w1 = d_shared_w1[L]; lw.d_shared_w2 = d_shared_w2[L]; lw.d_shared_w3 = d_shared_w3[L];
+            lw.d_gate_w_bf16 = d_gate_w[L];
+            lw.is_hash = is_hash;
+            lw.d_routed_w1 = d_routed_w1; lw.d_routed_w2 = d_routed_w2; lw.d_routed_w3 = d_routed_w3;
+            ls.d_kv_cache = d_kv_cache[L];
+            if (is_hash) {
+                const int32_t* row = h_tid2eid_table[L] + static_cast<size_t>(token) * topk;
+                int64_t h_slice[8];
+                for (int k = 0; k < topk; ++k) h_slice[k] = row[k];
+                check_cuda(cudaMemcpy(d_tid2eid_i64, h_slice, topk * sizeof(int64_t),
+                                      cudaMemcpyHostToDevice), "copy tid2eid slice");
+                lw.d_tid2eid_i64 = d_tid2eid_i64;
+                lw.d_gate_bias_f32 = nullptr;
+            } else {
+                lw.d_tid2eid_i64 = nullptr;
+                lw.d_gate_bias_f32 = d_gate_bias[L];
+            }
+            gguf_layer_forward_attn_to_gate(lw, ls, ld, position);
+            check_cuda(cudaMemcpy(h_gate_indices.data(), d_gate_indices, topk * sizeof(int64_t),
+                                  cudaMemcpyDeviceToHost), "copy gate indices");
+            const std::string lp = "layers." + std::to_string(L);
+            const std::string w1_name = lp + ".ffn.experts.routed.w1";
+            const std::string w2_name = lp + ".ffn.experts.routed.w2";
+            const std::string w3_name = lp + ".ffn.experts.routed.w3";
+            for (int k = 0; k < topk; ++k) {
+                const int eid = static_cast<int>(h_gate_indices[k]);
+                if (eid < 0 || eid >= n_experts)
+                    throw std::runtime_error("gate produced out-of-range expert id");
+                auto wv1 = gws.get_expert(w1_name, w1_name, eid);
+                auto wv2 = gws.get_expert(w2_name, w2_name, eid);
+                auto wv3 = gws.get_expert(w3_name, w3_name, eid);
+                if (!wv1.found || !wv2.found || !wv3.found)
+                    throw std::runtime_error("get_expert failed during decode staging");
+                check_cuda(cudaMemcpy(d_routed_w1 + per_w1_bytes * k, wv1.data, per_w1_bytes,
+                                      cudaMemcpyHostToDevice), "stage routed_w1");
+                check_cuda(cudaMemcpy(d_routed_w2 + per_w2_bytes * k, wv2.data, per_w2_bytes,
+                                      cudaMemcpyHostToDevice), "stage routed_w2");
+                check_cuda(cudaMemcpy(d_routed_w3 + per_w3_bytes * k, wv3.data, per_w3_bytes,
+                                      cudaMemcpyHostToDevice), "stage routed_w3");
+            }
+            gguf_layer_forward_moe(lw, ls, ld);
+        }
+        if (!rmsnorm_bf16_gamma_cuda(d_x, d_final_norm_gamma, d_x_normed, dim, 1e-6f))
+            throw std::runtime_error("final norm failed");
+        if (!q8_0_matvec_cuda(d_x_normed, d_head, d_logits, vocab, dim))
+            throw std::runtime_error("head matvec failed");
+        check_cuda(cudaDeviceSynchronize(), "sync after head");
+        check_cuda(cudaMemcpy(h_logits.data(), d_logits, vocab * sizeof(float),
+                              cudaMemcpyDeviceToHost), "copy logits");
+        int top_t = 0;
+        float top_l = -INFINITY;
+        for (int i = 0; i < vocab; ++i) {
+            if (h_logits[i] > top_l) { top_l = h_logits[i]; top_t = i; }
+        }
+        return {top_t, top_l};
+    };
+
+    // ===== generate loop =====
+    GgufDecodeResult r;
+    r.n_layers = n_layers;
+    r.dim = dim;
+    r.vocab = vocab;
+    r.prompt_tokens = static_cast<int>(seed_tokens.size());
+    r.decode_tokens = max_new_tokens;
+    r.top_logits.reserve(total_positions);
+    r.generated_tokens.reserve(max_new_tokens);
+
+    auto t_forward_start = std::chrono::steady_clock::now();
+    int last_argmax = 0;
+    for (int pos = 0; pos < total_positions; ++pos) {
+        const int feed_token = (pos < r.prompt_tokens) ? seed_tokens[pos] : last_argmax;
+        auto [argmax, logit] = run_step(feed_token, pos);
+        r.top_logits.push_back(logit);
+        // argmax produced at position p predicts the token for position p+1.
+        // Record argmax once we reach the last seed (its prediction is the first
+        // generated token) and every step thereafter.
+        if (pos >= r.prompt_tokens - 1 &&
+            static_cast<int>(r.generated_tokens.size()) < max_new_tokens) {
+            r.generated_tokens.push_back(argmax);
+        }
+        last_argmax = argmax;
+    }
+    auto t_forward_end = std::chrono::steady_clock::now();
+    r.load_seconds = std::chrono::duration<double>(t_load_end - t_load_start).count();
+    r.forward_seconds = std::chrono::duration<double>(t_forward_end - t_forward_start).count();
+
+    // ===== cleanup =====
+    auto free_vec_u8 = [](std::vector<uint8_t*>& v) { for (auto* p : v) cudaFree(p); };
+    auto free_vec_u16 = [](std::vector<uint16_t*>& v) { for (auto* p : v) cudaFree(p); };
+    auto free_vec_f32 = [](std::vector<float*>& v) { for (auto* p : v) cudaFree(p); };
+    free_vec_u16(d_attn_gamma); free_vec_u16(d_q_gamma); free_vec_u16(d_kv_gamma);
+    free_vec_u16(d_ffn_gamma); free_vec_f32(d_attn_sink);
+    free_vec_u8(d_wq_a); free_vec_u8(d_wq_b); free_vec_u8(d_wkv);
+    free_vec_u8(d_wo_a); free_vec_u8(d_wo_b);
+    free_vec_u8(d_shared_w1); free_vec_u8(d_shared_w2); free_vec_u8(d_shared_w3);
+    free_vec_u16(d_gate_w); free_vec_f32(d_gate_bias);
+    cudaFree(d_final_norm_gamma); cudaFree(d_head);
+    cudaFree(d_routed_w1); cudaFree(d_routed_w2); cudaFree(d_routed_w3);
+    free_vec_f32(d_kv_cache);
+    cudaFree(d_x); cudaFree(d_x_pre_attn); cudaFree(d_x_normed);
+    cudaFree(d_q_a); cudaFree(d_q_normed); cudaFree(d_q);
+    cudaFree(d_kv_a); cudaFree(d_kv); cudaFree(d_attn_value);
+    cudaFree(d_attn_mid); cudaFree(d_attn_out);
+    cudaFree(d_x_pre_ffn); cudaFree(d_x_normed_ffn);
+    cudaFree(d_shared_gate); cudaFree(d_shared_up); cudaFree(d_shared_hidden);
+    cudaFree(d_shared_out); cudaFree(d_moe_out); cudaFree(d_ffn_combined);
+    cudaFree(d_x_q); cudaFree(d_x_scale);
+    cudaFree(d_route_slots); cudaFree(d_route_weights);
+    cudaFree(d_route_gate); cudaFree(d_route_up);
+    cudaFree(d_route_hidden_q); cudaFree(d_route_hidden_scale);
+    cudaFree(d_gate_scores_scratch); cudaFree(d_gate_scored_scratch); cudaFree(d_gate_indices);
+    cudaFree(d_tid2eid_i64); cudaFree(d_embed_row_f16); cudaFree(d_logits);
+    return r;
+}
+
 // --- PersistentEngine implementation ---------------------------------------
 
 struct PersistentEngine::State {

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -5830,6 +5830,25 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
     GgufForwardContext ctx(ckpt_path);
     GGUFWeightSource& gws = *ctx.weight_source;
 
+    // ===== pin the GGUF mmap region for async H2D out of expert bytes =====
+    // The routed expert per-step staging dominates decode wall time. Pinning
+    // the mmap region lets cudaMemcpyAsync DMA directly from the file pages
+    // at ~10 GB/s instead of the ~4 GB/s pageable+staging-copy path.
+    // ReadOnly avoids any RLIMIT_MEMLOCK pressure on systems that support it
+    // (CUDA 11.4+); fall back to default flags otherwise.
+    void* gguf_base = const_cast<uint8_t*>(gws.file().bytes());
+    const size_t gguf_bytes = gws.file().file_size();
+    bool gguf_registered = false;
+    if (cudaHostRegister(gguf_base, gguf_bytes, cudaHostRegisterReadOnly) == cudaSuccess) {
+        gguf_registered = true;
+    } else if (cudaHostRegister(gguf_base, gguf_bytes, cudaHostRegisterDefault) == cudaSuccess) {
+        gguf_registered = true;
+    } else {
+        // Clear the error and continue with the pageable path; correctness
+        // is unaffected, only bandwidth.
+        cudaGetLastError();
+    }
+
     // ===== model dims =====
     const int n_layers = static_cast<int>(ctx.config.n_layers);
     const int n_hash = static_cast<int>(ctx.config.n_hash_layers);
@@ -6158,12 +6177,12 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
                 auto wv3 = gws.get_expert(w3_name, w3_name, eid);
                 if (!wv1.found || !wv2.found || !wv3.found)
                     throw std::runtime_error("get_expert failed during decode staging");
-                check_cuda(cudaMemcpy(d_routed_w1 + per_w1_bytes * k, wv1.data, per_w1_bytes,
-                                      cudaMemcpyHostToDevice), "stage routed_w1");
-                check_cuda(cudaMemcpy(d_routed_w2 + per_w2_bytes * k, wv2.data, per_w2_bytes,
-                                      cudaMemcpyHostToDevice), "stage routed_w2");
-                check_cuda(cudaMemcpy(d_routed_w3 + per_w3_bytes * k, wv3.data, per_w3_bytes,
-                                      cudaMemcpyHostToDevice), "stage routed_w3");
+                check_cuda(cudaMemcpyAsync(d_routed_w1 + per_w1_bytes * k, wv1.data, per_w1_bytes,
+                                      cudaMemcpyHostToDevice, 0), "stage routed_w1");
+                check_cuda(cudaMemcpyAsync(d_routed_w2 + per_w2_bytes * k, wv2.data, per_w2_bytes,
+                                      cudaMemcpyHostToDevice, 0), "stage routed_w2");
+                check_cuda(cudaMemcpyAsync(d_routed_w3 + per_w3_bytes * k, wv3.data, per_w3_bytes,
+                                      cudaMemcpyHostToDevice, 0), "stage routed_w3");
             }
             gguf_layer_forward_moe(lw, ls, ld);
         }
@@ -6237,6 +6256,7 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
     cudaFree(d_route_hidden_q); cudaFree(d_route_hidden_scale);
     cudaFree(d_gate_scores_scratch); cudaFree(d_gate_scored_scratch); cudaFree(d_gate_indices);
     cudaFree(d_tid2eid_i64); cudaFree(d_embed_row_f16); cudaFree(d_logits);
+    if (gguf_registered) cudaHostUnregister(gguf_base);
     return r;
 }
 

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -3606,13 +3606,14 @@ struct GgufLayerScratch {
     int64_t* d_gate_indices = nullptr;    // [topk]
 };
 
-void gguf_layer_forward(const GgufLayerDeviceWeights& w,
-                        GgufLayerScratch& s,
-                        const GgufLayerDims& d,
-                        int token,
-                        int position) {
-    const int routes = d.topk;
-
+// Phase 1: attention residual + ffn_norm + shared expert + gate scoring.
+// On exit, d_gate_indices contains the top-k expert ids for this token (both
+// hash and non-hash layers populate this). The caller stages those experts'
+// w1/w2/w3 into w.d_routed_* before calling gguf_layer_forward_moe.
+void gguf_layer_forward_attn_to_gate(const GgufLayerDeviceWeights& w,
+                                     GgufLayerScratch& s,
+                                     const GgufLayerDims& d,
+                                     int position) {
     // ===== Attention =====
     check_cuda(cudaMemcpy(s.d_x_pre_attn, s.d_x, d.dim * sizeof(float),
                           cudaMemcpyDeviceToDevice), "save x_pre_attn");
@@ -3657,7 +3658,7 @@ void gguf_layer_forward(const GgufLayerDeviceWeights& w,
     if (!vector_add_cuda(s.d_x_pre_attn, s.d_attn_out, s.d_x, d.dim))
         throw std::runtime_error("attn residual add failed");
 
-    // ===== FFN =====
+    // ===== FFN: norm + shared expert + gate =====
     check_cuda(cudaMemcpy(s.d_x_pre_ffn, s.d_x, d.dim * sizeof(float),
                           cudaMemcpyDeviceToDevice), "save x_pre_ffn");
     if (!rmsnorm_bf16_gamma_cuda(s.d_x, w.d_ffn_gamma, s.d_x_normed_ffn, d.dim, 1e-6f))
@@ -3678,7 +3679,6 @@ void gguf_layer_forward(const GgufLayerDeviceWeights& w,
 
     // Gate scoring → route weights + indices.
     if (w.is_hash) {
-        // tid2eid lookup happens inside kernel; we pre-staged the per-token slice.
         if (!gate_hash_bf16_cuda(s.d_x_normed_ffn, w.d_gate_w_bf16, w.d_tid2eid_i64,
                                  s.d_gate_scores_scratch, s.d_gate_indices,
                                  s.d_route_weights,
@@ -3694,9 +3694,16 @@ void gguf_layer_forward(const GgufLayerDeviceWeights& w,
                 d.n_experts, d.dim, d.topk, d.route_scale))
             throw std::runtime_error("gate_topk_bf16_cuda failed");
     }
+}
 
-    // Routed Q2 MoE: q8_1 x → IQ2_XXS w13 → SwiGLU + route_weight + q8_1 hidden
-    // → Q2_K w2 (atomicAdd across routes).
+// Phase 2: routed Q2 MoE compute + FFN residual.
+// Caller must have staged the top-k routed experts (matching s.d_gate_indices)
+// into w.d_routed_w1/w2/w3 before this call.
+void gguf_layer_forward_moe(const GgufLayerDeviceWeights& w,
+                            GgufLayerScratch& s,
+                            const GgufLayerDims& d) {
+    const int routes = d.topk;
+
     check_cuda(cudaMemset(s.d_moe_out, 0, d.dim * sizeof(float)), "zero moe_out");
     if (!q2_quantize_x_q8_1_cuda(s.d_x_normed_ffn, s.d_x_q, s.d_x_scale,
                                   /*routes=*/1, d.dim))
@@ -3718,11 +3725,22 @@ void gguf_layer_forward(const GgufLayerDeviceWeights& w,
                                     d.dim, d.moe_inter))
         throw std::runtime_error("q2 w2 q2k failed");
 
-    // FFN residual: x = x_pre_ffn + (shared_out + moe_out).
     if (!vector_add_cuda(s.d_shared_out, s.d_moe_out, s.d_ffn_combined, d.dim))
         throw std::runtime_error("ffn combined add failed");
     if (!vector_add_cuda(s.d_x_pre_ffn, s.d_ffn_combined, s.d_x, d.dim))
         throw std::runtime_error("ffn residual add failed");
+}
+
+// Convenience wrapper for the legacy single-layer smoke that pre-stages
+// experts (the layer-0 smoke uses this since experts are derived from
+// tid2eid before any compute runs).
+void gguf_layer_forward(const GgufLayerDeviceWeights& w,
+                        GgufLayerScratch& s,
+                        const GgufLayerDims& d,
+                        int /*token*/,
+                        int position) {
+    gguf_layer_forward_attn_to_gate(w, s, d, position);
+    gguf_layer_forward_moe(w, s, d);
 }
 
 }  // namespace
@@ -5336,6 +5354,424 @@ GgufLayer0FullResult run_gguf_layer0_full_smoke(const std::string& ckpt_path,
     cudaFree(d_route_up);
     cudaFree(d_route_hidden_q);
     cudaFree(d_route_hidden_scale);
+    return r;
+}
+
+GgufFullForwardResult run_gguf_full_forward_smoke(const std::string& ckpt_path,
+                                                  int token,
+                                                  int position) {
+    if (!is_gguf_path(ckpt_path)) {
+        throw std::runtime_error("run_gguf_full_forward_smoke: not a GGUF path: " + ckpt_path);
+    }
+    if (token < 0) throw std::runtime_error("token must be >= 0");
+    if (position < 0) throw std::runtime_error("position must be >= 0");
+
+    GgufForwardContext ctx(ckpt_path);
+    GGUFWeightSource& gws = *ctx.weight_source;
+
+    // ===== model dims =====
+    const int n_layers = static_cast<int>(ctx.config.n_layers);
+    const int n_hash = static_cast<int>(ctx.config.n_hash_layers);
+    const int dim = static_cast<int>(ctx.config.dim);
+    const int heads = static_cast<int>(ctx.config.n_heads);
+    const int n_experts = static_cast<int>(ctx.config.n_routed_experts);
+    const int topk = static_cast<int>(ctx.config.n_activated_experts);
+    const int rope_dim = static_cast<int>(ctx.config.rope_dim);
+    const int o_groups = static_cast<int>(ctx.config.o_groups);
+    const int o_lora_rank = static_cast<int>(ctx.config.o_lora_rank);
+    const int moe_inter = static_cast<int>(ctx.config.moe_inter_dim);
+    if (topk <= 0 || topk > 8) throw std::runtime_error("topk out of supported range");
+
+    // Derive q_a_dim / q_full / kv_dim from layer-0 weights.
+    WeightView wq_a0 = gws.require("layers.0.attn.wq_a.weight");
+    WeightView wq_b0 = gws.require("layers.0.attn.wq_b.weight");
+    WeightView wkv0 = gws.require("layers.0.attn.wkv.weight");
+    const int q_a_dim = static_cast<int>(wq_a0.shape[1]);
+    const int q_full = static_cast<int>(wq_b0.shape[1]);
+    if (q_full % heads != 0) throw std::runtime_error("wq_b cols % heads");
+    const int head_dim = q_full / heads;
+    const int kv_dim = static_cast<int>(wkv0.shape[1]);
+    if (q_full % o_groups != 0) throw std::runtime_error("q_full % o_groups");
+    const int group_in_dim = q_full / o_groups;
+    const int attn_mid = o_groups * o_lora_rank;
+
+    WeightView embed = gws.require("embed.weight");
+    if (embed.dtype != DType::F16 || embed.shape.size() != 2 || static_cast<int>(embed.shape[0]) != dim)
+        throw std::runtime_error("embed shape/dtype mismatch");
+    const int vocab = static_cast<int>(embed.shape[1]);
+    if (token >= vocab) throw std::runtime_error("token id out of vocab range");
+
+    // ===== upload helpers =====
+    auto upload_u8 = [](const void* src, size_t bytes) {
+        uint8_t* d = nullptr;
+        check_cuda(cudaMalloc(&d, bytes), "alloc u8");
+        check_cuda(cudaMemcpy(d, src, bytes, cudaMemcpyHostToDevice), "copy u8");
+        return d;
+    };
+    auto upload_f32 = [](const void* src, size_t n) {
+        float* d = nullptr;
+        check_cuda(cudaMalloc(&d, n * sizeof(float)), "alloc f32");
+        check_cuda(cudaMemcpy(d, src, n * sizeof(float), cudaMemcpyHostToDevice), "copy f32");
+        return d;
+    };
+    auto upload_bf16_from_f32 = [&](const void* src, size_t n) {
+        auto bf = f32_to_bf16_host(reinterpret_cast<const float*>(src), n);
+        uint16_t* d = nullptr;
+        check_cuda(cudaMalloc(&d, n * sizeof(uint16_t)), "alloc bf16");
+        check_cuda(cudaMemcpy(d, bf.data(), n * sizeof(uint16_t), cudaMemcpyHostToDevice), "copy bf16");
+        return d;
+    };
+    auto upload_bf16_from_f16 = [&](const void* src, size_t n) {
+        auto bf = f16_to_bf16_host(reinterpret_cast<const uint16_t*>(src), n);
+        uint16_t* d = nullptr;
+        check_cuda(cudaMalloc(&d, n * sizeof(uint16_t)), "alloc bf16-from-f16");
+        check_cuda(cudaMemcpy(d, bf.data(), n * sizeof(uint16_t), cudaMemcpyHostToDevice), "copy bf16-from-f16");
+        return d;
+    };
+
+    // ===== per-layer dense weights resident on device =====
+    std::vector<uint16_t*> d_attn_gamma(n_layers, nullptr);
+    std::vector<uint16_t*> d_q_gamma(n_layers, nullptr);
+    std::vector<uint16_t*> d_kv_gamma(n_layers, nullptr);
+    std::vector<uint16_t*> d_ffn_gamma(n_layers, nullptr);
+    std::vector<float*> d_attn_sink(n_layers, nullptr);
+    std::vector<uint8_t*> d_wq_a(n_layers, nullptr);
+    std::vector<uint8_t*> d_wq_b(n_layers, nullptr);
+    std::vector<uint8_t*> d_wkv(n_layers, nullptr);
+    std::vector<uint8_t*> d_wo_a(n_layers, nullptr);
+    std::vector<uint8_t*> d_wo_b(n_layers, nullptr);
+    std::vector<uint8_t*> d_shared_w1(n_layers, nullptr);
+    std::vector<uint8_t*> d_shared_w2(n_layers, nullptr);
+    std::vector<uint8_t*> d_shared_w3(n_layers, nullptr);
+    std::vector<uint16_t*> d_gate_w(n_layers, nullptr);
+    std::vector<float*> d_gate_bias(n_layers, nullptr);
+    // Per-layer host pointer to tid2eid raw bytes for hash layers (i32 [topk, vocab]).
+    std::vector<const int32_t*> h_tid2eid_table(n_layers, nullptr);
+
+    for (int L = 0; L < n_layers; ++L) {
+        const std::string lp = "layers." + std::to_string(L);
+        WeightView attn_norm = gws.require(lp + ".attn_norm.weight");
+        WeightView q_norm = gws.require(lp + ".attn.q_norm.weight");
+        WeightView kv_norm = gws.require(lp + ".attn.kv_norm.weight");
+        WeightView ffn_norm = gws.require(lp + ".ffn_norm.weight");
+        WeightView attn_sink = gws.require(lp + ".attn.attn_sink");
+        WeightView wq_a = gws.require(lp + ".attn.wq_a.weight");
+        WeightView wq_b = gws.require(lp + ".attn.wq_b.weight");
+        WeightView wkv = gws.require(lp + ".attn.wkv.weight");
+        WeightView wo_a = gws.require(lp + ".attn.wo_a.weight");
+        WeightView wo_b = gws.require(lp + ".attn.wo_b.weight");
+        WeightView shared_w1 = gws.require(lp + ".ffn.shared_experts.w1.weight");
+        WeightView shared_w2 = gws.require(lp + ".ffn.shared_experts.w2.weight");
+        WeightView shared_w3 = gws.require(lp + ".ffn.shared_experts.w3.weight");
+        WeightView gate_w = gws.require(lp + ".ffn.gate.weight");
+
+        d_attn_gamma[L] = upload_bf16_from_f32(attn_norm.data, dim);
+        d_q_gamma[L] = upload_bf16_from_f32(q_norm.data, q_a_dim);
+        d_kv_gamma[L] = upload_bf16_from_f32(kv_norm.data, kv_dim);
+        d_ffn_gamma[L] = upload_bf16_from_f32(ffn_norm.data, dim);
+        d_attn_sink[L] = upload_f32(attn_sink.data, heads);
+        d_wq_a[L] = upload_u8(wq_a.data, wq_a.nbytes);
+        d_wq_b[L] = upload_u8(wq_b.data, wq_b.nbytes);
+        d_wkv[L] = upload_u8(wkv.data, wkv.nbytes);
+        d_wo_a[L] = upload_u8(wo_a.data, wo_a.nbytes);
+        d_wo_b[L] = upload_u8(wo_b.data, wo_b.nbytes);
+        d_shared_w1[L] = upload_u8(shared_w1.data, shared_w1.nbytes);
+        d_shared_w2[L] = upload_u8(shared_w2.data, shared_w2.nbytes);
+        d_shared_w3[L] = upload_u8(shared_w3.data, shared_w3.nbytes);
+        d_gate_w[L] = upload_bf16_from_f16(gate_w.data,
+                                            static_cast<size_t>(dim) * static_cast<size_t>(n_experts));
+
+        if (L < n_hash) {
+            WeightView tid2eid = gws.require(lp + ".ffn.gate.tid2eid");
+            if (tid2eid.nbytes < static_cast<uint64_t>(vocab) * topk * sizeof(int32_t))
+                throw std::runtime_error("tid2eid table truncated");
+            h_tid2eid_table[L] = reinterpret_cast<const int32_t*>(tid2eid.data);
+            d_gate_bias[L] = nullptr;
+        } else {
+            WeightView bias = gws.require(lp + ".ffn.gate.bias");
+            if (bias.dtype != DType::F32 || bias.shape.size() != 1 ||
+                static_cast<int>(bias.shape[0]) != n_experts)
+                throw std::runtime_error("exp_probs_b.bias shape/dtype");
+            d_gate_bias[L] = upload_f32(bias.data, n_experts);
+            h_tid2eid_table[L] = nullptr;
+        }
+    }
+
+    // ===== final norm + head =====
+    WeightView final_norm = gws.require("norm.weight");
+    WeightView head = gws.require("head.weight");
+    if (final_norm.dtype != DType::F32 || final_norm.shape.size() != 1 ||
+        static_cast<int>(final_norm.shape[0]) != dim)
+        throw std::runtime_error("norm.weight shape/dtype");
+    if (head.dtype != DType::Q8_0 || head.shape.size() != 2 ||
+        static_cast<int>(head.shape[0]) != dim ||
+        static_cast<int>(head.shape[1]) != vocab)
+        throw std::runtime_error("head.weight shape/dtype (expected Q8_0 [dim, vocab])");
+    uint16_t* d_final_norm_gamma = upload_bf16_from_f32(final_norm.data, dim);
+    uint8_t* d_head = upload_u8(head.data, head.nbytes);
+
+    // ===== expert staging buffers (reused per layer) =====
+    auto first_w1 = gws.get_expert("layers.0.ffn.experts.routed.w1",
+                                    "layers.0.ffn.experts.routed.w1", 0);
+    auto first_w2 = gws.get_expert("layers.0.ffn.experts.routed.w2",
+                                    "layers.0.ffn.experts.routed.w2", 0);
+    auto first_w3 = gws.get_expert("layers.0.ffn.experts.routed.w3",
+                                    "layers.0.ffn.experts.routed.w3", 0);
+    if (!first_w1.found || !first_w2.found || !first_w3.found)
+        throw std::runtime_error("get_expert(0) failed");
+    const uint64_t per_w1_bytes = first_w1.nbytes;
+    const uint64_t per_w2_bytes = first_w2.nbytes;
+    const uint64_t per_w3_bytes = first_w3.nbytes;
+
+    uint8_t* d_routed_w1 = nullptr;
+    uint8_t* d_routed_w2 = nullptr;
+    uint8_t* d_routed_w3 = nullptr;
+    check_cuda(cudaMalloc(&d_routed_w1, per_w1_bytes * topk), "alloc routed_w1");
+    check_cuda(cudaMalloc(&d_routed_w2, per_w2_bytes * topk), "alloc routed_w2");
+    check_cuda(cudaMalloc(&d_routed_w3, per_w3_bytes * topk), "alloc routed_w3");
+
+    // ===== activation + scratch buffers (allocated once, reused per layer) =====
+    const int x_groups = (dim + 31) / 32;
+    const int hidden_groups = (moe_inter + 15) / 16;
+    const int gate_scratch_n = std::max(topk, n_experts);
+    float* d_x = nullptr;
+    float* d_x_pre_attn = nullptr;
+    float* d_x_normed = nullptr;
+    float* d_q_a = nullptr;
+    float* d_q_normed = nullptr;
+    float* d_q = nullptr;
+    float* d_kv_a = nullptr;
+    float* d_kv = nullptr;
+    float* d_attn_value = nullptr;
+    float* d_attn_mid = nullptr;
+    float* d_attn_out = nullptr;
+    float* d_x_pre_ffn = nullptr;
+    float* d_x_normed_ffn = nullptr;
+    float* d_shared_gate = nullptr;
+    float* d_shared_up = nullptr;
+    float* d_shared_hidden = nullptr;
+    float* d_shared_out = nullptr;
+    float* d_moe_out = nullptr;
+    float* d_ffn_combined = nullptr;
+    int8_t* d_x_q = nullptr;
+    float* d_x_scale = nullptr;
+    int64_t* d_route_slots = nullptr;
+    float* d_route_weights = nullptr;
+    float* d_route_gate = nullptr;
+    float* d_route_up = nullptr;
+    int8_t* d_route_hidden_q = nullptr;
+    float* d_route_hidden_scale = nullptr;
+    float* d_gate_scores_scratch = nullptr;
+    float* d_gate_scored_scratch = nullptr;
+    int64_t* d_gate_indices = nullptr;
+    int64_t* d_tid2eid_i64 = nullptr;
+    uint16_t* d_embed_row_f16 = nullptr;
+    float* d_logits = nullptr;
+    check_cuda(cudaMalloc(&d_x, dim * sizeof(float)), "alloc d_x");
+    check_cuda(cudaMalloc(&d_x_pre_attn, dim * sizeof(float)), "alloc d_x_pre_attn");
+    check_cuda(cudaMalloc(&d_x_normed, dim * sizeof(float)), "alloc d_x_normed");
+    check_cuda(cudaMalloc(&d_q_a, q_a_dim * sizeof(float)), "alloc d_q_a");
+    check_cuda(cudaMalloc(&d_q_normed, q_a_dim * sizeof(float)), "alloc d_q_normed");
+    check_cuda(cudaMalloc(&d_q, q_full * sizeof(float)), "alloc d_q");
+    check_cuda(cudaMalloc(&d_kv_a, kv_dim * sizeof(float)), "alloc d_kv_a");
+    check_cuda(cudaMalloc(&d_kv, kv_dim * sizeof(float)), "alloc d_kv");
+    check_cuda(cudaMalloc(&d_attn_value, q_full * sizeof(float)), "alloc d_attn_value");
+    check_cuda(cudaMalloc(&d_attn_mid, attn_mid * sizeof(float)), "alloc d_attn_mid");
+    check_cuda(cudaMalloc(&d_attn_out, dim * sizeof(float)), "alloc d_attn_out");
+    check_cuda(cudaMalloc(&d_x_pre_ffn, dim * sizeof(float)), "alloc d_x_pre_ffn");
+    check_cuda(cudaMalloc(&d_x_normed_ffn, dim * sizeof(float)), "alloc d_x_normed_ffn");
+    check_cuda(cudaMalloc(&d_shared_gate, moe_inter * sizeof(float)), "alloc d_shared_gate");
+    check_cuda(cudaMalloc(&d_shared_up, moe_inter * sizeof(float)), "alloc d_shared_up");
+    check_cuda(cudaMalloc(&d_shared_hidden, moe_inter * sizeof(float)), "alloc d_shared_hidden");
+    check_cuda(cudaMalloc(&d_shared_out, dim * sizeof(float)), "alloc d_shared_out");
+    check_cuda(cudaMalloc(&d_moe_out, dim * sizeof(float)), "alloc d_moe_out");
+    check_cuda(cudaMalloc(&d_ffn_combined, dim * sizeof(float)), "alloc d_ffn_combined");
+    check_cuda(cudaMalloc(&d_x_q, dim), "alloc d_x_q");
+    check_cuda(cudaMalloc(&d_x_scale, x_groups * sizeof(float)), "alloc d_x_scale");
+    check_cuda(cudaMalloc(&d_route_slots, topk * sizeof(int64_t)), "alloc d_route_slots");
+    check_cuda(cudaMalloc(&d_route_weights, topk * sizeof(float)), "alloc d_route_weights");
+    check_cuda(cudaMalloc(&d_route_gate, static_cast<size_t>(topk) * moe_inter * sizeof(float)),
+               "alloc d_route_gate");
+    check_cuda(cudaMalloc(&d_route_up, static_cast<size_t>(topk) * moe_inter * sizeof(float)),
+               "alloc d_route_up");
+    check_cuda(cudaMalloc(&d_route_hidden_q, static_cast<size_t>(topk) * moe_inter),
+               "alloc d_route_hidden_q");
+    check_cuda(cudaMalloc(&d_route_hidden_scale,
+                          static_cast<size_t>(topk) * hidden_groups * sizeof(float)),
+               "alloc d_route_hidden_scale");
+    check_cuda(cudaMalloc(&d_gate_scores_scratch, gate_scratch_n * sizeof(float)),
+               "alloc d_gate_scores_scratch");
+    check_cuda(cudaMalloc(&d_gate_scored_scratch, n_experts * sizeof(float)),
+               "alloc d_gate_scored_scratch");
+    check_cuda(cudaMalloc(&d_gate_indices, topk * sizeof(int64_t)), "alloc d_gate_indices");
+    check_cuda(cudaMalloc(&d_tid2eid_i64, topk * sizeof(int64_t)), "alloc d_tid2eid_i64");
+    check_cuda(cudaMalloc(&d_embed_row_f16, dim * sizeof(uint16_t)), "alloc d_embed_row_f16");
+    check_cuda(cudaMalloc(&d_logits, vocab * sizeof(float)), "alloc d_logits");
+
+    std::vector<int64_t> h_route_slots(topk);
+    for (int k = 0; k < topk; ++k) h_route_slots[k] = k;
+    check_cuda(cudaMemcpy(d_route_slots, h_route_slots.data(),
+                          topk * sizeof(int64_t), cudaMemcpyHostToDevice),
+               "copy d_route_slots");
+
+    // ===== embed =====
+    const uint16_t* host_embed_row =
+        reinterpret_cast<const uint16_t*>(embed.data) +
+        static_cast<size_t>(token) * dim;
+    check_cuda(cudaMemcpy(d_embed_row_f16, host_embed_row, dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy embed row");
+    if (!f16_row_to_float_cuda(d_embed_row_f16, d_x, /*row=*/0, dim))
+        throw std::runtime_error("f16 embed failed");
+
+    // ===== shared dims for helper =====
+    GgufLayerDims ld;
+    ld.dim = dim; ld.q_a_dim = q_a_dim; ld.heads = heads; ld.head_dim = head_dim;
+    ld.q_full = q_full; ld.kv_dim = kv_dim; ld.rope_dim = rope_dim;
+    ld.o_groups = o_groups; ld.o_lora_rank = o_lora_rank; ld.group_in_dim = group_in_dim;
+    ld.attn_mid = attn_mid; ld.moe_inter = moe_inter;
+    ld.n_experts = n_experts; ld.topk = topk;
+    ld.rope_theta = static_cast<float>(ctx.config.rope_theta);
+    ld.swiglu_limit = static_cast<float>(ctx.config.swiglu_limit);
+    ld.route_scale = static_cast<float>(ctx.config.route_scale);
+
+    GgufLayerScratch ls;
+    ls.d_x = d_x;
+    ls.d_x_pre_attn = d_x_pre_attn; ls.d_x_normed = d_x_normed;
+    ls.d_q_a = d_q_a; ls.d_q_normed = d_q_normed; ls.d_q = d_q;
+    ls.d_kv_a = d_kv_a; ls.d_kv = d_kv;
+    ls.d_attn_value = d_attn_value; ls.d_attn_mid = d_attn_mid; ls.d_attn_out = d_attn_out;
+    ls.d_x_pre_ffn = d_x_pre_ffn; ls.d_x_normed_ffn = d_x_normed_ffn;
+    ls.d_shared_gate = d_shared_gate; ls.d_shared_up = d_shared_up;
+    ls.d_shared_hidden = d_shared_hidden; ls.d_shared_out = d_shared_out;
+    ls.d_moe_out = d_moe_out; ls.d_ffn_combined = d_ffn_combined;
+    ls.d_x_q = d_x_q; ls.d_x_scale = d_x_scale;
+    ls.d_route_slots = d_route_slots; ls.d_route_weights = d_route_weights;
+    ls.d_route_gate = d_route_gate; ls.d_route_up = d_route_up;
+    ls.d_route_hidden_q = d_route_hidden_q; ls.d_route_hidden_scale = d_route_hidden_scale;
+    ls.d_gate_scores_scratch = d_gate_scores_scratch;
+    ls.d_gate_scored_scratch = d_gate_scored_scratch;
+    ls.d_gate_indices = d_gate_indices;
+
+    // ===== per-layer loop =====
+    std::vector<int64_t> h_gate_indices(topk);
+    for (int L = 0; L < n_layers; ++L) {
+        const bool is_hash = (L < n_hash);
+
+        GgufLayerDeviceWeights lw;
+        lw.d_attn_gamma = d_attn_gamma[L]; lw.d_q_gamma = d_q_gamma[L]; lw.d_kv_gamma = d_kv_gamma[L];
+        lw.d_wq_a = d_wq_a[L]; lw.d_wq_b = d_wq_b[L]; lw.d_wkv = d_wkv[L];
+        lw.d_wo_a = d_wo_a[L]; lw.d_wo_b = d_wo_b[L];
+        lw.d_attn_sink = d_attn_sink[L];
+        lw.d_ffn_gamma = d_ffn_gamma[L];
+        lw.d_shared_w1 = d_shared_w1[L]; lw.d_shared_w2 = d_shared_w2[L]; lw.d_shared_w3 = d_shared_w3[L];
+        lw.d_gate_w_bf16 = d_gate_w[L];
+        lw.is_hash = is_hash;
+        lw.d_routed_w1 = d_routed_w1; lw.d_routed_w2 = d_routed_w2; lw.d_routed_w3 = d_routed_w3;
+
+        if (is_hash) {
+            // Upload per-token tid2eid row, converted to int64 (kernel expects i64).
+            const int32_t* row = h_tid2eid_table[L] + static_cast<size_t>(token) * topk;
+            int64_t h_slice[8];
+            for (int k = 0; k < topk; ++k) h_slice[k] = row[k];
+            check_cuda(cudaMemcpy(d_tid2eid_i64, h_slice, topk * sizeof(int64_t),
+                                  cudaMemcpyHostToDevice), "copy tid2eid slice");
+            lw.d_tid2eid_i64 = d_tid2eid_i64;
+            lw.d_gate_bias_f32 = nullptr;
+        } else {
+            lw.d_tid2eid_i64 = nullptr;
+            lw.d_gate_bias_f32 = d_gate_bias[L];
+        }
+
+        // Phase A: attention + ffn_norm + shared + gate.
+        gguf_layer_forward_attn_to_gate(lw, ls, ld, position);
+
+        // Read gate's chosen expert ids, then stage those experts H2D.
+        check_cuda(cudaMemcpy(h_gate_indices.data(), d_gate_indices, topk * sizeof(int64_t),
+                              cudaMemcpyDeviceToHost), "copy gate indices");
+        const std::string lp = "layers." + std::to_string(L);
+        const std::string w1_name = lp + ".ffn.experts.routed.w1";
+        const std::string w2_name = lp + ".ffn.experts.routed.w2";
+        const std::string w3_name = lp + ".ffn.experts.routed.w3";
+        for (int k = 0; k < topk; ++k) {
+            const int eid = static_cast<int>(h_gate_indices[k]);
+            if (eid < 0 || eid >= n_experts)
+                throw std::runtime_error("gate produced out-of-range expert id");
+            auto wv1 = gws.get_expert(w1_name, w1_name, eid);
+            auto wv2 = gws.get_expert(w2_name, w2_name, eid);
+            auto wv3 = gws.get_expert(w3_name, w3_name, eid);
+            if (!wv1.found || !wv2.found || !wv3.found)
+                throw std::runtime_error("get_expert failed during full forward staging");
+            check_cuda(cudaMemcpy(d_routed_w1 + per_w1_bytes * k, wv1.data, per_w1_bytes,
+                                  cudaMemcpyHostToDevice), "stage routed_w1");
+            check_cuda(cudaMemcpy(d_routed_w2 + per_w2_bytes * k, wv2.data, per_w2_bytes,
+                                  cudaMemcpyHostToDevice), "stage routed_w2");
+            check_cuda(cudaMemcpy(d_routed_w3 + per_w3_bytes * k, wv3.data, per_w3_bytes,
+                                  cudaMemcpyHostToDevice), "stage routed_w3");
+        }
+
+        // Phase B: routed MoE + FFN residual.
+        gguf_layer_forward_moe(lw, ls, ld);
+    }
+
+    // ===== final norm + head =====
+    if (!rmsnorm_bf16_gamma_cuda(d_x, d_final_norm_gamma, d_x_normed, dim, 1e-6f))
+        throw std::runtime_error("final norm failed");
+    if (!q8_0_matvec_cuda(d_x_normed, d_head, d_logits, vocab, dim))
+        throw std::runtime_error("head matvec failed");
+    check_cuda(cudaDeviceSynchronize(), "sync after head");
+
+    std::vector<float> h_logits(vocab);
+    check_cuda(cudaMemcpy(h_logits.data(), d_logits, vocab * sizeof(float),
+                          cudaMemcpyDeviceToHost), "copy logits");
+
+    int top_token = 0;
+    float top_logit = -INFINITY;
+    double sum = 0.0;
+    double sq = 0.0;
+    for (int i = 0; i < vocab; ++i) {
+        const float v = h_logits[i];
+        sum += v;
+        sq += static_cast<double>(v) * static_cast<double>(v);
+        if (v > top_logit) { top_logit = v; top_token = i; }
+    }
+
+    GgufFullForwardResult r;
+    r.n_layers = n_layers;
+    r.dim = dim;
+    r.vocab = vocab;
+    r.top_token = top_token;
+    r.top_logit = top_logit;
+    r.checksum = static_cast<float>(sum);
+    r.final_x_rms = device_vector_rms(d_x, dim);
+    r.final_normed_rms = device_vector_rms(d_x_normed, dim);
+    r.logits_rms = static_cast<float>(std::sqrt(sq / vocab));
+    for (int i = 0; i < 4; ++i) r.logits_first[i] = h_logits[i];
+
+    // ===== cleanup =====
+    auto free_vec_u8 = [](std::vector<uint8_t*>& v) { for (auto* p : v) cudaFree(p); };
+    auto free_vec_u16 = [](std::vector<uint16_t*>& v) { for (auto* p : v) cudaFree(p); };
+    auto free_vec_f32 = [](std::vector<float*>& v) { for (auto* p : v) cudaFree(p); };
+    free_vec_u16(d_attn_gamma); free_vec_u16(d_q_gamma); free_vec_u16(d_kv_gamma);
+    free_vec_u16(d_ffn_gamma); free_vec_f32(d_attn_sink);
+    free_vec_u8(d_wq_a); free_vec_u8(d_wq_b); free_vec_u8(d_wkv);
+    free_vec_u8(d_wo_a); free_vec_u8(d_wo_b);
+    free_vec_u8(d_shared_w1); free_vec_u8(d_shared_w2); free_vec_u8(d_shared_w3);
+    free_vec_u16(d_gate_w); free_vec_f32(d_gate_bias);
+    cudaFree(d_final_norm_gamma); cudaFree(d_head);
+    cudaFree(d_routed_w1); cudaFree(d_routed_w2); cudaFree(d_routed_w3);
+    cudaFree(d_x); cudaFree(d_x_pre_attn); cudaFree(d_x_normed);
+    cudaFree(d_q_a); cudaFree(d_q_normed); cudaFree(d_q);
+    cudaFree(d_kv_a); cudaFree(d_kv); cudaFree(d_attn_value);
+    cudaFree(d_attn_mid); cudaFree(d_attn_out);
+    cudaFree(d_x_pre_ffn); cudaFree(d_x_normed_ffn);
+    cudaFree(d_shared_gate); cudaFree(d_shared_up); cudaFree(d_shared_hidden);
+    cudaFree(d_shared_out); cudaFree(d_moe_out); cudaFree(d_ffn_combined);
+    cudaFree(d_x_q); cudaFree(d_x_scale);
+    cudaFree(d_route_slots); cudaFree(d_route_weights);
+    cudaFree(d_route_gate); cudaFree(d_route_up);
+    cudaFree(d_route_hidden_q); cudaFree(d_route_hidden_scale);
+    cudaFree(d_gate_scores_scratch); cudaFree(d_gate_scored_scratch); cudaFree(d_gate_indices);
+    cudaFree(d_tid2eid_i64); cudaFree(d_embed_row_f16); cudaFree(d_logits);
     return r;
 }
 

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -4392,6 +4392,213 @@ GgufRoutedExpertResult run_gguf_routed_expert_smoke(const std::string& ckpt_path
     return r;
 }
 
+GgufRoutedMoeResult run_gguf_routed_moe_smoke(const std::string& ckpt_path, int token) {
+    if (!is_gguf_path(ckpt_path)) {
+        throw std::runtime_error("run_gguf_routed_moe_smoke: not a GGUF path: " + ckpt_path);
+    }
+    if (token < 0) throw std::runtime_error("token must be >= 0");
+
+    GgufForwardContext ctx(ckpt_path);
+    GGUFWeightSource& gws = *ctx.weight_source;
+
+    WeightView embed = gws.require("embed.weight");
+    WeightView ffn_norm = gws.require("layers.0.ffn_norm.weight");
+    if (embed.dtype != DType::F16) throw std::runtime_error("embed dtype");
+    if (ffn_norm.dtype != DType::F32) throw std::runtime_error("ffn_norm dtype");
+
+    // Layer 0 is a hash gate layer: read precomputed expert ids from tid2eid.
+    // GGUF native shape [topk, vocab] = [6, 129280] stored as int32 row-major
+    // where the outer dim (vocab) varies slowest. Per-token row offset:
+    // token * topk * sizeof(int32). Internal-name lookup goes through the
+    // mapping table which Transpose2Ds the shape view to [vocab, topk].
+    WeightView tid2eid = gws.require("layers.0.ffn.gate.tid2eid");
+    // tid2eid dtype is i32 which is not in DType; just verify byte count.
+    const int topk = static_cast<int>(ctx.config.n_activated_experts);
+    const int vocab = static_cast<int>(embed.shape[1]);
+    if (topk <= 0 || topk > 8) {
+        throw std::runtime_error("topk out of supported range (1..8)");
+    }
+    if (token >= vocab) throw std::runtime_error("token id out of vocab range");
+    if (tid2eid.nbytes < static_cast<uint64_t>(token + 1) * topk * sizeof(int32_t)) {
+        throw std::runtime_error("tid2eid too small for requested token");
+    }
+    const int32_t* token_eids =
+        reinterpret_cast<const int32_t*>(tid2eid.data) +
+        static_cast<size_t>(token) * topk;
+    int h_expert_ids[8] = {0};
+    for (int k = 0; k < topk; ++k) h_expert_ids[k] = token_eids[k];
+
+    const int dim = static_cast<int>(embed.shape[0]);
+    const int moe_inter = static_cast<int>(ctx.config.moe_inter_dim);
+
+    // ----- Embed → ffn_norm -----
+    const uint16_t* host_row =
+        reinterpret_cast<const uint16_t*>(embed.data) +
+        static_cast<size_t>(token) * dim;
+    uint16_t* d_row_f16 = nullptr;
+    float* d_x = nullptr;
+    check_cuda(cudaMalloc(&d_row_f16, dim * sizeof(uint16_t)), "alloc d_row_f16");
+    check_cuda(cudaMalloc(&d_x, dim * sizeof(float)), "alloc d_x");
+    check_cuda(cudaMemcpy(d_row_f16, host_row, dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy embed row");
+    if (!f16_row_to_float_cuda(d_row_f16, d_x, /*row=*/0, dim)) {
+        throw std::runtime_error("f16 embed failed");
+    }
+    auto ffn_bf16 = f32_to_bf16_host(reinterpret_cast<const float*>(ffn_norm.data), dim);
+    uint16_t* d_ffn_gamma = nullptr;
+    check_cuda(cudaMalloc(&d_ffn_gamma, dim * sizeof(uint16_t)), "alloc d_ffn_gamma");
+    check_cuda(cudaMemcpy(d_ffn_gamma, ffn_bf16.data(), dim * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy ffn_gamma");
+    float* d_x_normed = nullptr;
+    check_cuda(cudaMalloc(&d_x_normed, dim * sizeof(float)), "alloc d_x_normed");
+    if (!rmsnorm_bf16_gamma_cuda(d_x, d_ffn_gamma, d_x_normed, dim, 1e-6f)) {
+        throw std::runtime_error("ffn_norm failed");
+    }
+
+    // ----- Active expert staging: pack topk experts' w1/w2/w3 bytes -----
+    // Use the first expert's view to learn per-expert sizes. Each routed
+    // tensor has shape [inner=4096, mid=2048, n_experts=256] (or w2 variant
+    // with mid=4096, inner=2048); per-expert byte size is total_nbytes / 256.
+    auto first_w1 = gws.get_expert("layers.0.ffn.experts.routed.w1",
+                                    "layers.0.ffn.experts.routed.w1", 0);
+    auto first_w2 = gws.get_expert("layers.0.ffn.experts.routed.w2",
+                                    "layers.0.ffn.experts.routed.w2", 0);
+    auto first_w3 = gws.get_expert("layers.0.ffn.experts.routed.w3",
+                                    "layers.0.ffn.experts.routed.w3", 0);
+    if (!first_w1.found || !first_w2.found || !first_w3.found) {
+        throw std::runtime_error("get_expert(0) failed");
+    }
+    const uint64_t per_w1_bytes = first_w1.nbytes;
+    const uint64_t per_w2_bytes = first_w2.nbytes;
+    const uint64_t per_w3_bytes = first_w3.nbytes;
+    const uint64_t staged_w1_bytes = per_w1_bytes * static_cast<uint64_t>(topk);
+    const uint64_t staged_w2_bytes = per_w2_bytes * static_cast<uint64_t>(topk);
+    const uint64_t staged_w3_bytes = per_w3_bytes * static_cast<uint64_t>(topk);
+    uint8_t* d_w1 = nullptr;
+    uint8_t* d_w2 = nullptr;
+    uint8_t* d_w3 = nullptr;
+    check_cuda(cudaMalloc(&d_w1, staged_w1_bytes), "alloc staged d_w1");
+    check_cuda(cudaMalloc(&d_w2, staged_w2_bytes), "alloc staged d_w2");
+    check_cuda(cudaMalloc(&d_w3, staged_w3_bytes), "alloc staged d_w3");
+    for (int k = 0; k < topk; ++k) {
+        const int eid = h_expert_ids[k];
+        auto wv1 = gws.get_expert("layers.0.ffn.experts.routed.w1",
+                                   "layers.0.ffn.experts.routed.w1", eid);
+        auto wv2 = gws.get_expert("layers.0.ffn.experts.routed.w2",
+                                   "layers.0.ffn.experts.routed.w2", eid);
+        auto wv3 = gws.get_expert("layers.0.ffn.experts.routed.w3",
+                                   "layers.0.ffn.experts.routed.w3", eid);
+        if (!wv1.found || !wv2.found || !wv3.found) {
+            throw std::runtime_error("get_expert failed for active expert");
+        }
+        check_cuda(cudaMemcpy(d_w1 + per_w1_bytes * k, wv1.data, per_w1_bytes,
+                              cudaMemcpyHostToDevice), "stage w1");
+        check_cuda(cudaMemcpy(d_w2 + per_w2_bytes * k, wv2.data, per_w2_bytes,
+                              cudaMemcpyHostToDevice), "stage w2");
+        check_cuda(cudaMemcpy(d_w3 + per_w3_bytes * k, wv3.data, per_w3_bytes,
+                              cudaMemcpyHostToDevice), "stage w3");
+    }
+
+    // ----- Routes / quant buffers -----
+    const int routes = topk;
+    const int x_groups = (dim + 31) / 32;
+    const int hidden_groups = (moe_inter + 15) / 16;
+    int8_t* d_x_q = nullptr;
+    float* d_x_scale = nullptr;
+    int64_t* d_route_slots = nullptr;
+    float* d_route_weights = nullptr;
+    float* d_gate = nullptr;
+    float* d_up = nullptr;
+    int8_t* d_hidden_q = nullptr;
+    float* d_hidden_scale = nullptr;
+    float* d_y = nullptr;
+    check_cuda(cudaMalloc(&d_x_q, dim), "alloc d_x_q");
+    check_cuda(cudaMalloc(&d_x_scale, x_groups * sizeof(float)), "alloc d_x_scale");
+    check_cuda(cudaMalloc(&d_route_slots, routes * sizeof(int64_t)), "alloc slots");
+    check_cuda(cudaMalloc(&d_route_weights, routes * sizeof(float)), "alloc weights");
+    // Per-route gate / up / hidden buffers (kernel addresses by route).
+    check_cuda(cudaMalloc(&d_gate, static_cast<size_t>(routes) * moe_inter * sizeof(float)),
+               "alloc d_gate");
+    check_cuda(cudaMalloc(&d_up, static_cast<size_t>(routes) * moe_inter * sizeof(float)),
+               "alloc d_up");
+    check_cuda(cudaMalloc(&d_hidden_q, static_cast<size_t>(routes) * moe_inter),
+               "alloc d_hidden_q");
+    check_cuda(cudaMalloc(&d_hidden_scale,
+                          static_cast<size_t>(routes) * hidden_groups * sizeof(float)),
+               "alloc d_hidden_scale");
+    check_cuda(cudaMalloc(&d_y, dim * sizeof(float)), "alloc d_y");
+    check_cuda(cudaMemset(d_y, 0, dim * sizeof(float)), "zero d_y");
+
+    // Staged expert buffer holds K experts back-to-back; slots index 0..K-1.
+    std::vector<int64_t> h_slots(routes);
+    for (int k = 0; k < routes; ++k) h_slots[k] = k;
+    std::vector<float> h_weights(routes, 1.0f / static_cast<float>(routes));
+    check_cuda(cudaMemcpy(d_route_slots, h_slots.data(), routes * sizeof(int64_t),
+                          cudaMemcpyHostToDevice), "copy slots");
+    check_cuda(cudaMemcpy(d_route_weights, h_weights.data(), routes * sizeof(float),
+                          cudaMemcpyHostToDevice), "copy weights");
+
+    // ----- Quantize x once (the w13 kernel reads x_q without per-route stride) -----
+    if (!q2_quantize_x_q8_1_cuda(d_x_normed, d_x_q, d_x_scale, /*routes=*/1, dim)) {
+        throw std::runtime_error("q2_quantize_x_q8_1 failed");
+    }
+
+    // ----- Batched IQ2_XXS w1/w3 across all active experts -----
+    if (!q2_moe_single_w13_iq2_xxs_cuda(d_x_q, d_x_scale, d_route_slots,
+                                         d_w1, d_w3, d_gate, d_up,
+                                         routes, /*n_experts=*/routes,
+                                         dim, moe_inter)) {
+        throw std::runtime_error("q2 w13 iq2_xxs failed");
+    }
+
+    // ----- SwiGLU + route weight + Q8_1 quantize hidden per-route -----
+    const float swiglu_limit = static_cast<float>(ctx.config.swiglu_limit);
+    if (!q2_route_swiglu_quantize_hidden_q8_1_cuda(d_gate, d_up, d_route_weights,
+                                                   d_hidden_q, d_hidden_scale,
+                                                   routes, moe_inter, swiglu_limit)) {
+        throw std::runtime_error("q2 swiglu + quantize failed");
+    }
+
+    // ----- Batched Q2_K w2 (accumulates into d_y via atomicAdd) -----
+    if (!q2_moe_single_w2_q2k_cuda(d_hidden_q, d_hidden_scale, d_route_slots,
+                                    d_w2, d_y,
+                                    routes, /*n_experts=*/routes,
+                                    dim, moe_inter)) {
+        throw std::runtime_error("q2 w2 q2k failed");
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync after routed moe");
+
+    GgufRoutedMoeResult r;
+    r.dim = dim;
+    r.moe_inter_dim = moe_inter;
+    r.n_active = topk;
+    for (int k = 0; k < topk; ++k) r.expert_ids[k] = h_expert_ids[k];
+    r.ffn_normed_rms = device_vector_rms(d_x_normed, dim);
+    r.moe_out_rms = device_vector_rms(d_y, dim);
+    std::vector<float> first(4);
+    check_cuda(cudaMemcpy(first.data(), d_y, 4 * sizeof(float),
+                          cudaMemcpyDeviceToHost), "copy moe_out first");
+    for (int i = 0; i < 4; ++i) r.moe_out_first[i] = first[i];
+
+    cudaFree(d_row_f16);
+    cudaFree(d_x);
+    cudaFree(d_ffn_gamma);
+    cudaFree(d_x_normed);
+    cudaFree(d_w1);
+    cudaFree(d_w2);
+    cudaFree(d_w3);
+    cudaFree(d_x_q);
+    cudaFree(d_x_scale);
+    cudaFree(d_route_slots);
+    cudaFree(d_route_weights);
+    cudaFree(d_gate);
+    cudaFree(d_up);
+    cudaFree(d_hidden_q);
+    cudaFree(d_hidden_scale);
+    cudaFree(d_y);
+    return r;
+}
+
 // --- PersistentEngine implementation ---------------------------------------
 
 struct PersistentEngine::State {

--- a/cpp_engine/src/weight_source.cpp
+++ b/cpp_engine/src/weight_source.cpp
@@ -1,0 +1,214 @@
+#include "weight_source.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace dsv4 {
+
+namespace {
+
+bool ends_with(const std::string& s, const std::string& suffix) {
+    if (s.size() < suffix.size()) return false;
+    return std::equal(suffix.rbegin(), suffix.rend(), s.rbegin());
+}
+
+DType safe_dtype_to_dtype(SafeDType s) {
+    switch (s) {
+        case SafeDType::BF16: return DType::BF16;
+        case SafeDType::F32: return DType::F32;
+        default: return DType::Unknown;
+    }
+}
+
+uint64_t gguf_metadata_int(const GGUFFile& f, const std::string& key, uint64_t default_value) {
+    if (auto v = f.metadata_u64(key)) return *v;
+    if (auto v = f.metadata_i64(key)) return static_cast<uint64_t>(*v);
+    return default_value;
+}
+
+}  // namespace
+
+WeightView WeightSource::require(const std::string& name) const {
+    WeightView view = get(name);
+    if (!view.found) {
+        throw std::runtime_error("WeightSource: required tensor missing: " + name);
+    }
+    return view;
+}
+
+bool is_gguf_path(const std::string& path) {
+    return ends_with(path, ".gguf");
+}
+
+std::unique_ptr<WeightSource> open_weight_source(const std::string& path) {
+    if (is_gguf_path(path)) {
+        return std::make_unique<GGUFWeightSource>(path);
+    }
+    return std::make_unique<SafetensorsWeightSource>(path);
+}
+
+// ---------- SafetensorsWeightSource ----------
+
+SafetensorsWeightSource::SafetensorsWeightSource(const std::string& ckpt_dir)
+    : index_(ckpt_dir) {}
+
+SafeTensorsShard& SafetensorsWeightSource::shard_for(const std::string& tensor_name) const {
+    const std::string* shard_name = index_.shard_for_tensor(tensor_name);
+    if (shard_name == nullptr) {
+        throw std::runtime_error("safetensors index missing tensor: " + tensor_name);
+    }
+    auto it = shards_.find(*shard_name);
+    if (it == shards_.end()) {
+        auto shard = std::make_unique<SafeTensorsShard>(index_.shard_path(*shard_name));
+        it = shards_.emplace(*shard_name, std::move(shard)).first;
+    }
+    return *it->second;
+}
+
+bool SafetensorsWeightSource::has(const std::string& name) const {
+    return index_.shard_for_tensor(name) != nullptr;
+}
+
+WeightView SafetensorsWeightSource::get(const std::string& name) const {
+    WeightView view;
+    view.name = name;
+    if (!has(name)) return view;
+    SafeTensorsShard& shard = shard_for(name);
+    const SafeTensorInfo* info = shard.find_tensor(name);
+    if (info == nullptr) return view;
+    view.dtype = safe_dtype_to_dtype(info->dtype);
+    view.shape = info->shape;
+    view.data = shard.tensor_data(*info);
+    view.nbytes = info->nbytes;
+    view.found = true;
+    return view;
+}
+
+WeightView SafetensorsWeightSource::get_expert(const std::string& /*routed_name_3d*/,
+                                                const std::string& per_expert_name,
+                                                int /*expert_id*/) const {
+    return get(per_expert_name);
+}
+
+// ---------- GGUFWeightSource ----------
+
+GGUFWeightSource::GGUFWeightSource(const std::string& path) : file_(path) {
+    int n_layers = static_cast<int>(gguf_metadata_int(file_, "deepseek4.block_count", 43));
+    int n_hash_layers = static_cast<int>(gguf_metadata_int(file_, "deepseek4.hash_layer_count", 3));
+    int n_experts = static_cast<int>(gguf_metadata_int(file_, "deepseek4.expert_count", 256));
+    build_mapping(n_layers, n_hash_layers, n_experts);
+}
+
+void GGUFWeightSource::build_mapping(int n_layers, int n_hash_layers, int /*n_experts*/) {
+    auto add = [&](const std::string& internal, const std::string& gguf, Transform transform) {
+        by_internal_name_[internal] = Mapping{gguf, transform};
+    };
+
+    add("embed.weight", "token_embd.weight", Transform::Transpose2D);
+    add("head.weight", "output.weight", Transform::Transpose2D);
+    add("norm.weight", "output_norm.weight", Transform::Direct);
+    add("hc_head_fn", "output_hc_fn.weight", Transform::Transpose2D);
+    add("hc_head_base", "output_hc_base.weight", Transform::Direct);
+    add("hc_head_scale", "output_hc_scale.weight", Transform::Direct);
+
+    for (int layer = 0; layer < n_layers; ++layer) {
+        const std::string gp = "blk." + std::to_string(layer);
+        const std::string tp = "layers." + std::to_string(layer);
+
+        add(tp + ".attn.attn_sink", gp + ".attn_sinks.weight", Transform::Direct);
+        add(tp + ".attn.wq_a.weight", gp + ".attn_q_a.weight", Transform::Transpose2D);
+        add(tp + ".attn.q_norm.weight", gp + ".attn_q_a_norm.weight", Transform::Direct);
+        add(tp + ".attn.wq_b.weight", gp + ".attn_q_b.weight", Transform::Transpose2D);
+        add(tp + ".attn.wkv.weight", gp + ".attn_kv.weight", Transform::Transpose2D);
+        add(tp + ".attn.kv_norm.weight", gp + ".attn_kv_a_norm.weight", Transform::Direct);
+        add(tp + ".attn.wo_a.weight", gp + ".attn_output_a.weight", Transform::Transpose2D);
+        add(tp + ".attn.wo_b.weight", gp + ".attn_output_b.weight", Transform::Transpose2D);
+        add(tp + ".attn_norm.weight", gp + ".attn_norm.weight", Transform::Direct);
+
+        add(tp + ".ffn.gate.weight", gp + ".ffn_gate_inp.weight", Transform::Transpose2D);
+        if (layer < n_hash_layers) {
+            add(tp + ".ffn.gate.tid2eid", gp + ".ffn_gate_tid2eid.weight", Transform::Transpose2D);
+        } else {
+            add(tp + ".ffn.gate.bias", gp + ".exp_probs_b.bias", Transform::Direct);
+        }
+
+        // Routed experts share a 3D tensor in GGUF; per-expert slices resolve
+        // through get_expert() rather than the per-expert internal name lookup.
+        add(tp + ".ffn.experts.routed.w1", gp + ".ffn_gate_exps.weight", Transform::RoutedExpertTranspose);
+        add(tp + ".ffn.experts.routed.w2", gp + ".ffn_down_exps.weight", Transform::RoutedExpertTranspose);
+        add(tp + ".ffn.experts.routed.w3", gp + ".ffn_up_exps.weight", Transform::RoutedExpertTranspose);
+
+        add(tp + ".ffn.shared_experts.w1.weight", gp + ".ffn_gate_shexp.weight", Transform::Transpose2D);
+        add(tp + ".ffn.shared_experts.w2.weight", gp + ".ffn_down_shexp.weight", Transform::Transpose2D);
+        add(tp + ".ffn.shared_experts.w3.weight", gp + ".ffn_up_shexp.weight", Transform::Transpose2D);
+        add(tp + ".ffn_norm.weight", gp + ".ffn_norm.weight", Transform::Direct);
+
+        add(tp + ".hc_attn_fn", gp + ".hc_attn_fn.weight", Transform::Transpose2D);
+        add(tp + ".hc_attn_base", gp + ".hc_attn_base.weight", Transform::Direct);
+        add(tp + ".hc_attn_scale", gp + ".hc_attn_scale.weight", Transform::Direct);
+        add(tp + ".hc_ffn_fn", gp + ".hc_ffn_fn.weight", Transform::Transpose2D);
+        add(tp + ".hc_ffn_base", gp + ".hc_ffn_base.weight", Transform::Direct);
+        add(tp + ".hc_ffn_scale", gp + ".hc_ffn_scale.weight", Transform::Direct);
+
+        add(tp + ".attn.compressor.ape", gp + ".attn_compressor_ape.weight", Transform::Transpose2D);
+        add(tp + ".attn.compressor.wkv.weight", gp + ".attn_compressor_kv.weight", Transform::Transpose2D);
+        add(tp + ".attn.compressor.wgate.weight", gp + ".attn_compressor_gate.weight", Transform::Transpose2D);
+        add(tp + ".attn.compressor.norm.weight", gp + ".attn_compressor_norm.weight", Transform::Direct);
+
+        add(tp + ".attn.indexer.wq_b.weight", gp + ".indexer.attn_q_b.weight", Transform::Transpose2D);
+        add(tp + ".attn.indexer.weights_proj.weight", gp + ".indexer.proj.weight", Transform::Transpose2D);
+        add(tp + ".attn.indexer.compressor.ape", gp + ".indexer_compressor_ape.weight", Transform::Transpose2D);
+        add(tp + ".attn.indexer.compressor.wkv.weight", gp + ".indexer_compressor_kv.weight", Transform::Transpose2D);
+        add(tp + ".attn.indexer.compressor.wgate.weight", gp + ".indexer_compressor_gate.weight", Transform::Transpose2D);
+        add(tp + ".attn.indexer.compressor.norm.weight", gp + ".indexer_compressor_norm.weight", Transform::Direct);
+    }
+}
+
+bool GGUFWeightSource::has(const std::string& name) const {
+    auto it = by_internal_name_.find(name);
+    if (it == by_internal_name_.end()) return false;
+    return file_.find_tensor(it->second.gguf_name) != nullptr;
+}
+
+WeightView GGUFWeightSource::get(const std::string& name) const {
+    WeightView view;
+    view.name = name;
+    auto it = by_internal_name_.find(name);
+    if (it == by_internal_name_.end()) return view;
+    const GGUFTensorInfo* info = file_.find_tensor(it->second.gguf_name);
+    if (info == nullptr) return view;
+    TensorView tv = file_.tensor_view(*info);
+    view.dtype = tv.dtype;
+    view.shape = tv.shape;
+    view.data = tv.data;
+    view.nbytes = tv.nbytes;
+    view.found = true;
+    return view;
+}
+
+WeightView GGUFWeightSource::get_expert(const std::string& routed_name_3d,
+                                         const std::string& per_expert_name,
+                                         int expert_id) const {
+    WeightView view;
+    view.name = per_expert_name;
+    auto it = by_internal_name_.find(routed_name_3d);
+    if (it == by_internal_name_.end()) return view;
+    const GGUFTensorInfo* info = file_.find_tensor(it->second.gguf_name);
+    if (info == nullptr) return view;
+    if (info->shape.size() != 3) return view;
+    const uint64_t a = info->shape[0];
+    const uint64_t b = info->shape[1];
+    const uint64_t n_experts = info->shape[2];
+    if (static_cast<uint64_t>(expert_id) >= n_experts) return view;
+    if (info->nbytes % n_experts != 0) return view;
+    const uint64_t per_expert_nbytes = info->nbytes / n_experts;
+    TensorView tv = file_.tensor_view(*info);
+    view.dtype = info->dtype;
+    view.shape = {b, a};  // routed_expert_transpose: [a,b,n_experts] -> per-expert [b,a]
+    view.data = tv.data + per_expert_nbytes * static_cast<uint64_t>(expert_id);
+    view.nbytes = per_expert_nbytes;
+    view.found = true;
+    return view;
+}
+
+}  // namespace dsv4

--- a/cpp_engine/tests/probe_host_register.cpp
+++ b/cpp_engine/tests/probe_host_register.cpp
@@ -1,0 +1,88 @@
+// Measure cudaHostRegister overhead on the full GGUF mmap region and verify
+// that subsequent H2D from that region is async + high-bandwidth (pinned).
+// Goal: confirm the "register-once at load, async H2D forever after" pattern
+// before wiring it into the decode path.
+
+#include "gguf_reader.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <chrono>
+#include <cuda_runtime.h>
+
+static void check(cudaError_t err, const char* msg) {
+    if (err != cudaSuccess) {
+        std::cerr << msg << ": " << cudaGetErrorString(err) << "\n";
+        std::exit(1);
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: probe_host_register <model.gguf>\n";
+        return 2;
+    }
+
+    dsv4::GGUFFile gguf(argv[1]);
+    const void* base = gguf.bytes();
+    const size_t bytes = gguf.file_size();
+    std::printf("gguf size = %.2f GB\n", bytes / (1024.0 * 1024.0 * 1024.0));
+
+    auto t0 = std::chrono::steady_clock::now();
+    cudaError_t err = cudaHostRegister(const_cast<void*>(base), bytes,
+                                       cudaHostRegisterReadOnly);
+    auto t1 = std::chrono::steady_clock::now();
+    if (err != cudaSuccess) {
+        std::printf("cudaHostRegister(ReadOnly) failed: %s; trying default flags\n",
+                    cudaGetErrorString(err));
+        t0 = std::chrono::steady_clock::now();
+        err = cudaHostRegister(const_cast<void*>(base), bytes, cudaHostRegisterDefault);
+        t1 = std::chrono::steady_clock::now();
+        if (err != cudaSuccess) {
+            std::printf("cudaHostRegister(Default) failed: %s\n", cudaGetErrorString(err));
+            return 1;
+        }
+        std::printf("register(Default) ok, took %.3f s\n",
+                    std::chrono::duration<double>(t1 - t0).count());
+    } else {
+        std::printf("register(ReadOnly) ok, took %.3f s\n",
+                    std::chrono::duration<double>(t1 - t0).count());
+    }
+
+    // Bandwidth test: copy a 100 MB region (offset 1 GB in to skip header/metadata).
+    constexpr size_t test_bytes = 100ull * 1024 * 1024;
+    constexpr size_t test_offset = 1ull * 1024 * 1024 * 1024;
+    if (test_offset + test_bytes > bytes) {
+        std::printf("file too small for bandwidth test\n");
+        cudaHostUnregister(const_cast<void*>(base));
+        return 0;
+    }
+    void* d_buf = nullptr;
+    check(cudaMalloc(&d_buf, test_bytes), "cudaMalloc");
+
+    // Warmup + 3 trials
+    const char* src = reinterpret_cast<const char*>(base) + test_offset;
+    for (int trial = -1; trial < 3; ++trial) {
+        check(cudaDeviceSynchronize(), "sync before");
+        auto t_h = std::chrono::steady_clock::now();
+        check(cudaMemcpy(d_buf, src, test_bytes, cudaMemcpyHostToDevice), "memcpy");
+        check(cudaDeviceSynchronize(), "sync after");
+        auto t_e = std::chrono::steady_clock::now();
+        double s = std::chrono::duration<double>(t_e - t_h).count();
+        double gbs = (test_bytes / s) / (1024.0 * 1024.0 * 1024.0);
+        if (trial >= 0) {
+            std::printf("trial %d: 100 MB H2D in %.3f ms = %.2f GB/s\n",
+                        trial, s * 1000.0, gbs);
+        }
+    }
+
+    check(cudaFree(d_buf), "free");
+    auto u0 = std::chrono::steady_clock::now();
+    check(cudaHostUnregister(const_cast<void*>(base)), "cudaHostUnregister");
+    auto u1 = std::chrono::steady_clock::now();
+    std::printf("unregister took %.3f s\n",
+                std::chrono::duration<double>(u1 - u0).count());
+    return 0;
+}

--- a/cpp_engine/tests/test_gguf_attn_full.cpp
+++ b/cpp_engine/tests/test_gguf_attn_full.cpp
@@ -1,0 +1,65 @@
+// Phase 3 step: full single-token dense attention chain for layer 0.
+// Embed -> attn_norm -> Q & KV projections -> sparse attention with attn_sink
+// -> inverse RoPE -> grouped wo_a Q8_0 -> wo_b Q8_0 -> attn_out[dim].
+
+#include "dsv4_engine.hpp"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: test_gguf_attn_full <model.gguf> [token] [position]\n";
+        return 2;
+    }
+    const int token = argc >= 3 ? std::atoi(argv[2]) : 1234;
+    const int position = argc >= 4 ? std::atoi(argv[3]) : 0;
+    try {
+        auto r = dsv4::run_gguf_attn_full_smoke(argv[1], token, position);
+        std::printf("token=%d position=%d dim=%d heads=%d head_dim=%d kv_dim=%d rope_dim=%d\n",
+                    token, position, r.dim, r.heads, r.head_dim, r.kv_dim, r.rope_dim);
+        std::printf("o_groups=%d o_lora_rank=%d attn_mid=%d\n",
+                    r.o_groups, r.o_lora_rank, r.attn_mid);
+        std::printf("q_rms                  = %.4f\n", r.q_rms);
+        std::printf("kv_rms                 = %.4f\n", r.kv_rms);
+        std::printf("attn_value_rms         = %.4f\n", r.attn_value_rms);
+        std::printf("attn_value_post_inv_rms= %.4f  (inverse RoPE preserves L2)\n",
+                    r.attn_value_post_inv_rms);
+        std::printf("attn_mid_rms           = %.4f\n", r.attn_mid_rms);
+        std::printf("attn_out_rms           = %.4f\n", r.attn_out_rms);
+        std::printf("attn_out[0..3]         = %.4f %.4f %.4f %.4f\n",
+                    r.attn_out_first[0], r.attn_out_first[1],
+                    r.attn_out_first[2], r.attn_out_first[3]);
+
+        if (!(r.q_rms > 1e-4f && r.q_rms < 1000.0f)) {
+            std::cerr << "[FAIL] q_rms\n"; return 1;
+        }
+        if (!(r.kv_rms > 1e-4f && r.kv_rms < 1000.0f)) {
+            std::cerr << "[FAIL] kv_rms\n"; return 1;
+        }
+        if (!(r.attn_value_rms > 1e-6f && r.attn_value_rms < 1000.0f)) {
+            std::cerr << "[FAIL] attn_value_rms\n"; return 1;
+        }
+        // Inverse RoPE is an orthogonal rotation per pair; preserves total L2.
+        const float ratio =
+            r.attn_value_post_inv_rms / std::max(r.attn_value_rms, 1e-12f);
+        if (!(ratio > 0.99f && ratio < 1.01f)) {
+            std::cerr << "[FAIL] inverse RoPE changed RMS: ratio=" << ratio << "\n";
+            return 1;
+        }
+        if (!(r.attn_mid_rms > 1e-6f && r.attn_mid_rms < 1000.0f)) {
+            std::cerr << "[FAIL] attn_mid_rms\n"; return 1;
+        }
+        if (!(r.attn_out_rms > 1e-6f && r.attn_out_rms < 1000.0f)) {
+            std::cerr << "[FAIL] attn_out_rms\n"; return 1;
+        }
+        std::cout << "[PASS] gguf attn full smoke\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "[FAIL] " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_gguf_attn_kv_path.cpp
+++ b/cpp_engine/tests/test_gguf_attn_kv_path.cpp
@@ -1,0 +1,53 @@
+// Phase 3 step: GGUF attention KV-path smoke for layer 0.
+// Embed -> attn_norm -> wkv -> kv_norm -> head_rmsnorm_rope (heads=1).
+//
+// kv_dim = 512 (= kv_lora_rank 448 + rope_dim 64). RoPE is a rotation so the
+// post-rope L2 norm equals the post-rmsnorm L2 norm. Since RMSNorm with gamma
+// gives RMS ~ |gamma|_avg, we check the rope step preserves the kv RMS.
+
+#include "dsv4_engine.hpp"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: test_gguf_attn_kv_path <model.gguf> [token] [position]\n";
+        return 2;
+    }
+    const int token = argc >= 3 ? std::atoi(argv[2]) : 1234;
+    const int position = argc >= 4 ? std::atoi(argv[3]) : 0;
+    try {
+        auto r = dsv4::run_gguf_attn_kv_path_smoke(argv[1], token, position);
+        std::printf("token=%d position=%d dim=%d kv_dim=%d rope_dim=%d\n",
+                    token, position, r.dim, r.kv_dim, r.rope_dim);
+        std::printf("kv_a_rms         = %.4f\n", r.kv_a_rms);
+        std::printf("kv_norm_rms      = %.4f\n", r.kv_norm_rms);
+        std::printf("kv_post_rope_rms = %.4f  (RoPE preserves L2 norm)\n",
+                    r.kv_post_rope_rms);
+        std::printf("kv[0..3]         = %.4f %.4f %.4f %.4f\n",
+                    r.kv_first[0], r.kv_first[1], r.kv_first[2], r.kv_first[3]);
+
+        if (!(r.kv_a_rms > 1e-4f && r.kv_a_rms < 1000.0f)) {
+            std::cerr << "[FAIL] kv_a_rms\n"; return 1;
+        }
+        if (!(r.kv_norm_rms > 1e-4f && r.kv_norm_rms < 1000.0f)) {
+            std::cerr << "[FAIL] kv_norm_rms\n"; return 1;
+        }
+        // RoPE is an orthogonal rotation per pair; full-tensor L2 (and hence RMS)
+        // is preserved.
+        const float ratio = r.kv_post_rope_rms / std::max(r.kv_norm_rms, 1e-12f);
+        if (!(ratio > 0.99f && ratio < 1.01f)) {
+            std::cerr << "[FAIL] RoPE changed kv RMS: ratio=" << ratio << "\n";
+            return 1;
+        }
+        std::cout << "[PASS] gguf attn kv path smoke\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "[FAIL] " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_gguf_attn_norm_wqa.cpp
+++ b/cpp_engine/tests/test_gguf_attn_norm_wqa.cpp
@@ -1,0 +1,46 @@
+// Phase 3 step: GGUF dense q_a chain (embed -> attn_norm RMSNorm -> wq_a).
+// Validates the F32 norm gamma conversion path and the first Q8_0 attention
+// projection against real GGUF data, paving the way for the rest of the
+// attention forward.
+
+#include "dsv4_engine.hpp"
+
+#include <cstdio>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: test_gguf_attn_norm_wqa <model.gguf> [token]\n";
+        return 2;
+    }
+    const int token = argc >= 3 ? std::atoi(argv[2]) : 1234;
+    try {
+        auto r = dsv4::run_gguf_attn_norm_wq_a_smoke(argv[1], token);
+        std::printf("token=%d dim=%d q_a_dim=%d\n", token, r.dim, r.q_a_dim);
+        std::printf("embed_rms  = %.4f\n", r.embed_rms);
+        std::printf("normed_rms = %.4f  (RMSNorm should bring this to ~|gamma|_rms)\n",
+                    r.normed_rms);
+        std::printf("q_a_rms    = %.4f\n", r.q_a_rms);
+        std::printf("q_a[0..3]  = %.4f %.4f %.4f %.4f\n",
+                    r.q_a_first[0], r.q_a_first[1], r.q_a_first[2], r.q_a_first[3]);
+        if (!(r.embed_rms > 1e-6f && r.embed_rms < 100.0f)) {
+            std::cerr << "[FAIL] embed_rms out of plausible range\n";
+            return 1;
+        }
+        if (!(r.normed_rms > 1e-3f && r.normed_rms < 100.0f)) {
+            std::cerr << "[FAIL] normed_rms out of plausible range\n";
+            return 1;
+        }
+        if (!(r.q_a_rms > 1e-3f && r.q_a_rms < 1000.0f)) {
+            std::cerr << "[FAIL] q_a_rms out of plausible range\n";
+            return 1;
+        }
+        std::cout << "[PASS] gguf attn_norm + wq_a smoke\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "[FAIL] " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_gguf_attn_q_path.cpp
+++ b/cpp_engine/tests/test_gguf_attn_q_path.cpp
@@ -1,0 +1,47 @@
+// Phase 3 step: full GGUF attention Q-path smoke for layer 0.
+// Embed -> attn_norm -> wq_a -> q_norm -> wq_b -> head_rmsnorm_rope.
+
+#include "dsv4_engine.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: test_gguf_attn_q_path <model.gguf> [token] [position]\n";
+        return 2;
+    }
+    const int token = argc >= 3 ? std::atoi(argv[2]) : 1234;
+    const int position = argc >= 4 ? std::atoi(argv[3]) : 0;
+    try {
+        auto r = dsv4::run_gguf_attn_q_path_smoke(argv[1], token, position);
+        std::printf("token=%d position=%d dim=%d q_a_dim=%d heads=%d head_dim=%d rope_dim=%d\n",
+                    token, position, r.dim, r.q_a_dim, r.heads, r.head_dim, r.rope_dim);
+        std::printf("q_normed_rms    = %.4f\n", r.q_normed_rms);
+        std::printf("q_pre_rope_rms  = %.4f\n", r.q_pre_rope_rms);
+        std::printf("q_post_rope_rms = %.4f  (per-head norm makes head-RMS == 1)\n",
+                    r.q_post_rope_rms);
+        std::printf("q[0..3]         = %.4f %.4f %.4f %.4f\n",
+                    r.q_first[0], r.q_first[1], r.q_first[2], r.q_first[3]);
+        if (!(r.q_normed_rms > 1e-3f && r.q_normed_rms < 100.0f)) {
+            std::cerr << "[FAIL] q_normed_rms\n"; return 1;
+        }
+        if (!(r.q_pre_rope_rms > 1e-3f && r.q_pre_rope_rms < 1000.0f)) {
+            std::cerr << "[FAIL] q_pre_rope_rms\n"; return 1;
+        }
+        // After per-head RMSNorm each head has RMS==1, so the full-tensor RMS
+        // is also ~1 (RoPE is a rotation that preserves L2 norm).
+        if (!(r.q_post_rope_rms > 0.5f && r.q_post_rope_rms < 2.0f)) {
+            std::cerr << "[FAIL] q_post_rope_rms expected ~1, got "
+                      << r.q_post_rope_rms << "\n";
+            return 1;
+        }
+        std::cout << "[PASS] gguf attn q path smoke\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "[FAIL] " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_gguf_dense_smoke.cpp
+++ b/cpp_engine/tests/test_gguf_dense_smoke.cpp
@@ -1,0 +1,158 @@
+// Minimum smoke test for the GGUF dense forward primitives.
+//
+// Validates that:
+//   1. open_weight_source() returns a working GGUFWeightSource for a .gguf
+//      checkpoint and that the mapping table resolves the dense (non-MoE)
+//      tensors needed for forward (embed/head/norm/attn projections).
+//   2. f16_row_to_float_cuda correctly dequantizes a single token's embedding
+//      row from the F16 embed matrix (mirrors the FP4 path's bf16_row_to_float
+//      step for embed lookup).
+//
+// This is the first wired-up brick of the GGUF dense forward path; the full
+// embed→attn→head chain will be assembled in follow-up commits.
+
+#include "cuda_ops.hpp"
+#include "weight_source.hpp"
+
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+#define CHECK_CUDA(expr) do { \
+    cudaError_t _err = (expr); \
+    if (_err != cudaSuccess) { \
+        throw std::runtime_error(std::string("cuda: ") + cudaGetErrorString(_err)); \
+    } \
+} while (0)
+
+const char* dt_name(dsv4::DType dt) {
+    using dsv4::DType;
+    switch (dt) {
+        case DType::F16: return "f16";
+        case DType::BF16: return "bf16";
+        case DType::F32: return "f32";
+        case DType::Q8_0: return "q8_0";
+        case DType::Q2_K: return "q2_k";
+        case DType::IQ2_XXS: return "iq2_xxs";
+        default: return "unknown";
+    }
+}
+
+void describe(const dsv4::WeightSource& ws, const std::string& name) {
+    if (!ws.has(name)) {
+        std::printf("  %-44s MISSING\n", name.c_str());
+        return;
+    }
+    auto view = ws.require(name);
+    std::string shape = "[";
+    for (size_t i = 0; i < view.shape.size(); ++i) {
+        if (i) shape += ",";
+        shape += std::to_string(view.shape[i]);
+    }
+    shape += "]";
+    std::printf("  %-44s %-7s %-22s nbytes=%llu\n",
+                name.c_str(), dt_name(view.dtype), shape.c_str(),
+                static_cast<unsigned long long>(view.nbytes));
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: test_gguf_dense_smoke <model.gguf>\n";
+        return 2;
+    }
+    try {
+        auto ws = dsv4::open_weight_source(argv[1]);
+        if (ws->format() != dsv4::WeightSource::Format::GGUF_Q2) {
+            throw std::runtime_error("test requires a GGUF Q2 checkpoint");
+        }
+
+        std::printf("=== layer 0 dense tensors ===\n");
+        describe(*ws, "embed.weight");
+        describe(*ws, "head.weight");
+        describe(*ws, "norm.weight");
+        describe(*ws, "layers.0.attn_norm.weight");
+        describe(*ws, "layers.0.ffn_norm.weight");
+        describe(*ws, "layers.0.attn.wq_a.weight");
+        describe(*ws, "layers.0.attn.q_norm.weight");
+        describe(*ws, "layers.0.attn.wq_b.weight");
+        describe(*ws, "layers.0.attn.wkv.weight");
+        describe(*ws, "layers.0.attn.kv_norm.weight");
+        describe(*ws, "layers.0.attn.wo_a.weight");
+        describe(*ws, "layers.0.attn.wo_b.weight");
+        describe(*ws, "layers.0.attn.attn_sink");
+        describe(*ws, "layers.0.ffn.shared_experts.w1.weight");
+        describe(*ws, "layers.0.ffn.shared_experts.w2.weight");
+        describe(*ws, "layers.0.ffn.shared_experts.w3.weight");
+
+        // --- Embed F16 lookup smoke test ---
+        auto embed = ws->require("embed.weight");
+        if (embed.dtype != dsv4::DType::F16) {
+            throw std::runtime_error(std::string("embed dtype expected f16, got ") +
+                                     dt_name(embed.dtype));
+        }
+        if (embed.shape.size() != 2) {
+            throw std::runtime_error("embed shape rank != 2");
+        }
+        // GGUF stores token_embd as [dim, vocab]; per-token row is contiguous
+        // (dim elements per token), matching FP4's [vocab, dim] row-major.
+        const int dim = static_cast<int>(embed.shape[0]);
+        const int vocab = static_cast<int>(embed.shape[1]);
+        const int token = 1234;
+        if (token >= vocab) {
+            throw std::runtime_error("token id out of vocab");
+        }
+
+        const uint16_t* host_row = reinterpret_cast<const uint16_t*>(embed.data) +
+                                   static_cast<size_t>(token) * dim;
+
+        uint16_t* d_row_f16 = nullptr;
+        float* d_x_f32 = nullptr;
+        CHECK_CUDA(cudaMalloc(&d_row_f16, dim * sizeof(uint16_t)));
+        CHECK_CUDA(cudaMalloc(&d_x_f32, dim * sizeof(float)));
+        CHECK_CUDA(cudaMemcpy(d_row_f16, host_row, dim * sizeof(uint16_t),
+                              cudaMemcpyHostToDevice));
+
+        if (!dsv4::f16_row_to_float_cuda(d_row_f16, d_x_f32, /*row=*/0, dim)) {
+            throw std::runtime_error("f16_row_to_float_cuda failed");
+        }
+        CHECK_CUDA(cudaDeviceSynchronize());
+
+        std::vector<float> h_x(dim);
+        CHECK_CUDA(cudaMemcpy(h_x.data(), d_x_f32, dim * sizeof(float),
+                              cudaMemcpyDeviceToHost));
+
+        double sumsq = 0.0;
+        for (float v : h_x) sumsq += static_cast<double>(v) * static_cast<double>(v);
+        const float rms = static_cast<float>(std::sqrt(sumsq / dim));
+
+        std::printf("\n=== embed lookup ===\n");
+        std::printf("token=%d dim=%d vocab=%d\n", token, dim, vocab);
+        std::printf("first[0..7] = %.4f %.4f %.4f %.4f %.4f %.4f %.4f %.4f\n",
+                    h_x[0], h_x[1], h_x[2], h_x[3],
+                    h_x[4], h_x[5], h_x[6], h_x[7]);
+        std::printf("rms=%.4f\n", rms);
+
+        cudaFree(d_row_f16);
+        cudaFree(d_x_f32);
+
+        if (!(rms > 1e-6f && rms < 100.0f)) {
+            std::cerr << "[FAIL] rms outside plausible range\n";
+            return 1;
+        }
+        std::cout << "[PASS] gguf dense smoke\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "[FAIL] " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_gguf_full_forward.cpp
+++ b/cpp_engine/tests/test_gguf_full_forward.cpp
@@ -1,0 +1,51 @@
+// Phase 3 milestone: full 43-layer GGUF forward + final norm + Q8_0 head +
+// argmax. Validates that the per-layer helper composes correctly across all
+// layers, both hash (0..n_hash-1) and non-hash (n_hash..n_layers-1) gate
+// paths, and ends with a sane top token + logit.
+
+#include "dsv4_engine.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: test_gguf_full_forward <model.gguf> [token] [position]\n";
+        return 2;
+    }
+    const int token = argc >= 3 ? std::atoi(argv[2]) : 1234;
+    const int position = argc >= 4 ? std::atoi(argv[3]) : 0;
+    try {
+        auto r = dsv4::run_gguf_full_forward_smoke(argv[1], token, position);
+        std::printf("token=%d position=%d n_layers=%d dim=%d vocab=%d\n",
+                    token, position, r.n_layers, r.dim, r.vocab);
+        std::printf("final_x_rms      = %.4f\n", r.final_x_rms);
+        std::printf("final_normed_rms = %.4f\n", r.final_normed_rms);
+        std::printf("logits_rms       = %.4f\n", r.logits_rms);
+        std::printf("logits[0..3]     = %.4f %.4f %.4f %.4f\n",
+                    r.logits_first[0], r.logits_first[1],
+                    r.logits_first[2], r.logits_first[3]);
+        std::printf("top_token=%d top_logit=%.4f checksum=%.4f\n",
+                    r.top_token, r.top_logit, r.checksum);
+
+        if (!(r.final_x_rms > 0.01f && r.final_x_rms < 1000.0f)) {
+            std::cerr << "[FAIL] final_x_rms out of range\n"; return 1;
+        }
+        if (!(r.logits_rms > 0.01f && r.logits_rms < 1000.0f)) {
+            std::cerr << "[FAIL] logits_rms out of range\n"; return 1;
+        }
+        if (r.top_token < 0 || r.top_token >= r.vocab) {
+            std::cerr << "[FAIL] top_token out of range\n"; return 1;
+        }
+        if (!(r.top_logit > -1e6f && r.top_logit < 1e6f)) {
+            std::cerr << "[FAIL] top_logit out of range\n"; return 1;
+        }
+        std::cout << "[PASS] gguf full 43-layer forward smoke\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "[FAIL] " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_gguf_generate.cpp
+++ b/cpp_engine/tests/test_gguf_generate.cpp
@@ -4,57 +4,84 @@
 //   - the run completes without OOM/throw,
 //   - each step produces a valid in-range token,
 //   - per-step wall time is reported for a coarse decode-tps signal.
+//
+// TP mode (optional, all ranks must agree):
+//   --tp-world W --tp-rank R --nccl-id-path PATH [--device D]
+//
+// Positional args are: <model.gguf> [max_new_tokens] [seed1 seed2 ...]
 
 #include "dsv4_engine.hpp"
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 int main(int argc, char** argv) {
-    if (argc < 2) {
-        std::cerr << "usage: test_gguf_generate <model.gguf> [max_new_tokens] [seed1 seed2 ...]\n";
+    dsv4::ForwardSmokeOptions opts;
+    std::string ckpt;
+    int max_new = 4;
+    std::vector<int> seeds;
+
+    std::vector<std::string> positional;
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        auto need = [&](const char* name) {
+            if (i + 1 >= argc) throw std::runtime_error(std::string("missing value for ") + name);
+            return std::string(argv[++i]);
+        };
+        if (a == "--tp-world") opts.tp_world = std::stoi(need("--tp-world"));
+        else if (a == "--tp-rank") opts.tp_rank = std::stoi(need("--tp-rank"));
+        else if (a == "--device") opts.device = std::stoi(need("--device"));
+        else if (a == "--nccl-id-path") opts.nccl_id_path = need("--nccl-id-path");
+        else positional.push_back(a);
+    }
+    if (positional.empty()) {
+        std::cerr << "usage: test_gguf_generate <model.gguf> [max_new_tokens] [seed1 seed2 ...] "
+                     "[--tp-world W --tp-rank R --nccl-id-path PATH --device D]\n";
         return 2;
     }
-    const std::string ckpt = argv[1];
-    const int max_new = argc >= 3 ? std::atoi(argv[2]) : 4;
-    std::vector<int> seeds;
-    for (int i = 3; i < argc; ++i) seeds.push_back(std::atoi(argv[i]));
+    ckpt = positional[0];
+    if (positional.size() >= 2) max_new = std::atoi(positional[1].c_str());
+    for (size_t i = 2; i < positional.size(); ++i) seeds.push_back(std::atoi(positional[i].c_str()));
     if (seeds.empty()) seeds = {1234};
 
     try {
-        auto r = dsv4::run_gguf_generate_smoke(ckpt, seeds, max_new);
-        std::printf("n_layers=%d dim=%d vocab=%d prompt_tokens=%d decode_tokens=%d\n",
-                    r.n_layers, r.dim, r.vocab, r.prompt_tokens, r.decode_tokens);
-        std::printf("load_seconds   = %.3f\n", r.load_seconds);
-        std::printf("forward_seconds= %.3f (%d positions; %.1f ms/step)\n",
-                    r.forward_seconds,
-                    static_cast<int>(r.top_logits.size()),
-                    r.top_logits.empty() ? 0.0
-                                         : 1000.0 * r.forward_seconds /
-                                               static_cast<double>(r.top_logits.size()));
-        if (r.decode_tokens > 0) {
-            const double tps = static_cast<double>(r.decode_tokens) / r.forward_seconds;
-            std::printf("decode_tps     = %.2f (decode_tokens / total_forward)\n", tps);
+        auto r = dsv4::run_gguf_generate_smoke(ckpt, seeds, max_new, opts);
+        const bool is_root = (opts.tp_rank == 0);
+        if (is_root) {
+            std::printf("n_layers=%d dim=%d vocab=%d prompt_tokens=%d decode_tokens=%d\n",
+                        r.n_layers, r.dim, r.vocab, r.prompt_tokens, r.decode_tokens);
+            std::printf("load_seconds   = %.3f\n", r.load_seconds);
+            std::printf("forward_seconds= %.3f (%d positions; %.1f ms/step)\n",
+                        r.forward_seconds,
+                        static_cast<int>(r.top_logits.size()),
+                        r.top_logits.empty() ? 0.0
+                                             : 1000.0 * r.forward_seconds /
+                                                   static_cast<double>(r.top_logits.size()));
+            if (r.decode_tokens > 0) {
+                const double tps = static_cast<double>(r.decode_tokens) / r.forward_seconds;
+                std::printf("decode_tps     = %.2f (decode_tokens / total_forward)\n", tps);
+            }
+            std::printf("seeds          = [");
+            for (size_t i = 0; i < seeds.size(); ++i) {
+                std::printf("%s%d", i ? ", " : "", seeds[i]);
+            }
+            std::printf("]\n");
+            std::printf("generated      = [");
+            for (size_t i = 0; i < r.generated_tokens.size(); ++i) {
+                std::printf("%s%d", i ? ", " : "", r.generated_tokens[i]);
+            }
+            std::printf("]\n");
+            std::printf("top_logits[first..last] = ");
+            for (size_t i = 0; i < r.top_logits.size(); ++i) {
+                std::printf("%s%.3f", i ? ", " : "", r.top_logits[i]);
+            }
+            std::printf("\n");
         }
-        std::printf("seeds          = [");
-        for (size_t i = 0; i < seeds.size(); ++i) {
-            std::printf("%s%d", i ? ", " : "", seeds[i]);
-        }
-        std::printf("]\n");
-        std::printf("generated      = [");
-        for (size_t i = 0; i < r.generated_tokens.size(); ++i) {
-            std::printf("%s%d", i ? ", " : "", r.generated_tokens[i]);
-        }
-        std::printf("]\n");
-        std::printf("top_logits[first..last] = ");
-        for (size_t i = 0; i < r.top_logits.size(); ++i) {
-            std::printf("%s%.3f", i ? ", " : "", r.top_logits[i]);
-        }
-        std::printf("\n");
 
         if (static_cast<int>(r.generated_tokens.size()) != max_new) {
             std::cerr << "[FAIL] generated_tokens size mismatch\n"; return 1;
@@ -64,7 +91,7 @@ int main(int argc, char** argv) {
                 std::cerr << "[FAIL] generated token out of vocab\n"; return 1;
             }
         }
-        std::cout << "[PASS] gguf greedy decode smoke\n";
+        if (is_root) std::cout << "[PASS] gguf greedy decode smoke\n";
         return 0;
     } catch (const std::exception& ex) {
         std::cerr << "[FAIL] " << ex.what() << "\n";

--- a/cpp_engine/tests/test_gguf_generate.cpp
+++ b/cpp_engine/tests/test_gguf_generate.cpp
@@ -1,0 +1,73 @@
+// Phase 3 step: end-to-end greedy decode smoke. Loads the model once and runs
+// a per-step forward over [seed_tokens] + [max_new_tokens] positions, with
+// KV cache sized to the full sequence. Validates that:
+//   - the run completes without OOM/throw,
+//   - each step produces a valid in-range token,
+//   - per-step wall time is reported for a coarse decode-tps signal.
+
+#include "dsv4_engine.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: test_gguf_generate <model.gguf> [max_new_tokens] [seed1 seed2 ...]\n";
+        return 2;
+    }
+    const std::string ckpt = argv[1];
+    const int max_new = argc >= 3 ? std::atoi(argv[2]) : 4;
+    std::vector<int> seeds;
+    for (int i = 3; i < argc; ++i) seeds.push_back(std::atoi(argv[i]));
+    if (seeds.empty()) seeds = {1234};
+
+    try {
+        auto r = dsv4::run_gguf_generate_smoke(ckpt, seeds, max_new);
+        std::printf("n_layers=%d dim=%d vocab=%d prompt_tokens=%d decode_tokens=%d\n",
+                    r.n_layers, r.dim, r.vocab, r.prompt_tokens, r.decode_tokens);
+        std::printf("load_seconds   = %.3f\n", r.load_seconds);
+        std::printf("forward_seconds= %.3f (%d positions; %.1f ms/step)\n",
+                    r.forward_seconds,
+                    static_cast<int>(r.top_logits.size()),
+                    r.top_logits.empty() ? 0.0
+                                         : 1000.0 * r.forward_seconds /
+                                               static_cast<double>(r.top_logits.size()));
+        if (r.decode_tokens > 0) {
+            const double tps = static_cast<double>(r.decode_tokens) / r.forward_seconds;
+            std::printf("decode_tps     = %.2f (decode_tokens / total_forward)\n", tps);
+        }
+        std::printf("seeds          = [");
+        for (size_t i = 0; i < seeds.size(); ++i) {
+            std::printf("%s%d", i ? ", " : "", seeds[i]);
+        }
+        std::printf("]\n");
+        std::printf("generated      = [");
+        for (size_t i = 0; i < r.generated_tokens.size(); ++i) {
+            std::printf("%s%d", i ? ", " : "", r.generated_tokens[i]);
+        }
+        std::printf("]\n");
+        std::printf("top_logits[first..last] = ");
+        for (size_t i = 0; i < r.top_logits.size(); ++i) {
+            std::printf("%s%.3f", i ? ", " : "", r.top_logits[i]);
+        }
+        std::printf("\n");
+
+        if (static_cast<int>(r.generated_tokens.size()) != max_new) {
+            std::cerr << "[FAIL] generated_tokens size mismatch\n"; return 1;
+        }
+        for (int t : r.generated_tokens) {
+            if (t < 0 || t >= r.vocab) {
+                std::cerr << "[FAIL] generated token out of vocab\n"; return 1;
+            }
+        }
+        std::cout << "[PASS] gguf greedy decode smoke\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "[FAIL] " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_gguf_layer0_full.cpp
+++ b/cpp_engine/tests/test_gguf_layer0_full.cpp
@@ -1,0 +1,68 @@
+// Phase 3 step: GGUF layer-0 full forward composition with residuals.
+// Embed -> attn_norm -> attention (Q/KV/sparse_attn/inv_rope/wo_a/wo_b) ->
+// +x (residual) -> ffn_norm -> (Q8_0 shared expert + Q2 routed MoE with real
+// hash-gate weights) -> +x (residual) -> x_out.
+
+#include "dsv4_engine.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: test_gguf_layer0_full <model.gguf> [token] [position]\n";
+        return 2;
+    }
+    const int token = argc >= 3 ? std::atoi(argv[2]) : 1234;
+    const int position = argc >= 4 ? std::atoi(argv[3]) : 0;
+    try {
+        auto r = dsv4::run_gguf_layer0_full_smoke(argv[1], token, position);
+        std::printf("token=%d position=%d dim=%d moe_inter=%d heads=%d head_dim=%d n_active=%d\n",
+                    token, position, r.dim, r.moe_inter_dim, r.heads, r.head_dim, r.n_active);
+        std::printf("expert_ids        = [");
+        for (int k = 0; k < r.n_active; ++k) {
+            std::printf("%d%s", r.expert_ids[k], k + 1 < r.n_active ? ", " : "");
+        }
+        std::printf("]\n");
+        std::printf("embed_rms         = %.4f\n", r.embed_rms);
+        std::printf("attn_out_rms      = %.4f\n", r.attn_out_rms);
+        std::printf("x_post_attn_rms   = %.4f  (embed + attn_out)\n", r.x_post_attn_rms);
+        std::printf("shared_out_rms    = %.4f\n", r.shared_out_rms);
+        std::printf("moe_out_rms       = %.4f\n", r.moe_out_rms);
+        std::printf("ffn_combined_rms  = %.4f  (shared_out + moe_out)\n", r.ffn_combined_rms);
+        std::printf("x_post_ffn_rms    = %.4f  (x_post_attn + ffn_combined)\n", r.x_post_ffn_rms);
+        std::printf("x_post_ffn[0..3]  = %.4f %.4f %.4f %.4f\n",
+                    r.x_post_ffn_first[0], r.x_post_ffn_first[1],
+                    r.x_post_ffn_first[2], r.x_post_ffn_first[3]);
+        std::printf("route_weights_sum = %.4f\n", r.route_weights_sum);
+
+        if (!(r.embed_rms > 1e-4f && r.embed_rms < 1000.0f)) {
+            std::cerr << "[FAIL] embed_rms\n"; return 1;
+        }
+        if (!(r.attn_out_rms > 1e-6f && r.attn_out_rms < 1000.0f)) {
+            std::cerr << "[FAIL] attn_out_rms\n"; return 1;
+        }
+        if (!(r.x_post_attn_rms > 1e-4f && r.x_post_attn_rms < 1000.0f)) {
+            std::cerr << "[FAIL] x_post_attn_rms\n"; return 1;
+        }
+        if (!(r.shared_out_rms > 1e-6f && r.shared_out_rms < 1000.0f)) {
+            std::cerr << "[FAIL] shared_out_rms\n"; return 1;
+        }
+        if (!(r.moe_out_rms > 1e-6f && r.moe_out_rms < 1000.0f)) {
+            std::cerr << "[FAIL] moe_out_rms\n"; return 1;
+        }
+        if (!(r.x_post_ffn_rms > 1e-4f && r.x_post_ffn_rms < 1000.0f)) {
+            std::cerr << "[FAIL] x_post_ffn_rms\n"; return 1;
+        }
+        if (!(r.route_weights_sum > 0.5f && r.route_weights_sum < 5.0f)) {
+            std::cerr << "[FAIL] route_weights_sum\n"; return 1;
+        }
+        std::cout << "[PASS] gguf layer-0 full forward smoke\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "[FAIL] " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_gguf_min_layer_smoke.cpp
+++ b/cpp_engine/tests/test_gguf_min_layer_smoke.cpp
@@ -1,0 +1,35 @@
+// Phase 3 entry-point smoke test for the GGUF Q2 forward path.
+//
+// Verifies that run_gguf_min_layer_smoke() can construct a GgufForwardContext
+// from a real .gguf checkpoint and surface the model dimensions we'll need
+// for subsequent dense + MoE wiring (n_layers, dim, n_experts, vocab, etc.).
+//
+// This is the parallel of test_min_layer_smoke for the GGUF path; future
+// commits will add real forward verification (embed → attn → dense layer
+// output parity, then full layer forward).
+
+#include "dsv4_engine.hpp"
+
+#include <cstdio>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: test_gguf_min_layer_smoke <model.gguf>\n";
+        return 2;
+    }
+    try {
+        auto r = dsv4::run_gguf_min_layer_smoke(argv[1]);
+        std::printf("[PASS] gguf_min_layer_smoke "
+                    "layers=%d hash_layers=%d dim=%d moe_inter=%d "
+                    "experts=%d topk=%d vocab=%d\n",
+                    r.n_layers, r.n_hash_layers, r.dim, r.moe_inter_dim,
+                    r.n_routed_experts, r.n_activated_experts, r.vocab);
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "[FAIL] " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_gguf_routed_expert.cpp
+++ b/cpp_engine/tests/test_gguf_routed_expert.cpp
@@ -1,0 +1,51 @@
+// Phase 3 step: GGUF single routed Q2 expert smoke for layer 0.
+// Embed -> ffn_norm -> q8_1 quantize -> IQ2_XXS w1/w3 -> SwiGLU+q8_1 ->
+// Q2_K w2. Loads only the single expert's bytes from the routed 3D tensor.
+
+#include "dsv4_engine.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: test_gguf_routed_expert <model.gguf> [token] [expert_id]\n";
+        return 2;
+    }
+    const int token = argc >= 3 ? std::atoi(argv[2]) : 1234;
+    const int expert_id = argc >= 4 ? std::atoi(argv[3]) : 0;
+    try {
+        auto r = dsv4::run_gguf_routed_expert_smoke(argv[1], token, expert_id);
+        std::printf("token=%d expert_id=%d dim=%d moe_inter_dim=%d\n",
+                    token, r.expert_id, r.dim, r.moe_inter_dim);
+        std::printf("ffn_normed_rms = %.4f\n", r.ffn_normed_rms);
+        std::printf("gate_rms       = %.4f\n", r.gate_rms);
+        std::printf("up_rms         = %.4f\n", r.up_rms);
+        std::printf("hidden_rms     = %.4f  (post swiglu+route_weight, Q8_1 view)\n",
+                    r.hidden_rms);
+        std::printf("route_out_rms  = %.4f\n", r.route_out_rms);
+        std::printf("route_out[0..3]= %.4f %.4f %.4f %.4f\n",
+                    r.route_out_first[0], r.route_out_first[1],
+                    r.route_out_first[2], r.route_out_first[3]);
+
+        if (!(r.gate_rms > 1e-4f && r.gate_rms < 1000.0f)) {
+            std::cerr << "[FAIL] gate_rms\n"; return 1;
+        }
+        if (!(r.up_rms > 1e-4f && r.up_rms < 1000.0f)) {
+            std::cerr << "[FAIL] up_rms\n"; return 1;
+        }
+        if (!(r.hidden_rms > 1e-6f && r.hidden_rms < 1000.0f)) {
+            std::cerr << "[FAIL] hidden_rms\n"; return 1;
+        }
+        if (!(r.route_out_rms > 1e-6f && r.route_out_rms < 1000.0f)) {
+            std::cerr << "[FAIL] route_out_rms\n"; return 1;
+        }
+        std::cout << "[PASS] gguf routed expert smoke\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "[FAIL] " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_gguf_routed_moe.cpp
+++ b/cpp_engine/tests/test_gguf_routed_moe.cpp
@@ -30,6 +30,12 @@ int main(int argc, char** argv) {
         std::printf("moe_out[0..3]  = %.4f %.4f %.4f %.4f\n",
                     r.moe_out_first[0], r.moe_out_first[1],
                     r.moe_out_first[2], r.moe_out_first[3]);
+        std::printf("route_weights  = [");
+        for (int k = 0; k < r.n_active; ++k) {
+            std::printf("%.4f%s", r.route_weights[k],
+                        k + 1 < r.n_active ? ", " : "");
+        }
+        std::printf("] sum=%.4f\n", r.route_weights_sum);
 
         if (!(r.n_active >= 1 && r.n_active <= 8)) {
             std::cerr << "[FAIL] n_active range\n"; return 1;
@@ -54,6 +60,20 @@ int main(int argc, char** argv) {
         }
         if (!(r.moe_out_rms > 1e-6f && r.moe_out_rms < 1000.0f)) {
             std::cerr << "[FAIL] moe_out_rms out of range\n"; return 1;
+        }
+        // Route weights: normalized to sum=1, ×route_scale=1.5 in DSV4-Flash.
+        // Accept any sum in (0.5, 5.0) — any sensible scaling.
+        if (!(r.route_weights_sum > 0.5f && r.route_weights_sum < 5.0f)) {
+            std::cerr << "[FAIL] route_weights_sum out of plausible range: "
+                      << r.route_weights_sum << "\n";
+            return 1;
+        }
+        for (int k = 0; k < r.n_active; ++k) {
+            if (!(r.route_weights[k] >= 0.0f && r.route_weights[k] < 5.0f)) {
+                std::cerr << "[FAIL] route_weights[" << k << "] = "
+                          << r.route_weights[k] << "\n";
+                return 1;
+            }
         }
         std::cout << "[PASS] gguf routed multi-active MoE smoke\n";
         return 0;

--- a/cpp_engine/tests/test_gguf_routed_moe.cpp
+++ b/cpp_engine/tests/test_gguf_routed_moe.cpp
@@ -1,0 +1,64 @@
+// Phase 3 step: GGUF multi-active-expert routed Q2 MoE smoke for layer 0.
+// Embed -> ffn_norm -> tid2eid (hash gate) -> stage top-k experts ->
+// batched IQ2_XXS w1/w3 -> SwiGLU + route_weight + Q8_1 quantize ->
+// batched Q2_K w2 (atomicAdd across routes) -> MoE residual output.
+
+#include "dsv4_engine.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: test_gguf_routed_moe <model.gguf> [token]\n";
+        return 2;
+    }
+    const int token = argc >= 3 ? std::atoi(argv[2]) : 1234;
+    try {
+        auto r = dsv4::run_gguf_routed_moe_smoke(argv[1], token);
+        std::printf("token=%d dim=%d moe_inter_dim=%d n_active=%d\n",
+                    token, r.dim, r.moe_inter_dim, r.n_active);
+        std::printf("expert_ids   = [");
+        for (int k = 0; k < r.n_active; ++k) {
+            std::printf("%d%s", r.expert_ids[k], k + 1 < r.n_active ? ", " : "");
+        }
+        std::printf("]\n");
+        std::printf("ffn_normed_rms = %.4f\n", r.ffn_normed_rms);
+        std::printf("moe_out_rms    = %.4f\n", r.moe_out_rms);
+        std::printf("moe_out[0..3]  = %.4f %.4f %.4f %.4f\n",
+                    r.moe_out_first[0], r.moe_out_first[1],
+                    r.moe_out_first[2], r.moe_out_first[3]);
+
+        if (!(r.n_active >= 1 && r.n_active <= 8)) {
+            std::cerr << "[FAIL] n_active range\n"; return 1;
+        }
+        // Distinct expert ids: hash-gate top-k typically returns no dupes.
+        for (int i = 0; i < r.n_active; ++i) {
+            for (int j = i + 1; j < r.n_active; ++j) {
+                if (r.expert_ids[i] == r.expert_ids[j]) {
+                    std::cerr << "[FAIL] duplicate expert id at slots "
+                              << i << "," << j << "\n";
+                    return 1;
+                }
+            }
+            if (r.expert_ids[i] < 0 || r.expert_ids[i] >= 256) {
+                std::cerr << "[FAIL] expert id out of range: "
+                          << r.expert_ids[i] << "\n";
+                return 1;
+            }
+        }
+        if (!(r.ffn_normed_rms > 1e-4f && r.ffn_normed_rms < 1000.0f)) {
+            std::cerr << "[FAIL] ffn_normed_rms out of range\n"; return 1;
+        }
+        if (!(r.moe_out_rms > 1e-6f && r.moe_out_rms < 1000.0f)) {
+            std::cerr << "[FAIL] moe_out_rms out of range\n"; return 1;
+        }
+        std::cout << "[PASS] gguf routed multi-active MoE smoke\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "[FAIL] " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_gguf_shared_expert.cpp
+++ b/cpp_engine/tests/test_gguf_shared_expert.cpp
@@ -1,0 +1,51 @@
+// Phase 3 step: GGUF shared-expert FFN smoke for layer 0.
+// Embed -> ffn_norm -> shared w1 / w3 Q8_0 -> silu_mul -> shared w2 Q8_0.
+
+#include "dsv4_engine.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: test_gguf_shared_expert <model.gguf> [token]\n";
+        return 2;
+    }
+    const int token = argc >= 3 ? std::atoi(argv[2]) : 1234;
+    try {
+        auto r = dsv4::run_gguf_shared_expert_smoke(argv[1], token);
+        std::printf("token=%d dim=%d moe_inter_dim=%d\n",
+                    token, r.dim, r.moe_inter_dim);
+        std::printf("ffn_normed_rms = %.4f\n", r.ffn_normed_rms);
+        std::printf("gate_rms       = %.4f\n", r.gate_rms);
+        std::printf("up_rms         = %.4f\n", r.up_rms);
+        std::printf("hidden_rms     = %.4f  (post silu_mul)\n", r.hidden_rms);
+        std::printf("shared_out_rms = %.4f\n", r.shared_out_rms);
+        std::printf("shared_out[0..3] = %.4f %.4f %.4f %.4f\n",
+                    r.shared_out_first[0], r.shared_out_first[1],
+                    r.shared_out_first[2], r.shared_out_first[3]);
+
+        if (!(r.ffn_normed_rms > 1e-4f && r.ffn_normed_rms < 100.0f)) {
+            std::cerr << "[FAIL] ffn_normed_rms\n"; return 1;
+        }
+        if (!(r.gate_rms > 1e-4f && r.gate_rms < 1000.0f)) {
+            std::cerr << "[FAIL] gate_rms\n"; return 1;
+        }
+        if (!(r.up_rms > 1e-4f && r.up_rms < 1000.0f)) {
+            std::cerr << "[FAIL] up_rms\n"; return 1;
+        }
+        if (!(r.hidden_rms > 1e-6f && r.hidden_rms < 1000.0f)) {
+            std::cerr << "[FAIL] hidden_rms\n"; return 1;
+        }
+        if (!(r.shared_out_rms > 1e-6f && r.shared_out_rms < 1000.0f)) {
+            std::cerr << "[FAIL] shared_out_rms\n"; return 1;
+        }
+        std::cout << "[PASS] gguf shared expert smoke\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "[FAIL] " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_q2_matvec.cpp
+++ b/cpp_engine/tests/test_q2_matvec.cpp
@@ -1,0 +1,354 @@
+// Q2 single-expert matvec parity test.
+//
+// Loads expert 0 of layer 0 (IQ2_XXS w1/w3, Q2_K w2) from the GGUF mmap,
+// runs the cpp_engine GPU kernel chain (W13 + SwiGLU+Q8_1 + W2), and
+// compares the GPU output against a host CPU reference that dequantizes
+// the GGUF blocks to fp32 and does naive matvec.
+//
+// Pass criterion: RMSE < 5e-3 (lossy quantization tolerance).
+
+#include "cuda_ops.hpp"
+#include "weight_source.hpp"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+#define CHECK_CUDA(expr) do { \
+    cudaError_t _err = (expr); \
+    if (_err != cudaSuccess) { \
+        throw std::runtime_error(std::string("cuda: ") + cudaGetErrorString(_err)); \
+    } \
+} while (0)
+
+float f16_to_f32(uint16_t bits) {
+    __half h;
+    std::memcpy(&h, &bits, sizeof(bits));
+    return __half2float(h);
+}
+
+uint64_t iq2xxs_grid_value(int grid_id) {
+    // Mirror of cuda/q2_ops.cu kIQ2XXSGrid; we just inline the entries we need
+    // by re-reading via a host helper at runtime. To avoid duplicating 256
+    // hex constants, we lean on the GPU-built signed grid: we'll copy 256*128*8
+    // back to host once at start. So this function is unused; left as a stub.
+    (void)grid_id;
+    return 0;
+}
+
+// Dequantize one IQ2_XXS block (66 bytes → 256 fp32 weights).
+// signed_grid is the host-mirror of the GPU table: [256][128][8] int8.
+void iq2_xxs_dequant_block(const uint8_t* block, const int8_t* signed_grid, float* out) {
+    const float d = f16_to_f32(static_cast<uint16_t>(block[0]) |
+                               (static_cast<uint16_t>(block[1]) << 8));
+    for (int sub = 0; sub < 8; ++sub) {
+        const uint8_t* chunk = block + 2 + sub * 8;
+        const uint32_t aux = static_cast<uint32_t>(chunk[4]) |
+            (static_cast<uint32_t>(chunk[5]) << 8) |
+            (static_cast<uint32_t>(chunk[6]) << 16) |
+            (static_cast<uint32_t>(chunk[7]) << 24);
+        const float s = 0.125f * d * static_cast<float>(2 * (aux >> 28) + 1);
+        for (int part = 0; part < 4; ++part) {
+            const int grid_id = chunk[part];
+            const int sign_idx = static_cast<int>((aux >> (7 * part)) & 0x7f);
+            const int8_t* vals = signed_grid + (grid_id * 128 + sign_idx) * 8;
+            const int dest_off = sub * 32 + part * 8;
+            for (int b = 0; b < 8; ++b) {
+                out[dest_off + b] = static_cast<float>(vals[b]) * s;
+            }
+        }
+    }
+}
+
+// Dequantize one Q2_K block (84 bytes → 256 fp32 weights).
+void q2_k_dequant_block(const uint8_t* block, float* out) {
+    const uint8_t* scales = block;
+    const uint8_t* qs = block + 16;
+    const float d = f16_to_f32(static_cast<uint16_t>(block[80]) |
+                               (static_cast<uint16_t>(block[81]) << 8));
+    const float dmin = f16_to_f32(static_cast<uint16_t>(block[82]) |
+                                  (static_cast<uint16_t>(block[83]) << 8));
+    for (int group = 0; group < 16; ++group) {
+        const int half_block = group >> 3;
+        const int group_in_half = group & 7;
+        const int shift = (group_in_half >> 1) * 2;
+        const int byte_start = half_block * 32 + (group_in_half & 1) * 16;
+        const float qscale = d * static_cast<float>(scales[group] & 0x0f);
+        const float base = dmin * static_cast<float>(scales[group] >> 4);
+        for (int idx_in_group = 0; idx_in_group < 16; ++idx_in_group) {
+            const int q = static_cast<int>((qs[byte_start + idx_in_group] >> shift) & 0x03);
+            out[group * 16 + idx_in_group] = qscale * static_cast<float>(q) - base;
+        }
+    }
+}
+
+void dequant_iq2_xxs_row(const uint8_t* row_blocks, int n_blocks, const int8_t* signed_grid, float* out) {
+    for (int b = 0; b < n_blocks; ++b) {
+        iq2_xxs_dequant_block(row_blocks + b * 66, signed_grid, out + b * 256);
+    }
+}
+
+void dequant_q2k_row(const uint8_t* row_blocks, int n_blocks, float* out) {
+    for (int b = 0; b < n_blocks; ++b) {
+        q2_k_dequant_block(row_blocks + b * 84, out + b * 256);
+    }
+}
+
+float rmse(const std::vector<float>& a, const std::vector<float>& b) {
+    if (a.size() != b.size()) throw std::runtime_error("rmse: size mismatch");
+    double acc = 0.0;
+    for (size_t i = 0; i < a.size(); ++i) {
+        const double diff = static_cast<double>(a[i]) - static_cast<double>(b[i]);
+        acc += diff * diff;
+    }
+    return static_cast<float>(std::sqrt(acc / a.size()));
+}
+
+float silu(float v) { return v / (1.0f + std::exp(-v)); }
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: test_q2_matvec <model.gguf>\n";
+        return 2;
+    }
+    try {
+        auto ws = dsv4::open_weight_source(argv[1]);
+        if (ws->format() != dsv4::WeightSource::Format::GGUF_Q2) {
+            throw std::runtime_error("test requires a GGUF Q2 checkpoint");
+        }
+
+        // Resolve routed expert 0 of layer 0 for w1 / w3 (IQ2_XXS) and w2 (Q2_K).
+        const std::string w1_3d = "layers.0.ffn.experts.routed.w1";
+        const std::string w2_3d = "layers.0.ffn.experts.routed.w2";
+        const std::string w3_3d = "layers.0.ffn.experts.routed.w3";
+
+        dsv4::WeightView w1_top = ws->require(w1_3d);
+        dsv4::WeightView w2_top = ws->require(w2_3d);
+        dsv4::WeightView w3_top = ws->require(w3_3d);
+        if (w1_top.shape.size() != 3 || w2_top.shape.size() != 3 || w3_top.shape.size() != 3) {
+            throw std::runtime_error("routed expert weights are not 3D");
+        }
+        const int dim = static_cast<int>(w1_top.shape[0]);
+        const int inter_dim = static_cast<int>(w1_top.shape[1]);
+        const int n_experts = static_cast<int>(w1_top.shape[2]);
+        if (dim != static_cast<int>(w3_top.shape[0]) || inter_dim != static_cast<int>(w3_top.shape[1])) {
+            throw std::runtime_error("w1/w3 shape mismatch");
+        }
+        if (inter_dim != static_cast<int>(w2_top.shape[0]) || dim != static_cast<int>(w2_top.shape[1])) {
+            throw std::runtime_error("w2 shape mismatch (expected [inter,dim,n_experts])");
+        }
+        const int expert_id = 0;
+        const int w13_blocks_per_row = dim / 256;  // IQ2_XXS, 256 elems / block
+        const int w2_blocks_per_row = inter_dim / 256;  // Q2_K, 256 elems / block
+        std::printf("dim=%d inter_dim=%d n_experts=%d expert=%d\n", dim, inter_dim, n_experts, expert_id);
+
+        dsv4::WeightView w1_view = ws->get_expert(w1_3d, "w1.expert0", expert_id);
+        dsv4::WeightView w2_view = ws->get_expert(w2_3d, "w2.expert0", expert_id);
+        dsv4::WeightView w3_view = ws->get_expert(w3_3d, "w3.expert0", expert_id);
+        if (!w1_view.found || !w2_view.found || !w3_view.found) {
+            throw std::runtime_error("get_expert failed");
+        }
+
+        // --- 1. Fetch the GPU signed_grid into host memory for the CPU reference. ---
+        const int8_t* d_signed_grid = dsv4::q2_signed_grid_device();
+        if (d_signed_grid == nullptr) {
+            throw std::runtime_error("signed_grid_device returned null");
+        }
+        std::vector<int8_t> host_signed_grid(256ULL * 128 * 8);
+        CHECK_CUDA(cudaMemcpy(host_signed_grid.data(), d_signed_grid,
+                              host_signed_grid.size(), cudaMemcpyDeviceToHost));
+
+        // --- 2. Build a random fp32 activation row. ---
+        std::mt19937 rng(0xC0FFEE);
+        std::normal_distribution<float> dist(0.0f, 1.0f);
+        std::vector<float> h_x(static_cast<size_t>(dim));
+        for (int i = 0; i < dim; ++i) h_x[i] = dist(rng);
+
+        // --- 3. CPU reference: dequantize expert 0 W1/W2/W3 and run matmul + SwiGLU. ---
+        // For perf we only dequant a window of out_cols to keep the test light; full
+        // expert dequant for inter_dim=2048 × dim=4096 is 32 MiB fp32 — still cheap.
+        std::vector<float> w1_fp32(static_cast<size_t>(inter_dim) * dim);
+        std::vector<float> w3_fp32(static_cast<size_t>(inter_dim) * dim);
+        for (int r = 0; r < inter_dim; ++r) {
+            const uint8_t* row = w1_view.data + static_cast<size_t>(r) * w13_blocks_per_row * 66;
+            dequant_iq2_xxs_row(row, w13_blocks_per_row, host_signed_grid.data(), w1_fp32.data() + r * dim);
+            const uint8_t* row3 = w3_view.data + static_cast<size_t>(r) * w13_blocks_per_row * 66;
+            dequant_iq2_xxs_row(row3, w13_blocks_per_row, host_signed_grid.data(), w3_fp32.data() + r * dim);
+        }
+
+        std::vector<float> ref_gate(inter_dim, 0.0f);
+        std::vector<float> ref_up(inter_dim, 0.0f);
+        for (int r = 0; r < inter_dim; ++r) {
+            float g = 0.0f, u = 0.0f;
+            const float* w1r = w1_fp32.data() + r * dim;
+            const float* w3r = w3_fp32.data() + r * dim;
+            for (int k = 0; k < dim; ++k) {
+                g += w1r[k] * h_x[k];
+                u += w3r[k] * h_x[k];
+            }
+            ref_gate[r] = g;
+            ref_up[r] = u;
+        }
+
+        // Hidden = SwiGLU(gate, up) * route_weight (route_weight=1.0 in this test).
+        const float route_weight = 1.0f;
+        std::vector<float> ref_hidden(inter_dim, 0.0f);
+        for (int r = 0; r < inter_dim; ++r) {
+            ref_hidden[r] = silu(ref_gate[r]) * ref_up[r] * route_weight;
+        }
+
+        // W2 reference: y[dim] = W2 @ hidden where W2 has shape [dim, inter_dim] per expert.
+        std::vector<float> w2_fp32(static_cast<size_t>(dim) * inter_dim);
+        for (int r = 0; r < dim; ++r) {
+            const uint8_t* row = w2_view.data + static_cast<size_t>(r) * w2_blocks_per_row * 84;
+            dequant_q2k_row(row, w2_blocks_per_row, w2_fp32.data() + r * inter_dim);
+        }
+        std::vector<float> ref_y(dim, 0.0f);
+        for (int r = 0; r < dim; ++r) {
+            const float* w2r = w2_fp32.data() + r * inter_dim;
+            float acc = 0.0f;
+            for (int k = 0; k < inter_dim; ++k) acc += w2r[k] * ref_hidden[k];
+            ref_y[r] = acc;
+        }
+
+        // --- 4. GPU path. ---
+        // Upload x, w1/w2/w3 expert-slice bytes, route_slots=[0], route_weights=[1].
+        float* d_x = nullptr;
+        int8_t* d_x_q = nullptr;
+        float* d_x_scale = nullptr;
+        uint8_t* d_w1 = nullptr;
+        uint8_t* d_w2 = nullptr;
+        uint8_t* d_w3 = nullptr;
+        int64_t* d_route_slots = nullptr;
+        float* d_route_weights = nullptr;
+        float* d_gate = nullptr;
+        float* d_up = nullptr;
+        int8_t* d_hidden_q = nullptr;
+        float* d_hidden_scale = nullptr;
+        float* d_y = nullptr;
+
+        const int routes = 1;
+        const int x_groups = (dim + 31) / 32;
+        const int hidden_groups = (inter_dim + 15) / 16;
+
+        // Allocate flat byte buffers covering the FULL expert tensor (n_experts × per_expert_bytes),
+        // so the kernel's per-expert pointer arithmetic with expert_id=0 lands at the start.
+        CHECK_CUDA(cudaMalloc(&d_x, dim * sizeof(float)));
+        CHECK_CUDA(cudaMalloc(&d_x_q, dim));
+        CHECK_CUDA(cudaMalloc(&d_x_scale, x_groups * sizeof(float)));
+        CHECK_CUDA(cudaMalloc(&d_w1, w1_view.nbytes));
+        CHECK_CUDA(cudaMalloc(&d_w2, w2_view.nbytes));
+        CHECK_CUDA(cudaMalloc(&d_w3, w3_view.nbytes));
+        CHECK_CUDA(cudaMalloc(&d_route_slots, sizeof(int64_t)));
+        CHECK_CUDA(cudaMalloc(&d_route_weights, sizeof(float)));
+        CHECK_CUDA(cudaMalloc(&d_gate, inter_dim * sizeof(float)));
+        CHECK_CUDA(cudaMalloc(&d_up, inter_dim * sizeof(float)));
+        CHECK_CUDA(cudaMalloc(&d_hidden_q, inter_dim));
+        CHECK_CUDA(cudaMalloc(&d_hidden_scale, hidden_groups * sizeof(float)));
+        CHECK_CUDA(cudaMalloc(&d_y, dim * sizeof(float)));
+
+        CHECK_CUDA(cudaMemcpy(d_x, h_x.data(), dim * sizeof(float), cudaMemcpyHostToDevice));
+        CHECK_CUDA(cudaMemcpy(d_w1, w1_view.data, w1_view.nbytes, cudaMemcpyHostToDevice));
+        CHECK_CUDA(cudaMemcpy(d_w2, w2_view.data, w2_view.nbytes, cudaMemcpyHostToDevice));
+        CHECK_CUDA(cudaMemcpy(d_w3, w3_view.data, w3_view.nbytes, cudaMemcpyHostToDevice));
+        const int64_t h_route_slots = static_cast<int64_t>(expert_id);
+        CHECK_CUDA(cudaMemcpy(d_route_slots, &h_route_slots, sizeof(int64_t), cudaMemcpyHostToDevice));
+        CHECK_CUDA(cudaMemcpy(d_route_weights, &route_weight, sizeof(float), cudaMemcpyHostToDevice));
+        CHECK_CUDA(cudaMemset(d_y, 0, dim * sizeof(float)));
+
+        // We're operating with a buffer that only holds 1 expert, so to make
+        // pointer arithmetic with expert=0 land correctly, the kernel only
+        // needs to see expert_count=1. The kernels read route_slots[route],
+        // so we pass route_slots=[0] and n_experts=1.
+        const int kernel_n_experts = 1;
+
+        if (!dsv4::q2_quantize_x_q8_1_cuda(d_x, d_x_q, d_x_scale, routes, dim)) {
+            throw std::runtime_error("q2_quantize_x_q8_1_cuda failed");
+        }
+        if (!dsv4::q2_moe_single_w13_iq2_xxs_cuda(d_x_q, d_x_scale, d_route_slots, d_w1, d_w3,
+                                                  d_gate, d_up, routes, kernel_n_experts, dim, inter_dim)) {
+            throw std::runtime_error("q2_moe_single_w13_iq2_xxs_cuda failed");
+        }
+        if (!dsv4::q2_route_swiglu_quantize_hidden_q8_1_cuda(
+                d_gate, d_up, d_route_weights, d_hidden_q, d_hidden_scale,
+                routes, inter_dim, 0.0f)) {
+            throw std::runtime_error("q2_route_swiglu_quantize_hidden_q8_1_cuda failed");
+        }
+        if (!dsv4::q2_moe_single_w2_q2k_cuda(d_hidden_q, d_hidden_scale, d_route_slots, d_w2,
+                                              d_y, routes, kernel_n_experts, dim, inter_dim)) {
+            throw std::runtime_error("q2_moe_single_w2_q2k_cuda failed");
+        }
+        CHECK_CUDA(cudaDeviceSynchronize());
+
+        // Copy back gate/up/y for comparison.
+        std::vector<float> gpu_gate(inter_dim);
+        std::vector<float> gpu_up(inter_dim);
+        std::vector<float> gpu_y(dim);
+        CHECK_CUDA(cudaMemcpy(gpu_gate.data(), d_gate, inter_dim * sizeof(float), cudaMemcpyDeviceToHost));
+        CHECK_CUDA(cudaMemcpy(gpu_up.data(), d_up, inter_dim * sizeof(float), cudaMemcpyDeviceToHost));
+        CHECK_CUDA(cudaMemcpy(gpu_y.data(), d_y, dim * sizeof(float), cudaMemcpyDeviceToHost));
+
+        // --- 5. Compare. ---
+        const float ref_gate_rmse_pass = 1.0f;     // generous: Q8_1 activation + IQ2_XXS lossy
+        const float ref_up_rmse_pass = 1.0f;
+        const float ref_y_rmse_pass = 5.0f;        // accumulated through full chain
+
+        // For gate/up we additionally normalize by RMS of the reference because the
+        // raw magnitudes scale with dim and IQ2_XXS weight values, so relative error
+        // (= RMSE / RMS(ref)) is the meaningful metric.
+        auto rms = [](const std::vector<float>& v) {
+            double acc = 0.0;
+            for (float x : v) acc += static_cast<double>(x) * static_cast<double>(x);
+            return static_cast<float>(std::sqrt(acc / v.size()));
+        };
+
+        const float gate_rmse = rmse(gpu_gate, ref_gate);
+        const float up_rmse = rmse(gpu_up, ref_up);
+        const float y_rmse = rmse(gpu_y, ref_y);
+        const float gate_rel = gate_rmse / std::max(rms(ref_gate), 1e-6f);
+        const float up_rel = up_rmse / std::max(rms(ref_up), 1e-6f);
+        const float y_rel = y_rmse / std::max(rms(ref_y), 1e-6f);
+        const float pass_rel = 0.05f;  // 5% RMSE on lossy Q2 weight + Q8_1 activation is reasonable
+
+        std::printf("gate: rmse=%.4f rms=%.4f rel=%.4f  (target rel < %.2f)\n",
+                    gate_rmse, rms(ref_gate), gate_rel, pass_rel);
+        std::printf("up  : rmse=%.4f rms=%.4f rel=%.4f\n", up_rmse, rms(ref_up), up_rel);
+        std::printf("y   : rmse=%.4f rms=%.4f rel=%.4f\n", y_rmse, rms(ref_y), y_rel);
+
+        // Print a few values for visual sanity.
+        std::printf("ref_y[0..3] = %.4f %.4f %.4f %.4f\n", ref_y[0], ref_y[1], ref_y[2], ref_y[3]);
+        std::printf("gpu_y[0..3] = %.4f %.4f %.4f %.4f\n", gpu_y[0], gpu_y[1], gpu_y[2], gpu_y[3]);
+
+        cudaFree(d_x); cudaFree(d_x_q); cudaFree(d_x_scale);
+        cudaFree(d_w1); cudaFree(d_w2); cudaFree(d_w3);
+        cudaFree(d_route_slots); cudaFree(d_route_weights);
+        cudaFree(d_gate); cudaFree(d_up);
+        cudaFree(d_hidden_q); cudaFree(d_hidden_scale);
+        cudaFree(d_y);
+
+        if (gate_rel > pass_rel || up_rel > pass_rel || y_rel > pass_rel) {
+            std::cerr << "[FAIL] RMSE exceeded threshold\n";
+            return 1;
+        }
+        (void)ref_gate_rmse_pass; (void)ref_up_rmse_pass; (void)ref_y_rmse_pass;
+        std::cout << "[PASS] q2 single-expert matvec parity\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "[FAIL] " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_weight_source.cpp
+++ b/cpp_engine/tests/test_weight_source.cpp
@@ -1,0 +1,151 @@
+// Smoke test: open the GGUF Q2 checkpoint and verify the WeightSource mapping
+// can resolve representative tensors (dense layer attention/embed/head/norm/HC,
+// shared experts, hash gate, and 3D routed-expert slices) by shape and dtype.
+#include "weight_source.hpp"
+
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace dsv4;
+
+void expect_present(const WeightSource& ws, const std::string& name,
+                    DType expected_dtype, std::vector<uint64_t> expected_shape) {
+    if (!ws.has(name)) {
+        throw std::runtime_error("missing tensor: " + name);
+    }
+    WeightView v = ws.get(name);
+    if (!v.found) {
+        throw std::runtime_error("get() returned not-found despite has()=true: " + name);
+    }
+    if (v.dtype != expected_dtype) {
+        throw std::runtime_error("dtype mismatch for " + name + " expected=" + dtype_name(expected_dtype) + " actual=" + dtype_name(v.dtype));
+    }
+    if (v.shape != expected_shape) {
+        std::string err = "shape mismatch for " + name + " expected=[";
+        for (size_t i = 0; i < expected_shape.size(); ++i) err += (i ? "," : "") + std::to_string(expected_shape[i]);
+        err += "] actual=[";
+        for (size_t i = 0; i < v.shape.size(); ++i) err += (i ? "," : "") + std::to_string(v.shape[i]);
+        err += "]";
+        throw std::runtime_error(err);
+    }
+    if (v.data == nullptr || v.nbytes == 0) {
+        throw std::runtime_error("empty data/nbytes for " + name);
+    }
+}
+
+void expect_expert_slice(const WeightSource& ws, const std::string& routed_3d,
+                         int expert_id, DType expected_dtype,
+                         std::vector<uint64_t> expected_shape, uint64_t expected_nbytes) {
+    const std::string per_expert_name = routed_3d + ".expert" + std::to_string(expert_id);
+    WeightView v = ws.get_expert(routed_3d, per_expert_name, expert_id);
+    if (!v.found) {
+        throw std::runtime_error("get_expert() not-found for " + routed_3d + " expert=" + std::to_string(expert_id));
+    }
+    if (v.dtype != expected_dtype) {
+        throw std::runtime_error("expert dtype mismatch for " + routed_3d);
+    }
+    if (v.shape != expected_shape) {
+        std::string err = "expert shape mismatch for " + routed_3d + " expected=[";
+        for (size_t i = 0; i < expected_shape.size(); ++i) err += (i ? "," : "") + std::to_string(expected_shape[i]);
+        err += "] actual=[";
+        for (size_t i = 0; i < v.shape.size(); ++i) err += (i ? "," : "") + std::to_string(v.shape[i]);
+        err += "]";
+        throw std::runtime_error(err);
+    }
+    if (v.nbytes != expected_nbytes) {
+        throw std::runtime_error("expert nbytes mismatch for " + routed_3d + " expected=" + std::to_string(expected_nbytes) + " actual=" + std::to_string(v.nbytes));
+    }
+    if (v.data == nullptr) {
+        throw std::runtime_error("expert null data for " + routed_3d);
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: test_weight_source <model.gguf or safetensors-dir>\n";
+        return 2;
+    }
+    try {
+        auto ws = dsv4::open_weight_source(argv[1]);
+
+        // Embed/head/norm and dense layer 0 attention should always be present
+        // regardless of GGUF or safetensors. Shapes below match
+        // DeepSeek-V4-Flash (dim=4096, q_lora=1536, kv_lora=512, etc.).
+        // We don't pin every shape — just spot-check enough to know the mapping
+        // is wired. Concrete tensor shape verification is done in the dense
+        // layer parity gate, not here.
+        if (!ws->has("embed.weight") || !ws->has("head.weight") || !ws->has("norm.weight")) {
+            throw std::runtime_error("embed/head/norm missing");
+        }
+        if (!ws->has("layers.0.attn.wq_a.weight") ||
+            !ws->has("layers.0.attn_norm.weight") ||
+            !ws->has("layers.0.ffn_norm.weight") ||
+            !ws->has("layers.0.ffn.gate.weight") ||
+            !ws->has("layers.0.ffn.shared_experts.w1.weight")) {
+            throw std::runtime_error("dense layer 0 tensors missing");
+        }
+        if (!ws->has("layers.0.hc_attn_fn") || !ws->has("layers.0.hc_ffn_fn")) {
+            throw std::runtime_error("HC tensors missing");
+        }
+
+        // Hash layers expect ffn.gate.tid2eid; non-hash layers expect ffn.gate.bias.
+        if (!ws->has("layers.0.ffn.gate.tid2eid")) {
+            throw std::runtime_error("layer 0 (hash) missing ffn.gate.tid2eid");
+        }
+        if (!ws->has("layers.3.ffn.gate.bias")) {
+            throw std::runtime_error("layer 3 (non-hash) missing ffn.gate.bias");
+        }
+
+        // GGUF-specific: routed experts are 3D tensors, per-expert slices through get_expert.
+        // Skip routed-expert slice check for safetensors (per-expert names are flat).
+        if (ws->format() == dsv4::WeightSource::Format::GGUF_Q2) {
+            const std::string routed_w1 = "layers.0.ffn.experts.routed.w1";
+            const std::string routed_w2 = "layers.0.ffn.experts.routed.w2";
+            const std::string routed_w3 = "layers.0.ffn.experts.routed.w3";
+            if (!ws->has(routed_w1) || !ws->has(routed_w2) || !ws->has(routed_w3)) {
+                throw std::runtime_error("3D routed expert tensors missing");
+            }
+            // Inspect expert 0 of w1: should be IQ2_XXS, shape [inter, dim]=[2048, 4096],
+            // nbytes per expert = 2048 * 4096 / 256 * 66 = 2162688.
+            WeightView routed_view = ws->get(routed_w1);
+            if (routed_view.shape.size() != 3) {
+                throw std::runtime_error("routed w1 not 3D");
+            }
+            const uint64_t a = routed_view.shape[0];
+            const uint64_t b = routed_view.shape[1];
+            const uint64_t n_experts = routed_view.shape[2];
+            if (n_experts == 0 || routed_view.nbytes % n_experts != 0) {
+                throw std::runtime_error("routed w1 shape inconsistent");
+            }
+            const uint64_t per_expert_nbytes = routed_view.nbytes / n_experts;
+            expect_expert_slice(*ws, routed_w1, 0, routed_view.dtype, {b, a}, per_expert_nbytes);
+            expect_expert_slice(*ws, routed_w1, static_cast<int>(n_experts - 1), routed_view.dtype, {b, a}, per_expert_nbytes);
+            std::cout << "routed w1 layer0: " << dtype_name(routed_view.dtype)
+                      << " [" << a << "," << b << "," << n_experts << "]"
+                      << " per_expert_nbytes=" << per_expert_nbytes << "\n";
+
+            WeightView routed_w2_view = ws->get(routed_w2);
+            std::cout << "routed w2 layer0: " << dtype_name(routed_w2_view.dtype)
+                      << " [" << routed_w2_view.shape[0] << "," << routed_w2_view.shape[1] << "," << routed_w2_view.shape[2] << "]"
+                      << " nbytes=" << routed_w2_view.nbytes << "\n";
+        }
+
+        // Print one summary line for visual confirmation.
+        WeightView embed = ws->require("embed.weight");
+        WeightView wq_a = ws->require("layers.0.attn.wq_a.weight");
+        std::cout << "embed:    " << dtype_name(embed.dtype) << " shape=[" << embed.shape[0] << "," << embed.shape[1] << "] nbytes=" << embed.nbytes << "\n";
+        std::cout << "wq_a@L0:  " << dtype_name(wq_a.dtype) << " shape=[" << wq_a.shape[0] << "," << wq_a.shape[1] << "] nbytes=" << wq_a.nbytes << "\n";
+        std::cout << "[PASS] weight_source smoke ok\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "[FAIL] " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/scripts/run_gguf_q2_tp_generate.sh
+++ b/scripts/run_gguf_q2_tp_generate.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Launch test_gguf_generate on 4×GPU TP=4 to validate GGUF Q2 TP decode.
+# Rank 0 prints results; ranks 1-3 are silent (no PASS line, no stats).
+set -e
+
+CKPT="${CKPT:-/mnt/data1/dsv4_inference/DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2.gguf}"
+NCCL_ID="${NCCL_ID:-/tmp/dsv4_gguf_tp4_nccl.id}"
+BIN="${BIN:-/mnt/data1/dsv4_inference/build/cpp_engine/tests/test_gguf_generate}"
+LOG_DIR="${LOG_DIR:-/tmp}"
+MAX_NEW="${MAX_NEW:-8}"
+SEED="${SEED:-1234}"
+EXTRA_ENV="${EXTRA_ENV:-}"
+
+rm -f "$NCCL_ID"
+
+for rank in 0 1 2 3; do
+  eval "$EXTRA_ENV CUDA_VISIBLE_DEVICES=$rank $BIN $CKPT $MAX_NEW $SEED \
+        --tp-world 4 --tp-rank $rank --device 0 --nccl-id-path $NCCL_ID \
+        > $LOG_DIR/dsv4_gguf_tp4_rank${rank}.log 2>&1 &"
+done
+
+echo "started 4 ranks; PIDs:" >&2
+jobs -p
+wait
+echo "==== rank 0 log ====" >&2
+cat $LOG_DIR/dsv4_gguf_tp4_rank0.log


### PR DESCRIPTION
## Summary

Phase 3 of the GGUF Q2 cpp_engine plan: end-to-end greedy decode for DeepSeek-V4-Flash IQ2XXS/Q2K mixed-quant checkpoints, single-GPU and TP=4. FP4 safetensors path remains untouched.

- **GGUF loading + Q2 kernels** (commits f1a78bf..9222ede): `WeightSource` abstraction over safetensors / GGUF, IQ2_XXS w1/w3 + Q2_K w2 single-token DP4A matvecs ported from the PyTorch CUDA module, validated against per-block CPU dequant reference.
- **End-to-end decode** (commits 6956fab..11a9b1d): embed → attn (MLA q_lora=1024, head_dim=512, kv_lora=512) → shared expert → hash / Sinkhorn gate → routed Q2 MoE → reduce → ffn residual → 43 layers → final norm + Q8_0 head + argmax. Per-layer KV cache + multi-token greedy decode loop. Single-GPU 2.80 tps (token=1234 → 91096, 120682, 12272, 55889, …).
- **Pinned mmap + async H2D** (commit 9588fec): `host_register` the GGUF mmap and use `cudaMemcpyAsync` for routed expert staging. 542 → 346 ms/step → 1.6× decode speedup on single GPU.
- **TP=4 wiring** (commit 84cc339): 4-way row/col Q8_0 sharding (`q8_0_row_bytes`/`slice_q8_0_rows`/`slice_q8_0_cols`), expert round-robin EP, fp32 NCCL allreduce (`DSV4_GGUF_REDUCE_FP32=1` default — bf16 round-trip compounds Q2 quantization noise across 43 layers and breaks parity). Result: 180.4 ms/step → **5.37 tps** (1.92× single-GPU, Gate A ≥ 5 tps).
- **Decode profile + copy stream** (commit e6310f3): `DSV4_GGUF_PROFILE=1` reports per-step embed/attn+gate/stage/moe/head timing; routed staging moved onto `gguf_moe_copy_stream` with event sync.
- **Hash-layer pre-stage** (commit 2448247): hash-layer L=0..2 routes are token-deterministic; issue `routed_w*` H2D on copy stream BEFORE `attn_to_gate` launches → 1.17 ms stage hides behind 1.93 ms attn compute. Measured TP=4 MAX_NEW=32: 181.4 → 177.3 ms/step (**5.34 → 5.47 tps, +2.4%**, token-perfect parity).

FP4 path (`test_min_layer_smoke`) still reports `top_token=52818 top_logit=27.4924 checksum=-60198.9`.

## Test plan

- [x] FP4 baseline regression: `test_min_layer_smoke /mnt/data1/modelscope/deepseek-ai/DeepSeek-V4-Flash` → `top_token=52818 top_logit=27.4924 checksum=-60198.9`
- [x] GGUF single-GPU forward parity: `test_gguf_full_forward <gguf> 1234 0` → `top_token=91096 top_logit=13.3562 checksum=-9539.27`
- [x] GGUF single-GPU forward parity: `test_gguf_full_forward <gguf> 0 0` → `top_token=86362 top_logit=16.4038`
- [x] GGUF TP=4 multi-token decode: `MAX_NEW=32 SEED=1234 bash scripts/run_gguf_q2_tp_generate.sh` → tokens [91096, 120682, 12272, 55889, …] match TP=1, 5.47 tps over 3 trials
- [x] All standalone Q2 primitive smoke tests pass (`test_q2_matvec`, `test_gguf_attn_norm_wqa`, `test_gguf_attn_q_path`, `test_gguf_attn_kv_path`, `test_gguf_attn_full`, `test_gguf_shared_expert`, `test_gguf_routed_expert`, `test_gguf_routed_moe`, `test_gguf_layer0_full`)
- [ ] (Deferred) Phase 4 prefill MoE + 2K real prompt vs PyTorch GGUF parity
- [ ] (Deferred) Wire GGUF into `PersistentEngine` + `main.cpp` serve subcommand for production OpenAI HTTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)