### PR TITLE
Implement IQ1_M grouped GEMM prefill

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -184,6 +184,14 @@ add_executable(test_moe_grouped_fp4 tests/test_moe_grouped_fp4.cpp)
 target_link_libraries(test_moe_grouped_fp4 PRIVATE dsv4_cpp_core)
 set_target_properties(test_moe_grouped_fp4 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_moe_grouped_iq1 tests/test_moe_grouped_iq1.cpp)
+target_link_libraries(test_moe_grouped_iq1 PRIVATE dsv4_cpp_core)
+set_target_properties(test_moe_grouped_iq1 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_moe_grouped_q2 tests/test_moe_grouped_q2.cpp)
+target_link_libraries(test_moe_grouped_q2 PRIVATE dsv4_cpp_core)
+set_target_properties(test_moe_grouped_q2 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_embedding_head tests/test_embedding_head.cpp)
 target_link_libraries(test_embedding_head PRIVATE dsv4_cpp_core)
 set_target_properties(test_embedding_head PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/cuda/cuda_ops.cu
+++ b/cpp_engine/cuda/cuda_ops.cu
@@ -397,6 +397,51 @@ __global__ void rope_kernel(
     }
 }
 
+__global__ void head_rmsnorm_rope_rows_kernel(
+    float* x,
+    int tokens,
+    int heads,
+    int head_dim,
+    int rope_dim,
+    int start_position,
+    float theta,
+    bool inverse,
+    float eps) {
+    const int head = blockIdx.x;
+    const int token = blockIdx.y;
+    if (token >= tokens || head >= heads) return;
+    float* row = x + (static_cast<size_t>(token) * heads + head) * head_dim;
+    if (eps > 0.0f) {
+        float sum_sq = 0.0f;
+        for (int i = threadIdx.x; i < head_dim; i += blockDim.x) {
+            const float v = row[i];
+            sum_sq += v * v;
+        }
+        __shared__ float partial[256];
+        partial[threadIdx.x] = sum_sq;
+        __syncthreads();
+        for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+            if (threadIdx.x < stride) partial[threadIdx.x] += partial[threadIdx.x + stride];
+            __syncthreads();
+        }
+        const float norm = rsqrtf(partial[0] / static_cast<float>(head_dim) + eps);
+        for (int i = threadIdx.x; i < head_dim; i += blockDim.x) row[i] *= norm;
+        __syncthreads();
+    }
+    const int rope_start = head_dim - rope_dim;
+    const int position = start_position + token;
+    for (int pair = threadIdx.x * 2; pair < rope_dim; pair += blockDim.x * 2) {
+        const int offset = rope_start + pair;
+        const float angle = static_cast<float>(position) / powf(theta, static_cast<float>(pair) / static_cast<float>(rope_dim));
+        const float c = cosf(angle);
+        const float s = inverse ? -sinf(angle) : sinf(angle);
+        const float a = row[offset];
+        const float b = row[offset + 1];
+        row[offset] = a * c - b * s;
+        row[offset + 1] = a * s + b * c;
+    }
+}
+
 __global__ void head_rmsnorm_rope_freqs_kernel(
     float* x,
     const float* inv_freqs,
@@ -595,6 +640,145 @@ __global__ void prefill_causal_attention_kernel(
     }
 }
 
+__global__ void prefill_causal_attention_chunk_slow_kernel(
+    const float* q,
+    const float* kv,
+    const float* attn_sink,
+    float* y,
+    int tokens,
+    int heads,
+    int kv_len,
+    int head_dim,
+    int window_size,
+    int start_position,
+    float scale) {
+    const int head = blockIdx.x;
+    const int token = blockIdx.y;
+    if (head >= heads || token >= tokens) return;
+    const int abs_token = start_position + token;
+    const int start = max(0, abs_token - window_size + 1);
+    const int end = min(abs_token, kv_len - 1);
+    const float* qh = q + (static_cast<size_t>(token) * heads + head) * head_dim;
+    __shared__ float denom;
+    __shared__ float max_logit;
+    __shared__ float partial[256];
+    float local_max = attn_sink == nullptr ? -INFINITY : attn_sink[head];
+    for (int t = start + threadIdx.x; t <= end; t += blockDim.x) {
+        const float* kth = kv + static_cast<size_t>(t % window_size) * head_dim;
+        float dot = 0.0f;
+        for (int d = 0; d < head_dim; ++d) dot += qh[d] * kth[d];
+        local_max = fmaxf(local_max, dot * scale);
+    }
+    partial[threadIdx.x] = local_max;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) partial[threadIdx.x] = fmaxf(partial[threadIdx.x], partial[threadIdx.x + stride]);
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) max_logit = partial[0];
+    __syncthreads();
+
+    float local_denom = 0.0f;
+    for (int t = start + threadIdx.x; t <= end; t += blockDim.x) {
+        const float* kth = kv + static_cast<size_t>(t % window_size) * head_dim;
+        float dot = 0.0f;
+        for (int d = 0; d < head_dim; ++d) dot += qh[d] * kth[d];
+        local_denom += expf(dot * scale - max_logit);
+    }
+    partial[threadIdx.x] = local_denom;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) partial[threadIdx.x] += partial[threadIdx.x + stride];
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) denom = partial[0] + (attn_sink == nullptr ? 0.0f : expf(attn_sink[head] - max_logit));
+    __syncthreads();
+
+    float* yh = y + (static_cast<size_t>(token) * heads + head) * head_dim;
+    for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        float out = 0.0f;
+        for (int t = start; t <= end; ++t) {
+            const float* kth = kv + static_cast<size_t>(t % window_size) * head_dim;
+            float dot = 0.0f;
+            for (int i = 0; i < head_dim; ++i) dot += qh[i] * kth[i];
+            const float w = expf(dot * scale - max_logit) / denom;
+            out += w * kth[d];
+        }
+        yh[d] = out;
+    }
+}
+
+__global__ void prefill_causal_attention_chunk_kernel(
+    const float* q,
+    const float* kv,
+    const float* attn_sink,
+    float* y,
+    int tokens,
+    int heads,
+    int kv_len,
+    int head_dim,
+    int window_size,
+    int start_position,
+    float scale) {
+    const int head = blockIdx.x;
+    const int token = blockIdx.y;
+    if (head >= heads || token >= tokens) return;
+    const int abs_token = start_position + token;
+    const int start = max(0, abs_token - window_size + 1);
+    const int end = min(abs_token, kv_len - 1);
+    const int tid = threadIdx.x;
+    extern __shared__ float smem[];
+    float* q_shared = smem;
+    float* weights = q_shared + head_dim;
+    float* partial = weights + kv_len;
+    const float* qh = q + (static_cast<size_t>(token) * heads + head) * head_dim;
+    for (int d = tid; d < head_dim; d += blockDim.x) q_shared[d] = qh[d];
+    __syncthreads();
+
+    const float sink_logit = attn_sink == nullptr ? -INFINITY : attn_sink[head];
+    float local_max = sink_logit;
+    for (int t = start + tid; t <= end; t += blockDim.x) {
+        const float* kth = kv + static_cast<size_t>(t % window_size) * head_dim;
+        float dot = 0.0f;
+        for (int d = 0; d < head_dim; ++d) dot += q_shared[d] * kth[d];
+        const float logit = dot * scale;
+        weights[t] = logit;
+        local_max = fmaxf(local_max, logit);
+    }
+    partial[tid] = local_max;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) partial[tid] = fmaxf(partial[tid], partial[tid + stride]);
+        __syncthreads();
+    }
+    const float max_logit = partial[0];
+
+    float local_denom = 0.0f;
+    for (int t = start + tid; t <= end; t += blockDim.x) {
+        const float w = expf(weights[t] - max_logit);
+        weights[t] = w;
+        local_denom += w;
+    }
+    partial[tid] = local_denom;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) partial[tid] += partial[tid + stride];
+        __syncthreads();
+    }
+    const float denom = partial[0] + (attn_sink == nullptr ? 0.0f : expf(sink_logit - max_logit));
+    const float inv_denom = 1.0f / denom;
+
+    float* yh = y + (static_cast<size_t>(token) * heads + head) * head_dim;
+    for (int d = tid; d < head_dim; d += blockDim.x) {
+        float out = 0.0f;
+        for (int t = start; t <= end; ++t) {
+            const float* kth = kv + static_cast<size_t>(t % window_size) * head_dim;
+            out += weights[t] * kth[d];
+        }
+        yh[d] = out * inv_denom;
+    }
+}
+
 
 __global__ void build_prefill_window_indices_kernel(int32_t* indices, int tokens, int window_size, int topk) {
     const int token = blockIdx.x;
@@ -620,6 +804,82 @@ __global__ void build_decode_kv_indices_kernel(
         } else {
             indices[i] = compressed_offset + (i - window_len);
         }
+    }
+}
+
+__global__ void prefill_sparse_attention_indexed_kernel(
+    const float* __restrict__ q,
+    const float* __restrict__ kv,
+    const float* __restrict__ attn_sink,
+    const int32_t* __restrict__ topk_idxs,
+    float* __restrict__ out,
+    int tokens,
+    int heads,
+    int kv_len,
+    int topk,
+    int head_dim,
+    float scale) {
+    const int head = blockIdx.x;
+    const int token = blockIdx.y;
+    if (head >= heads || token >= tokens) return;
+    const int tid = threadIdx.x;
+    extern __shared__ float smem[];
+    float* q_shared = smem;
+    float* weights = q_shared + head_dim;
+    float* partial = weights + topk;
+    const float* qh = q + (static_cast<size_t>(token) * heads + head) * head_dim;
+    const int32_t* idx_row = topk_idxs + static_cast<size_t>(token) * topk;
+    for (int d = tid; d < head_dim; d += blockDim.x) q_shared[d] = qh[d];
+    __syncthreads();
+
+    const float sink_logit = attn_sink == nullptr ? -INFINITY : attn_sink[head];
+    float local_max = sink_logit;
+    for (int t = tid; t < topk; t += blockDim.x) {
+        const int idx = idx_row[t];
+        float logit = -INFINITY;
+        if (idx >= 0 && idx < kv_len) {
+            const float* kth = kv + static_cast<size_t>(idx) * head_dim;
+            float dot = 0.0f;
+            for (int d = 0; d < head_dim; ++d) dot += q_shared[d] * kth[d];
+            logit = dot * scale;
+            local_max = fmaxf(local_max, logit);
+        }
+        weights[t] = logit;
+    }
+    partial[tid] = local_max;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) partial[tid] = fmaxf(partial[tid], partial[tid + stride]);
+        __syncthreads();
+    }
+    const float max_logit = partial[0];
+
+    float local_denom = 0.0f;
+    for (int t = tid; t < topk; t += blockDim.x) {
+        const float w = expf(weights[t] - max_logit);
+        weights[t] = w;
+        local_denom += w;
+    }
+    partial[tid] = local_denom;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) partial[tid] += partial[tid + stride];
+        __syncthreads();
+    }
+    const float denom = partial[0] + (attn_sink == nullptr ? 0.0f : expf(sink_logit - max_logit));
+    const float inv_denom = 1.0f / denom;
+
+    float* yh = out + (static_cast<size_t>(token) * heads + head) * head_dim;
+    for (int d = tid; d < head_dim; d += blockDim.x) {
+        float acc = 0.0f;
+        for (int t = 0; t < topk; ++t) {
+            const int idx = idx_row[t];
+            if (idx >= 0 && idx < kv_len) {
+                const float* kth = kv + static_cast<size_t>(idx) * head_dim;
+                acc += weights[t] * kth[d];
+            }
+        }
+        yh[d] = acc * inv_denom;
     }
 }
 
@@ -1459,6 +1719,39 @@ bool prefill_causal_attention_cuda(
     return cudaGetLastError() == cudaSuccess;
 }
 
+bool prefill_causal_attention_chunk_cuda(
+    const float* d_q,
+    const float* d_kv,
+    const float* d_attn_sink,
+    float* d_y,
+    int tokens,
+    int heads,
+    int kv_len,
+    int head_dim,
+    int window_size,
+    int start_position,
+    float scale,
+    void* stream) {
+    if (d_q == nullptr || d_kv == nullptr || d_y == nullptr || tokens <= 0 || heads <= 0 || kv_len <= 0 || head_dim <= 0 || window_size <= 0 || start_position < 0) return false;
+    auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
+    constexpr int threads = 256;
+    // The fast parity path mirrors cached_single_token_attention_workspace_cuda by
+    // storing logits/weights once in shared memory instead of recomputing Q·K in
+    // the output pass. Keep a conservative 48 KiB cap for 2080Ti; longer exact
+    // contexts fall back to the original recompute kernel rather than failing the
+    // launch. (Long-context performance should move to a tiled/global-scratch
+    // kernel later.)
+    const size_t shared_bytes = (static_cast<size_t>(head_dim) + static_cast<size_t>(kv_len) + threads) * sizeof(float);
+    if (shared_bytes <= 48 * 1024) {
+        prefill_causal_attention_chunk_kernel<<<dim3(heads, tokens), threads, shared_bytes, cuda_stream>>>(
+            d_q, d_kv, d_attn_sink, d_y, tokens, heads, kv_len, head_dim, window_size, start_position, scale);
+    } else {
+        prefill_causal_attention_chunk_slow_kernel<<<dim3(heads, tokens), threads, 0, cuda_stream>>>(
+            d_q, d_kv, d_attn_sink, d_y, tokens, heads, kv_len, head_dim, window_size, start_position, scale);
+    }
+    return cudaGetLastError() == cudaSuccess;
+}
+
 bool build_prefill_window_indices_cuda(int32_t* d_indices, int tokens, int window_size, int topk, void* stream) {
     if (d_indices == nullptr || tokens <= 0 || window_size <= 0 || topk <= 0) return false;
     auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
@@ -1481,6 +1774,28 @@ bool build_decode_kv_indices_cuda(
     const int blocks = std::min((total + threads - 1) / threads, 65535);
     auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
     build_decode_kv_indices_kernel<<<blocks, threads, 0, cuda_stream>>>(d_indices, window_start, window_len, window_size, compressed_count, compressed_offset);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool prefill_sparse_attention_indexed_cuda(
+    const float* d_q,
+    const float* d_kv,
+    const float* d_attn_sink,
+    const int32_t* d_topk_indices,
+    float* d_y,
+    int tokens,
+    int heads,
+    int kv_len,
+    int topk,
+    int head_dim,
+    float scale,
+    void* stream) {
+    if (d_q == nullptr || d_kv == nullptr || d_attn_sink == nullptr || d_topk_indices == nullptr || d_y == nullptr) return false;
+    if (tokens <= 0 || heads <= 0 || kv_len <= 0 || topk <= 0 || head_dim <= 0) return false;
+    const int threads = 256;
+    const size_t shared_bytes = (static_cast<size_t>(head_dim) + static_cast<size_t>(topk) + static_cast<size_t>(threads)) * sizeof(float);
+    auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
+    prefill_sparse_attention_indexed_kernel<<<dim3(heads, tokens), threads, shared_bytes, cuda_stream>>>(d_q, d_kv, d_attn_sink, d_topk_indices, d_y, tokens, heads, kv_len, topk, head_dim, scale);
     return cudaGetLastError() == cudaSuccess;
 }
 
@@ -1715,6 +2030,24 @@ bool head_rmsnorm_rope_cuda(
     } else {
         rope_kernel<<<heads, 256, 0, cuda_stream>>>(d_x, head_dim, rope_dim, position, theta, inverse);
     }
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool head_rmsnorm_rope_rows_cuda(
+    float* d_x,
+    int tokens,
+    int heads,
+    int head_dim,
+    int rope_dim,
+    int start_position,
+    float theta,
+    bool inverse,
+    float eps,
+    void* stream) {
+    if (d_x == nullptr || tokens <= 0 || heads <= 0 || head_dim <= 0 || rope_dim < 0 || rope_dim > head_dim || (rope_dim % 2) != 0 || start_position < 0 || theta <= 0.0f) return false;
+    auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
+    head_rmsnorm_rope_rows_kernel<<<dim3(heads, tokens), 256, 0, cuda_stream>>>(
+        d_x, tokens, heads, head_dim, rope_dim, start_position, theta, inverse, eps);
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/cuda/iq1_ops.cu
+++ b/cpp_engine/cuda/iq1_ops.cu
@@ -6,9 +6,11 @@
 
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#include <mma.h>
 
 #include <cstdint>
 #include <cstdlib>
+#include <iostream>
 #include <mutex>
 
 namespace dsv4 {
@@ -17,6 +19,26 @@ namespace {
 #include "iq1_grid.inc"
 
 constexpr int kIQ1TileN = 8;
+constexpr int kIQ1WmmaTile = 16;
+
+constexpr size_t IQ1_W13_SHARED_NSPLIT_BYTES(int W) {
+    return kIQ1WmmaTile * kIQ1WmmaTile * 1
+         + 2 * static_cast<size_t>(W) * kIQ1WmmaTile * kIQ1WmmaTile * 1
+         + static_cast<size_t>(W) * kIQ1WmmaTile * kIQ1WmmaTile * sizeof(int)
+         + 2 * kIQ1WmmaTile * sizeof(int)
+         + 6 * static_cast<size_t>(W) * kIQ1WmmaTile * sizeof(float)
+         + 2 * static_cast<size_t>(W) * kIQ1WmmaTile * kIQ1WmmaTile * sizeof(float);
+}
+
+constexpr size_t IQ1_W2_SHARED_NSPLIT_BYTES(int W) {
+    return kIQ1WmmaTile * kIQ1WmmaTile * 1
+         + static_cast<size_t>(W) * kIQ1WmmaTile * kIQ1WmmaTile * 1
+         + static_cast<size_t>(W) * kIQ1WmmaTile * kIQ1WmmaTile * sizeof(int)
+         + 2 * kIQ1WmmaTile * sizeof(int)
+         + 3 * static_cast<size_t>(W) * kIQ1WmmaTile * sizeof(float)
+         + static_cast<size_t>(W) * kIQ1WmmaTile * kIQ1WmmaTile * sizeof(float);
+}
+
 static int8_t* g_iq1_grid_device = nullptr;
 static std::once_flag g_iq1_grid_init_flag;
 
@@ -37,11 +59,23 @@ const int8_t* iq1_grid_device() {
 
 inline int ceil_div(int a, int b) { return (a + b - 1) / b; }
 
+int local_env_int_or_default(const char* name, int fallback) {
+    const char* v = std::getenv(name);
+    if (v == nullptr || *v == '\0') return fallback;
+    char* end = nullptr;
+    const long parsed = std::strtol(v, &end, 10);
+    return (end == v) ? fallback : static_cast<int>(parsed);
+}
+
 __device__ __forceinline__ float iq1m_super_scale(const uint16_t* sc) {
     const uint16_t d_bits = static_cast<uint16_t>(
         ((sc[0] & 0xF000u) >> 12) | ((sc[1] & 0xF000u) >> 8) |
         ((sc[2] & 0xF000u) >> 4) | (sc[3] & 0xF000u));
     return __half2float(__ushort_as_half(d_bits));
+}
+
+__device__ __forceinline__ int iq1_pack_i8x4(int a, int b, int c, int d) {
+    return (a & 0xff) | ((b & 0xff) << 8) | ((c & 0xff) << 16) | ((d & 0xff) << 24);
 }
 
 __device__ __forceinline__ float iq1m_block_dot_256(
@@ -77,6 +111,60 @@ __device__ __forceinline__ float iq1m_block_dot_256(
         local += __shfl_down_sync(0xffffffff, local, offset);
     }
     return local;
+}
+
+__device__ __forceinline__ float iq1m_block_dot_q8_256(
+    const int8_t* __restrict__ xq_shared,
+    const float* __restrict__ xs_shared,
+    const uint8_t* __restrict__ block,
+    const int8_t* __restrict__ iq1_grid,
+    int lane) {
+    const uint8_t* qs = block;
+    const uint8_t* qh = block + 32;
+    const uint16_t* sc = reinterpret_cast<const uint16_t*>(block + 48);
+    const float d = iq1m_super_scale(sc);
+    const int j = lane;
+    const int sub = j >> 2;
+    const int half = (j >> 1) & 1;
+    const int pair = j & 1;
+    const int s = sub * 2 + half;
+    const int local_scale = (sc[s >> 2] >> ((s & 3) * 3)) & 0x07;
+    const float dl = d * static_cast<float>(2 * local_scale + 1);
+    const int qhv = (qh[j >> 1] >> ((j & 1) * 4)) & 0x0F;
+    const int qidx = static_cast<int>(qs[j]) | ((qhv & 0x07) << 8);
+    const float delta = (qhv & 0x08) ? -0.125f : 0.125f;
+    const int8_t* gvals = iq1_grid + qidx * 8;
+    const int k_out = sub * 32 + half * 16 + pair * 8;
+    const int h0 = iq1_pack_i8x4(static_cast<int>(xq_shared[k_out + 0]), static_cast<int>(xq_shared[k_out + 1]), static_cast<int>(xq_shared[k_out + 2]), static_cast<int>(xq_shared[k_out + 3]));
+    const int h1 = iq1_pack_i8x4(static_cast<int>(xq_shared[k_out + 4]), static_cast<int>(xq_shared[k_out + 5]), static_cast<int>(xq_shared[k_out + 6]), static_cast<int>(xq_shared[k_out + 7]));
+    const int g0 = iq1_pack_i8x4(static_cast<int>(gvals[0]), static_cast<int>(gvals[1]), static_cast<int>(gvals[2]), static_cast<int>(gvals[3]));
+    const int g1 = iq1_pack_i8x4(static_cast<int>(gvals[4]), static_cast<int>(gvals[5]), static_cast<int>(gvals[6]), static_cast<int>(gvals[7]));
+    const int dot = __dp4a(h0, g0, 0) + __dp4a(h1, g1, 0);
+    const int sum_h = __dp4a(h0, 0x01010101, 0) + __dp4a(h1, 0x01010101, 0);
+    float local = dl * xs_shared[s] * (static_cast<float>(dot) + delta * static_cast<float>(sum_h));
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        local += __shfl_down_sync(0xffffffff, local, offset);
+    }
+    return local;
+}
+
+__device__ __forceinline__ int iq1_grouped_route_expert(
+    const int32_t* __restrict__ seg_starts,
+    int n_experts,
+    int route) {
+    int lo = 0;
+    int hi = n_experts;
+    while (lo < hi) {
+        const int mid = (lo + hi + 1) >> 1;
+        if (seg_starts[mid] <= route) {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    if (lo >= n_experts || route < seg_starts[lo] || route >= seg_starts[lo + 1]) return -1;
+    return lo;
 }
 
 __global__ void iq1_moe_single_w13_kernel(
@@ -278,6 +366,821 @@ __global__ void iq1_moe_single_w2_reduce_kernel(
     if (lane == 0) y[out_col] = total;
 }
 
+__global__ void iq1_moe_grouped_w13_swiglu_kernel(
+    const float* __restrict__ x_rows,
+    const int64_t* __restrict__ route_tokens,
+    const float* __restrict__ route_weights,
+    const int32_t* __restrict__ seg_starts,
+    const uint8_t* __restrict__ w1_blocks,
+    const uint8_t* __restrict__ w3_blocks,
+    const int8_t* __restrict__ iq1_grid,
+    float* __restrict__ hidden,
+    int routes,
+    int n_experts,
+    int dim,
+    int inter_dim,
+    int blocks_per_row,
+    float swiglu_limit) {
+    const int expert = blockIdx.z;
+    const int route_ordinal = blockIdx.y;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int out_col = blockIdx.x * kIQ1TileN + warp;
+    if (expert >= n_experts || route_ordinal >= (seg_starts[expert + 1] - seg_starts[expert]) ||
+        warp >= kIQ1TileN || out_col >= inter_dim) return;
+    const int route = seg_starts[expert] + route_ordinal;
+    if (route < 0 || route >= routes) return;
+    const int64_t token = route_tokens[route];
+    if (token < 0) return;
+
+    __shared__ float x_shared[256];
+    const float* x = x_rows + token * static_cast<int64_t>(dim);
+    const uint8_t* w1_row = w1_blocks + (static_cast<int64_t>(expert) * inter_dim + out_col) * blocks_per_row * 56;
+    const uint8_t* w3_row = w3_blocks + (static_cast<int64_t>(expert) * inter_dim + out_col) * blocks_per_row * 56;
+    float acc1 = 0.0f;
+    float acc3 = 0.0f;
+    for (int block_idx = 0; block_idx < blocks_per_row; ++block_idx) {
+        const int k_base = block_idx * 256;
+        for (int k = threadIdx.x; k < 256; k += blockDim.x) {
+            const int idx = k_base + k;
+            x_shared[k] = idx < dim ? x[idx] : 0.0f;
+        }
+        __syncthreads();
+        const float b1 = iq1m_block_dot_256(x_shared, w1_row + static_cast<int64_t>(block_idx) * 56, iq1_grid, lane);
+        const float b3 = iq1m_block_dot_256(x_shared, w3_row + static_cast<int64_t>(block_idx) * 56, iq1_grid, lane);
+        if (lane == 0) {
+            acc1 += b1;
+            acc3 += b3;
+        }
+        __syncthreads();
+    }
+    if (lane == 0) {
+        float g = acc1;
+        float u = acc3;
+        if (swiglu_limit > 0.0f) {
+            u = fminf(fmaxf(u, -swiglu_limit), swiglu_limit);
+            g = fminf(g, swiglu_limit);
+        }
+        hidden[static_cast<int64_t>(route) * inter_dim + out_col] =
+            (g / (1.0f + expf(-g))) * u * route_weights[route];
+    }
+}
+
+__global__ void iq1_moe_grouped_w13_swiglu_route_kernel(
+    const float* __restrict__ x_rows,
+    const int64_t* __restrict__ route_tokens,
+    const float* __restrict__ route_weights,
+    const int32_t* __restrict__ seg_starts,
+    const uint8_t* __restrict__ w1_blocks,
+    const uint8_t* __restrict__ w3_blocks,
+    const int8_t* __restrict__ iq1_grid,
+    float* __restrict__ hidden,
+    int routes,
+    int n_experts,
+    int dim,
+    int inter_dim,
+    int blocks_per_row,
+    float swiglu_limit) {
+    const int route = blockIdx.y;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int out_col = blockIdx.x * kIQ1TileN + warp;
+    if (route >= routes || warp >= kIQ1TileN || out_col >= inter_dim) return;
+    const int expert = iq1_grouped_route_expert(seg_starts, n_experts, route);
+    if (expert < 0) return;
+    const int64_t token = route_tokens[route];
+    if (token < 0) return;
+
+    __shared__ float x_shared[256];
+    const float* x = x_rows + token * static_cast<int64_t>(dim);
+    const uint8_t* w1_row = w1_blocks + (static_cast<int64_t>(expert) * inter_dim + out_col) * blocks_per_row * 56;
+    const uint8_t* w3_row = w3_blocks + (static_cast<int64_t>(expert) * inter_dim + out_col) * blocks_per_row * 56;
+    float acc1 = 0.0f;
+    float acc3 = 0.0f;
+    for (int block_idx = 0; block_idx < blocks_per_row; ++block_idx) {
+        const int k_base = block_idx * 256;
+        for (int k = threadIdx.x; k < 256; k += blockDim.x) {
+            const int idx = k_base + k;
+            x_shared[k] = idx < dim ? x[idx] : 0.0f;
+        }
+        __syncthreads();
+        const float b1 = iq1m_block_dot_256(x_shared, w1_row + static_cast<int64_t>(block_idx) * 56, iq1_grid, lane);
+        const float b3 = iq1m_block_dot_256(x_shared, w3_row + static_cast<int64_t>(block_idx) * 56, iq1_grid, lane);
+        if (lane == 0) {
+            acc1 += b1;
+            acc3 += b3;
+        }
+        __syncthreads();
+    }
+    if (lane == 0) {
+        float g = acc1;
+        float u = acc3;
+        if (swiglu_limit > 0.0f) {
+            u = fminf(fmaxf(u, -swiglu_limit), swiglu_limit);
+            g = fminf(g, swiglu_limit);
+        }
+        hidden[static_cast<int64_t>(route) * inter_dim + out_col] =
+            (g / (1.0f + expf(-g))) * u * route_weights[route];
+    }
+}
+
+__global__ void iq1_moe_grouped_w2_kernel(
+    const float* __restrict__ hidden,
+    const int64_t* __restrict__ route_tokens,
+    const int32_t* __restrict__ seg_starts,
+    const uint8_t* __restrict__ w2_blocks,
+    const int8_t* __restrict__ iq1_grid,
+    float* __restrict__ y_rows,
+    int routes,
+    int n_experts,
+    int dim,
+    int inter_dim,
+    int blocks_per_row) {
+    const int expert = blockIdx.z;
+    const int route_ordinal = blockIdx.y;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int out_col = blockIdx.x * kIQ1TileN + warp;
+    if (expert >= n_experts || route_ordinal >= (seg_starts[expert + 1] - seg_starts[expert]) ||
+        warp >= kIQ1TileN || out_col >= dim) return;
+    const int route = seg_starts[expert] + route_ordinal;
+    if (route < 0 || route >= routes) return;
+    const int64_t token = route_tokens[route];
+    if (token < 0) return;
+
+    __shared__ float h_shared[256];
+    const float* hidden_row = hidden + static_cast<int64_t>(route) * inter_dim;
+    const uint8_t* w2_row = w2_blocks + (static_cast<int64_t>(expert) * dim + out_col) * blocks_per_row * 56;
+    float acc = 0.0f;
+    for (int block_idx = 0; block_idx < blocks_per_row; ++block_idx) {
+        const int k_base = block_idx * 256;
+        for (int k = threadIdx.x; k < 256; k += blockDim.x) {
+            const int idx = k_base + k;
+            h_shared[k] = idx < inter_dim ? hidden_row[idx] : 0.0f;
+        }
+        __syncthreads();
+        const float b = iq1m_block_dot_256(h_shared, w2_row + static_cast<int64_t>(block_idx) * 56, iq1_grid, lane);
+        if (lane == 0) acc += b;
+        __syncthreads();
+    }
+    if (lane == 0) {
+        atomicAdd(y_rows + token * static_cast<int64_t>(dim) + out_col, acc);
+    }
+}
+
+__global__ void iq1_moe_grouped_w2_route_kernel(
+    const float* __restrict__ hidden,
+    const int64_t* __restrict__ route_tokens,
+    const int32_t* __restrict__ seg_starts,
+    const uint8_t* __restrict__ w2_blocks,
+    const int8_t* __restrict__ iq1_grid,
+    float* __restrict__ y_rows,
+    int routes,
+    int n_experts,
+    int dim,
+    int inter_dim,
+    int blocks_per_row) {
+    const int route = blockIdx.y;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int out_col = blockIdx.x * kIQ1TileN + warp;
+    if (route >= routes || warp >= kIQ1TileN || out_col >= dim) return;
+    const int expert = iq1_grouped_route_expert(seg_starts, n_experts, route);
+    if (expert < 0) return;
+    const int64_t token = route_tokens[route];
+    if (token < 0) return;
+
+    __shared__ float h_shared[256];
+    const float* hidden_row = hidden + static_cast<int64_t>(route) * inter_dim;
+    const uint8_t* w2_row = w2_blocks + (static_cast<int64_t>(expert) * dim + out_col) * blocks_per_row * 56;
+    float acc = 0.0f;
+    for (int block_idx = 0; block_idx < blocks_per_row; ++block_idx) {
+        const int k_base = block_idx * 256;
+        for (int k = threadIdx.x; k < 256; k += blockDim.x) {
+            const int idx = k_base + k;
+            h_shared[k] = idx < inter_dim ? hidden_row[idx] : 0.0f;
+        }
+        __syncthreads();
+        const float b = iq1m_block_dot_256(h_shared, w2_row + static_cast<int64_t>(block_idx) * 56, iq1_grid, lane);
+        if (lane == 0) acc += b;
+        __syncthreads();
+    }
+    if (lane == 0) atomicAdd(y_rows + token * static_cast<int64_t>(dim) + out_col, acc);
+}
+
+__global__ void iq1_moe_grouped_w2_q8_kernel(
+    const int8_t* __restrict__ hidden_q,
+    const float* __restrict__ hidden_scale,
+    const int64_t* __restrict__ route_tokens,
+    const int32_t* __restrict__ seg_starts,
+    const uint8_t* __restrict__ w2_blocks,
+    const int8_t* __restrict__ iq1_grid,
+    float* __restrict__ y_rows,
+    int routes,
+    int n_experts,
+    int max_count,
+    int dim,
+    int inter_dim,
+    int blocks_per_row,
+    int hidden_groups) {
+    const int expert = blockIdx.z;
+    const int route_ordinal = blockIdx.y;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int out_col = blockIdx.x * kIQ1TileN + warp;
+    if (expert >= n_experts || route_ordinal >= max_count || warp >= kIQ1TileN || out_col >= dim) return;
+    const int route = seg_starts[expert] + route_ordinal;
+    if (route >= seg_starts[expert + 1] || route >= routes) return;
+    const int64_t token = route_tokens[route];
+    if (token < 0) return;
+
+    __shared__ int8_t hq_shared[256];
+    __shared__ float hs_shared[16];
+    const int8_t* hidden_row = hidden_q + static_cast<int64_t>(route) * inter_dim;
+    const float* scale_row = hidden_scale + static_cast<int64_t>(route) * hidden_groups;
+    const uint8_t* w2_row = w2_blocks + (static_cast<int64_t>(expert) * dim + out_col) * blocks_per_row * 56;
+    float acc = 0.0f;
+    for (int block_idx = 0; block_idx < blocks_per_row; ++block_idx) {
+        const int k_base = block_idx * 256;
+        for (int k = threadIdx.x; k < 256; k += blockDim.x) {
+            const int idx = k_base + k;
+            hq_shared[k] = idx < inter_dim ? hidden_row[idx] : 0;
+        }
+        for (int g = threadIdx.x; g < 16; g += blockDim.x) {
+            hs_shared[g] = (block_idx * 16 + g) < hidden_groups ? scale_row[block_idx * 16 + g] : 0.0f;
+        }
+        __syncthreads();
+        const float b = iq1m_block_dot_q8_256(hq_shared, hs_shared, w2_row + static_cast<int64_t>(block_idx) * 56, iq1_grid, lane);
+        if (lane == 0) acc += b;
+        __syncthreads();
+    }
+    if (lane == 0) atomicAdd(y_rows + token * static_cast<int64_t>(dim) + out_col, acc);
+}
+
+__global__ void iq1_moe_grouped_w2_q8_route_kernel(
+    const int8_t* __restrict__ hidden_q,
+    const float* __restrict__ hidden_scale,
+    const int64_t* __restrict__ route_tokens,
+    const int32_t* __restrict__ seg_starts,
+    const uint8_t* __restrict__ w2_blocks,
+    const int8_t* __restrict__ iq1_grid,
+    float* __restrict__ y_rows,
+    int routes,
+    int n_experts,
+    int dim,
+    int inter_dim,
+    int blocks_per_row,
+    int hidden_groups) {
+    const int route = blockIdx.y;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int out_col = blockIdx.x * kIQ1TileN + warp;
+    if (route >= routes || warp >= kIQ1TileN || out_col >= dim) return;
+    const int expert = iq1_grouped_route_expert(seg_starts, n_experts, route);
+    if (expert < 0) return;
+    const int64_t token = route_tokens[route];
+    if (token < 0) return;
+
+    __shared__ int8_t hq_shared[256];
+    __shared__ float hs_shared[16];
+    const int8_t* hidden_row = hidden_q + static_cast<int64_t>(route) * inter_dim;
+    const float* scale_row = hidden_scale + static_cast<int64_t>(route) * hidden_groups;
+    const uint8_t* w2_row = w2_blocks + (static_cast<int64_t>(expert) * dim + out_col) * blocks_per_row * 56;
+    float acc = 0.0f;
+    for (int block_idx = 0; block_idx < blocks_per_row; ++block_idx) {
+        const int k_base = block_idx * 256;
+        for (int k = threadIdx.x; k < 256; k += blockDim.x) {
+            const int idx = k_base + k;
+            hq_shared[k] = idx < inter_dim ? hidden_row[idx] : 0;
+        }
+        for (int g = threadIdx.x; g < 16; g += blockDim.x) {
+            hs_shared[g] = (block_idx * 16 + g) < hidden_groups ? scale_row[block_idx * 16 + g] : 0.0f;
+        }
+        __syncthreads();
+        const float b = iq1m_block_dot_q8_256(hq_shared, hs_shared, w2_row + static_cast<int64_t>(block_idx) * 56, iq1_grid, lane);
+        if (lane == 0) acc += b;
+        __syncthreads();
+    }
+    if (lane == 0) atomicAdd(y_rows + token * static_cast<int64_t>(dim) + out_col, acc);
+}
+
+__global__ void iq1_quantize_route_rows_q8_16_kernel(
+    const float* __restrict__ x_rows,
+    const int64_t* __restrict__ route_tokens,
+    int8_t* __restrict__ x_q,
+    float* __restrict__ x_scale,
+    int routes,
+    int dim,
+    int x_groups) {
+    const int route = blockIdx.x;
+    const int group = blockIdx.y;
+    const int lane = threadIdx.x;
+    if (route >= routes || group >= x_groups || lane >= 16) return;
+    const int k = group * 16 + lane;
+    const int64_t token = route_tokens[route];
+    const bool valid = token >= 0 && k < dim;
+    const float xv = valid ? x_rows[token * static_cast<int64_t>(dim) + k] : 0.0f;
+    float maxv = fabsf(xv);
+    #pragma unroll
+    for (int offset = 8; offset > 0; offset >>= 1) {
+        maxv = fmaxf(maxv, __shfl_down_sync(0xffff, maxv, offset));
+    }
+    const float scale = __shfl_sync(0xffff, maxv > 0.0f ? maxv / 127.0f : 1.0e-8f, 0);
+    if (lane == 0) {
+        x_scale[static_cast<int64_t>(route) * x_groups + group] = scale;
+    }
+    if (k < dim) {
+        int q = __float2int_rn(xv / scale);
+        q = q < -127 ? -127 : (q > 127 ? 127 : q);
+        x_q[static_cast<int64_t>(route) * dim + k] = static_cast<int8_t>(valid ? q : 0);
+    }
+}
+
+__device__ __forceinline__ void iq1m_group_meta(
+    const uint8_t* __restrict__ block,
+    int s,
+    float& dl,
+    float& delta0,
+    float& delta1) {
+    const uint8_t* qh = block + 32;
+    const uint16_t* sc = reinterpret_cast<const uint16_t*>(block + 48);
+    const float d = iq1m_super_scale(sc);
+    const int local_scale = (sc[s >> 2] >> ((s & 3) * 3)) & 0x07;
+    dl = d * static_cast<float>(2 * local_scale + 1);
+    const int sub = s >> 1;
+    const int half = s & 1;
+    const int j0 = sub * 4 + half * 2;
+    const int qhv0 = (qh[j0 >> 1] >> ((j0 & 1) * 4)) & 0x0F;
+    const int qhv1 = (qh[(j0 + 1) >> 1] >> (((j0 + 1) & 1) * 4)) & 0x0F;
+    delta0 = (qhv0 & 0x08) ? -0.125f : 0.125f;
+    delta1 = (qhv1 & 0x08) ? -0.125f : 0.125f;
+}
+
+__device__ __forceinline__ signed char iq1m_group_value(
+    const uint8_t* __restrict__ block,
+    const int8_t* __restrict__ iq1_grid,
+    int s,
+    int k) {
+    const uint8_t* qs = block;
+    const uint8_t* qh = block + 32;
+    const int sub = s >> 1;
+    const int half = s & 1;
+    const int pair = k >> 3;
+    const int g = k & 7;
+    const int j = sub * 4 + half * 2 + pair;
+    const int qhv = (qh[j >> 1] >> ((j & 1) * 4)) & 0x0F;
+    const int qidx = static_cast<int>(qs[j]) | ((qhv & 0x07) << 8);
+    return static_cast<signed char>(iq1_grid[qidx * 8 + g]);
+}
+
+template <int WARPS>
+__global__ void iq1_moe_grouped_w13_q8_wmma_compact_nsplit_kernel(
+    const int8_t* __restrict__ x_q,
+    const float* __restrict__ x_scale,
+    const float* __restrict__ route_weights,
+    const int32_t* __restrict__ seg_starts,
+    const int32_t* __restrict__ tile_experts,
+    const int32_t* __restrict__ tile_rows,
+    const uint8_t* __restrict__ w1_blocks,
+    const uint8_t* __restrict__ w3_blocks,
+    const int8_t* __restrict__ iq1_grid,
+    float* __restrict__ hidden,
+    int tile_count,
+    int dim,
+    int inter_dim,
+    int blocks_per_row,
+    int x_groups,
+    float swiglu_limit) {
+    using namespace nvcuda;
+    constexpr int TILE = kIQ1WmmaTile;
+    const int tile_id = blockIdx.y;
+    if (tile_id >= tile_count) return;
+    const int expert = tile_experts[tile_id];
+    const int row_base = tile_rows[tile_id];
+    const int col_base_block = blockIdx.x * (TILE * WARPS);
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+    const int col_base = col_base_block + warp_id * TILE;
+    const int count = seg_starts[expert + 1] - seg_starts[expert];
+    extern __shared__ __align__(16) unsigned char smem[];
+    signed char* a_tile = reinterpret_cast<signed char*>(smem);
+    signed char* b_tile_block = a_tile + TILE * TILE;
+    signed char* b_tile_w1 = b_tile_block + warp_id * TILE * TILE;
+    signed char* b_tile_w3 = b_tile_block + (WARPS + warp_id) * TILE * TILE;
+    int* c_tile_block = reinterpret_cast<int*>(b_tile_block + 2 * WARPS * TILE * TILE);
+    int* c_tile_warp = c_tile_block + warp_id * TILE * TILE;
+    int* sum0 = c_tile_block + WARPS * TILE * TILE;
+    int* sum1 = sum0 + TILE;
+    float* meta = reinterpret_cast<float*>(sum1 + TILE);
+    float* w1_dl = meta + warp_id * TILE;
+    float* w1_delta0 = meta + (WARPS + warp_id) * TILE;
+    float* w1_delta1 = meta + (2 * WARPS + warp_id) * TILE;
+    float* w3_dl = meta + (3 * WARPS + warp_id) * TILE;
+    float* w3_delta0 = meta + (4 * WARPS + warp_id) * TILE;
+    float* w3_delta1 = meta + (5 * WARPS + warp_id) * TILE;
+    float* acc_base = meta + 6 * WARPS * TILE;
+    float* gate_acc = acc_base + warp_id * TILE * TILE;
+    float* up_acc = acc_base + (WARPS + warp_id) * TILE * TILE;
+
+    #pragma unroll
+    for (int i = lane; i < TILE * TILE; i += 32) {
+        gate_acc[i] = 0.0f;
+        up_acc[i] = 0.0f;
+    }
+    __syncthreads();
+
+    for (int kg = 0; kg < x_groups; ++kg) {
+        const int block_idx = kg >> 4;
+        const int s = kg & 15;
+        const int k0 = kg * TILE;
+        wmma::fragment<wmma::matrix_a, TILE, TILE, TILE, signed char, wmma::row_major> a_frag;
+        wmma::fragment<wmma::matrix_b, TILE, TILE, TILE, signed char, wmma::col_major> b_frag;
+        wmma::fragment<wmma::accumulator, TILE, TILE, TILE, int> c1_frag;
+        wmma::fragment<wmma::accumulator, TILE, TILE, TILE, int> c3_frag;
+        wmma::fill_fragment(c1_frag, 0);
+        wmma::fill_fragment(c3_frag, 0);
+
+        for (int i = tid; i < TILE * TILE; i += blockDim.x) {
+            const int r = i / TILE;
+            const int k = i & (TILE - 1);
+            const int row = row_base + r;
+            const int route = seg_starts[expert] + row;
+            a_tile[i] = (row < count && (k0 + k) < dim) ? x_q[static_cast<int64_t>(route) * dim + k0 + k] : 0;
+        }
+        __syncthreads();
+        if (tid < TILE) {
+            int s0 = 0;
+            int s1 = 0;
+            #pragma unroll
+            for (int k = 0; k < 8; ++k) s0 += static_cast<int>(a_tile[tid * TILE + k]);
+            #pragma unroll
+            for (int k = 8; k < 16; ++k) s1 += static_cast<int>(a_tile[tid * TILE + k]);
+            sum0[tid] = s0;
+            sum1[tid] = s1;
+        }
+        for (int i = lane; i < TILE * TILE; i += 32) {
+            const int k = i & (TILE - 1);
+            const int n = i >> 4;
+            const int col = col_base + n;
+            signed char v1 = 0;
+            signed char v3 = 0;
+            if (col < inter_dim && (k0 + k) < dim && block_idx < blocks_per_row) {
+                const uint8_t* w1_block = w1_blocks + ((static_cast<int64_t>(expert) * inter_dim + col) * blocks_per_row + block_idx) * 56;
+                const uint8_t* w3_block = w3_blocks + ((static_cast<int64_t>(expert) * inter_dim + col) * blocks_per_row + block_idx) * 56;
+                v1 = iq1m_group_value(w1_block, iq1_grid, s, k);
+                v3 = iq1m_group_value(w3_block, iq1_grid, s, k);
+            }
+            b_tile_w1[k + n * TILE] = v1;
+            b_tile_w3[k + n * TILE] = v3;
+        }
+        if (lane < TILE) {
+            const int n = lane;
+            const int col = col_base + n;
+            float dl1 = 0.0f, d10 = 0.0f, d11 = 0.0f;
+            float dl3 = 0.0f, d30 = 0.0f, d31 = 0.0f;
+            if (col < inter_dim && block_idx < blocks_per_row) {
+                const uint8_t* w1_block = w1_blocks + ((static_cast<int64_t>(expert) * inter_dim + col) * blocks_per_row + block_idx) * 56;
+                const uint8_t* w3_block = w3_blocks + ((static_cast<int64_t>(expert) * inter_dim + col) * blocks_per_row + block_idx) * 56;
+                iq1m_group_meta(w1_block, s, dl1, d10, d11);
+                iq1m_group_meta(w3_block, s, dl3, d30, d31);
+            }
+            w1_dl[n] = dl1; w1_delta0[n] = d10; w1_delta1[n] = d11;
+            w3_dl[n] = dl3; w3_delta0[n] = d30; w3_delta1[n] = d31;
+        }
+        __syncthreads();
+        wmma::load_matrix_sync(a_frag, a_tile, TILE);
+        wmma::load_matrix_sync(b_frag, b_tile_w1, TILE);
+        wmma::mma_sync(c1_frag, a_frag, b_frag, c1_frag);
+        wmma::load_matrix_sync(b_frag, b_tile_w3, TILE);
+        wmma::mma_sync(c3_frag, a_frag, b_frag, c3_frag);
+        wmma::store_matrix_sync(c_tile_warp, c1_frag, TILE, wmma::mem_row_major);
+        #pragma unroll
+        for (int i = lane; i < TILE * TILE; i += 32) {
+            const int r = i / TILE;
+            const int n = i & (TILE - 1);
+            const int row = row_base + r;
+            const int route = seg_starts[expert] + row;
+            const int col = col_base + n;
+            if (row < count && col < inter_dim) {
+                const float xs = x_scale[static_cast<int64_t>(route) * x_groups + kg];
+                const float corrected = static_cast<float>(c_tile_warp[i]) + w1_delta0[n] * static_cast<float>(sum0[r]) + w1_delta1[n] * static_cast<float>(sum1[r]);
+                gate_acc[i] += xs * w1_dl[n] * corrected;
+            }
+        }
+        wmma::store_matrix_sync(c_tile_warp, c3_frag, TILE, wmma::mem_row_major);
+        #pragma unroll
+        for (int i = lane; i < TILE * TILE; i += 32) {
+            const int r = i / TILE;
+            const int n = i & (TILE - 1);
+            const int row = row_base + r;
+            const int route = seg_starts[expert] + row;
+            const int col = col_base + n;
+            if (row < count && col < inter_dim) {
+                const float xs = x_scale[static_cast<int64_t>(route) * x_groups + kg];
+                const float corrected = static_cast<float>(c_tile_warp[i]) + w3_delta0[n] * static_cast<float>(sum0[r]) + w3_delta1[n] * static_cast<float>(sum1[r]);
+                up_acc[i] += xs * w3_dl[n] * corrected;
+            }
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int i = lane; i < TILE * TILE; i += 32) {
+        const int r = i / TILE;
+        const int n = i & (TILE - 1);
+        const int row = row_base + r;
+        const int col = col_base + n;
+        if (row < count && col < inter_dim) {
+            const int route = seg_starts[expert] + row;
+            float g = gate_acc[i];
+            float u = up_acc[i];
+            if (swiglu_limit > 0.0f) {
+                u = fminf(fmaxf(u, -swiglu_limit), swiglu_limit);
+                g = fminf(g, swiglu_limit);
+            }
+            hidden[static_cast<int64_t>(route) * inter_dim + col] =
+                (g / (1.0f + expf(-g))) * u * route_weights[route];
+        }
+    }
+}
+
+template <int WARPS>
+__global__ void iq1_moe_grouped_w2_q8_wmma_compact_nsplit_kernel(
+    const int8_t* __restrict__ hidden_q,
+    const float* __restrict__ hidden_scale,
+    const int64_t* __restrict__ route_tokens,
+    const int32_t* __restrict__ seg_starts,
+    const int32_t* __restrict__ tile_experts,
+    const int32_t* __restrict__ tile_rows,
+    const uint8_t* __restrict__ w2_blocks,
+    const int8_t* __restrict__ iq1_grid,
+    float* __restrict__ y_rows,
+    int tile_count,
+    int dim,
+    int inter_dim,
+    int blocks_per_row,
+    int hidden_groups) {
+    using namespace nvcuda;
+    constexpr int TILE = kIQ1WmmaTile;
+    const int tile_id = blockIdx.y;
+    if (tile_id >= tile_count) return;
+    const int expert = tile_experts[tile_id];
+    const int row_base = tile_rows[tile_id];
+    const int col_base_block = blockIdx.x * (TILE * WARPS);
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+    const int col_base = col_base_block + warp_id * TILE;
+    const int count = seg_starts[expert + 1] - seg_starts[expert];
+    extern __shared__ __align__(16) unsigned char smem[];
+    signed char* a_tile = reinterpret_cast<signed char*>(smem);
+    signed char* b_tile_block = a_tile + TILE * TILE;
+    signed char* b_tile = b_tile_block + warp_id * TILE * TILE;
+    int* c_tile_block = reinterpret_cast<int*>(b_tile_block + WARPS * TILE * TILE);
+    int* c_tile_warp = c_tile_block + warp_id * TILE * TILE;
+    int* sum0 = c_tile_block + WARPS * TILE * TILE;
+    int* sum1 = sum0 + TILE;
+    float* meta = reinterpret_cast<float*>(sum1 + TILE);
+    float* w2_dl = meta + warp_id * TILE;
+    float* w2_delta0 = meta + (WARPS + warp_id) * TILE;
+    float* w2_delta1 = meta + (2 * WARPS + warp_id) * TILE;
+    float* acc_base = meta + 3 * WARPS * TILE;
+    float* acc = acc_base + warp_id * TILE * TILE;
+
+    #pragma unroll
+    for (int i = lane; i < TILE * TILE; i += 32) acc[i] = 0.0f;
+    __syncthreads();
+
+    for (int kg = 0; kg < hidden_groups; ++kg) {
+        const int block_idx = kg >> 4;
+        const int s = kg & 15;
+        const int k0 = kg * TILE;
+        wmma::fragment<wmma::matrix_a, TILE, TILE, TILE, signed char, wmma::row_major> a_frag;
+        wmma::fragment<wmma::matrix_b, TILE, TILE, TILE, signed char, wmma::col_major> b_frag;
+        wmma::fragment<wmma::accumulator, TILE, TILE, TILE, int> c_frag;
+        wmma::fill_fragment(c_frag, 0);
+
+        for (int i = tid; i < TILE * TILE; i += blockDim.x) {
+            const int r = i / TILE;
+            const int k = i & (TILE - 1);
+            const int row = row_base + r;
+            const int route = seg_starts[expert] + row;
+            a_tile[i] = (row < count && (k0 + k) < inter_dim) ? hidden_q[static_cast<int64_t>(route) * inter_dim + k0 + k] : 0;
+        }
+        __syncthreads();
+        if (tid < TILE) {
+            int s0 = 0;
+            int s1 = 0;
+            #pragma unroll
+            for (int k = 0; k < 8; ++k) s0 += static_cast<int>(a_tile[tid * TILE + k]);
+            #pragma unroll
+            for (int k = 8; k < 16; ++k) s1 += static_cast<int>(a_tile[tid * TILE + k]);
+            sum0[tid] = s0;
+            sum1[tid] = s1;
+        }
+        for (int i = lane; i < TILE * TILE; i += 32) {
+            const int k = i & (TILE - 1);
+            const int n = i >> 4;
+            const int col = col_base + n;
+            signed char v = 0;
+            if (col < dim && (k0 + k) < inter_dim && block_idx < blocks_per_row) {
+                const uint8_t* w2_block = w2_blocks + ((static_cast<int64_t>(expert) * dim + col) * blocks_per_row + block_idx) * 56;
+                v = iq1m_group_value(w2_block, iq1_grid, s, k);
+            }
+            b_tile[k + n * TILE] = v;
+        }
+        if (lane < TILE) {
+            const int n = lane;
+            const int col = col_base + n;
+            float dl = 0.0f, d0 = 0.0f, d1 = 0.0f;
+            if (col < dim && block_idx < blocks_per_row) {
+                const uint8_t* w2_block = w2_blocks + ((static_cast<int64_t>(expert) * dim + col) * blocks_per_row + block_idx) * 56;
+                iq1m_group_meta(w2_block, s, dl, d0, d1);
+            }
+            w2_dl[n] = dl; w2_delta0[n] = d0; w2_delta1[n] = d1;
+        }
+        __syncthreads();
+        wmma::load_matrix_sync(a_frag, a_tile, TILE);
+        wmma::load_matrix_sync(b_frag, b_tile, TILE);
+        wmma::mma_sync(c_frag, a_frag, b_frag, c_frag);
+        wmma::store_matrix_sync(c_tile_warp, c_frag, TILE, wmma::mem_row_major);
+        #pragma unroll
+        for (int i = lane; i < TILE * TILE; i += 32) {
+            const int r = i / TILE;
+            const int n = i & (TILE - 1);
+            const int row = row_base + r;
+            const int route = seg_starts[expert] + row;
+            const int col = col_base + n;
+            if (row < count && col < dim) {
+                const float hs = hidden_scale[static_cast<int64_t>(route) * hidden_groups + kg];
+                const float corrected = static_cast<float>(c_tile_warp[i]) + w2_delta0[n] * static_cast<float>(sum0[r]) + w2_delta1[n] * static_cast<float>(sum1[r]);
+                acc[i] += hs * w2_dl[n] * corrected;
+            }
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int i = lane; i < TILE * TILE; i += 32) {
+        const int r = i / TILE;
+        const int n = i & (TILE - 1);
+        const int row = row_base + r;
+        const int col = col_base + n;
+        if (row < count && col < dim) {
+            const int route = seg_starts[expert] + row;
+            const int64_t token = route_tokens[route];
+            if (token >= 0) {
+                atomicAdd(y_rows + token * static_cast<int64_t>(dim) + col, acc[i]);
+            }
+        }
+    }
+}
+
+__global__ void iq1_moe_grouped_w13_swiglu_tile4_kernel(
+    const float* __restrict__ x_rows,
+    const int64_t* __restrict__ route_tokens,
+    const float* __restrict__ route_weights,
+    const int32_t* __restrict__ seg_starts,
+    const uint8_t* __restrict__ w1_blocks,
+    const uint8_t* __restrict__ w3_blocks,
+    const int8_t* __restrict__ iq1_grid,
+    float* __restrict__ hidden,
+    int routes,
+    int n_experts,
+    int max_count,
+    int dim,
+    int inter_dim,
+    int blocks_per_row,
+    float swiglu_limit) {
+    constexpr int route_tile = 4;
+    const int expert = blockIdx.z;
+    const int route_base_ordinal = blockIdx.y * route_tile;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int out_col = blockIdx.x * kIQ1TileN + warp;
+    if (expert >= n_experts || route_base_ordinal >= max_count || warp >= kIQ1TileN || out_col >= inter_dim) return;
+    const int count = seg_starts[expert + 1] - seg_starts[expert];
+    const int base_route = seg_starts[expert] + route_base_ordinal;
+    int route[route_tile];
+    int64_t token[route_tile];
+    bool valid[route_tile];
+    #pragma unroll
+    for (int r = 0; r < route_tile; ++r) {
+        route[r] = base_route + r;
+        valid[r] = (route_base_ordinal + r) < count && route[r] >= 0 && route[r] < routes;
+        token[r] = valid[r] ? route_tokens[route[r]] : -1;
+        valid[r] = valid[r] && token[r] >= 0;
+    }
+
+    __shared__ float x_shared[route_tile][256];
+    const uint8_t* w1_row = w1_blocks + (static_cast<int64_t>(expert) * inter_dim + out_col) * blocks_per_row * 56;
+    const uint8_t* w3_row = w3_blocks + (static_cast<int64_t>(expert) * inter_dim + out_col) * blocks_per_row * 56;
+    float acc1[route_tile] = {0.0f, 0.0f, 0.0f, 0.0f};
+    float acc3[route_tile] = {0.0f, 0.0f, 0.0f, 0.0f};
+    for (int block_idx = 0; block_idx < blocks_per_row; ++block_idx) {
+        const int k_base = block_idx * 256;
+        for (int k = threadIdx.x; k < 256; k += blockDim.x) {
+            const int idx = k_base + k;
+            #pragma unroll
+            for (int r = 0; r < route_tile; ++r) {
+                const float* x = valid[r] ? (x_rows + token[r] * static_cast<int64_t>(dim)) : nullptr;
+                x_shared[r][k] = (valid[r] && idx < dim) ? x[idx] : 0.0f;
+            }
+        }
+        __syncthreads();
+        const uint8_t* w1_block = w1_row + static_cast<int64_t>(block_idx) * 56;
+        const uint8_t* w3_block = w3_row + static_cast<int64_t>(block_idx) * 56;
+        #pragma unroll
+        for (int r = 0; r < route_tile; ++r) {
+            const float b1 = iq1m_block_dot_256(x_shared[r], w1_block, iq1_grid, lane);
+            const float b3 = iq1m_block_dot_256(x_shared[r], w3_block, iq1_grid, lane);
+            if (lane == 0) {
+                acc1[r] += b1;
+                acc3[r] += b3;
+            }
+        }
+        __syncthreads();
+    }
+    if (lane == 0) {
+        #pragma unroll
+        for (int r = 0; r < route_tile; ++r) {
+            if (!valid[r]) continue;
+            float g = acc1[r];
+            float u = acc3[r];
+            if (swiglu_limit > 0.0f) {
+                u = fminf(fmaxf(u, -swiglu_limit), swiglu_limit);
+                g = fminf(g, swiglu_limit);
+            }
+            hidden[static_cast<int64_t>(route[r]) * inter_dim + out_col] =
+                (g / (1.0f + expf(-g))) * u * route_weights[route[r]];
+        }
+    }
+}
+
+__global__ void iq1_moe_grouped_w2_tile4_kernel(
+    const float* __restrict__ hidden,
+    const int64_t* __restrict__ route_tokens,
+    const int32_t* __restrict__ seg_starts,
+    const uint8_t* __restrict__ w2_blocks,
+    const int8_t* __restrict__ iq1_grid,
+    float* __restrict__ y_rows,
+    int routes,
+    int n_experts,
+    int max_count,
+    int dim,
+    int inter_dim,
+    int blocks_per_row) {
+    constexpr int route_tile = 4;
+    const int expert = blockIdx.z;
+    const int route_base_ordinal = blockIdx.y * route_tile;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int out_col = blockIdx.x * kIQ1TileN + warp;
+    if (expert >= n_experts || route_base_ordinal >= max_count || warp >= kIQ1TileN || out_col >= dim) return;
+    const int count = seg_starts[expert + 1] - seg_starts[expert];
+    const int base_route = seg_starts[expert] + route_base_ordinal;
+    int route[route_tile];
+    int64_t token[route_tile];
+    bool valid[route_tile];
+    #pragma unroll
+    for (int r = 0; r < route_tile; ++r) {
+        route[r] = base_route + r;
+        valid[r] = (route_base_ordinal + r) < count && route[r] >= 0 && route[r] < routes;
+        token[r] = valid[r] ? route_tokens[route[r]] : -1;
+        valid[r] = valid[r] && token[r] >= 0;
+    }
+
+    __shared__ float h_shared[route_tile][256];
+    const uint8_t* w2_row = w2_blocks + (static_cast<int64_t>(expert) * dim + out_col) * blocks_per_row * 56;
+    float acc[route_tile] = {0.0f, 0.0f, 0.0f, 0.0f};
+    for (int block_idx = 0; block_idx < blocks_per_row; ++block_idx) {
+        const int k_base = block_idx * 256;
+        for (int k = threadIdx.x; k < 256; k += blockDim.x) {
+            const int idx = k_base + k;
+            #pragma unroll
+            for (int r = 0; r < route_tile; ++r) {
+                const float* hidden_row = valid[r] ? (hidden + static_cast<int64_t>(route[r]) * inter_dim) : nullptr;
+                h_shared[r][k] = (valid[r] && idx < inter_dim) ? hidden_row[idx] : 0.0f;
+            }
+        }
+        __syncthreads();
+        const uint8_t* w2_block = w2_row + static_cast<int64_t>(block_idx) * 56;
+        #pragma unroll
+        for (int r = 0; r < route_tile; ++r) {
+            const float b = iq1m_block_dot_256(h_shared[r], w2_block, iq1_grid, lane);
+            if (lane == 0) acc[r] += b;
+        }
+        __syncthreads();
+    }
+    if (lane == 0) {
+        #pragma unroll
+        for (int r = 0; r < route_tile; ++r) {
+            if (valid[r]) atomicAdd(y_rows + token[r] * static_cast<int64_t>(dim) + out_col, acc[r]);
+        }
+    }
+}
+
 }  // namespace
 
 bool iq1_moe_single_w13_cuda(
@@ -389,6 +1292,239 @@ bool iq1_moe_single_w2_reduce_cuda(
         d_hidden, d_route_slots, d_w2_blocks, grid, d_y,
         routes, n_experts, dim, inter_dim, blocks_per_row);
     return cudaGetLastError() == cudaSuccess;
+}
+
+bool iq1_moe_grouped_w13_swiglu_cuda(
+    const float* d_x_rows,
+    const int64_t* d_route_tokens,
+    const float* d_route_weights,
+    const int32_t* d_seg_starts,
+    const uint8_t* d_w1_blocks,
+    const uint8_t* d_w3_blocks,
+    float* d_hidden,
+    int routes,
+    int n_experts,
+    int max_count,
+    int dim,
+    int inter_dim,
+    float swiglu_limit,
+    void* stream) {
+    if (d_x_rows == nullptr || d_route_tokens == nullptr || d_route_weights == nullptr ||
+        d_seg_starts == nullptr || d_w1_blocks == nullptr || d_w3_blocks == nullptr ||
+        d_hidden == nullptr) return false;
+    if (routes <= 0 || n_experts <= 0 || max_count <= 0 || dim <= 0 || inter_dim <= 0) return true;
+    const int8_t* grid = iq1_grid_device();
+    if (grid == nullptr) return false;
+    const int w13_blocks_per_row = (dim + 255) / 256;
+    dim3 block(256);
+    const bool route_tile4 = local_env_int_or_default("DSV4_IQ1_GROUPED_ROUTE_TILE4", 0) != 0 && max_count >= 4;
+    const bool route_major = !route_tile4 && local_env_int_or_default("DSV4_IQ1_GROUPED_ROUTE_MAJOR", 1) != 0;
+    if (route_tile4) {
+        constexpr int route_tile = 4;
+        dim3 grid_w13(ceil_div(inter_dim, kIQ1TileN), ceil_div(max_count, route_tile), n_experts);
+        iq1_moe_grouped_w13_swiglu_tile4_kernel<<<grid_w13, block, 0, static_cast<cudaStream_t>(stream)>>>(
+            d_x_rows, d_route_tokens, d_route_weights, d_seg_starts,
+            d_w1_blocks, d_w3_blocks, grid, d_hidden,
+            routes, n_experts, max_count, dim, inter_dim, w13_blocks_per_row, swiglu_limit);
+    } else if (route_major) {
+        dim3 grid_w13(ceil_div(inter_dim, kIQ1TileN), routes);
+        iq1_moe_grouped_w13_swiglu_route_kernel<<<grid_w13, block, 0, static_cast<cudaStream_t>(stream)>>>(
+            d_x_rows, d_route_tokens, d_route_weights, d_seg_starts,
+            d_w1_blocks, d_w3_blocks, grid, d_hidden,
+            routes, n_experts, dim, inter_dim, w13_blocks_per_row, swiglu_limit);
+    } else {
+        dim3 grid_w13(ceil_div(inter_dim, kIQ1TileN), max_count, n_experts);
+        iq1_moe_grouped_w13_swiglu_kernel<<<grid_w13, block, 0, static_cast<cudaStream_t>(stream)>>>(
+            d_x_rows, d_route_tokens, d_route_weights, d_seg_starts,
+            d_w1_blocks, d_w3_blocks, grid, d_hidden,
+            routes, n_experts, dim, inter_dim, w13_blocks_per_row, swiglu_limit);
+    }
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool moe_prefill_iq1_grouped_cuda_with_workspace(
+    const float* d_x_rows,
+    const int64_t* d_route_tokens,
+    const float* d_route_weights,
+    const int32_t* d_seg_starts,
+    const uint8_t* d_w1_blocks,
+    const uint8_t* d_w2_blocks,
+    const uint8_t* d_w3_blocks,
+    float* d_y_rows,
+    int tokens,
+    int routes,
+    int n_experts,
+    int max_count,
+    int dim,
+    int inter_dim,
+    float swiglu_limit,
+    MoePrefillIq1GroupedWorkspace workspace,
+    void* stream) {
+    if (d_x_rows == nullptr || d_route_tokens == nullptr || d_route_weights == nullptr ||
+        d_seg_starts == nullptr || d_w1_blocks == nullptr || d_w2_blocks == nullptr ||
+        d_w3_blocks == nullptr || d_y_rows == nullptr) return false;
+    if (tokens <= 0 || routes < 0 || n_experts <= 0 || max_count < 0 || dim <= 0 || inter_dim <= 0) return false;
+    if (routes == 0 || max_count == 0) {
+        return cudaMemsetAsync(d_y_rows, 0, static_cast<size_t>(tokens) * dim * sizeof(float),
+                              static_cast<cudaStream_t>(stream)) == cudaSuccess;
+    }
+    if (workspace.d_hidden == nullptr || workspace.routes_cap < routes || workspace.inter_dim < inter_dim) return false;
+    const int8_t* grid = iq1_grid_device();
+    if (grid == nullptr) return false;
+    cudaStream_t cs = static_cast<cudaStream_t>(stream);
+    const bool profile_iq1 = local_env_int_or_default("DSV4_IQ1_GROUPED_PROFILE", 0) != 0;
+    cudaEvent_t ev0 = nullptr, ev1 = nullptr, ev2 = nullptr, ev3 = nullptr, ev4 = nullptr;
+    if (profile_iq1) {
+        cudaEventCreate(&ev0); cudaEventCreate(&ev1); cudaEventCreate(&ev2); cudaEventCreate(&ev3); cudaEventCreate(&ev4);
+        cudaEventRecord(ev0, cs);
+    }
+    if (cudaMemsetAsync(d_y_rows, 0, static_cast<size_t>(tokens) * dim * sizeof(float), cs) != cudaSuccess) return false;
+
+    const int w13_blocks_per_row = (dim + 255) / 256;
+    const int w2_blocks_per_row = (inter_dim + 255) / 256;
+    const int x_groups16 = ceil_div(dim, 16);
+    const int hidden_groups = ceil_div(inter_dim, 16);
+    dim3 block(256);
+    const bool route_tile4 = local_env_int_or_default("DSV4_IQ1_GROUPED_ROUTE_TILE4", 0) != 0 && max_count >= 4;
+    const bool route_major = !route_tile4 && local_env_int_or_default("DSV4_IQ1_GROUPED_ROUTE_MAJOR", 1) != 0;
+    const bool q8_w2 = local_env_int_or_default("DSV4_IQ1_GROUPED_W2_Q8", 1) != 0 &&
+        workspace.d_hidden_q != nullptr && workspace.d_hidden_scale != nullptr;
+    const bool tile_workspace = workspace.d_tile_experts != nullptr && workspace.d_tile_rows != nullptr &&
+        workspace.tile_count > 0 && workspace.tile_cap >= workspace.tile_count && workspace.routes_cap >= routes;
+    const bool gemm_enabled = local_env_int_or_default("DSV4_IQ1_GROUPED_GEMM", 1) != 0 && tile_workspace;
+    const bool gemm_w13 = gemm_enabled && local_env_int_or_default("DSV4_IQ1_GROUPED_GEMM_W13", 1) != 0 &&
+        workspace.d_x_q != nullptr && workspace.d_x_scale != nullptr && workspace.dim >= dim;
+    const bool gemm_w2 = gemm_enabled && local_env_int_or_default("DSV4_IQ1_GROUPED_GEMM_W2", 1) != 0 && q8_w2;
+    const int nsplit = local_env_int_or_default("DSV4_IQ1_GROUPED_GEMM_NSPLIT", 4);
+
+    if (gemm_w13) {
+        dim3 q_grid(routes, x_groups16);
+        iq1_quantize_route_rows_q8_16_kernel<<<q_grid, 16, 0, cs>>>(
+            d_x_rows, d_route_tokens, workspace.d_x_q, workspace.d_x_scale, routes, dim, x_groups16);
+        if (cudaGetLastError() != cudaSuccess) return false;
+        if (profile_iq1) cudaEventRecord(ev1, cs);
+        if (nsplit == 2) {
+            dim3 grid_w13(ceil_div(inter_dim, kIQ1WmmaTile * 2), workspace.tile_count);
+            iq1_moe_grouped_w13_q8_wmma_compact_nsplit_kernel<2><<<grid_w13, 64, IQ1_W13_SHARED_NSPLIT_BYTES(2), cs>>>(
+                workspace.d_x_q, workspace.d_x_scale, d_route_weights, d_seg_starts,
+                workspace.d_tile_experts, workspace.d_tile_rows, d_w1_blocks, d_w3_blocks, grid,
+                workspace.d_hidden, workspace.tile_count, dim, inter_dim, w13_blocks_per_row, x_groups16, swiglu_limit);
+        } else {
+            dim3 grid_w13(ceil_div(inter_dim, kIQ1WmmaTile * 4), workspace.tile_count);
+            iq1_moe_grouped_w13_q8_wmma_compact_nsplit_kernel<4><<<grid_w13, 128, IQ1_W13_SHARED_NSPLIT_BYTES(4), cs>>>(
+                workspace.d_x_q, workspace.d_x_scale, d_route_weights, d_seg_starts,
+                workspace.d_tile_experts, workspace.d_tile_rows, d_w1_blocks, d_w3_blocks, grid,
+                workspace.d_hidden, workspace.tile_count, dim, inter_dim, w13_blocks_per_row, x_groups16, swiglu_limit);
+        }
+    } else if (route_tile4) {
+        constexpr int route_tile = 4;
+        dim3 grid_w13(ceil_div(inter_dim, kIQ1TileN), ceil_div(max_count, route_tile), n_experts);
+        iq1_moe_grouped_w13_swiglu_tile4_kernel<<<grid_w13, block, 0, cs>>>(
+            d_x_rows, d_route_tokens, d_route_weights, d_seg_starts,
+            d_w1_blocks, d_w3_blocks, grid, workspace.d_hidden,
+            routes, n_experts, max_count, dim, inter_dim, w13_blocks_per_row, swiglu_limit);
+    } else if (route_major) {
+        dim3 grid_w13(ceil_div(inter_dim, kIQ1TileN), routes);
+        iq1_moe_grouped_w13_swiglu_route_kernel<<<grid_w13, block, 0, cs>>>(
+            d_x_rows, d_route_tokens, d_route_weights, d_seg_starts,
+            d_w1_blocks, d_w3_blocks, grid, workspace.d_hidden,
+            routes, n_experts, dim, inter_dim, w13_blocks_per_row, swiglu_limit);
+    } else {
+        dim3 grid_w13(ceil_div(inter_dim, kIQ1TileN), max_count, n_experts);
+        iq1_moe_grouped_w13_swiglu_kernel<<<grid_w13, block, 0, cs>>>(
+            d_x_rows, d_route_tokens, d_route_weights, d_seg_starts,
+            d_w1_blocks, d_w3_blocks, grid, workspace.d_hidden,
+            routes, n_experts, dim, inter_dim, w13_blocks_per_row, swiglu_limit);
+    }
+    if (cudaGetLastError() != cudaSuccess) return false;
+    if (profile_iq1) cudaEventRecord(ev2, cs);
+
+    if (q8_w2) {
+        if (!q2_quantize_hidden_q8_1_cuda(workspace.d_hidden, workspace.d_hidden_q, workspace.d_hidden_scale, routes, inter_dim, cs)) return false;
+        if (profile_iq1) cudaEventRecord(ev3, cs);
+        if (gemm_w2) {
+            if (nsplit == 2) {
+                dim3 grid_w2(ceil_div(dim, kIQ1WmmaTile * 2), workspace.tile_count);
+                iq1_moe_grouped_w2_q8_wmma_compact_nsplit_kernel<2><<<grid_w2, 64, IQ1_W2_SHARED_NSPLIT_BYTES(2), cs>>>(
+                    workspace.d_hidden_q, workspace.d_hidden_scale, d_route_tokens, d_seg_starts,
+                    workspace.d_tile_experts, workspace.d_tile_rows, d_w2_blocks, grid, d_y_rows,
+                    workspace.tile_count, dim, inter_dim, w2_blocks_per_row, hidden_groups);
+            } else {
+                dim3 grid_w2(ceil_div(dim, kIQ1WmmaTile * 4), workspace.tile_count);
+                iq1_moe_grouped_w2_q8_wmma_compact_nsplit_kernel<4><<<grid_w2, 128, IQ1_W2_SHARED_NSPLIT_BYTES(4), cs>>>(
+                    workspace.d_hidden_q, workspace.d_hidden_scale, d_route_tokens, d_seg_starts,
+                    workspace.d_tile_experts, workspace.d_tile_rows, d_w2_blocks, grid, d_y_rows,
+                    workspace.tile_count, dim, inter_dim, w2_blocks_per_row, hidden_groups);
+            }
+        } else if (route_major) {
+            dim3 grid_w2(ceil_div(dim, kIQ1TileN), routes);
+            iq1_moe_grouped_w2_q8_route_kernel<<<grid_w2, block, 0, cs>>>(
+                workspace.d_hidden_q, workspace.d_hidden_scale, d_route_tokens, d_seg_starts, d_w2_blocks, grid, d_y_rows,
+                routes, n_experts, dim, inter_dim, w2_blocks_per_row, hidden_groups);
+        } else {
+            dim3 grid_w2(ceil_div(dim, kIQ1TileN), max_count, n_experts);
+            iq1_moe_grouped_w2_q8_kernel<<<grid_w2, block, 0, cs>>>(
+                workspace.d_hidden_q, workspace.d_hidden_scale, d_route_tokens, d_seg_starts, d_w2_blocks, grid, d_y_rows,
+                routes, n_experts, max_count, dim, inter_dim, w2_blocks_per_row, hidden_groups);
+        }
+    } else {
+        if (profile_iq1) cudaEventRecord(ev3, cs);
+        if (route_tile4) {
+            constexpr int route_tile = 4;
+            dim3 grid_w2(ceil_div(dim, kIQ1TileN), ceil_div(max_count, route_tile), n_experts);
+            iq1_moe_grouped_w2_tile4_kernel<<<grid_w2, block, 0, cs>>>(
+                workspace.d_hidden, d_route_tokens, d_seg_starts, d_w2_blocks, grid, d_y_rows,
+                routes, n_experts, max_count, dim, inter_dim, w2_blocks_per_row);
+        } else if (route_major) {
+            dim3 grid_w2(ceil_div(dim, kIQ1TileN), routes);
+            iq1_moe_grouped_w2_route_kernel<<<grid_w2, block, 0, cs>>>(
+                workspace.d_hidden, d_route_tokens, d_seg_starts, d_w2_blocks, grid, d_y_rows,
+                routes, n_experts, dim, inter_dim, w2_blocks_per_row);
+        } else {
+            dim3 grid_w2(ceil_div(dim, kIQ1TileN), max_count, n_experts);
+            iq1_moe_grouped_w2_kernel<<<grid_w2, block, 0, cs>>>(
+                workspace.d_hidden, d_route_tokens, d_seg_starts, d_w2_blocks, grid, d_y_rows,
+                routes, n_experts, dim, inter_dim, w2_blocks_per_row);
+        }
+    }
+    const cudaError_t last = cudaGetLastError();
+    if (profile_iq1) {
+        cudaEventRecord(ev4, cs);
+        cudaEventSynchronize(ev4);
+        float total_ms = 0.0f, x_quant_ms = 0.0f, w13_ms = 0.0f, quant_ms = 0.0f, w2_ms = 0.0f;
+        cudaEventElapsedTime(&total_ms, ev0, ev4);
+        if (gemm_w13) {
+            cudaEventElapsedTime(&x_quant_ms, ev0, ev1);
+            cudaEventElapsedTime(&w13_ms, ev1, ev2);
+        } else {
+            cudaEventElapsedTime(&w13_ms, ev0, ev2);
+        }
+        cudaEventElapsedTime(&quant_ms, ev2, ev3);
+        cudaEventElapsedTime(&w2_ms, ev3, ev4);
+        std::cerr << "iq1_grouped_profile routes=" << routes
+                  << " tokens=" << tokens
+                  << " max_count=" << max_count
+                  << " n_experts=" << n_experts
+                  << " dim=" << dim
+                  << " inter_dim=" << inter_dim
+                  << " q8_w2=" << (q8_w2 ? 1 : 0)
+                  << " gemm=" << ((gemm_w13 || gemm_w2) ? 1 : 0)
+                  << " gemm_w13=" << (gemm_w13 ? 1 : 0)
+                  << " gemm_w2=" << (gemm_w2 ? 1 : 0)
+                  << " tiles=" << workspace.tile_count
+                  << " nsplit=" << (nsplit == 2 ? 2 : 4)
+                  << " tile4=" << (route_tile4 ? 1 : 0)
+                  << " route_major=" << (route_major ? 1 : 0)
+                  << " hidden_q_present=" << (workspace.d_hidden_q != nullptr ? 1 : 0)
+                  << " hidden_scale_present=" << (workspace.d_hidden_scale != nullptr ? 1 : 0)
+                  << " total_ms=" << total_ms
+                  << " x_quant_ms=" << x_quant_ms
+                  << " w13_ms=" << w13_ms
+                  << " quant_ms=" << quant_ms
+                  << " w2_ms=" << w2_ms << "\n";
+        cudaEventDestroy(ev0); cudaEventDestroy(ev1); cudaEventDestroy(ev2); cudaEventDestroy(ev3); cudaEventDestroy(ev4);
+    }
+    return last == cudaSuccess;
 }
 
 }  // namespace dsv4

--- a/cpp_engine/cuda/q2_ops.cu
+++ b/cpp_engine/cuda/q2_ops.cu
@@ -403,42 +403,252 @@ __global__ void gguf_moe_single_w2_q2k_dp4a_kernel(
         const float d = gguf_block_scale_f16(block + 80);
         const float dmin = gguf_block_scale_f16(block + 82);
         const int k_base = block_idx * 256;
-        for (int group = 0; group < 16; ++group) {
-            float local = 0.0f;
-            if (lane < 4) {
-                const int half_block = group >> 3;
-                const int group_in_half = group & 7;
-                const int shift = (group_in_half >> 1) * 2;
-                const int byte_start = half_block * 32 + (group_in_half & 1) * 16;
-                const int idx = lane * 4;
-                const int q0 = static_cast<int>((qs[byte_start + idx + 0] >> shift) & 0x03);
-                const int q1 = static_cast<int>((qs[byte_start + idx + 1] >> shift) & 0x03);
-                const int q2 = static_cast<int>((qs[byte_start + idx + 2] >> shift) & 0x03);
-                const int q3 = static_cast<int>((qs[byte_start + idx + 3] >> shift) & 0x03);
-                const int w_pack = pack_i8x4(q0, q1, q2, q3);
-                const int h_idx = k_base + group * 16 + idx;
-                const int h_pack = pack_i8x4(
-                    static_cast<int>(hidden_row[h_idx + 0]),
-                    static_cast<int>(hidden_row[h_idx + 1]),
-                    static_cast<int>(hidden_row[h_idx + 2]),
-                    static_cast<int>(hidden_row[h_idx + 3]));
-                const int dot_q = __dp4a(w_pack, h_pack, 0);
-                const int sum_h = __dp4a(0x01010101, h_pack, 0);
-                const float qscale = d * static_cast<float>(scales[group] & 0x0f);
-                const float base = dmin * static_cast<float>(scales[group] >> 4);
-                local = hs_row[block_idx * 16 + group] * (qscale * static_cast<float>(dot_q) - base * static_cast<float>(sum_h));
-            }
+        for (int half = 0; half < 2; ++half) {
+            const int sub = lane >> 2;      // eight 4-lane groups per half-block.
+            const int part = lane & 3;
+            const int group = half * 8 + sub;
+            const int shift = (sub >> 1) * 2;
+            const int byte_start = half * 32 + (sub & 1) * 16;
+            const int idx = part * 4;
+            const int q0 = static_cast<int>((qs[byte_start + idx + 0] >> shift) & 0x03);
+            const int q1 = static_cast<int>((qs[byte_start + idx + 1] >> shift) & 0x03);
+            const int q2 = static_cast<int>((qs[byte_start + idx + 2] >> shift) & 0x03);
+            const int q3 = static_cast<int>((qs[byte_start + idx + 3] >> shift) & 0x03);
+            const int w_pack = pack_i8x4(q0, q1, q2, q3);
+            const int h_idx = k_base + group * 16 + idx;
+            const int h_pack = pack_i8x4(
+                static_cast<int>(hidden_row[h_idx + 0]),
+                static_cast<int>(hidden_row[h_idx + 1]),
+                static_cast<int>(hidden_row[h_idx + 2]),
+                static_cast<int>(hidden_row[h_idx + 3]));
+            const int dot_q = __dp4a(w_pack, h_pack, 0);
+            const int sum_h = __dp4a(0x01010101, h_pack, 0);
+            const float qscale = d * static_cast<float>(scales[group] & 0x0f);
+            const float base = dmin * static_cast<float>(scales[group] >> 4);
+            float local = hs_row[block_idx * 16 + group] * (qscale * static_cast<float>(dot_q) - base * static_cast<float>(sum_h));
+            const unsigned group_mask = 0x0fu << (sub * 4);
+            local += __shfl_down_sync(group_mask, local, 2, 4);
+            local += __shfl_down_sync(group_mask, local, 1, 4);
+            float group_sum = (part == 0) ? local : 0.0f;
             #pragma unroll
-            for (int offset = 2; offset > 0; offset >>= 1) {
-                local += __shfl_down_sync(0x0f, local, offset);
+            for (int offset = 16; offset > 0; offset >>= 1) {
+                group_sum += __shfl_down_sync(0xffffffff, group_sum, offset);
             }
-            if (lane == 0) acc += local;
+            if (lane == 0) acc += group_sum;
         }
     }
 
     if (lane == 0) {
         atomicAdd(y + out_col, acc);
     }
+}
+
+__global__ void gather_q2_route_rows_kernel(
+    const float* __restrict__ x_rows,
+    const int64_t* __restrict__ route_tokens,
+    float* __restrict__ x_route_rows,
+    int routes,
+    int dim) {
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int64_t total = static_cast<int64_t>(routes) * dim;
+    if (idx >= total) return;
+    const int route = idx / dim;
+    const int col = idx - route * dim;
+    const int64_t token = route_tokens[route];
+    x_route_rows[idx] = token >= 0 ? x_rows[token * static_cast<int64_t>(dim) + col] : 0.0f;
+}
+
+__global__ void gguf_moe_grouped_w13_iq2_xxs_dp4a_kernel(
+    const int8_t* __restrict__ x_q,
+    const float* __restrict__ x_scale,
+    const int64_t* __restrict__ route_slots,
+    const uint8_t* __restrict__ w1_blocks,
+    const uint8_t* __restrict__ w3_blocks,
+    const int8_t* __restrict__ signed_grid,
+    float* __restrict__ gate,
+    float* __restrict__ up,
+    int routes,
+    int n_experts,
+    int dim,
+    int inter_dim,
+    int blocks_per_row,
+    int x_groups) {
+    const int route = blockIdx.y;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int out_col = blockIdx.x * kQ2TileN + warp;
+    if (route >= routes || warp >= kQ2TileN) return;
+    const int expert = static_cast<int>(route_slots[route]);
+    if (expert < 0 || expert >= n_experts) return;
+
+    const int8_t* xq_row = x_q + static_cast<int64_t>(route) * dim;
+    const float* xs_row = x_scale + static_cast<int64_t>(route) * x_groups;
+    const uint8_t* w1_row = w1_blocks + (static_cast<int64_t>(expert) * inter_dim + out_col) * blocks_per_row * 66;
+    const uint8_t* w3_row = w3_blocks + (static_cast<int64_t>(expert) * inter_dim + out_col) * blocks_per_row * 66;
+
+    __shared__ int x_shared_q[64];
+    __shared__ float x_shared_scale[8];
+    float acc1 = 0.0f;
+    float acc3 = 0.0f;
+    for (int block_idx = 0; block_idx < blocks_per_row; ++block_idx) {
+        const int k_base = block_idx * 256;
+        const int tid = threadIdx.x;
+        if (tid < 64) {
+            const int byte_off = tid * 4;
+            int v = 0;
+            if (k_base + byte_off + 4 <= dim) {
+                v = *reinterpret_cast<const int*>(xq_row + k_base + byte_off);
+            }
+            x_shared_q[tid] = v;
+        }
+        if (tid < 8) {
+            const int sg_idx = block_idx * 8 + tid;
+            x_shared_scale[tid] = sg_idx < x_groups ? xs_row[sg_idx] : 0.0f;
+        }
+        __syncthreads();
+        if (out_col < inter_dim) {
+            const int sub = lane >> 2;
+            const int part = lane & 3;
+            const uint8_t* w1_block = w1_row + static_cast<int64_t>(block_idx) * 66;
+            const uint8_t* w3_block = w3_row + static_cast<int64_t>(block_idx) * 66;
+            const uint8_t* chunk1 = w1_block + 2 + sub * 8;
+            const uint8_t* chunk3 = w3_block + 2 + sub * 8;
+            const float d1 = gguf_block_scale_f16(w1_block);
+            const float d3 = gguf_block_scale_f16(w3_block);
+            const uint32_t aux1 = static_cast<uint32_t>(chunk1[4]) |
+                (static_cast<uint32_t>(chunk1[5]) << 8) |
+                (static_cast<uint32_t>(chunk1[6]) << 16) |
+                (static_cast<uint32_t>(chunk1[7]) << 24);
+            const uint32_t aux3 = static_cast<uint32_t>(chunk3[4]) |
+                (static_cast<uint32_t>(chunk3[5]) << 8) |
+                (static_cast<uint32_t>(chunk3[6]) << 16) |
+                (static_cast<uint32_t>(chunk3[7]) << 24);
+            const int grid_id1 = chunk1[part];
+            const int grid_id3 = chunk3[part];
+            const int sign_idx1 = static_cast<int>((aux1 >> (7 * part)) & 127);
+            const int sign_idx3 = static_cast<int>((aux3 >> (7 * part)) & 127);
+            const float s1 = 0.125f * d1 * static_cast<float>(2 * (aux1 >> 28) + 1);
+            const float s3 = 0.125f * d3 * static_cast<float>(2 * (aux3 >> 28) + 1);
+            const int8_t* vals1 = signed_grid + (grid_id1 * 128 + sign_idx1) * 8;
+            const int8_t* vals3 = signed_grid + (grid_id3 * 128 + sign_idx3) * 8;
+            const int v1_p0 = *reinterpret_cast<const int*>(vals1);
+            const int v1_p1 = *reinterpret_cast<const int*>(vals1 + 4);
+            const int v3_p0 = *reinterpret_cast<const int*>(vals3);
+            const int v3_p1 = *reinterpret_cast<const int*>(vals3 + 4);
+            const int xq_base = sub * 8 + part * 2;
+            const int x_p0 = x_shared_q[xq_base];
+            const int x_p1 = x_shared_q[xq_base + 1];
+            int sumi1 = __dp4a(v1_p0, x_p0, 0);
+            sumi1 = __dp4a(v1_p1, x_p1, sumi1);
+            int sumi3 = __dp4a(v3_p0, x_p0, 0);
+            sumi3 = __dp4a(v3_p1, x_p1, sumi3);
+            const float xs = x_shared_scale[sub];
+            float local1 = s1 * xs * static_cast<float>(sumi1);
+            float local3 = s3 * xs * static_cast<float>(sumi3);
+            #pragma unroll
+            for (int offset = 16; offset > 0; offset >>= 1) {
+                local1 += __shfl_down_sync(0xffffffff, local1, offset);
+                local3 += __shfl_down_sync(0xffffffff, local3, offset);
+            }
+            if (lane == 0) {
+                acc1 += local1;
+                acc3 += local3;
+            }
+        }
+        __syncthreads();
+    }
+    if (lane == 0 && out_col < inter_dim) {
+        gate[static_cast<int64_t>(route) * inter_dim + out_col] = acc1;
+        up[static_cast<int64_t>(route) * inter_dim + out_col] = acc3;
+    }
+}
+
+__global__ void q2_route_slots_from_segments_kernel(
+    const int32_t* __restrict__ seg_starts,
+    int64_t* __restrict__ route_slots,
+    int routes,
+    int n_experts,
+    int max_count) {
+    const int expert = blockIdx.x;
+    const int ordinal = blockIdx.y * blockDim.x + threadIdx.x;
+    if (expert >= n_experts || ordinal >= max_count) return;
+    const int start = seg_starts[expert];
+    const int end = seg_starts[expert + 1];
+    const int route = start + ordinal;
+    if (route < end && route < routes) route_slots[route] = expert;
+}
+
+__global__ void gguf_moe_grouped_w2_q2k_dp4a_kernel(
+    const int8_t* __restrict__ hidden_q,
+    const float* __restrict__ hidden_scale,
+    const int64_t* __restrict__ route_tokens,
+    const int32_t* __restrict__ seg_starts,
+    const uint8_t* __restrict__ w2_blocks,
+    float* __restrict__ y_rows,
+    int routes,
+    int n_experts,
+    int max_count,
+    int dim,
+    int inter_dim,
+    int w2_blocks_per_row,
+    int hidden_groups) {
+    const int expert = blockIdx.z;
+    const int route_ordinal = blockIdx.y;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int out_col = blockIdx.x * kQ2TileN + warp;
+    if (expert >= n_experts || route_ordinal >= max_count || warp >= kQ2TileN || out_col >= dim) return;
+    const int route = seg_starts[expert] + route_ordinal;
+    if (route >= seg_starts[expert + 1] || route >= routes) return;
+    const int64_t token = route_tokens[route];
+    if (token < 0) return;
+
+    const int8_t* hidden_row = hidden_q + static_cast<int64_t>(route) * inter_dim;
+    const float* hs_row = hidden_scale + static_cast<int64_t>(route) * hidden_groups;
+    const uint8_t* w2_row = w2_blocks + (static_cast<int64_t>(expert) * dim + out_col) * w2_blocks_per_row * 84;
+    float acc = 0.0f;
+    for (int block_idx = 0; block_idx < w2_blocks_per_row; ++block_idx) {
+        const uint8_t* block = w2_row + static_cast<int64_t>(block_idx) * 84;
+        const uint8_t* scales = block;
+        const uint8_t* qs = block + 16;
+        const float d = gguf_block_scale_f16(block + 80);
+        const float dmin = gguf_block_scale_f16(block + 82);
+        const int k_base = block_idx * 256;
+        for (int half = 0; half < 2; ++half) {
+            const int sub = lane >> 2;      // eight 4-lane groups per half-block.
+            const int part = lane & 3;
+            const int group = half * 8 + sub;
+            const int shift = (sub >> 1) * 2;
+            const int byte_start = half * 32 + (sub & 1) * 16;
+            const int idx = part * 4;
+            const int q0 = static_cast<int>((qs[byte_start + idx + 0] >> shift) & 0x03);
+            const int q1 = static_cast<int>((qs[byte_start + idx + 1] >> shift) & 0x03);
+            const int q2 = static_cast<int>((qs[byte_start + idx + 2] >> shift) & 0x03);
+            const int q3 = static_cast<int>((qs[byte_start + idx + 3] >> shift) & 0x03);
+            const int w_pack = pack_i8x4(q0, q1, q2, q3);
+            const int h_idx = k_base + group * 16 + idx;
+            const int h_pack = pack_i8x4(
+                static_cast<int>(hidden_row[h_idx + 0]),
+                static_cast<int>(hidden_row[h_idx + 1]),
+                static_cast<int>(hidden_row[h_idx + 2]),
+                static_cast<int>(hidden_row[h_idx + 3]));
+            const int dot_q = __dp4a(w_pack, h_pack, 0);
+            const int sum_h = __dp4a(0x01010101, h_pack, 0);
+            const float qscale = d * static_cast<float>(scales[group] & 0x0f);
+            const float base = dmin * static_cast<float>(scales[group] >> 4);
+            float local = hs_row[block_idx * 16 + group] * (qscale * static_cast<float>(dot_q) - base * static_cast<float>(sum_h));
+            const unsigned group_mask = 0x0fu << (sub * 4);
+            local += __shfl_down_sync(group_mask, local, 2, 4);
+            local += __shfl_down_sync(group_mask, local, 1, 4);
+            float group_sum = (part == 0) ? local : 0.0f;
+            #pragma unroll
+            for (int offset = 16; offset > 0; offset >>= 1) {
+                group_sum += __shfl_down_sync(0xffffffff, group_sum, offset);
+            }
+            if (lane == 0) acc += group_sum;
+        }
+    }
+    if (lane == 0) atomicAdd(y_rows + token * static_cast<int64_t>(dim) + out_col, acc);
 }
 
 inline int ceil_div(int a, int b) { return (a + b - 1) / b; }
@@ -546,6 +756,97 @@ bool q2_moe_single_w2_q2k_cuda(
     return cudaGetLastError() == cudaSuccess;
 }
 
+bool q2_moe_grouped_w2_q2k_cuda(
+    const int8_t* d_hidden_q,
+    const float* d_hidden_scale,
+    const int64_t* d_route_tokens,
+    const int32_t* d_seg_starts,
+    const uint8_t* d_w2_blocks,
+    float* d_y_rows,
+    int tokens,
+    int routes,
+    int n_experts,
+    int max_count,
+    int dim,
+    int inter_dim,
+    void* stream) {
+    if (tokens <= 0 || routes < 0 || n_experts <= 0 || max_count < 0 || dim <= 0 || inter_dim <= 0) return false;
+    cudaStream_t cs = static_cast<cudaStream_t>(stream);
+    if (cudaMemsetAsync(d_y_rows, 0, static_cast<size_t>(tokens) * dim * sizeof(float), cs) != cudaSuccess) return false;
+    if (routes == 0 || max_count == 0) return cudaGetLastError() == cudaSuccess;
+    const int w2_blocks_per_row = inter_dim / 256;
+    const int hidden_groups = ceil_div(inter_dim, 16);
+    dim3 grid(ceil_div(dim, kQ2TileN), max_count, n_experts);
+    dim3 block(256);
+    gguf_moe_grouped_w2_q2k_dp4a_kernel<<<grid, block, 0, cs>>>(
+        d_hidden_q, d_hidden_scale, d_route_tokens, d_seg_starts, d_w2_blocks,
+        d_y_rows, routes, n_experts, max_count, dim, inter_dim, w2_blocks_per_row, hidden_groups);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool moe_prefill_q2_grouped_cuda_with_workspace(
+    const float* d_x_rows,
+    const int64_t* d_route_tokens,
+    const float* d_route_weights,
+    const int32_t* d_seg_starts,
+    const uint8_t* d_w1_blocks,
+    const uint8_t* d_w2_blocks,
+    const uint8_t* d_w3_blocks,
+    float* d_y_rows,
+    int tokens,
+    int routes,
+    int n_experts,
+    int max_count,
+    int dim,
+    int inter_dim,
+    float swiglu_limit,
+    MoePrefillQ2GroupedWorkspace workspace,
+    void* stream) {
+    if (d_x_rows == nullptr || d_route_tokens == nullptr || d_route_weights == nullptr ||
+        d_seg_starts == nullptr || d_w1_blocks == nullptr || d_w2_blocks == nullptr ||
+        d_w3_blocks == nullptr || d_y_rows == nullptr) return false;
+    if (tokens <= 0 || routes < 0 || n_experts <= 0 || max_count < 0 || dim <= 0 || inter_dim <= 0) return false;
+    cudaStream_t cs = static_cast<cudaStream_t>(stream);
+    if (cudaMemsetAsync(d_y_rows, 0, static_cast<size_t>(tokens) * dim * sizeof(float), cs) != cudaSuccess) return false;
+    if (routes == 0 || max_count == 0) return cudaGetLastError() == cudaSuccess;
+    if (workspace.routes_cap < routes || workspace.dim < dim || workspace.inter_dim < inter_dim ||
+        workspace.d_x_route == nullptr || workspace.d_x_q == nullptr || workspace.d_x_scale == nullptr ||
+        workspace.d_route_slots == nullptr || workspace.d_gate == nullptr || workspace.d_up == nullptr ||
+        workspace.d_hidden_q == nullptr || workspace.d_hidden_scale == nullptr) return false;
+    const int8_t* sg = signed_grid_device();
+    if (sg == nullptr) return false;
+    const int threads = 256;
+    const int64_t routes_dim = static_cast<int64_t>(routes) * dim;
+    gather_q2_route_rows_kernel<<<static_cast<int>((routes_dim + threads - 1) / threads), threads, 0, cs>>>(
+        d_x_rows, d_route_tokens, workspace.d_x_route, routes, dim);
+    if (cudaGetLastError() != cudaSuccess) return false;
+    if (!q2_quantize_x_q8_1_cuda(workspace.d_x_route, workspace.d_x_q, workspace.d_x_scale, routes, dim, stream)) return false;
+    dim3 slot_grid(n_experts, (max_count + threads - 1) / threads);
+    q2_route_slots_from_segments_kernel<<<slot_grid, threads, 0, cs>>>(
+        d_seg_starts, workspace.d_route_slots, routes, n_experts, max_count);
+    if (cudaGetLastError() != cudaSuccess) return false;
+    const int blocks_per_row = dim / 256;
+    const int x_groups = ceil_div(dim, 32);
+    dim3 grid_w13(ceil_div(inter_dim, kQ2TileN), routes);
+    dim3 block(256);
+    gguf_moe_grouped_w13_iq2_xxs_dp4a_kernel<<<grid_w13, block, 0, cs>>>(
+        workspace.d_x_q, workspace.d_x_scale, workspace.d_route_slots, d_w1_blocks, d_w3_blocks, sg,
+        workspace.d_gate, workspace.d_up, routes, n_experts, dim, inter_dim, blocks_per_row, x_groups);
+    if (cudaGetLastError() != cudaSuccess) return false;
+    if (!q2_route_swiglu_quantize_hidden_q8_1_cuda(workspace.d_gate, workspace.d_up, d_route_weights,
+                                                   workspace.d_hidden_q, workspace.d_hidden_scale,
+                                                   routes, inter_dim, swiglu_limit, stream)) {
+        return false;
+    }
+    const int w2_blocks_per_row = inter_dim / 256;
+    const int hidden_groups = ceil_div(inter_dim, 16);
+    dim3 grid_w2(ceil_div(dim, kQ2TileN), max_count, n_experts);
+    gguf_moe_grouped_w2_q2k_dp4a_kernel<<<grid_w2, block, 0, cs>>>(
+        workspace.d_hidden_q, workspace.d_hidden_scale, d_route_tokens, d_seg_starts, d_w2_blocks,
+        d_y_rows, routes, n_experts, max_count, dim, inter_dim, w2_blocks_per_row, hidden_groups);
+    return cudaGetLastError() == cudaSuccess;
+}
+
 // --- Generic F16 row dequant ------------------------------------------------
 // GGUF stores `token_embd.weight` and `output.weight` as F16. The layout is
 // row-major [vocab, dim] (per-token row is contiguous), matching the FP4 path's
@@ -563,6 +864,21 @@ __global__ void f16_row_to_float_kernel(
     }
 }
 
+__global__ void f16_rows_to_float_kernel(
+    const uint16_t* matrix,
+    const int* rows,
+    float* y,
+    int count,
+    int cols) {
+    const int out_row = blockIdx.x;
+    if (out_row >= count) return;
+    const uint16_t* src = matrix + static_cast<size_t>(rows[out_row]) * cols;
+    float* dst = y + static_cast<size_t>(out_row) * cols;
+    for (int c = threadIdx.x; c < cols; c += blockDim.x) {
+        dst[c] = __half2float(__ushort_as_half(src[c]));
+    }
+}
+
 bool f16_row_to_float_cuda(
     const uint16_t* d_matrix_f16,
     float* d_y,
@@ -572,6 +888,33 @@ bool f16_row_to_float_cuda(
     if (cols <= 0) return true;
     cudaStream_t cs = static_cast<cudaStream_t>(stream);
     f16_row_to_float_kernel<<<1, 256, 0, cs>>>(d_matrix_f16, d_y, row, cols);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool f16_rows_to_float_cuda(
+    const uint16_t* d_matrix_f16,
+    const int* d_rows,
+    float* d_y,
+    int rows,
+    int cols,
+    void* stream) {
+    if (rows <= 0 || cols <= 0) return true;
+    if (d_matrix_f16 == nullptr || d_rows == nullptr || d_y == nullptr) return false;
+    cudaStream_t cs = static_cast<cudaStream_t>(stream);
+    f16_rows_to_float_kernel<<<rows, 256, 0, cs>>>(d_matrix_f16, d_rows, d_y, rows, cols);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool f16_contiguous_rows_to_float_cuda(
+    const uint16_t* d_matrix_f16,
+    float* d_y,
+    int rows,
+    int cols,
+    void* stream) {
+    if (rows <= 0 || cols <= 0) return true;
+    if (d_matrix_f16 == nullptr || d_y == nullptr) return false;
+    cudaStream_t cs = static_cast<cudaStream_t>(stream);
+    f16_row_to_float_kernel<<<rows, 256, 0, cs>>>(d_matrix_f16, d_y, 0, cols);
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/cuda/quant_gemm.cu
+++ b/cpp_engine/cuda/quant_gemm.cu
@@ -3,9 +3,18 @@
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cstdint>
+#include <cstdlib>
 
 namespace dsv4 {
 namespace {
+
+int local_env_int_or_default(const char* name, int fallback) {
+    const char* v = std::getenv(name);
+    if (v == nullptr || *v == '\0') return fallback;
+    char* end = nullptr;
+    const long parsed = std::strtol(v, &end, 10);
+    return (end == v) ? fallback : static_cast<int>(parsed);
+}
 
 __device__ __forceinline__ float load_f16_scale(const uint8_t* p) {
     const uint16_t h = static_cast<uint16_t>(p[0]) | (static_cast<uint16_t>(p[1]) << 8);
@@ -48,6 +57,134 @@ __global__ void q8_0_matvec_kernel(const float* __restrict__ x, const uint8_t* _
     }
 }
 
+__global__ void q8_0_matmul_rows_kernel(
+    const float* __restrict__ x,
+    const uint8_t* __restrict__ w,
+    float* __restrict__ y,
+    int batch,
+    int rows,
+    int cols,
+    int x_stride,
+    int y_stride,
+    int blocks_per_row) {
+    const int out_row = blockIdx.x;
+    const int batch_row = blockIdx.y;
+    if (batch_row >= batch || out_row >= rows) return;
+    extern __shared__ float shared[];
+    float sum = 0.0f;
+    const int tid = threadIdx.x;
+    const float* x_row = x + static_cast<size_t>(batch_row) * x_stride;
+    const uint8_t* w_row = w + static_cast<size_t>(out_row) * blocks_per_row * 34;
+    for (int b = tid; b < blocks_per_row; b += blockDim.x) {
+        const uint8_t* block = w_row + b * 34;
+        const float d = load_f16_scale(block);
+        const int8_t* qs = reinterpret_cast<const int8_t*>(block + 2);
+        const int base = b * 32;
+        float block_sum = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < 32; ++j) {
+            const int col = base + j;
+            if (col < cols) block_sum += x_row[col] * static_cast<float>(qs[j]);
+        }
+        sum += d * block_sum;
+    }
+    shared[tid] = sum;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) shared[tid] += shared[tid + stride];
+        __syncthreads();
+    }
+    if (tid == 0) y[static_cast<size_t>(batch_row) * y_stride + out_row] = shared[0];
+}
+
+__global__ void q8_0_matmul_rows_warp_kernel(
+    const float* __restrict__ x,
+    const uint8_t* __restrict__ w,
+    float* __restrict__ y,
+    int batch,
+    int rows,
+    int cols,
+    int x_stride,
+    int y_stride,
+    int blocks_per_row) {
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+    const int warps_per_block = blockDim.x >> 5;
+    const int out_row = blockIdx.x * warps_per_block + warp;
+    const int batch_row = blockIdx.y;
+    if (batch_row >= batch || out_row >= rows) return;
+
+    const float* x_row = x + static_cast<size_t>(batch_row) * x_stride;
+    const uint8_t* w_row = w + static_cast<size_t>(out_row) * blocks_per_row * 34;
+    float sum = 0.0f;
+    for (int b = 0; b < blocks_per_row; ++b) {
+        const uint8_t* block = w_row + static_cast<size_t>(b) * 34;
+        const int col = b * 32 + lane;
+        if (col < cols) {
+            const float d = load_f16_scale(block);
+            const int8_t* qs = reinterpret_cast<const int8_t*>(block + 2);
+            sum += d * x_row[col] * static_cast<float>(qs[lane]);
+        }
+    }
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        sum += __shfl_down_sync(0xffffffff, sum, offset);
+    }
+    if (lane == 0) y[static_cast<size_t>(batch_row) * y_stride + out_row] = sum;
+}
+
+__global__ void q8_0_matmul_rows_warp_batch4_kernel(
+    const float* __restrict__ x,
+    const uint8_t* __restrict__ w,
+    float* __restrict__ y,
+    int batch,
+    int rows,
+    int cols,
+    int x_stride,
+    int y_stride,
+    int blocks_per_row) {
+    constexpr int batch_tile = 4;
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+    const int warps_per_block = blockDim.x >> 5;
+    const int out_row = blockIdx.x * warps_per_block + warp;
+    const int batch_base = blockIdx.y * batch_tile;
+    if (out_row >= rows || batch_base >= batch) return;
+
+    const uint8_t* w_row = w + static_cast<size_t>(out_row) * blocks_per_row * 34;
+    float sum0 = 0.0f;
+    float sum1 = 0.0f;
+    float sum2 = 0.0f;
+    float sum3 = 0.0f;
+    for (int b = 0; b < blocks_per_row; ++b) {
+        const uint8_t* block = w_row + static_cast<size_t>(b) * 34;
+        const int col = b * 32 + lane;
+        if (col < cols) {
+            const float d = load_f16_scale(block);
+            const int8_t* qs = reinterpret_cast<const int8_t*>(block + 2);
+            const float qv = static_cast<float>(qs[lane]);
+            const size_t base0 = static_cast<size_t>(batch_base) * x_stride + col;
+            sum0 += d * x[base0] * qv;
+            if (batch_base + 1 < batch) sum1 += d * x[base0 + static_cast<size_t>(x_stride)] * qv;
+            if (batch_base + 2 < batch) sum2 += d * x[base0 + static_cast<size_t>(2) * x_stride] * qv;
+            if (batch_base + 3 < batch) sum3 += d * x[base0 + static_cast<size_t>(3) * x_stride] * qv;
+        }
+    }
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        sum0 += __shfl_down_sync(0xffffffff, sum0, offset);
+        sum1 += __shfl_down_sync(0xffffffff, sum1, offset);
+        sum2 += __shfl_down_sync(0xffffffff, sum2, offset);
+        sum3 += __shfl_down_sync(0xffffffff, sum3, offset);
+    }
+    if (lane == 0) {
+        y[static_cast<size_t>(batch_base) * y_stride + out_row] = sum0;
+        if (batch_base + 1 < batch) y[static_cast<size_t>(batch_base + 1) * y_stride + out_row] = sum1;
+        if (batch_base + 2 < batch) y[static_cast<size_t>(batch_base + 2) * y_stride + out_row] = sum2;
+        if (batch_base + 3 < batch) y[static_cast<size_t>(batch_base + 3) * y_stride + out_row] = sum3;
+    }
+}
+
 }  // namespace
 
 bool q8_0_matvec_cuda(const float* d_x, const uint8_t* d_w, float* d_y, int rows, int cols, void* stream) {
@@ -59,6 +196,52 @@ bool q8_0_matvec_cuda(const float* d_x, const uint8_t* d_w, float* d_y, int rows
     cudaStream_t cuda_stream = reinterpret_cast<cudaStream_t>(stream);
     q8_0_matvec_kernel<<<rows, threads, threads * sizeof(float), cuda_stream>>>(d_x, d_w, d_y, rows, cols, blocks_per_row);
     return cudaGetLastError() == cudaSuccess;
+}
+
+bool q8_0_matmul_rows_strided_cuda(
+    const float* d_x,
+    const uint8_t* d_w,
+    float* d_y,
+    int batch,
+    int rows,
+    int cols,
+    int x_stride,
+    int y_stride,
+    void* stream) {
+    if (d_x == nullptr || d_w == nullptr || d_y == nullptr || batch <= 0 || rows <= 0 || cols <= 0 ||
+        x_stride < cols || y_stride < rows) {
+        return false;
+    }
+    const int blocks_per_row = (cols + 31) / 32;
+    cudaStream_t cuda_stream = reinterpret_cast<cudaStream_t>(stream);
+    if (cols >= 256 && (cols % 32) == 0) {
+        constexpr int threads = 256;
+        constexpr int warps_per_block = threads / 32;
+        if (batch >= 4 && local_env_int_or_default("DSV4_Q8_ROWS_BATCH4", 1) != 0) {
+            constexpr int batch_tile = 4;
+            q8_0_matmul_rows_warp_batch4_kernel<<<dim3((rows + warps_per_block - 1) / warps_per_block, (batch + batch_tile - 1) / batch_tile), threads, 0, cuda_stream>>>(
+                d_x, d_w, d_y, batch, rows, cols, x_stride, y_stride, blocks_per_row);
+        } else {
+            q8_0_matmul_rows_warp_kernel<<<dim3((rows + warps_per_block - 1) / warps_per_block, batch), threads, 0, cuda_stream>>>(
+                d_x, d_w, d_y, batch, rows, cols, x_stride, y_stride, blocks_per_row);
+        }
+    } else {
+        const int threads = 128;
+        q8_0_matmul_rows_kernel<<<dim3(rows, batch), threads, threads * sizeof(float), cuda_stream>>>(
+            d_x, d_w, d_y, batch, rows, cols, x_stride, y_stride, blocks_per_row);
+    }
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool q8_0_matmul_rows_cuda(
+    const float* d_x,
+    const uint8_t* d_w,
+    float* d_y,
+    int batch,
+    int rows,
+    int cols,
+    void* stream) {
+    return q8_0_matmul_rows_strided_cuda(d_x, d_w, d_y, batch, rows, cols, cols, rows, stream);
 }
 
 }  // namespace dsv4

--- a/cpp_engine/include/cuda_ops.hpp
+++ b/cpp_engine/include/cuda_ops.hpp
@@ -15,6 +15,26 @@ bool q8_0_matvec_cuda(
     int cols,
     void* stream = nullptr);
 
+bool q8_0_matmul_rows_cuda(
+    const float* d_x,
+    const uint8_t* d_w,
+    float* d_y,
+    int batch,
+    int rows,
+    int cols,
+    void* stream = nullptr);
+
+bool q8_0_matmul_rows_strided_cuda(
+    const float* d_x,
+    const uint8_t* d_w,
+    float* d_y,
+    int batch,
+    int rows,
+    int cols,
+    int x_stride,
+    int y_stride,
+    void* stream = nullptr);
+
 // --- IQ2_XXS / Q2_K single-token MoE decode kernels (cuda/q2_ops.cu). ---
 
 // Returns a device pointer to the lazy-initialized signed_grid lookup table
@@ -83,6 +103,54 @@ bool q2_moe_single_w2_q2k_cuda(
     int inter_dim,
     void* stream = nullptr);
 
+bool q2_moe_grouped_w2_q2k_cuda(
+    const int8_t* d_hidden_q,
+    const float* d_hidden_scale,
+    const int64_t* d_route_tokens,
+    const int32_t* d_seg_starts,
+    const uint8_t* d_w2_blocks,
+    float* d_y_rows,
+    int tokens,
+    int routes,
+    int n_experts,
+    int max_count,
+    int dim,
+    int inter_dim,
+    void* stream = nullptr);
+
+struct MoePrefillQ2GroupedWorkspace {
+    float* d_x_route = nullptr;    // [routes_cap, dim]
+    int8_t* d_x_q = nullptr;       // [routes_cap, dim]
+    float* d_x_scale = nullptr;    // [routes_cap, ceil(dim/32)]
+    int64_t* d_route_slots = nullptr; // [routes_cap]
+    float* d_gate = nullptr;       // [routes_cap, inter_dim]
+    float* d_up = nullptr;         // [routes_cap, inter_dim]
+    int8_t* d_hidden_q = nullptr;  // [routes_cap, inter_dim]
+    float* d_hidden_scale = nullptr; // [routes_cap, ceil(inter_dim/16)]
+    int routes_cap = 0;
+    int dim = 0;
+    int inter_dim = 0;
+};
+
+bool moe_prefill_q2_grouped_cuda_with_workspace(
+    const float* d_x_rows,
+    const int64_t* d_route_tokens,
+    const float* d_route_weights,
+    const int32_t* d_seg_starts,
+    const uint8_t* d_w1_blocks,
+    const uint8_t* d_w2_blocks,
+    const uint8_t* d_w3_blocks,
+    float* d_y_rows,
+    int tokens,
+    int routes,
+    int n_experts,
+    int max_count,
+    int dim,
+    int inter_dim,
+    float swiglu_limit,
+    MoePrefillQ2GroupedWorkspace workspace,
+    void* stream = nullptr);
+
 // --- IQ1_M single-token MoE decode kernels (cuda/iq1_ops.cu). ---
 
 bool iq1_moe_single_w13_cuda(
@@ -147,6 +215,60 @@ bool iq1_moe_single_w2_reduce_cuda(
     int n_experts,
     int dim,
     int inter_dim,
+    void* stream = nullptr);
+
+bool iq1_moe_grouped_w13_swiglu_cuda(
+    const float* d_x_rows,
+    const int64_t* d_route_tokens,
+    const float* d_route_weights,
+    const int32_t* d_seg_starts,
+    const uint8_t* d_w1_blocks,
+    const uint8_t* d_w3_blocks,
+    float* d_hidden,
+    int routes,
+    int n_experts,
+    int max_count,
+    int dim,
+    int inter_dim,
+    float swiglu_limit,
+    void* stream = nullptr);
+
+struct MoePrefillIq1GroupedWorkspace {
+    float* d_hidden = nullptr;       // [routes_cap, inter_dim]
+    int8_t* d_hidden_q = nullptr;    // [routes_cap, inter_dim], for IQ1 grouped W2 q8 path and IQ1 W13 + Q2_K W2 recipe
+    float* d_hidden_scale = nullptr; // [routes_cap, ceil(inter_dim/16)]
+    int8_t* d_x_q = nullptr;         // [routes_cap, dim], IQ1 grouped-GEMM W13 q8 route rows
+    float* d_x_scale = nullptr;      // [routes_cap, ceil(dim/16)]
+    int32_t* d_tile_experts = nullptr; // [tile_cap], compact route tiles
+    int32_t* d_tile_rows = nullptr;    // [tile_cap], row offset within expert segment
+    int routes_cap = 0;
+    int tile_cap = 0;
+    int tile_count = 0;
+    int dim = 0;
+    int inter_dim = 0;
+};
+
+// IQ1_M grouped routed MoE for prefill. Routes are grouped by local expert via
+// moe_group_routes_cuda: d_seg_starts[e]..d_seg_starts[e+1] are route ids for
+// expert e, and d_route_tokens[route] selects the source/output token row.
+// Consumes raw IQ1_M blocks directly and writes d_y_rows [tokens, dim].
+bool moe_prefill_iq1_grouped_cuda_with_workspace(
+    const float* d_x_rows,
+    const int64_t* d_route_tokens,
+    const float* d_route_weights,
+    const int32_t* d_seg_starts,
+    const uint8_t* d_w1_blocks,
+    const uint8_t* d_w2_blocks,
+    const uint8_t* d_w3_blocks,
+    float* d_y_rows,
+    int tokens,
+    int routes,
+    int n_experts,
+    int max_count,
+    int dim,
+    int inter_dim,
+    float swiglu_limit,
+    MoePrefillIq1GroupedWorkspace workspace,
     void* stream = nullptr);
 
 bool fp4_e2m1_e8m0_matvec_cuda(
@@ -389,6 +511,21 @@ bool f16_row_to_float_cuda(
     int cols,
     void* stream = nullptr);
 
+bool f16_rows_to_float_cuda(
+    const uint16_t* d_matrix_f16,
+    const int* d_rows,
+    float* d_y,
+    int rows,
+    int cols,
+    void* stream = nullptr);
+
+bool f16_contiguous_rows_to_float_cuda(
+    const uint16_t* d_matrix_f16,
+    float* d_y,
+    int rows,
+    int cols,
+    void* stream = nullptr);
+
 bool bf16_rows_to_float_cuda(
     const uint16_t* d_matrix_bf16,
     const int* d_rows,
@@ -564,6 +701,20 @@ bool prefill_causal_attention_cuda(
     float scale,
     void* stream = nullptr);
 
+bool prefill_causal_attention_chunk_cuda(
+    const float* d_q,
+    const float* d_kv,
+    const float* d_attn_sink,
+    float* d_y,
+    int tokens,
+    int heads,
+    int kv_len,
+    int head_dim,
+    int window_size,
+    int start_position,
+    float scale,
+    void* stream = nullptr);
+
 bool build_prefill_window_indices_cuda(
     int32_t* d_indices,
     int tokens,
@@ -578,6 +729,20 @@ bool build_decode_kv_indices_cuda(
     int window_size,
     int compressed_count,
     int compressed_offset,
+    void* stream = nullptr);
+
+bool prefill_sparse_attention_indexed_cuda(
+    const float* d_q,
+    const float* d_kv,
+    const float* d_attn_sink,
+    const int32_t* d_topk_indices,
+    float* d_y,
+    int tokens,
+    int heads,
+    int kv_len,
+    int topk,
+    int head_dim,
+    float scale,
     void* stream = nullptr);
 
 bool prefill_sparse_attention_headpair_cuda(
@@ -707,6 +872,18 @@ bool head_rmsnorm_rope_cuda(
     int head_dim,
     int rope_dim,
     int position,
+    float theta,
+    bool inverse,
+    float eps,
+    void* stream = nullptr);
+
+bool head_rmsnorm_rope_rows_cuda(
+    float* d_x,
+    int tokens,
+    int heads,
+    int head_dim,
+    int rope_dim,
+    int start_position,
     float theta,
     bool inverse,
     float eps,

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -6730,9 +6730,10 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
     uint8_t* d_routed_w1 = nullptr;
     uint8_t* d_routed_w2 = nullptr;
     uint8_t* d_routed_w3 = nullptr;
-    check_cuda(cudaMalloc(&d_routed_w1, max_per_w1_bytes * topk), "alloc routed_w1");
-    check_cuda(cudaMalloc(&d_routed_w2, max_per_w2_bytes * topk), "alloc routed_w2");
-    check_cuda(cudaMalloc(&d_routed_w3, max_per_w3_bytes * topk), "alloc routed_w3");
+    const int routed_stage_slots = std::max(topk, experts_per_rank);
+    check_cuda(cudaMalloc(&d_routed_w1, max_per_w1_bytes * routed_stage_slots), "alloc routed_w1");
+    check_cuda(cudaMalloc(&d_routed_w2, max_per_w2_bytes * routed_stage_slots), "alloc routed_w2");
+    check_cuda(cudaMalloc(&d_routed_w3, max_per_w3_bytes * routed_stage_slots), "alloc routed_w3");
 
     // Optional resident local routed experts. The legacy path stages active top-k
     // experts every token/layer from the GGUF mmap; with TP=4 that H2D staging
@@ -7185,6 +7186,34 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
     std::vector<int64_t> h_gate_indices(topk);
     std::vector<int64_t> h_route_slots(topk);
     std::vector<float> h_logits(local_vocab);
+    std::vector<int> debug_logit_tokens;
+    if (const char* dbg = std::getenv("DSV4_GGUF_DEBUG_LOGIT_TOKENS")) {
+        std::stringstream ss(dbg);
+        std::string item;
+        while (std::getline(ss, item, ',')) {
+            if (!item.empty()) debug_logit_tokens.push_back(std::stoi(item));
+        }
+    }
+    auto debug_print_logits = [&](const char* tag, int position, int top_t, float top_l) {
+        if (debug_logit_tokens.empty()) return;
+        const int final_prompt_pos = static_cast<int>(seed_tokens.size()) - 1;
+        if (position != final_prompt_pos) return;
+        check_cuda(cudaDeviceSynchronize(), "sync GGUF debug logits");
+        std::ostringstream oss;
+        oss << "gguf_debug_logits tag=" << tag << " rank=" << tp_rank
+            << " position=" << position << " top=" << top_t << ":" << top_l;
+        for (int tok : debug_logit_tokens) {
+            oss << " token" << tok << "=";
+            if (tok >= local_vocab_start && tok < local_vocab_start + local_vocab) {
+                float v = -INFINITY;
+                check_cuda(cudaMemcpy(&v, d_logits + (tok - local_vocab_start), sizeof(float), cudaMemcpyDeviceToHost), "copy GGUF debug logit");
+                oss << v;
+            } else {
+                oss << "NA";
+            }
+        }
+        std::cout << oss.str() << "\n";
+    };
     auto run_step = [&](int token, int position) -> std::pair<int, float> {
         auto t_embed_start = sync_now();
         const uint16_t* host_embed_row =
@@ -7463,6 +7492,391 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
         return {top_t, top_l};
     };
 
+    const bool gguf_chunked_prefill_requested = env_int_or_default("DSV4_GGUF_CHUNKED_PREFILL", 0) != 0;
+    const bool gguf_chunked_prefill_available =
+        gguf_chunked_prefill_requested &&
+        decode_only_context == 0 &&
+        max_new_tokens > 0 &&
+        !gguf_load_only &&
+        !gguf_sparse_compressor &&
+        gguf_indexed_attn == 0 &&
+        hash_table_resident;
+    if (gguf_chunked_prefill_requested && !gguf_chunked_prefill_available && tp_rank == 0) {
+        const char* reason = "unknown";
+        if (decode_only_context != 0) reason = "decode_only";
+        else if (max_new_tokens <= 0) reason = "no_generation";
+        else if (gguf_load_only) reason = "load_only";
+        else if (gguf_sparse_compressor) reason = "sparse_compressor_not_supported";
+        else if (gguf_indexed_attn != 0) reason = "indexed_attention_not_supported";
+        else if (!hash_table_resident) reason = "requires_resident_hash_table";
+        std::cout << "gguf_chunked_prefill=0 reason=" << reason << "\n";
+    }
+
+    auto run_chunked_prefill = [&]() -> std::pair<int, float> {
+        const int prompt_tokens = static_cast<int>(seed_tokens.size());
+        int chunk_tokens = env_int_or_default("DSV4_GGUF_PREFILL_CHUNK_TOKENS", 512);
+        if (chunk_tokens <= 0 || chunk_tokens > prompt_tokens) chunk_tokens = prompt_tokens;
+        const int chunk_alloc = chunk_tokens;
+        const int routes_cap = chunk_alloc * topk;
+        const size_t chunk_dim = static_cast<size_t>(chunk_alloc) * dim;
+        const size_t chunk_q_a = static_cast<size_t>(chunk_alloc) * q_a_dim;
+        const size_t chunk_q = static_cast<size_t>(chunk_alloc) * q_full;
+        const size_t chunk_kv = static_cast<size_t>(chunk_alloc) * kv_dim;
+        const size_t chunk_attn_mid = static_cast<size_t>(chunk_alloc) * attn_mid;
+        const size_t chunk_inter = static_cast<size_t>(chunk_alloc) * moe_inter;
+        const size_t routes_dim = static_cast<size_t>(routes_cap) * dim;
+        const size_t routes_inter = static_cast<size_t>(routes_cap) * moe_inter;
+        int prefill_attn_window = env_int_or_default("DSV4_GGUF_PREFILL_ATTN_WINDOW", prompt_tokens);
+        if (prefill_attn_window <= 0 || prefill_attn_window > prompt_tokens) prefill_attn_window = prompt_tokens;
+        const int prefill_attn_topk = std::min(prompt_tokens, prefill_attn_window);
+        const int64_t prefill_attn_index_elems = static_cast<int64_t>(prompt_tokens) * prefill_attn_topk;
+        const int64_t prefill_attn_max_index_elems = static_cast<int64_t>(env_int_or_default("DSV4_GGUF_PREFILL_ATTN_MAX_INDEX_ELEMS", 64 * 1024 * 1024));
+        const int prefill_attn_max_index_topk = env_int_or_default("DSV4_GGUF_PREFILL_INDEXED_ATTN_MAX_TOPK", 8192);
+        const bool use_prefill_indexed_attn = env_int_or_default("DSV4_GGUF_PREFILL_INDEXED_ATTN", 0) != 0 &&
+            prefill_attn_topk > 0 && prefill_attn_index_elems > 0 &&
+            (prefill_attn_max_index_topk <= 0 || prefill_attn_topk <= prefill_attn_max_index_topk) &&
+            (prefill_attn_max_index_elems <= 0 || prefill_attn_index_elems <= prefill_attn_max_index_elems);
+        const bool iq1_grouped_w2_q8_enabled = env_int_or_default("DSV4_IQ1_GROUPED_W2_Q8", 1) != 0;
+        const bool iq1_grouped_gemm_enabled = env_int_or_default("DSV4_IQ1_GROUPED_GEMM", 1) != 0;
+        const bool iq1_grouped_route_tile4_enabled = env_int_or_default("DSV4_IQ1_GROUPED_ROUTE_TILE4", 0) != 0;
+        const bool iq1_grouped_route_major_enabled = !iq1_grouped_route_tile4_enabled && env_int_or_default("DSV4_IQ1_GROUPED_ROUTE_MAJOR", 1) != 0;
+        const int iq1_x_groups16 = (dim + 15) / 16;
+
+        std::vector<uint16_t> h_embed_chunk(static_cast<size_t>(chunk_alloc) * dim);
+        uint16_t* d_embed_chunk_f16 = nullptr;
+        int* d_prefill_token_ids = nullptr;
+        float* d_state_rows = nullptr;
+        float* d_attn_norm_rows = nullptr;
+        float* d_q_a_rows = nullptr;
+        float* d_q_norm_rows = nullptr;
+        float* d_q_rows = nullptr;
+        float* d_kv_a_rows = nullptr;
+        float* d_kv_rows = nullptr;
+        float* d_attn_value_rows = nullptr;
+        float* d_attn_mid_rows = nullptr;
+        float* d_attn_out_rows = nullptr;
+        float* d_ffn_norm_rows = nullptr;
+        float* d_shared_gate_rows = nullptr;
+        float* d_shared_up_rows = nullptr;
+        float* d_shared_hidden_rows = nullptr;
+        float* d_shared_out_rows = nullptr;
+        float* d_moe_rows = nullptr;
+        int64_t* d_prefill_route_indices = nullptr;
+        float* d_prefill_route_weights = nullptr;
+        int64_t* d_group_route_tokens = nullptr;
+        float* d_group_route_weights = nullptr;
+        int32_t* d_seg_starts = nullptr;
+        int32_t* d_counts = nullptr;
+        int32_t* d_offsets = nullptr;
+        int32_t* d_total_routes = nullptr;
+        int32_t* d_prefill_attn_indices = nullptr;
+        float* d_final_norm_rows = nullptr;
+
+        MoePrefillQ2GroupedWorkspace q2_ws;
+        MoePrefillIq1GroupedWorkspace iq1_ws;
+        bool need_q2_ws = false;
+        bool need_iq1_ws = false;
+        bool need_iq1_q2_ws = false;
+        bool need_iq1_gemm_ws = false;
+        for (int L = 0; L < n_layers; ++L) {
+            const bool q2_recipe = layer_w1_dtype[L] == DType::IQ2_XXS && layer_w3_dtype[L] == DType::IQ2_XXS && layer_w2_dtype[L] == DType::Q2_K;
+            const bool iq1_all_recipe = layer_w1_dtype[L] == DType::IQ1_M && layer_w3_dtype[L] == DType::IQ1_M && layer_w2_dtype[L] == DType::IQ1_M;
+            const bool iq1_w13_q2_w2_recipe = layer_w1_dtype[L] == DType::IQ1_M && layer_w3_dtype[L] == DType::IQ1_M && layer_w2_dtype[L] == DType::Q2_K;
+            need_q2_ws = need_q2_ws || q2_recipe;
+            need_iq1_ws = need_iq1_ws || iq1_all_recipe || iq1_w13_q2_w2_recipe;
+            need_iq1_q2_ws = need_iq1_q2_ws || iq1_w13_q2_w2_recipe;
+            need_iq1_gemm_ws = need_iq1_gemm_ws || iq1_all_recipe;
+        }
+
+        check_cuda(cudaMalloc(&d_embed_chunk_f16, chunk_dim * sizeof(uint16_t)), "alloc GGUF prefill embed chunk");
+        check_cuda(cudaMalloc(&d_prefill_token_ids, static_cast<size_t>(prompt_tokens) * sizeof(int)), "alloc GGUF prefill token ids");
+        check_cuda(cudaMalloc(&d_state_rows, static_cast<size_t>(prompt_tokens) * dim * sizeof(float)), "alloc GGUF prefill state rows");
+        check_cuda(cudaMalloc(&d_attn_norm_rows, chunk_dim * sizeof(float)), "alloc GGUF prefill attn norm rows");
+        check_cuda(cudaMalloc(&d_q_a_rows, chunk_q_a * sizeof(float)), "alloc GGUF prefill q_a rows");
+        check_cuda(cudaMalloc(&d_q_norm_rows, chunk_q_a * sizeof(float)), "alloc GGUF prefill q_norm rows");
+        check_cuda(cudaMalloc(&d_q_rows, chunk_q * sizeof(float)), "alloc GGUF prefill q rows");
+        check_cuda(cudaMalloc(&d_kv_a_rows, chunk_kv * sizeof(float)), "alloc GGUF prefill kv_a rows");
+        check_cuda(cudaMalloc(&d_kv_rows, chunk_kv * sizeof(float)), "alloc GGUF prefill kv rows");
+        check_cuda(cudaMalloc(&d_attn_value_rows, chunk_q * sizeof(float)), "alloc GGUF prefill attn value rows");
+        check_cuda(cudaMalloc(&d_attn_mid_rows, chunk_attn_mid * sizeof(float)), "alloc GGUF prefill attn mid rows");
+        check_cuda(cudaMalloc(&d_attn_out_rows, chunk_dim * sizeof(float)), "alloc GGUF prefill attn out rows");
+        check_cuda(cudaMalloc(&d_ffn_norm_rows, chunk_dim * sizeof(float)), "alloc GGUF prefill ffn norm rows");
+        check_cuda(cudaMalloc(&d_shared_gate_rows, chunk_inter * sizeof(float)), "alloc GGUF prefill shared gate rows");
+        check_cuda(cudaMalloc(&d_shared_up_rows, chunk_inter * sizeof(float)), "alloc GGUF prefill shared up rows");
+        check_cuda(cudaMalloc(&d_shared_hidden_rows, chunk_inter * sizeof(float)), "alloc GGUF prefill shared hidden rows");
+        check_cuda(cudaMalloc(&d_shared_out_rows, chunk_dim * sizeof(float)), "alloc GGUF prefill shared out rows");
+        check_cuda(cudaMalloc(&d_moe_rows, chunk_dim * sizeof(float)), "alloc GGUF prefill moe rows");
+        check_cuda(cudaMalloc(&d_prefill_route_indices, static_cast<size_t>(routes_cap) * sizeof(int64_t)), "alloc GGUF prefill route indices");
+        check_cuda(cudaMalloc(&d_prefill_route_weights, static_cast<size_t>(routes_cap) * sizeof(float)), "alloc GGUF prefill route weights");
+        check_cuda(cudaMalloc(&d_group_route_tokens, static_cast<size_t>(routes_cap) * sizeof(int64_t)), "alloc GGUF prefill grouped route tokens");
+        check_cuda(cudaMalloc(&d_group_route_weights, static_cast<size_t>(routes_cap) * sizeof(float)), "alloc GGUF prefill grouped route weights");
+        check_cuda(cudaMalloc(&d_seg_starts, static_cast<size_t>(experts_per_rank + 1) * sizeof(int32_t)), "alloc GGUF prefill seg starts");
+        check_cuda(cudaMalloc(&d_counts, static_cast<size_t>(experts_per_rank) * sizeof(int32_t)), "alloc GGUF prefill route counts");
+        check_cuda(cudaMalloc(&d_offsets, static_cast<size_t>(experts_per_rank) * sizeof(int32_t)), "alloc GGUF prefill route offsets");
+        check_cuda(cudaMalloc(&d_total_routes, sizeof(int32_t)), "alloc GGUF prefill total routes");
+        if (use_prefill_indexed_attn) {
+            check_cuda(cudaMalloc(&d_prefill_attn_indices, static_cast<size_t>(prefill_attn_index_elems) * sizeof(int32_t)), "alloc GGUF prefill attention indices");
+            if (!build_prefill_window_indices_cuda(d_prefill_attn_indices, prompt_tokens, prefill_attn_window, prefill_attn_topk))
+                throw std::runtime_error("GGUF prefill attention window indices failed");
+        } else if (tp_rank == 0 && env_int_or_default("DSV4_GGUF_VERBOSE", 0) != 0) {
+            std::cout << "gguf_prefill_indexed_attn=0 topk=" << prefill_attn_topk
+                      << " max_topk=" << prefill_attn_max_index_topk
+                      << " index_elems=" << prefill_attn_index_elems
+                      << " max_index_elems=" << prefill_attn_max_index_elems << "\n";
+        }
+        check_cuda(cudaMalloc(&d_final_norm_rows, static_cast<size_t>(dim) * sizeof(float)), "alloc GGUF prefill final norm");
+        if (need_q2_ws) {
+            q2_ws.routes_cap = routes_cap; q2_ws.dim = dim; q2_ws.inter_dim = moe_inter;
+            check_cuda(cudaMalloc(&q2_ws.d_x_route, routes_dim * sizeof(float)), "alloc GGUF prefill q2 x route");
+            check_cuda(cudaMalloc(&q2_ws.d_x_q, routes_dim), "alloc GGUF prefill q2 x q");
+            check_cuda(cudaMalloc(&q2_ws.d_x_scale, static_cast<size_t>(routes_cap) * x_groups * sizeof(float)), "alloc GGUF prefill q2 x scale");
+            check_cuda(cudaMalloc(&q2_ws.d_route_slots, static_cast<size_t>(routes_cap) * sizeof(int64_t)), "alloc GGUF prefill q2 route slots");
+            check_cuda(cudaMalloc(&q2_ws.d_gate, routes_inter * sizeof(float)), "alloc GGUF prefill q2 gate");
+            check_cuda(cudaMalloc(&q2_ws.d_up, routes_inter * sizeof(float)), "alloc GGUF prefill q2 up");
+            check_cuda(cudaMalloc(&q2_ws.d_hidden_q, routes_inter), "alloc GGUF prefill q2 hidden q");
+            check_cuda(cudaMalloc(&q2_ws.d_hidden_scale, static_cast<size_t>(routes_cap) * hidden_groups * sizeof(float)), "alloc GGUF prefill q2 hidden scale");
+        }
+        if (need_iq1_ws) {
+            iq1_ws.routes_cap = routes_cap; iq1_ws.dim = dim; iq1_ws.inter_dim = moe_inter;
+            check_cuda(cudaMalloc(&iq1_ws.d_hidden, routes_inter * sizeof(float)), "alloc GGUF prefill iq1 hidden");
+            if (need_iq1_q2_ws || iq1_grouped_w2_q8_enabled) {
+                check_cuda(cudaMalloc(&iq1_ws.d_hidden_q, routes_inter), "alloc GGUF prefill iq1 hidden q");
+                check_cuda(cudaMalloc(&iq1_ws.d_hidden_scale, static_cast<size_t>(routes_cap) * hidden_groups * sizeof(float)), "alloc GGUF prefill iq1 hidden scale");
+            }
+            if (iq1_grouped_gemm_enabled && need_iq1_gemm_ws) {
+                const int tile_cap = (routes_cap + 15) / 16 + experts_per_rank;
+                iq1_ws.tile_cap = tile_cap;
+                check_cuda(cudaMalloc(&iq1_ws.d_x_q, routes_dim), "alloc GGUF prefill iq1 x q");
+                check_cuda(cudaMalloc(&iq1_ws.d_x_scale, static_cast<size_t>(routes_cap) * iq1_x_groups16 * sizeof(float)), "alloc GGUF prefill iq1 x scale");
+                check_cuda(cudaMalloc(&iq1_ws.d_tile_experts, static_cast<size_t>(tile_cap) * sizeof(int32_t)), "alloc GGUF prefill iq1 tile experts");
+                check_cuda(cudaMalloc(&iq1_ws.d_tile_rows, static_cast<size_t>(tile_cap) * sizeof(int32_t)), "alloc GGUF prefill iq1 tile rows");
+            }
+        }
+
+        check_cuda(cudaMemcpy(d_prefill_token_ids, seed_tokens.data(), static_cast<size_t>(prompt_tokens) * sizeof(int), cudaMemcpyHostToDevice), "copy GGUF prefill token ids");
+        const uint16_t* embed_f16 = reinterpret_cast<const uint16_t*>(embed.data);
+        for (int cs = 0; cs < prompt_tokens; cs += chunk_tokens) {
+            const int cn = std::min(chunk_tokens, prompt_tokens - cs);
+            for (int t = 0; t < cn; ++t) {
+                const int tok = seed_tokens[static_cast<size_t>(cs + t)];
+                std::memcpy(h_embed_chunk.data() + static_cast<size_t>(t) * dim,
+                            embed_f16 + static_cast<size_t>(tok) * dim,
+                            static_cast<size_t>(dim) * sizeof(uint16_t));
+            }
+            check_cuda(cudaMemcpy(d_embed_chunk_f16, h_embed_chunk.data(), static_cast<size_t>(cn) * dim * sizeof(uint16_t), cudaMemcpyHostToDevice), "copy GGUF prefill embed chunk");
+            if (!f16_contiguous_rows_to_float_cuda(d_embed_chunk_f16, d_state_rows + static_cast<size_t>(cs) * dim, cn, dim))
+                throw std::runtime_error("GGUF prefill embed rows failed");
+        }
+
+        std::vector<int32_t> h_counts(static_cast<size_t>(experts_per_rank));
+        double prof_prefill_attn_ms = 0.0;
+        double prof_prefill_gate_ms = 0.0;
+        double prof_prefill_moe_ms = 0.0;
+        double prof_prefill_shared_ms = 0.0;
+        for (int L = 0; L < n_layers; ++L) {
+            const bool is_hash = (L < n_hash);
+            const bool q2_recipe = layer_w1_dtype[L] == DType::IQ2_XXS && layer_w3_dtype[L] == DType::IQ2_XXS && layer_w2_dtype[L] == DType::Q2_K;
+            const bool iq1_all_recipe = layer_w1_dtype[L] == DType::IQ1_M && layer_w3_dtype[L] == DType::IQ1_M && layer_w2_dtype[L] == DType::IQ1_M;
+            const bool iq1_w13_q2_w2_recipe = layer_w1_dtype[L] == DType::IQ1_M && layer_w3_dtype[L] == DType::IQ1_M && layer_w2_dtype[L] == DType::Q2_K;
+            // For host-routed GGUF prefill, keep the staged local expert arena valid
+            // across all chunks of this layer. Long prompts otherwise re-copy the same
+            // local expert weights once per chunk; the layer loop overwrites the arena
+            // before the next layer, so a per-layer bitmap is sufficient.
+            std::vector<uint8_t> h_prefill_staged_local(static_cast<size_t>(experts_per_rank), 0);
+            for (int cs = 0; cs < prompt_tokens; cs += chunk_tokens) {
+                const int cn = std::min(chunk_tokens, prompt_tokens - cs);
+                const int ce = cs + cn;
+                const size_t cn_dim = static_cast<size_t>(cn) * dim;
+                float* state_chunk = d_state_rows + static_cast<size_t>(cs) * dim;
+                auto stage_t = sync_now();
+                if (!rmsnorm_bf16_gamma_rows_cuda(state_chunk, d_attn_gamma[L], d_attn_norm_rows, cn, dim, 1e-6f)) throw std::runtime_error("GGUF prefill attn norm rows failed");
+                if (!q8_0_matmul_rows_cuda(d_attn_norm_rows, d_wq_a[L], d_q_a_rows, cn, q_a_dim, dim)) throw std::runtime_error("GGUF prefill wq_a rows failed");
+                if (!rmsnorm_bf16_gamma_rows_cuda(d_q_a_rows, d_q_gamma[L], d_q_norm_rows, cn, q_a_dim, 1e-6f)) throw std::runtime_error("GGUF prefill q norm rows failed");
+                if (!q8_0_matmul_rows_cuda(d_q_norm_rows, d_wq_b[L], d_q_rows, cn, q_full, q_a_dim)) throw std::runtime_error("GGUF prefill wq_b rows failed");
+                if (!head_rmsnorm_rope_rows_cuda(d_q_rows, cn, heads, head_dim, rope_dim, cs, ld.rope_theta, false, 1e-6f)) throw std::runtime_error("GGUF prefill q rope rows failed");
+                if (!q8_0_matmul_rows_cuda(d_attn_norm_rows, d_wkv[L], d_kv_a_rows, cn, kv_dim, dim)) throw std::runtime_error("GGUF prefill wkv rows failed");
+                if (!rmsnorm_bf16_gamma_rows_cuda(d_kv_a_rows, d_kv_gamma[L], d_kv_rows, cn, kv_dim, 1e-6f)) throw std::runtime_error("GGUF prefill kv norm rows failed");
+                if (!head_rmsnorm_rope_rows_cuda(d_kv_rows, cn, 1, head_dim, rope_dim, cs, ld.rope_theta, false, 0.0f)) throw std::runtime_error("GGUF prefill kv rope rows failed");
+                if (!copy_rows_to_kv_cache_cuda(d_kv_rows, d_kv_cache[L], cn, head_dim, layer_cache_capacity[L], cs)) throw std::runtime_error("GGUF prefill kv cache rows copy failed");
+                if (use_prefill_indexed_attn) {
+                    if (!prefill_sparse_attention_indexed_cuda(d_q_rows, d_kv_cache[L], d_attn_sink[L], d_prefill_attn_indices + static_cast<size_t>(cs) * prefill_attn_topk, d_attn_value_rows, cn, heads, ce, prefill_attn_topk, head_dim, 1.0f / std::sqrt(static_cast<float>(head_dim)))) throw std::runtime_error("GGUF prefill indexed attention rows failed");
+                } else {
+                    if (!prefill_causal_attention_chunk_cuda(d_q_rows, d_kv_cache[L], d_attn_sink[L], d_attn_value_rows, cn, heads, ce, head_dim, layer_cache_capacity[L], cs, 1.0f / std::sqrt(static_cast<float>(head_dim)))) throw std::runtime_error("GGUF prefill attention rows failed");
+                }
+                if (!head_rmsnorm_rope_rows_cuda(d_attn_value_rows, cn, heads, head_dim, rope_dim, cs, ld.rope_theta, true, 0.0f)) throw std::runtime_error("GGUF prefill inverse rope rows failed");
+                const size_t wo_a_row_bytes = static_cast<size_t>((group_in_dim + 31) / 32) * 34;
+                for (int g = 0; g < o_groups; ++g) {
+                    const float* group_x = d_attn_value_rows + static_cast<size_t>(g) * group_in_dim;
+                    const uint8_t* group_w = d_wo_a[L] + static_cast<size_t>(g) * o_lora_rank * wo_a_row_bytes;
+                    float* group_y = d_attn_mid_rows + static_cast<size_t>(g) * o_lora_rank;
+                    if (!q8_0_matmul_rows_strided_cuda(group_x, group_w, group_y, cn, o_lora_rank, group_in_dim, q_full, attn_mid)) throw std::runtime_error("GGUF prefill wo_a rows failed");
+                }
+                if (!q8_0_matmul_rows_cuda(d_attn_mid_rows, d_wo_b[L], d_attn_out_rows, cn, dim, attn_mid)) throw std::runtime_error("GGUF prefill wo_b rows failed");
+                gguf_all_reduce_sum_fp32_inplace(d_attn_out_rows, static_cast<int>(cn_dim), reduce_ctx_ptr, "GGUF prefill attention all-reduce");
+                if (!vector_accum_rows_cuda(d_attn_out_rows, state_chunk, cn, dim, 1.0f)) throw std::runtime_error("GGUF prefill attention residual failed");
+                if (profile_gguf) prof_prefill_attn_ms += elapsed_ms(stage_t, sync_now());
+
+                stage_t = sync_now();
+                if (!rmsnorm_bf16_gamma_rows_cuda(state_chunk, d_ffn_gamma[L], d_ffn_norm_rows, cn, dim, 1e-6f)) throw std::runtime_error("GGUF prefill ffn norm rows failed");
+                if (is_hash) {
+                    if (d_tid2eid_table[L] == nullptr) throw std::runtime_error("GGUF chunked prefill requires resident hash table");
+                    if (!gate_hash_bf16_rows_cuda(d_ffn_norm_rows, d_gate_w[L], d_tid2eid_table[L], d_prefill_token_ids + cs, d_prefill_route_indices, d_prefill_route_weights, cn, dim, topk, topk, ld.route_scale)) throw std::runtime_error("GGUF prefill hash gate rows failed");
+                } else {
+                    if (!gate_topk_bf16_rows_cuda(d_ffn_norm_rows, d_gate_w[L], d_gate_bias[L], d_prefill_route_indices, d_prefill_route_weights, cn, n_experts, dim, topk, ld.route_scale)) throw std::runtime_error("GGUF prefill topk gate rows failed");
+                }
+                if (profile_gguf) prof_prefill_gate_ms += elapsed_ms(stage_t, sync_now());
+
+                if (!moe_group_routes_cuda(d_prefill_route_indices, d_prefill_route_weights, d_group_route_tokens, d_group_route_weights, d_seg_starts, d_counts, d_offsets, d_total_routes, cn, topk, expert_start, experts_per_rank)) throw std::runtime_error("GGUF prefill group routes failed");
+                int32_t total_routes = 0;
+                check_cuda(cudaMemcpy(&total_routes, d_total_routes, sizeof(int32_t), cudaMemcpyDeviceToHost), "copy GGUF prefill total routes");
+                check_cuda(cudaMemcpy(h_counts.data(), d_counts, h_counts.size() * sizeof(int32_t), cudaMemcpyDeviceToHost), "copy GGUF prefill route counts");
+                int max_count = 0;
+                for (int32_t c : h_counts) max_count = std::max(max_count, static_cast<int>(c));
+                if (iq1_grouped_gemm_enabled && iq1_all_recipe && iq1_ws.d_tile_experts != nullptr && iq1_ws.d_tile_rows != nullptr) {
+                    std::vector<int32_t> h_iq1_tile_experts;
+                    std::vector<int32_t> h_iq1_tile_rows;
+                    h_iq1_tile_experts.reserve(static_cast<size_t>((total_routes + 15) / 16 + experts_per_rank));
+                    h_iq1_tile_rows.reserve(h_iq1_tile_experts.capacity());
+                    for (int local = 0; local < experts_per_rank; ++local) {
+                        const int count = h_counts[static_cast<size_t>(local)];
+                        for (int row = 0; row < count; row += 16) {
+                            h_iq1_tile_experts.push_back(local);
+                            h_iq1_tile_rows.push_back(row);
+                        }
+                    }
+                    iq1_ws.tile_count = static_cast<int>(h_iq1_tile_experts.size());
+                    if (iq1_ws.tile_count > iq1_ws.tile_cap) throw std::runtime_error("GGUF prefill IQ1 tile capacity exceeded");
+                    if (iq1_ws.tile_count > 0) {
+                        check_cuda(cudaMemcpy(iq1_ws.d_tile_experts, h_iq1_tile_experts.data(), h_iq1_tile_experts.size() * sizeof(int32_t), cudaMemcpyHostToDevice), "copy GGUF prefill iq1 tile experts");
+                        check_cuda(cudaMemcpy(iq1_ws.d_tile_rows, h_iq1_tile_rows.data(), h_iq1_tile_rows.size() * sizeof(int32_t), cudaMemcpyHostToDevice), "copy GGUF prefill iq1 tile rows");
+                    }
+                } else if (need_iq1_ws) {
+                    iq1_ws.tile_count = 0;
+                }
+
+                stage_t = sync_now();
+                if (total_routes > 0 && max_count > 0) {
+                    const uint8_t* routed_w1 = is_resident_routed_layer[L] ? d_resident_w1[L] : d_routed_w1;
+                    const uint8_t* routed_w2 = is_resident_routed_layer[L] ? d_resident_w2[L] : d_routed_w2;
+                    const uint8_t* routed_w3 = is_resident_routed_layer[L] ? d_resident_w3[L] : d_routed_w3;
+                    int routed_n = is_resident_routed_layer[L] ? experts_per_rank : experts_per_rank;
+                    if (!is_resident_routed_layer[L]) {
+                        const size_t w1_layer_bytes = static_cast<size_t>(layer_w1_bytes[L]);
+                        const size_t w2_layer_bytes = static_cast<size_t>(layer_w2_bytes[L]);
+                        const size_t w3_layer_bytes = static_cast<size_t>(layer_w3_bytes[L]);
+                        for (int local = 0; local < experts_per_rank; ++local) {
+                            if (h_counts[static_cast<size_t>(local)] == 0 || h_prefill_staged_local[static_cast<size_t>(local)] != 0) continue;
+                            const int eid = expert_start + local;
+                            const std::string lp = "layers." + std::to_string(L);
+                            auto wv1 = gws.get_expert(lp + ".ffn.experts.routed.w1", lp + ".ffn.experts.routed.w1", eid);
+                            auto wv2 = gws.get_expert(lp + ".ffn.experts.routed.w2", lp + ".ffn.experts.routed.w2", eid);
+                            auto wv3 = gws.get_expert(lp + ".ffn.experts.routed.w3", lp + ".ffn.experts.routed.w3", eid);
+                            if (!wv1.found || !wv2.found || !wv3.found) throw std::runtime_error("GGUF prefill get_expert failed");
+                            check_cuda(cudaMemcpy(d_routed_w1 + w1_layer_bytes * local, wv1.data, w1_layer_bytes, cudaMemcpyHostToDevice), "stage GGUF prefill routed w1");
+                            check_cuda(cudaMemcpy(d_routed_w2 + w2_layer_bytes * local, wv2.data, w2_layer_bytes, cudaMemcpyHostToDevice), "stage GGUF prefill routed w2");
+                            check_cuda(cudaMemcpy(d_routed_w3 + w3_layer_bytes * local, wv3.data, w3_layer_bytes, cudaMemcpyHostToDevice), "stage GGUF prefill routed w3");
+                            h_prefill_staged_local[static_cast<size_t>(local)] = 1;
+                        }
+                    }
+                    if (q2_recipe) {
+                        if (!moe_prefill_q2_grouped_cuda_with_workspace(d_ffn_norm_rows, d_group_route_tokens, d_group_route_weights, d_seg_starts, routed_w1, routed_w2, routed_w3, d_moe_rows, cn, total_routes, routed_n, max_count, dim, moe_inter, ld.swiglu_limit, q2_ws)) throw std::runtime_error("GGUF prefill grouped Q2 MoE failed");
+                    } else if (iq1_all_recipe) {
+                        if (!moe_prefill_iq1_grouped_cuda_with_workspace(d_ffn_norm_rows, d_group_route_tokens, d_group_route_weights, d_seg_starts, routed_w1, routed_w2, routed_w3, d_moe_rows, cn, total_routes, routed_n, max_count, dim, moe_inter, ld.swiglu_limit, iq1_ws)) throw std::runtime_error("GGUF prefill grouped IQ1 MoE failed");
+                    } else if (iq1_w13_q2_w2_recipe) {
+                        if (!iq1_moe_grouped_w13_swiglu_cuda(d_ffn_norm_rows, d_group_route_tokens, d_group_route_weights, d_seg_starts, routed_w1, routed_w3, iq1_ws.d_hidden, total_routes, routed_n, max_count, dim, moe_inter, ld.swiglu_limit)) throw std::runtime_error("GGUF prefill IQ1 W13 grouped failed");
+                        if (!q2_quantize_hidden_q8_1_cuda(iq1_ws.d_hidden, iq1_ws.d_hidden_q, iq1_ws.d_hidden_scale, total_routes, moe_inter)) throw std::runtime_error("GGUF prefill IQ1/Q2 hidden quant failed");
+                        if (!q2_moe_grouped_w2_q2k_cuda(iq1_ws.d_hidden_q, iq1_ws.d_hidden_scale, d_group_route_tokens, d_seg_starts, routed_w2, d_moe_rows, cn, total_routes, routed_n, max_count, dim, moe_inter)) throw std::runtime_error("GGUF prefill IQ1/Q2 grouped W2 failed");
+                    } else {
+                        throw std::runtime_error("GGUF prefill unsupported routed dtype recipe");
+                    }
+                } else {
+                    check_cuda(cudaMemset(d_moe_rows, 0, cn_dim * sizeof(float)), "zero GGUF prefill empty moe rows");
+                }
+                gguf_all_reduce_sum_fp32_inplace(d_moe_rows, static_cast<int>(cn_dim), reduce_ctx_ptr, "GGUF prefill MoE all-reduce");
+                if (profile_gguf) prof_prefill_moe_ms += elapsed_ms(stage_t, sync_now());
+
+                stage_t = sync_now();
+                if (!q8_0_matmul_rows_cuda(d_ffn_norm_rows, d_shared_w1[L], d_shared_gate_rows, cn, moe_inter, dim)) throw std::runtime_error("GGUF prefill shared w1 rows failed");
+                if (!q8_0_matmul_rows_cuda(d_ffn_norm_rows, d_shared_w3[L], d_shared_up_rows, cn, moe_inter, dim)) throw std::runtime_error("GGUF prefill shared w3 rows failed");
+                if (!silu_mul_rows_cuda(d_shared_gate_rows, d_shared_up_rows, d_shared_hidden_rows, cn, moe_inter)) throw std::runtime_error("GGUF prefill shared silu rows failed");
+                if (!q8_0_matmul_rows_cuda(d_shared_hidden_rows, d_shared_w2[L], d_shared_out_rows, cn, dim, moe_inter)) throw std::runtime_error("GGUF prefill shared w2 rows failed");
+                if (!vector_accum_rows_cuda(d_shared_out_rows, d_moe_rows, cn, dim, 1.0f)) throw std::runtime_error("GGUF prefill shared accum failed");
+                if (!vector_accum_rows_cuda(d_moe_rows, state_chunk, cn, dim, 1.0f)) throw std::runtime_error("GGUF prefill ffn residual failed");
+                if (profile_gguf) prof_prefill_shared_ms += elapsed_ms(stage_t, sync_now());
+            }
+        }
+
+        float* last_row = d_state_rows + static_cast<size_t>(prompt_tokens - 1) * dim;
+        if (!rmsnorm_bf16_gamma_cuda(last_row, d_final_norm_gamma, d_final_norm_rows, dim, 1e-6f)) throw std::runtime_error("GGUF prefill final norm failed");
+        if (!q8_0_matvec_cuda(d_final_norm_rows, d_head, d_logits, local_vocab, dim)) throw std::runtime_error("GGUF prefill head failed");
+        int top_t = local_vocab_start;
+        float top_l = -INFINITY;
+        if (gguf_host_logits) {
+            check_cuda(cudaDeviceSynchronize(), "sync GGUF prefill head");
+            check_cuda(cudaMemcpy(h_logits.data(), d_logits, local_vocab * sizeof(float), cudaMemcpyDeviceToHost), "copy GGUF prefill logits");
+            int local_t = 0;
+            float local_l = -INFINITY;
+            for (int i = 0; i < local_vocab; ++i) {
+                if (h_logits[i] > local_l) { local_l = h_logits[i]; local_t = i; }
+            }
+            top_t = local_t + local_vocab_start;
+            top_l = local_l;
+        } else {
+            if (!argmax_fp32_cuda(d_logits, d_argmax_token, d_argmax_logit, local_vocab, local_vocab_start)) throw std::runtime_error("GGUF prefill argmax failed");
+            check_cuda(cudaMemcpy(&top_t, d_argmax_token, sizeof(int), cudaMemcpyDeviceToHost), "copy GGUF prefill argmax token");
+            check_cuda(cudaMemcpy(&top_l, d_argmax_logit, sizeof(float), cudaMemcpyDeviceToHost), "copy GGUF prefill argmax logit");
+        }
+#ifdef DSV4_HAVE_NCCL
+        if (tp_world > 1 && !options.nccl_id_path.empty()) {
+            TpTopResult global = nccl_global_top1(tp_world, tp_rank, tp_device,
+                                                   options.nccl_id_path.c_str(),
+                                                   top_t, top_l);
+            top_t = global.token;
+            top_l = global.logit;
+        }
+#endif
+        double prof_prefill_refine_ms = 0.0;
+        int refine_last_tokens = env_int_or_default("DSV4_GGUF_PREFILL_REFINE_LAST_TOKENS", env_int_or_default("DSV4_GGUF_PREFILL_REFINE_LAST", 1) != 0 ? 1 : 0);
+        if (refine_last_tokens < 0) refine_last_tokens = 0;
+        if (refine_last_tokens > prompt_tokens) refine_last_tokens = prompt_tokens;
+        if (refine_last_tokens > 0 && prompt_tokens > 0) {
+            auto refine_t = sync_now();
+            const int refine_start = prompt_tokens - refine_last_tokens;
+            for (int pos = refine_start; pos < prompt_tokens; ++pos) {
+                auto refined = run_step(seed_tokens[static_cast<size_t>(pos)], pos);
+                top_t = refined.first;
+                top_l = refined.second;
+            }
+            if (profile_gguf) prof_prefill_refine_ms = elapsed_ms(refine_t, sync_now());
+        }
+        check_cuda(cudaDeviceSynchronize(), "sync GGUF chunked prefill");
+        if (profile_gguf && tp_rank == 0) {
+            std::cout << "gguf_chunked_prefill_profile chunk_tokens=" << chunk_tokens
+                      << " iq1_w2_q8=" << (iq1_grouped_w2_q8_enabled ? 1 : 0)
+                      << " iq1_gemm=" << (iq1_grouped_gemm_enabled ? 1 : 0)
+                      << " iq1_tile4=" << (iq1_grouped_route_tile4_enabled ? 1 : 0)
+                      << " iq1_route_major=" << (iq1_grouped_route_major_enabled ? 1 : 0)
+                      << " indexed_attn=" << (use_prefill_indexed_attn ? 1 : 0)
+                      << " attn_topk=" << prefill_attn_topk
+                      << " attn_ms=" << prof_prefill_attn_ms
+                      << " gate_ms=" << prof_prefill_gate_ms
+                      << " moe_ms=" << prof_prefill_moe_ms
+                      << " shared_ms=" << prof_prefill_shared_ms
+                      << " refine_last_tokens=" << refine_last_tokens
+                      << " refine_last_ms=" << prof_prefill_refine_ms << "\n";
+        }
+
+        cudaFree(d_embed_chunk_f16); cudaFree(d_prefill_token_ids); cudaFree(d_state_rows);
+        cudaFree(d_attn_norm_rows); cudaFree(d_q_a_rows); cudaFree(d_q_norm_rows); cudaFree(d_q_rows);
+        cudaFree(d_kv_a_rows); cudaFree(d_kv_rows); cudaFree(d_attn_value_rows); cudaFree(d_attn_mid_rows); cudaFree(d_attn_out_rows);
+        cudaFree(d_ffn_norm_rows); cudaFree(d_shared_gate_rows); cudaFree(d_shared_up_rows); cudaFree(d_shared_hidden_rows); cudaFree(d_shared_out_rows); cudaFree(d_moe_rows);
+        cudaFree(d_prefill_route_indices); cudaFree(d_prefill_route_weights); cudaFree(d_group_route_tokens); cudaFree(d_group_route_weights);
+        cudaFree(d_seg_starts); cudaFree(d_counts); cudaFree(d_offsets); cudaFree(d_total_routes); cudaFree(d_prefill_attn_indices); cudaFree(d_final_norm_rows);
+        cudaFree(q2_ws.d_x_route); cudaFree(q2_ws.d_x_q); cudaFree(q2_ws.d_x_scale); cudaFree(q2_ws.d_route_slots); cudaFree(q2_ws.d_gate); cudaFree(q2_ws.d_up); cudaFree(q2_ws.d_hidden_q); cudaFree(q2_ws.d_hidden_scale);
+        cudaFree(iq1_ws.d_hidden); cudaFree(iq1_ws.d_hidden_q); cudaFree(iq1_ws.d_hidden_scale); cudaFree(iq1_ws.d_x_q); cudaFree(iq1_ws.d_x_scale); cudaFree(iq1_ws.d_tile_experts); cudaFree(iq1_ws.d_tile_rows);
+        return {top_t, top_l};
+    };
+
     // ===== generate loop =====
     GgufDecodeResult r;
     r.n_layers = n_layers;
@@ -7516,22 +7930,43 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
         last_argmax = argmax;
     } else {
         const int forward_positions = (!gguf_load_only && max_new_tokens > 0) ? total_positions : 0;
-        for (int pos = 0; pos < forward_positions; ++pos) {
-            if (pos == r.prompt_tokens) t_decode_start = std::chrono::steady_clock::now();
-            const int feed_token = (pos < r.prompt_tokens) ? seed_tokens[pos] : last_argmax;
-            auto [argmax, logit] = run_step(feed_token, pos);
-            r.top_logits.push_back(logit);
-            // argmax produced at position p predicts the token for position p+1.
-            // Record argmax once we reach the last seed (its prediction is the first
-            // generated token) and every step thereafter.
-            if (pos >= r.prompt_tokens - 1 &&
-                static_cast<int>(r.generated_tokens.size()) < max_new_tokens) {
-                r.generated_tokens.push_back(argmax);
+        if (gguf_chunked_prefill_available && forward_positions > 0) {
+            if (tp_rank == 0) {
+                std::cout << "gguf_chunked_prefill=1 prompt_tokens=" << r.prompt_tokens
+                          << " resident_layers=" << resident_routed_layers << "/" << n_layers << "\n";
             }
+            auto [argmax, logit] = run_chunked_prefill();
+            r.top_logits.push_back(logit);
+            r.generated_tokens.push_back(argmax);
             last_argmax = argmax;
-            if (pos == r.prompt_tokens - 1) {
-                t_prefill_end = std::chrono::steady_clock::now();
-                t_decode_start = t_prefill_end;
+            t_prefill_end = std::chrono::steady_clock::now();
+            t_decode_start = t_prefill_end;
+            for (int pos = r.prompt_tokens; pos < forward_positions; ++pos) {
+                auto [step_argmax, step_logit] = run_step(last_argmax, pos);
+                r.top_logits.push_back(step_logit);
+                if (static_cast<int>(r.generated_tokens.size()) < max_new_tokens) {
+                    r.generated_tokens.push_back(step_argmax);
+                }
+                last_argmax = step_argmax;
+            }
+        } else {
+            for (int pos = 0; pos < forward_positions; ++pos) {
+                if (pos == r.prompt_tokens) t_decode_start = std::chrono::steady_clock::now();
+                const int feed_token = (pos < r.prompt_tokens) ? seed_tokens[pos] : last_argmax;
+                auto [argmax, logit] = run_step(feed_token, pos);
+                r.top_logits.push_back(logit);
+                // argmax produced at position p predicts the token for position p+1.
+                // Record argmax once we reach the last seed (its prediction is the first
+                // generated token) and every step thereafter.
+                if (pos >= r.prompt_tokens - 1 &&
+                    static_cast<int>(r.generated_tokens.size()) < max_new_tokens) {
+                    r.generated_tokens.push_back(argmax);
+                }
+                last_argmax = argmax;
+                if (pos == r.prompt_tokens - 1) {
+                    t_prefill_end = std::chrono::steady_clock::now();
+                    t_decode_start = t_prefill_end;
+                }
             }
         }
     }

--- a/cpp_engine/tests/test_moe_grouped_iq1.cpp
+++ b/cpp_engine/tests/test_moe_grouped_iq1.cpp
@@ -1,0 +1,270 @@
+#include "cuda_ops.hpp"
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void check_cuda(cudaError_t err, const char* what) {
+    if (err != cudaSuccess) {
+        throw std::runtime_error(std::string(what) + ": " + cudaGetErrorString(err));
+    }
+}
+
+uint16_t float_to_half_bits(float x) {
+    __half h = __float2half(x);
+    return *reinterpret_cast<uint16_t*>(&h);
+}
+
+std::vector<uint8_t> random_iq1_weight(int rows, int cols, std::mt19937& rng) {
+    const int blocks_per_row = (cols + 255) / 256;
+    std::vector<uint8_t> w(static_cast<size_t>(rows) * blocks_per_row * 56);
+    std::uniform_int_distribution<int> byte_dist(0, 255);
+    std::uniform_int_distribution<int> qh_dist(0, 127);  // keep delta positive for stability
+    std::uniform_int_distribution<int> sc_dist(0, 7);
+    std::uniform_real_distribution<float> d_dist(0.01f, 0.04f);
+    for (int r = 0; r < rows; ++r) {
+        for (int b = 0; b < blocks_per_row; ++b) {
+            uint8_t* block = w.data() + (static_cast<size_t>(r) * blocks_per_row + b) * 56;
+            for (int i = 0; i < 32; ++i) block[i] = static_cast<uint8_t>(byte_dist(rng));
+            for (int i = 0; i < 16; ++i) block[32 + i] = static_cast<uint8_t>(qh_dist(rng));
+            uint16_t sc[4] = {0, 0, 0, 0};
+            for (int s = 0; s < 8; ++s) {
+                sc[s >> 2] |= static_cast<uint16_t>(sc_dist(rng) << ((s & 3) * 3));
+            }
+            const uint16_t d_bits = float_to_half_bits(d_dist(rng));
+            sc[0] |= static_cast<uint16_t>((d_bits & 0x000fu) << 12);
+            sc[1] |= static_cast<uint16_t>(d_bits & 0x00f0u) << 8;
+            sc[2] |= static_cast<uint16_t>(d_bits & 0x0f00u) << 4;
+            sc[3] |= static_cast<uint16_t>(d_bits & 0xf000u);
+            std::memcpy(block + 48, sc, sizeof(sc));
+        }
+    }
+    return w;
+}
+
+int env_int_or_default(const char* name, int fallback) {
+    const char* v = std::getenv(name);
+    if (v == nullptr || *v == '\0') return fallback;
+    char* end = nullptr;
+    const long parsed = std::strtol(v, &end, 10);
+    return (end == v) ? fallback : static_cast<int>(parsed);
+}
+
+void compare(const std::vector<float>& a, const std::vector<float>& b, float tol, const std::string& tag) {
+    if (a.size() != b.size()) throw std::runtime_error(tag + ": size mismatch");
+    float max_abs = 0.0f;
+    float mean_abs = 0.0f;
+    int dump = 0;
+    for (size_t i = 0; i < a.size(); ++i) {
+        const float diff = std::fabs(a[i] - b[i]);
+        max_abs = std::max(max_abs, diff);
+        mean_abs += diff;
+        if (diff > tol && dump < 8) {
+            std::cerr << tag << " idx=" << i << " grouped=" << a[i]
+                      << " ref=" << b[i] << " diff=" << diff << "\n";
+            ++dump;
+        }
+    }
+    mean_abs /= static_cast<float>(a.size());
+    std::cout << tag << " max_abs=" << max_abs << " mean_abs=" << mean_abs
+              << " size=" << a.size() << "\n";
+    if (max_abs > tol) throw std::runtime_error(tag + ": max_abs above tolerance");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        const int tokens = 16;
+        const int n_local_experts = 4;
+        const int topk = 2;
+        const int dim = 256;
+        const int inter_dim = 256;
+        const float swiglu_limit = 7.0f;
+        std::mt19937 rng(0x1f00d);
+
+        std::uniform_real_distribution<float> xdist(-0.25f, 0.25f);
+        std::vector<float> x(static_cast<size_t>(tokens) * dim);
+        for (auto& v : x) v = xdist(rng);
+
+        const size_t w13_bytes_per_expert = static_cast<size_t>(inter_dim) * ((dim + 255) / 256) * 56;
+        const size_t w2_bytes_per_expert = static_cast<size_t>(dim) * ((inter_dim + 255) / 256) * 56;
+        std::vector<uint8_t> w1(static_cast<size_t>(n_local_experts) * w13_bytes_per_expert);
+        std::vector<uint8_t> w3(static_cast<size_t>(n_local_experts) * w13_bytes_per_expert);
+        std::vector<uint8_t> w2(static_cast<size_t>(n_local_experts) * w2_bytes_per_expert);
+        for (int e = 0; e < n_local_experts; ++e) {
+            auto ew1 = random_iq1_weight(inter_dim, dim, rng);
+            auto ew3 = random_iq1_weight(inter_dim, dim, rng);
+            auto ew2 = random_iq1_weight(dim, inter_dim, rng);
+            std::memcpy(w1.data() + static_cast<size_t>(e) * w13_bytes_per_expert, ew1.data(), w13_bytes_per_expert);
+            std::memcpy(w3.data() + static_cast<size_t>(e) * w13_bytes_per_expert, ew3.data(), w13_bytes_per_expert);
+            std::memcpy(w2.data() + static_cast<size_t>(e) * w2_bytes_per_expert, ew2.data(), w2_bytes_per_expert);
+        }
+
+        std::uniform_real_distribution<float> wdist(0.05f, 0.45f);
+        std::vector<std::vector<int>> token_routes(tokens);
+        std::vector<std::vector<float>> token_weights(tokens);
+        std::vector<std::vector<int64_t>> expert_tokens(n_local_experts);
+        std::vector<std::vector<float>> expert_weights(n_local_experts);
+        for (int t = 0; t < tokens; ++t) {
+            std::vector<int> experts;
+            for (int e = 0; e < n_local_experts; ++e) experts.push_back(e);
+            std::shuffle(experts.begin(), experts.end(), rng);
+            for (int k = 0; k < topk; ++k) {
+                const int e = experts[k];
+                const float weight = wdist(rng);
+                token_routes[t].push_back(e);
+                token_weights[t].push_back(weight);
+                expert_tokens[e].push_back(t);
+                expert_weights[e].push_back(weight);
+            }
+        }
+
+        std::vector<int32_t> seg_starts(n_local_experts + 1, 0);
+        for (int e = 0; e < n_local_experts; ++e) {
+            seg_starts[e + 1] = seg_starts[e] + static_cast<int32_t>(expert_tokens[e].size());
+        }
+        const int routes = seg_starts[n_local_experts];
+        int max_count = 0;
+        std::vector<int64_t> route_tokens(routes);
+        std::vector<float> route_weights(routes);
+        for (int e = 0; e < n_local_experts; ++e) {
+            max_count = std::max(max_count, static_cast<int>(expert_tokens[e].size()));
+            const int start = seg_starts[e];
+            for (size_t i = 0; i < expert_tokens[e].size(); ++i) {
+                route_tokens[start + static_cast<int>(i)] = expert_tokens[e][i];
+                route_weights[start + static_cast<int>(i)] = expert_weights[e][i];
+            }
+        }
+
+        std::vector<int32_t> tile_experts;
+        std::vector<int32_t> tile_rows;
+        for (int e = 0; e < n_local_experts; ++e) {
+            const int count = static_cast<int>(expert_tokens[e].size());
+            for (int row = 0; row < count; row += 16) {
+                tile_experts.push_back(e);
+                tile_rows.push_back(row);
+            }
+        }
+
+        float *d_x = nullptr, *d_y = nullptr, *d_hidden = nullptr, *d_hidden_scale = nullptr, *d_x_scale = nullptr;
+        int8_t *d_hidden_q = nullptr, *d_x_q = nullptr;
+        int32_t *d_tile_experts = nullptr, *d_tile_rows = nullptr;
+        int64_t* d_route_tokens = nullptr;
+        float* d_route_weights = nullptr;
+        int32_t* d_seg_starts = nullptr;
+        uint8_t *d_w1 = nullptr, *d_w2 = nullptr, *d_w3 = nullptr;
+        check_cuda(cudaMalloc(&d_x, x.size() * sizeof(float)), "malloc x");
+        check_cuda(cudaMalloc(&d_y, x.size() * sizeof(float)), "malloc y");
+        check_cuda(cudaMalloc(&d_hidden, static_cast<size_t>(routes) * inter_dim * sizeof(float)), "malloc hidden");
+        if (env_int_or_default("DSV4_IQ1_GROUPED_W2_Q8", 1) != 0) {
+            check_cuda(cudaMalloc(&d_hidden_q, static_cast<size_t>(routes) * inter_dim), "malloc hidden q");
+            check_cuda(cudaMalloc(&d_hidden_scale, static_cast<size_t>(routes) * ((inter_dim + 15) / 16) * sizeof(float)), "malloc hidden scale");
+        }
+        if (env_int_or_default("DSV4_IQ1_GROUPED_GEMM", 1) != 0) {
+            check_cuda(cudaMalloc(&d_x_q, static_cast<size_t>(routes) * dim), "malloc x q");
+            check_cuda(cudaMalloc(&d_x_scale, static_cast<size_t>(routes) * ((dim + 15) / 16) * sizeof(float)), "malloc x scale");
+            check_cuda(cudaMalloc(&d_tile_experts, static_cast<size_t>(tile_experts.size()) * sizeof(int32_t)), "malloc tile experts");
+            check_cuda(cudaMalloc(&d_tile_rows, static_cast<size_t>(tile_rows.size()) * sizeof(int32_t)), "malloc tile rows");
+        }
+        check_cuda(cudaMalloc(&d_route_tokens, route_tokens.size() * sizeof(int64_t)), "malloc route tokens");
+        check_cuda(cudaMalloc(&d_route_weights, route_weights.size() * sizeof(float)), "malloc route weights");
+        check_cuda(cudaMalloc(&d_seg_starts, seg_starts.size() * sizeof(int32_t)), "malloc seg starts");
+        check_cuda(cudaMalloc(&d_w1, w1.size()), "malloc w1");
+        check_cuda(cudaMalloc(&d_w2, w2.size()), "malloc w2");
+        check_cuda(cudaMalloc(&d_w3, w3.size()), "malloc w3");
+        check_cuda(cudaMemcpy(d_x, x.data(), x.size() * sizeof(float), cudaMemcpyHostToDevice), "copy x");
+        check_cuda(cudaMemcpy(d_route_tokens, route_tokens.data(), route_tokens.size() * sizeof(int64_t), cudaMemcpyHostToDevice), "copy route tokens");
+        check_cuda(cudaMemcpy(d_route_weights, route_weights.data(), route_weights.size() * sizeof(float), cudaMemcpyHostToDevice), "copy route weights");
+        check_cuda(cudaMemcpy(d_seg_starts, seg_starts.data(), seg_starts.size() * sizeof(int32_t), cudaMemcpyHostToDevice), "copy seg starts");
+        if (d_tile_experts != nullptr && !tile_experts.empty()) {
+            check_cuda(cudaMemcpy(d_tile_experts, tile_experts.data(), tile_experts.size() * sizeof(int32_t), cudaMemcpyHostToDevice), "copy tile experts");
+            check_cuda(cudaMemcpy(d_tile_rows, tile_rows.data(), tile_rows.size() * sizeof(int32_t), cudaMemcpyHostToDevice), "copy tile rows");
+        }
+        check_cuda(cudaMemcpy(d_w1, w1.data(), w1.size(), cudaMemcpyHostToDevice), "copy w1");
+        check_cuda(cudaMemcpy(d_w2, w2.data(), w2.size(), cudaMemcpyHostToDevice), "copy w2");
+        check_cuda(cudaMemcpy(d_w3, w3.data(), w3.size(), cudaMemcpyHostToDevice), "copy w3");
+
+        dsv4::MoePrefillIq1GroupedWorkspace ws;
+        ws.d_hidden = d_hidden;
+        ws.d_hidden_q = d_hidden_q;
+        ws.d_hidden_scale = d_hidden_scale;
+        ws.d_x_q = d_x_q;
+        ws.d_x_scale = d_x_scale;
+        ws.d_tile_experts = d_tile_experts;
+        ws.d_tile_rows = d_tile_rows;
+        ws.routes_cap = routes;
+        ws.tile_cap = static_cast<int>(tile_experts.size());
+        ws.tile_count = static_cast<int>(tile_experts.size());
+        ws.dim = dim;
+        ws.inter_dim = inter_dim;
+        if (!dsv4::moe_prefill_iq1_grouped_cuda_with_workspace(
+                d_x, d_route_tokens, d_route_weights, d_seg_starts,
+                d_w1, d_w2, d_w3, d_y,
+                tokens, routes, n_local_experts, max_count,
+                dim, inter_dim, swiglu_limit, ws)) {
+            throw std::runtime_error("grouped iq1 launch failed");
+        }
+        check_cuda(cudaDeviceSynchronize(), "sync grouped");
+        std::vector<float> grouped(x.size());
+        check_cuda(cudaMemcpy(grouped.data(), d_y, grouped.size() * sizeof(float), cudaMemcpyDeviceToHost), "copy grouped");
+
+        std::vector<float> ref(x.size(), 0.0f);
+        float *d_x_token = nullptr, *d_y_token = nullptr, *d_hidden_token = nullptr;
+        int64_t* d_slots = nullptr;
+        float* d_weights = nullptr;
+        check_cuda(cudaMalloc(&d_x_token, dim * sizeof(float)), "malloc x token");
+        check_cuda(cudaMalloc(&d_y_token, dim * sizeof(float)), "malloc y token");
+        check_cuda(cudaMalloc(&d_hidden_token, topk * inter_dim * sizeof(float)), "malloc hidden token");
+        check_cuda(cudaMalloc(&d_slots, topk * sizeof(int64_t)), "malloc slots");
+        check_cuda(cudaMalloc(&d_weights, topk * sizeof(float)), "malloc weights");
+        for (int t = 0; t < tokens; ++t) {
+            std::vector<int64_t> slots(token_routes[t].begin(), token_routes[t].end());
+            check_cuda(cudaMemcpy(d_x_token, x.data() + static_cast<size_t>(t) * dim, dim * sizeof(float), cudaMemcpyHostToDevice), "copy x token");
+            check_cuda(cudaMemcpy(d_slots, slots.data(), slots.size() * sizeof(int64_t), cudaMemcpyHostToDevice), "copy slots");
+            check_cuda(cudaMemcpy(d_weights, token_weights[t].data(), token_weights[t].size() * sizeof(float), cudaMemcpyHostToDevice), "copy weights");
+            check_cuda(cudaMemset(d_y_token, 0, dim * sizeof(float)), "zero y token");
+            if (!dsv4::iq1_moe_single_w13_swiglu_cuda(
+                    d_x_token, d_slots, d_weights, d_w1, d_w3, d_hidden_token,
+                    topk, n_local_experts, dim, inter_dim, swiglu_limit)) {
+                throw std::runtime_error("single w13 launch failed");
+            }
+            if (!dsv4::iq1_moe_single_w2_cuda(
+                    d_hidden_token, d_slots, d_w2, d_y_token,
+                    topk, n_local_experts, dim, inter_dim)) {
+                throw std::runtime_error("single w2 launch failed");
+            }
+            check_cuda(cudaDeviceSynchronize(), "sync single");
+            check_cuda(cudaMemcpy(ref.data() + static_cast<size_t>(t) * dim, d_y_token, dim * sizeof(float), cudaMemcpyDeviceToHost), "copy y token");
+        }
+
+        const bool q8_w2 = env_int_or_default("DSV4_IQ1_GROUPED_W2_Q8", 1) != 0;
+        const bool gemm = env_int_or_default("DSV4_IQ1_GROUPED_GEMM", 1) != 0;
+        compare(grouped, ref, gemm ? 8e-2f : (q8_w2 ? 5e-3f : 2e-4f), "iq1_grouped_vs_single");
+
+        cudaFree(d_x); cudaFree(d_y); cudaFree(d_hidden); cudaFree(d_hidden_q); cudaFree(d_hidden_scale); cudaFree(d_x_q); cudaFree(d_x_scale); cudaFree(d_tile_experts); cudaFree(d_tile_rows); cudaFree(d_route_tokens); cudaFree(d_route_weights); cudaFree(d_seg_starts);
+        cudaFree(d_w1); cudaFree(d_w2); cudaFree(d_w3);
+        cudaFree(d_x_token); cudaFree(d_y_token); cudaFree(d_hidden_token); cudaFree(d_slots); cudaFree(d_weights);
+
+        std::cout << "[PASS] moe_grouped_iq1 tokens=" << tokens
+                  << " routes=" << routes
+                  << " max_count=" << max_count
+                  << " n_local_experts=" << n_local_experts << "\n";
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "[FAIL] " << e.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_moe_grouped_q2.cpp
+++ b/cpp_engine/tests/test_moe_grouped_q2.cpp
@@ -1,0 +1,295 @@
+#include "cuda_ops.hpp"
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void check_cuda(cudaError_t err, const char* what) {
+    if (err != cudaSuccess) {
+        throw std::runtime_error(std::string(what) + ": " + cudaGetErrorString(err));
+    }
+}
+
+uint16_t float_to_half_bits(float x) {
+    __half h = __float2half(x);
+    return *reinterpret_cast<uint16_t*>(&h);
+}
+
+std::vector<uint8_t> random_iq2_xxs_weight(int rows, int cols, std::mt19937& rng) {
+    const int blocks_per_row = (cols + 255) / 256;
+    std::vector<uint8_t> w(static_cast<size_t>(rows) * blocks_per_row * 66);
+    std::uniform_int_distribution<int> grid_dist(0, 255);
+    std::uniform_int_distribution<int> sign_dist(0, 127);
+    std::uniform_int_distribution<int> high_dist(0, 1);
+    std::uniform_real_distribution<float> d_dist(0.005f, 0.025f);
+    for (int r = 0; r < rows; ++r) {
+        for (int b = 0; b < blocks_per_row; ++b) {
+            uint8_t* block = w.data() + (static_cast<size_t>(r) * blocks_per_row + b) * 66;
+            const uint16_t d_bits = float_to_half_bits(d_dist(rng));
+            block[0] = static_cast<uint8_t>(d_bits & 0xffu);
+            block[1] = static_cast<uint8_t>(d_bits >> 8);
+            for (int sub = 0; sub < 8; ++sub) {
+                uint8_t* chunk = block + 2 + sub * 8;
+                for (int part = 0; part < 4; ++part) {
+                    chunk[part] = static_cast<uint8_t>(grid_dist(rng));
+                }
+                uint32_t aux = static_cast<uint32_t>(high_dist(rng)) << 28;
+                for (int part = 0; part < 4; ++part) {
+                    aux |= static_cast<uint32_t>(sign_dist(rng)) << (7 * part);
+                }
+                chunk[4] = static_cast<uint8_t>(aux & 0xffu);
+                chunk[5] = static_cast<uint8_t>((aux >> 8) & 0xffu);
+                chunk[6] = static_cast<uint8_t>((aux >> 16) & 0xffu);
+                chunk[7] = static_cast<uint8_t>((aux >> 24) & 0xffu);
+            }
+        }
+    }
+    return w;
+}
+
+std::vector<uint8_t> random_q2_k_weight(int rows, int cols, std::mt19937& rng) {
+    const int blocks_per_row = (cols + 255) / 256;
+    std::vector<uint8_t> w(static_cast<size_t>(rows) * blocks_per_row * 84);
+    std::uniform_int_distribution<int> q_dist(0, 255);
+    std::uniform_int_distribution<int> qscale_dist(1, 7);
+    std::uniform_int_distribution<int> minscale_dist(0, 2);
+    std::uniform_real_distribution<float> d_dist(0.001f, 0.01f);
+    std::uniform_real_distribution<float> dmin_dist(0.0f, 0.002f);
+    for (int r = 0; r < rows; ++r) {
+        for (int b = 0; b < blocks_per_row; ++b) {
+            uint8_t* block = w.data() + (static_cast<size_t>(r) * blocks_per_row + b) * 84;
+            for (int i = 0; i < 16; ++i) {
+                block[i] = static_cast<uint8_t>(qscale_dist(rng) | (minscale_dist(rng) << 4));
+            }
+            for (int i = 0; i < 64; ++i) block[16 + i] = static_cast<uint8_t>(q_dist(rng));
+            const uint16_t d_bits = float_to_half_bits(d_dist(rng));
+            const uint16_t dmin_bits = float_to_half_bits(dmin_dist(rng));
+            block[80] = static_cast<uint8_t>(d_bits & 0xffu);
+            block[81] = static_cast<uint8_t>(d_bits >> 8);
+            block[82] = static_cast<uint8_t>(dmin_bits & 0xffu);
+            block[83] = static_cast<uint8_t>(dmin_bits >> 8);
+        }
+    }
+    return w;
+}
+
+void compare(const std::vector<float>& a, const std::vector<float>& b, float tol, const std::string& tag) {
+    if (a.size() != b.size()) throw std::runtime_error(tag + ": size mismatch");
+    float max_abs = 0.0f;
+    float mean_abs = 0.0f;
+    int dump = 0;
+    for (size_t i = 0; i < a.size(); ++i) {
+        const float diff = std::fabs(a[i] - b[i]);
+        max_abs = std::max(max_abs, diff);
+        mean_abs += diff;
+        if (diff > tol && dump < 8) {
+            std::cerr << tag << " idx=" << i << " grouped=" << a[i]
+                      << " ref=" << b[i] << " diff=" << diff << "\n";
+            ++dump;
+        }
+    }
+    mean_abs /= static_cast<float>(a.size());
+    std::cout << tag << " max_abs=" << max_abs << " mean_abs=" << mean_abs
+              << " size=" << a.size() << "\n";
+    if (max_abs > tol) throw std::runtime_error(tag + ": max_abs above tolerance");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        const int tokens = 5;
+        const int n_local_experts = 4;
+        const int topk = 2;
+        const int dim = 256;
+        const int inter_dim = 256;
+        const float swiglu_limit = 7.0f;
+        std::mt19937 rng(0x2202);
+
+        std::uniform_real_distribution<float> xdist(-0.25f, 0.25f);
+        std::vector<float> x(static_cast<size_t>(tokens) * dim);
+        for (auto& v : x) v = xdist(rng);
+
+        const size_t w13_bytes_per_expert = static_cast<size_t>(inter_dim) * ((dim + 255) / 256) * 66;
+        const size_t w2_bytes_per_expert = static_cast<size_t>(dim) * ((inter_dim + 255) / 256) * 84;
+        std::vector<uint8_t> w1(static_cast<size_t>(n_local_experts) * w13_bytes_per_expert);
+        std::vector<uint8_t> w3(static_cast<size_t>(n_local_experts) * w13_bytes_per_expert);
+        std::vector<uint8_t> w2(static_cast<size_t>(n_local_experts) * w2_bytes_per_expert);
+        for (int e = 0; e < n_local_experts; ++e) {
+            auto ew1 = random_iq2_xxs_weight(inter_dim, dim, rng);
+            auto ew3 = random_iq2_xxs_weight(inter_dim, dim, rng);
+            auto ew2 = random_q2_k_weight(dim, inter_dim, rng);
+            std::memcpy(w1.data() + static_cast<size_t>(e) * w13_bytes_per_expert, ew1.data(), w13_bytes_per_expert);
+            std::memcpy(w3.data() + static_cast<size_t>(e) * w13_bytes_per_expert, ew3.data(), w13_bytes_per_expert);
+            std::memcpy(w2.data() + static_cast<size_t>(e) * w2_bytes_per_expert, ew2.data(), w2_bytes_per_expert);
+        }
+
+        std::uniform_real_distribution<float> wdist(0.05f, 0.45f);
+        std::vector<std::vector<int>> token_routes(tokens);
+        std::vector<std::vector<float>> token_weights(tokens);
+        std::vector<std::vector<int64_t>> expert_tokens(n_local_experts);
+        std::vector<std::vector<float>> expert_weights(n_local_experts);
+        for (int t = 0; t < tokens; ++t) {
+            std::vector<int> experts;
+            for (int e = 0; e < n_local_experts; ++e) experts.push_back(e);
+            std::shuffle(experts.begin(), experts.end(), rng);
+            for (int k = 0; k < topk; ++k) {
+                const int e = experts[k];
+                const float weight = wdist(rng);
+                token_routes[t].push_back(e);
+                token_weights[t].push_back(weight);
+                expert_tokens[e].push_back(t);
+                expert_weights[e].push_back(weight);
+            }
+        }
+
+        std::vector<int32_t> seg_starts(n_local_experts + 1, 0);
+        for (int e = 0; e < n_local_experts; ++e) {
+            seg_starts[e + 1] = seg_starts[e] + static_cast<int32_t>(expert_tokens[e].size());
+        }
+        const int routes = seg_starts[n_local_experts];
+        int max_count = 0;
+        std::vector<int64_t> route_tokens(routes);
+        std::vector<float> route_weights(routes);
+        for (int e = 0; e < n_local_experts; ++e) {
+            max_count = std::max(max_count, static_cast<int>(expert_tokens[e].size()));
+            const int start = seg_starts[e];
+            for (size_t i = 0; i < expert_tokens[e].size(); ++i) {
+                route_tokens[start + static_cast<int>(i)] = expert_tokens[e][i];
+                route_weights[start + static_cast<int>(i)] = expert_weights[e][i];
+            }
+        }
+
+        float *d_x = nullptr, *d_y = nullptr, *d_x_route = nullptr, *d_x_scale = nullptr;
+        float *d_gate = nullptr, *d_up = nullptr, *d_hidden_scale = nullptr;
+        int8_t *d_x_q = nullptr, *d_hidden_q = nullptr;
+        int64_t *d_route_tokens = nullptr, *d_route_slots = nullptr;
+        float* d_route_weights = nullptr;
+        int32_t* d_seg_starts = nullptr;
+        uint8_t *d_w1 = nullptr, *d_w2 = nullptr, *d_w3 = nullptr;
+        const int x_groups = (dim + 31) / 32;
+        const int hidden_groups = (inter_dim + 15) / 16;
+
+        check_cuda(cudaMalloc(&d_x, x.size() * sizeof(float)), "malloc x");
+        check_cuda(cudaMalloc(&d_y, x.size() * sizeof(float)), "malloc y");
+        check_cuda(cudaMalloc(&d_x_route, static_cast<size_t>(routes) * dim * sizeof(float)), "malloc x route");
+        check_cuda(cudaMalloc(&d_x_q, static_cast<size_t>(routes) * dim * sizeof(int8_t)), "malloc x q");
+        check_cuda(cudaMalloc(&d_x_scale, static_cast<size_t>(routes) * x_groups * sizeof(float)), "malloc x scale");
+        check_cuda(cudaMalloc(&d_route_slots, static_cast<size_t>(routes) * sizeof(int64_t)), "malloc route slots");
+        check_cuda(cudaMalloc(&d_gate, static_cast<size_t>(routes) * inter_dim * sizeof(float)), "malloc gate");
+        check_cuda(cudaMalloc(&d_up, static_cast<size_t>(routes) * inter_dim * sizeof(float)), "malloc up");
+        check_cuda(cudaMalloc(&d_hidden_q, static_cast<size_t>(routes) * inter_dim * sizeof(int8_t)), "malloc hidden q");
+        check_cuda(cudaMalloc(&d_hidden_scale, static_cast<size_t>(routes) * hidden_groups * sizeof(float)), "malloc hidden scale");
+        check_cuda(cudaMalloc(&d_route_tokens, route_tokens.size() * sizeof(int64_t)), "malloc route tokens");
+        check_cuda(cudaMalloc(&d_route_weights, route_weights.size() * sizeof(float)), "malloc route weights");
+        check_cuda(cudaMalloc(&d_seg_starts, seg_starts.size() * sizeof(int32_t)), "malloc seg starts");
+        check_cuda(cudaMalloc(&d_w1, w1.size()), "malloc w1");
+        check_cuda(cudaMalloc(&d_w2, w2.size()), "malloc w2");
+        check_cuda(cudaMalloc(&d_w3, w3.size()), "malloc w3");
+        check_cuda(cudaMemcpy(d_x, x.data(), x.size() * sizeof(float), cudaMemcpyHostToDevice), "copy x");
+        check_cuda(cudaMemcpy(d_route_tokens, route_tokens.data(), route_tokens.size() * sizeof(int64_t), cudaMemcpyHostToDevice), "copy route tokens");
+        check_cuda(cudaMemcpy(d_route_weights, route_weights.data(), route_weights.size() * sizeof(float), cudaMemcpyHostToDevice), "copy route weights");
+        check_cuda(cudaMemcpy(d_seg_starts, seg_starts.data(), seg_starts.size() * sizeof(int32_t), cudaMemcpyHostToDevice), "copy seg starts");
+        check_cuda(cudaMemcpy(d_w1, w1.data(), w1.size(), cudaMemcpyHostToDevice), "copy w1");
+        check_cuda(cudaMemcpy(d_w2, w2.data(), w2.size(), cudaMemcpyHostToDevice), "copy w2");
+        check_cuda(cudaMemcpy(d_w3, w3.data(), w3.size(), cudaMemcpyHostToDevice), "copy w3");
+
+        dsv4::MoePrefillQ2GroupedWorkspace ws;
+        ws.d_x_route = d_x_route;
+        ws.d_x_q = d_x_q;
+        ws.d_x_scale = d_x_scale;
+        ws.d_route_slots = d_route_slots;
+        ws.d_gate = d_gate;
+        ws.d_up = d_up;
+        ws.d_hidden_q = d_hidden_q;
+        ws.d_hidden_scale = d_hidden_scale;
+        ws.routes_cap = routes;
+        ws.dim = dim;
+        ws.inter_dim = inter_dim;
+        if (!dsv4::moe_prefill_q2_grouped_cuda_with_workspace(
+                d_x, d_route_tokens, d_route_weights, d_seg_starts,
+                d_w1, d_w2, d_w3, d_y,
+                tokens, routes, n_local_experts, max_count,
+                dim, inter_dim, swiglu_limit, ws)) {
+            throw std::runtime_error("grouped q2 launch failed");
+        }
+        check_cuda(cudaDeviceSynchronize(), "sync grouped");
+        std::vector<float> grouped(x.size());
+        check_cuda(cudaMemcpy(grouped.data(), d_y, grouped.size() * sizeof(float), cudaMemcpyDeviceToHost), "copy grouped");
+
+        std::vector<float> ref(x.size(), 0.0f);
+        float *d_x_token = nullptr, *d_y_token = nullptr, *d_x_scale_token = nullptr;
+        float *d_gate_token = nullptr, *d_up_token = nullptr, *d_hidden_scale_token = nullptr;
+        int8_t *d_x_q_token = nullptr, *d_hidden_q_token = nullptr;
+        int64_t* d_slots = nullptr;
+        float* d_weights = nullptr;
+        check_cuda(cudaMalloc(&d_x_token, dim * sizeof(float)), "malloc x token");
+        check_cuda(cudaMalloc(&d_y_token, dim * sizeof(float)), "malloc y token");
+        check_cuda(cudaMalloc(&d_x_q_token, dim * sizeof(int8_t)), "malloc x q token");
+        check_cuda(cudaMalloc(&d_x_scale_token, x_groups * sizeof(float)), "malloc x scale token");
+        check_cuda(cudaMalloc(&d_gate_token, topk * inter_dim * sizeof(float)), "malloc gate token");
+        check_cuda(cudaMalloc(&d_up_token, topk * inter_dim * sizeof(float)), "malloc up token");
+        check_cuda(cudaMalloc(&d_hidden_q_token, topk * inter_dim * sizeof(int8_t)), "malloc hidden q token");
+        check_cuda(cudaMalloc(&d_hidden_scale_token, topk * hidden_groups * sizeof(float)), "malloc hidden scale token");
+        check_cuda(cudaMalloc(&d_slots, topk * sizeof(int64_t)), "malloc slots");
+        check_cuda(cudaMalloc(&d_weights, topk * sizeof(float)), "malloc weights");
+        for (int t = 0; t < tokens; ++t) {
+            std::vector<int64_t> slots(token_routes[t].begin(), token_routes[t].end());
+            check_cuda(cudaMemcpy(d_x_token, x.data() + static_cast<size_t>(t) * dim, dim * sizeof(float), cudaMemcpyHostToDevice), "copy x token");
+            check_cuda(cudaMemcpy(d_slots, slots.data(), slots.size() * sizeof(int64_t), cudaMemcpyHostToDevice), "copy slots");
+            check_cuda(cudaMemcpy(d_weights, token_weights[t].data(), token_weights[t].size() * sizeof(float), cudaMemcpyHostToDevice), "copy weights");
+            check_cuda(cudaMemset(d_y_token, 0, dim * sizeof(float)), "zero y token");
+            if (!dsv4::q2_quantize_x_q8_1_cuda(d_x_token, d_x_q_token, d_x_scale_token, 1, dim)) {
+                throw std::runtime_error("single x quant launch failed");
+            }
+            if (!dsv4::q2_moe_single_w13_iq2_xxs_cuda(
+                    d_x_q_token, d_x_scale_token, d_slots, d_w1, d_w3,
+                    d_gate_token, d_up_token,
+                    topk, n_local_experts, dim, inter_dim)) {
+                throw std::runtime_error("single w13 launch failed");
+            }
+            if (!dsv4::q2_route_swiglu_quantize_hidden_q8_1_cuda(
+                    d_gate_token, d_up_token, d_weights, d_hidden_q_token, d_hidden_scale_token,
+                    topk, inter_dim, swiglu_limit)) {
+                throw std::runtime_error("single swiglu quant launch failed");
+            }
+            if (!dsv4::q2_moe_single_w2_q2k_cuda(
+                    d_hidden_q_token, d_hidden_scale_token, d_slots, d_w2, d_y_token,
+                    topk, n_local_experts, dim, inter_dim)) {
+                throw std::runtime_error("single w2 launch failed");
+            }
+            check_cuda(cudaDeviceSynchronize(), "sync single");
+            check_cuda(cudaMemcpy(ref.data() + static_cast<size_t>(t) * dim, d_y_token, dim * sizeof(float), cudaMemcpyDeviceToHost), "copy y token");
+        }
+
+        compare(grouped, ref, 2e-4f, "q2_grouped_vs_single");
+
+        cudaFree(d_x); cudaFree(d_y); cudaFree(d_x_route); cudaFree(d_x_q); cudaFree(d_x_scale); cudaFree(d_route_slots);
+        cudaFree(d_gate); cudaFree(d_up); cudaFree(d_hidden_q); cudaFree(d_hidden_scale);
+        cudaFree(d_route_tokens); cudaFree(d_route_weights); cudaFree(d_seg_starts);
+        cudaFree(d_w1); cudaFree(d_w2); cudaFree(d_w3);
+        cudaFree(d_x_token); cudaFree(d_y_token); cudaFree(d_x_q_token); cudaFree(d_x_scale_token);
+        cudaFree(d_gate_token); cudaFree(d_up_token); cudaFree(d_hidden_q_token); cudaFree(d_hidden_scale_token);
+        cudaFree(d_slots); cudaFree(d_weights);
+
+        std::cout << "[PASS] moe_grouped_q2 tokens=" << tokens
+                  << " routes=" << routes
+                  << " max_count=" << max_count
+                  << " n_local_experts=" << n_local_experts << "\n";
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "[FAIL] " << e.what() << "\n";
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary
- add IQ1_M compact grouped-GEMM style prefill path for W13 and W2 with q8 activations
- preserve raw IQ1_M block consumption and delta compensation; keep route-major/scalar fallback gates
- wire GGUF chunked prefill workspace/tile metadata and add IQ1/Q2 grouped test targets

## Validation
- `conda run -n deepseek cmake --build /mnt/data1/dsv4_inference/build/cpp_engine --target test_moe_grouped_iq1 test_gguf_generate -j`
- `conda run -n deepseek env DSV4_IQ1_GROUPED_PROFILE=1 DSV4_IQ1_GROUPED_GEMM=1 /mnt/data1/dsv4_inference/build/cpp_engine/tests/test_moe_grouped_iq1`
- `conda run -n deepseek env DSV4_IQ1_GROUPED_GEMM=0 DSV4_IQ1_GROUPED_W2_Q8=1 /mnt/data1/dsv4_inference/build/cpp_engine/tests/test_moe_grouped_iq1`
- `conda run -n deepseek /mnt/data1/dsv4_inference/build/cpp_engine/tests/test_moe_grouped_q2`
- `conda run -n deepseek /mnt/data1/dsv4_inference/build/cpp_engine/tests/test_moe_grouped_fp4`
- real IQ1_M GGUF short prompt: 16 tokens, `DSV4_IQ1_GROUPED_GEMM=1`, `[PASS]`
- real IQ1_M GGUF long prompt: 512 tokens, `DSV4_IQ1_GROUPED_GEMM=1`, `[PASS]`, 31.45 tok/s vs prior ~13.73 tok/s baseline

## Notes
- `DSV4_IQ1_GROUPED_GEMM=0` keeps the existing fallback path available.
- `DSV4_IQ1_GROUPED_GEMM_NSPLIT=4` is the default; nsplit=2 tested slightly slower on 512-token prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
