### PR TITLE
Add PocketMoE model specs and MiniMax GGUF inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,266 +1,195 @@
-# DeepSeek-V4-Flash on 2080ti
+# PocketMoE（口袋 MoE）
 
 [English](README.md) | [中文](README_CN.md)
 
-## Description
+PocketMoE is a **MoE-only low-bit and heterogeneous inference engine for consumer GPUs**, targeting local deployment of MoE models up to roughly the 300B-parameter class on home/workstation hardware.
 
-I have a small 4-GPU RTX 2080 Ti server built around 2023, with a total hardware cost below CNY 20,000. I previously tried deployment approaches such as ktransformers and llama.cpp for large-model inference, but low-bit quantized versions often reduce model quality or runtime behavior. At the same time, Turing GPUs are no longer supported by many mainstream acceleration libraries such as FlashAttention and FlashInfer, nor by newer compiler stacks such as TileLang. Newer DeepSeek models also rely on data formats such as FP4 and FP8 that are only natively supported by newer GPUs, making it almost impossible to run DeepSeek directly on RTX 2080 Ti.
+The name means bringing hundred-billion-parameter MoE models that normally belong to data-center clusters into the user's “pocket” consumer GPUs through compression, quantized expert kernels, and CPU/GPU heterogeneous scheduling.
 
-This project starts from that constraint. It tries to make old RTX 2080 Ti cards run DeepSeek-V4 by combining heterogeneous CPU+GPU execution with custom DeepSeek-V4 components, including FP4/FP8 unpacking, sparse attention, indexer kernels, and other runtime paths.
+The project started as a DeepSeek-V4-on-4×RTX-2080-Ti engineering effort. DeepSeek-V4 remains the first validated backend and performance baseline, but the repository is now being organized as a broader MoE engine.
 
-## Motivation
+## Positioning
 
-DeepSeek-V4 is one of the strongest Chinese-developed models currently available. DeepSeek-V4-Flash keeps strong model quality while using fewer total parameters: 284B total parameters with only 13B active parameters. An RTX 2080 Ti still has meaningful raw compute: roughly 13.4 TFLOPS FP32 and 107.6 TFLOPS FP16 Tensor Core throughput per card, or about 53.8 TFLOPS FP32 and 430 TFLOPS FP16 Tensor Core throughput across 4 cards. Therefore, trying to run DeepSeek-V4-Flash on this hardware is still a realistic engineering target.
+PocketMoE focuses on MoE models and consumer/workstation GPUs such as:
 
-For DeepSeek-style MoE models, most weights are routed expert weights. If the memory-capacity problem can be handled, inference deployment becomes possible. This project uses GPU+CPU heterogeneous execution to support DeepSeek-V4-Flash inference, while also optimizing prefill and decode performance.
+- RTX 2080 Ti, including 22 GiB modded cards;
+- RTX 3090;
+- RTX 4090;
+- similar PCIe consumer GPU boxes without data-center memory capacity or NVLink.
 
-## Hardware and limitations
+The core question is simple:
 
-The measurements in this repository were taken on:
+> How can we run large MoE models on cards that were never meant to host them?
 
-- GPU: 4 x NVIDIA GeForce RTX 2080 Ti, 22 GiB each, Turing architecture.
+PocketMoE answers that with two execution modes.
+
+### 1. Low-bit all-device mode
+
+If a low-bit MoE checkpoint fits in aggregate GPU memory, keep the model on device as much as possible:
+
+- dense / attention weights on GPU;
+- router / gate weights on GPU;
+- routed experts on GPU;
+- decode without active-expert H2D copies;
+- prefill through grouped resident MoE kernels;
+- raw quantized blocks consumed directly by kernels instead of fp32 expansion.
+
+This is the preferred direction for GGUF IQ1/IQ2/Q2/Q3-style MoE checkpoints that can fit across multiple consumer GPUs.
+
+### 2. Heterogeneous routed-expert mode
+
+If the checkpoint does not fit on device, keep routed experts in CPU pinned/NUMA memory and move only the active experts needed for the current token or prefill chunk:
+
+- dense/router computation stays on GPU where possible;
+- routed experts live on CPU memory;
+- decode stages top-k active experts to GPU;
+- prefill overlaps expert H2D with GPU compute;
+- hot expert cache and layer-local prefetch can reduce repeated PCIe traffic.
+
+This mode is for higher-bit MoE checkpoints or low-bit checkpoints that exceed the practical GPU memory budget after KV cache and workspace are reserved.
+
+## Non-goals
+
+PocketMoE is intentionally **not** a general dense-model serving framework.
+
+Dense layers, attention, tokenization, and OpenAI-compatible serving are supported because MoE models need them, but the project does not try to compete with vLLM, SGLang, or llama.cpp as a general dense LLM runtime. The core focus is:
+
+- routed expert quantization;
+- routed expert placement;
+- active expert dispatch;
+- prefill/decode MoE kernels;
+- CPU/GPU heterogeneous scheduling on PCIe consumer hardware.
+
+## Current backend: DeepSeek-V4 / DSV4
+
+The first validated backend is DeepSeek-V4-Flash on a 4×RTX 2080 Ti machine. This backend includes custom handling for:
+
+- DeepSeek-V4 MLA, sparse attention, and C4 indexer paths;
+- DeepSeek-style hash routing and routed experts;
+- FP4 / FP8-style checkpoint formats on Turing GPUs without native FP4/FP8 tensor cores;
+- GGUF Q2/IQ2/IQ1 routed expert block paths;
+- CPU/GPU active expert staging;
+- PyTorch runtime and native C++/CUDA engine paths.
+
+Existing scripts and benchmark numbers in this repository are currently DeepSeek-V4 backend results unless explicitly stated otherwise.
+
+## Next backend: MiniMax-M2.7
+
+The next target is MiniMax-M2.7 GGUF. The downloaded `UD-IQ1_M` bundle is a 3-shard GGUF checkpoint with:
+
+- `general.architecture = minimax-m2`;
+- 62 layers;
+- hidden size 3072;
+- context length 196608;
+- 48 attention heads and 8 KV heads;
+- 256 routed experts, top-k 8;
+- routed experts stored as `iq2_xxs`;
+- attention projections stored as `q5_k`;
+- embedding/head stored as `q4_k`;
+- router/norm/bias tensors stored as `f32`.
+
+MiniMax-M2.7 support starts with:
+
+- sharded GGUF inspection;
+- architecture/spec parsing;
+- tensor schema validation;
+- quant capability reporting;
+- all-device versus heterogeneous placement planning.
+
+Full MiniMax generation is deferred until MiniMax GQA runtime, q4_k/q5_k kernels, and an all-`iq2_xxs` MoE path are implemented.
+
+## Hardware baseline
+
+The original benchmark machine is:
+
+- GPU: 4× NVIDIA GeForce RTX 2080 Ti, 22 GiB each, Turing architecture.
 - CPU: dual-socket Intel Xeon E5-2696 v4 @ 2.20 GHz.
 - CPU topology: 88 logical CPUs, 2 sockets, 22 cores/socket, 2 threads/core.
 - System memory: 1 TiB.
 - Runtime mode: `torchrun --nproc-per-node 4`, one rank per GPU.
 
-Instruction set and datatype limitations:
+Important constraints:
 
-- CPU supports AVX2/FMA/F16C, but not AVX-512, AMX, or BF16/FP16 matrix instructions.
-- RTX 2080 Ti supports CUDA Tensor Cores for FP16, but does not have native BF16, FP8, or FP4 tensor cores.
-- DeepSeek-V4 uses FP4/FP8-style formats and sparse/indexed attention paths that are designed for newer GPUs, so this project implements custom unpacking and kernels instead of relying on modern library support.
+- RTX 2080 Ti has no native BF16, FP8, or FP4 tensor cores.
+- The machine has no NVLink; GPU-GPU communication goes through PCIe/host bridges.
+- PCIe Gen3 x16 bandwidth makes routed-expert staging and overlap critical.
+- Single-request latency and decode TPS are the primary optimization targets.
 
-Memory and interconnect constraints:
+## DeepSeek-V4 backend performance snapshot
 
-- Total GPU memory is about 88 GiB across 4 cards, but each rank only has about 22 GiB locally.
-- The machine has no NVLink between GPUs. `nvidia-smi topo -m` reports PHB links within the same CPU socket pair and SYS links across sockets.
-- Each GPU is connected as PCIe Gen3 x16 at maximum link width. The theoretical one-direction PCIe payload bandwidth is about 15.75 GB/s per GPU.
-- GPU-GPU communication therefore goes through PCIe/host bridges, and cross-socket GPU-GPU traffic also crosses the CPU interconnect.
-- GPU-CPU expert staging is limited by PCIe bandwidth and NUMA placement, which is why active-expert H2D staging and CPU/GPU overlap are central to the runtime.
+### PyTorch FP4 heterogeneous path
 
-## Current performance
-
-Best currently validated FP4 resident path:
-
-- Routed MoE expert weights live on CPU.
-- Decode uses active routed-expert H2D staging and GPU MoE compute.
-- Decode keeps cross-layer MoE prefetch disabled by default because the latest long-prompt A/B is faster without it.
-- Shared experts use paired INT8 GPU kernels and the PD shared-expert FP16 path.
-- Sparse attention, C4 indexer, custom MoE finalize, async all-reduce, and HC pre/post CUDA kernels are enabled in the optimized FP4 resident path.
-- Logical PD scheduler is enabled.
-- OpenAI service uses the same default optimized environment as the best scheduler script.
-
-Representative FP4 benchmark results on this machine:
+Representative FP4 results on the 4×RTX 2080 Ti machine:
 
 | Scenario | Prompt / prefill tokens | Decode tokens | Prefill | Decode TPS | Notes |
 | --- | ---: | ---: | ---: | ---: | --- |
 | Maximum validated context | 65,536 | 2 | 257.45s (~255 tok/s) | n/a | OpenAI path, content check returned `OK`. |
-| Long prompt decode | 2,148 | 63 | 6.69s (~321 tok/s after warmup) | 3.49 tok/s mean | FP4 resident OpenAI path, `scripts/run_fp4_resident_best.sh`, 3 fresh runs: 3.464/3.500/3.507 tok/s. |
-| Short prompt decode | 29 | 127 | ~1.7-3.2s observed | 3.16 tok/s mean | Earlier OpenAI short-prompt reference; short prefill timing is noisier than the long-prompt case. |
+| Long prompt decode | 2,148 | 63 | 6.69s (~321 tok/s after warmup) | 3.49 tok/s mean | FP4 resident OpenAI path, 3 fresh runs: 3.464/3.500/3.507 tok/s. |
+| Short prompt decode | 29 | 127 | ~1.7-3.2s observed | 3.16 tok/s mean | Short prefill timing is noisy on this machine. |
 
-The runtime has validated 65,536-token prompts on this 4 x RTX 2080 Ti machine. The server script keeps `MAX_MODEL_LEN=4096` by default for normal serving; set `MAX_MODEL_LEN=65536` explicitly when testing the maximum context path. Short prefill numbers are noisy on this machine, so compare decode TPS and long-prompt cases when evaluating optimization changes.
+### GGUF Q2/IQ2 heterogeneous path
 
-### GGUF Q2 TP resident path
+The GGUF IQ2_XXS/Q2_K path uses 4-GPU TP, grouped GPU prefill, active-expert decode, slot caching, async all-reduce/fused finalize, and quantized-block expert staging. Routed GGUF expert weights remain CPU-resident and are staged to GPU as quantized blocks rather than expanded fp32 weights.
 
-The GGUF IQ2_XXS/Q2_K path is also supported through `scripts/run_gguf_q2_tp_resident.sh`. On 4 GPUs the script defaults to `PARTITION_POLICY=baseline_4gpu`, grouped GPU prefill, IQ2_XXS W1/W3 DP4A expert-tile kernels, Q2_K W2 DP4A expert-tile kernels, active-expert decode, the decode slot cache, async all-reduce/fused finalize, and 4096-token prefill chunks. Routed GGUF expert weights remain CPU-resident and are staged to GPU as quantized blocks rather than expanded fp32 weights.
-
-Resident OpenAI-compatible benchmark, no explicit warmup, `CASE=all REPEAT=2`, 4 x RTX 2080 Ti:
+Representative OpenAI-compatible benchmark, `CASE=all REPEAT=2`, 4×RTX 2080 Ti:
 
 | Case | Request | Prompt tokens | Service decode tokens | Prefill | Decode TPS | Wall time | Notes |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
 | `short_short` | 1 | 5 | 7 | 3.17s (1.58 tok/s) | 2.94 | 5.64s | Cold decode cache. |
-| `short_short` | 2 | 5 | 7 | 2.46s (2.03 tok/s) | 4.83 | 3.98s | Warm slot/cache path; meets the 4.5 tok/s short-decode target. |
-| `short_long` | 1 | 5 | 9 | 2.46s (2.03 tok/s) | 4.49 | 4.53s | Near the decode target even cold. |
-| `short_long` | 2 | 5 | 9 | 2.46s (2.03 tok/s) | 4.89 | 4.37s | Warm slot/cache path. |
-| `long_short` | 1 | 2,148 | 7 | 14.17s (151.58 tok/s) | 3.26 | 16.47s | Cold long prefill / decode-cache path. |
-| `long_short` | 2 | 2,148 | 7 | 9.94s (216.17 tok/s) | 4.44 | 11.66s | Warm prefill staging; just below the 4.5 tok/s decode target. |
-| `long_long` | 1 | 2,148 | 63 | 10.01s (214.52 tok/s) | 3.71 | 27.29s | Longer decode remains below the short-decode target. |
-| `long_long` | 2 | 2,148 | 63 | 10.08s (213.05 tok/s) | 3.75 | 27.18s | Warm prefill does not fully fix long decode. |
+| `short_short` | 2 | 5 | 7 | 2.46s (2.03 tok/s) | 4.83 | 3.98s | Warm slot/cache path. |
+| `long_short` | 2 | 2,148 | 7 | 9.94s (216.17 tok/s) | 4.44 | 11.66s | Warm prefill staging. |
+| `long_long` | 2 | 2,148 | 63 | 10.08s (213.05 tok/s) | 3.75 | 27.18s | Longer decode remains harder. |
 
-Single-GPU 2080 Ti + host-memory mode is also available by setting `NPROC_PER_NODE=1`; it is intended for smoke/demo use with very short prompts, not practical long-prompt serving. See [GGUF_Q2_SINGLE_GPU.md](GGUF_Q2_SINGLE_GPU.md) for run commands, memory usage, context limits, and benchmark results.
+Current conclusion: prefill is close to the best result reached by the current architecture on this hardware. Decode remains limited by active-expert cache misses/H2D copies, TP all-reduce/finalize, and long-context attention cost.
 
-Real HTTP `stream=true` SSE test with different realistic prompts and no warmup:
+### C++ engine
 
-| Order | Prompt type | Prompt tokens | Service decode tokens | Client TTFC | Prefill | Decode TPS | Client wall time |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1 | Short Chinese chat | 33 | 95 | 7.52s | 7.45s (4.43 tok/s) | 3.93 | 31.94s |
-| 2 | README summary | 918 | 159 | 7.40s | 7.32s (125.41 tok/s) | 3.82 | 49.44s |
-| 3 | Long technical summary | 2,148 | 115 | 10.15s | 10.01s (214.64 tok/s) | 3.81 | 40.68s |
+The native C++/CUDA engine under `cpp_engine/` removes Python/PyTorch per-step overhead for the DeepSeek-V4 backend. Rank 0 embeds an OpenAI-compatible HTTP server and ranks 1-3 are NCCL workers.
 
-Current GGUF Q2 conclusion: the prefill path is close to the best result reached by the current architecture for this checkpoint and hardware. Repeated or later requests become much faster in prefill/TTFC because the staged GGUF expert path and OS/GPU caches are hot, but decode remains limited by active-expert cache misses/H2D copies plus TP all-reduce/finalize and long-context attention cost. Short warm-cache decode can reach about 4.8 tok/s, while realistic heterogeneous streaming and long-output decode are typically about 3.7-3.9 tok/s. Further large gains likely require decode-side work such as better active-expert cache scheduling or reducing communication/copy cost, not more prefill kernel tuning.
-
-## C++ engine (cpp_engine)
-
-In addition to the PyTorch runtime above, this repository ships a native C++/CUDA inference engine under `cpp_engine/`. It loads the same DeepSeek-V4-Flash FP4 checkpoint but drives the model from a standalone binary, removing Python/PyTorch per-step overhead. Rank 0 embeds an OpenAI-compatible HTTP server (cpp-httplib + SSE); ranks 1-3 are NCCL workers driven over a CPU command channel. Tokenization and chat templating run inside a long-lived Python sidecar that reuses `src/encoding/dsv4.py`, so prompt template, tool-call format, and reasoning-effort handling match the Python server.
-
-Validated FP4 performance on the same 4 x RTX 2080 Ti machine, TP=4, with all defaults:
+Validated FP4 results on the same 4×RTX 2080 Ti machine:
 
 | Scenario | Prompt tokens | Prefill | Prefill TPS | Decode TPS | Peak GPU/rank |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | Short prompt | 2,101 | ~7.6s | ~275 tok/s | ~3.7 tok/s | ~7 GiB |
 | 32K context | 32,768 | ~82s | ~402 tok/s | n/a | ~11.2 GiB |
-| 64K context (max validated) | 65,536 | ~164s | ~401 tok/s | ~3.7 tok/s | ~14.5 GiB |
+| 64K context | 65,536 | ~164s | ~401 tok/s | ~3.7 tok/s | ~14.5 GiB |
 
-64K is the maximum context validated end-to-end so far; the 14.5 GiB peak per rank still leaves room on 22 GiB cards. At 64K, prefill is roughly 1.6x faster than the PyTorch FP4 path (164s vs 257s). Decode TPS at FP4 is similar to PyTorch because the bottleneck is PCIe expert staging, not host overhead.
+At 64K, prefill is roughly 1.6× faster than the PyTorch FP4 path. Decode TPS is similar because the bottleneck is PCIe expert staging rather than Python overhead.
 
-Long-context prefill relies on two paths that are on by default:
+## Build
 
-- **Chunked prefill** (`DSV4_CPP_PREFILL_CHUNK_TOKENS`, default `4096`): wraps each layer's body in a chunk loop so scratch stays chunk-sized instead of `token_count`-sized. Without it, 64K prompts OOM at the ~22 GiB attention-scratch allocation.
-- **Batched sparse attention** (`DSV4_CPP_PREFILL_BATCHED_ATTN`, default `1`): replaces the per-token attention kernel with a single batched kernel; ~8.6x faster on 64K (1415s → 164s). Set `=0` to fall back to the per-token path (kept for debugging).
+Python extensions:
 
-### Build
+```bash
+python -m pip install -r requirements.txt
+python setup.py build_ext
+```
 
-CUDA Toolkit and NCCL are required (NCCL is auto-detected; pass `-DNCCL_ROOT=/path/to/nccl` if it lives outside the default search path):
+C++ engine:
 
 ```bash
 cmake -S cpp_engine -B build/cpp_engine -DCMAKE_BUILD_TYPE=Release
 cmake --build build/cpp_engine -j
 ```
 
-The resulting binary is `build/cpp_engine/dsv4_cpp_engine`.
-
-### Run the OpenAI-compatible server
-
-The launch script forks 4 ranks (one per GPU) and exposes the OpenAI API on `$PORT`:
-
-```bash
-CKPT=/path/to/DeepSeek-V4-Flash \
-PORT=8000 \
-MAX_CONTEXT=8192 \
-PYTHON=/path/to/python \
-bash scripts/run_cpp_serve_tp4.sh
-```
-
-`CKPT` should point at the original DeepSeek-V4-Flash FP4 safetensors directory (not the W8A8 conversion used by the PyTorch path). `PYTHON` just needs `transformers` installed; the sidecar imports `src/encoding/dsv4` directly from the repo.
-
-To serve 64K-token prompts, raise `MAX_CONTEXT` to at least `65536 + max_completion_tokens` (e.g. `73728`):
-
-```bash
-CKPT=/path/to/DeepSeek-V4-Flash \
-MAX_CONTEXT=73728 \
-bash scripts/run_cpp_serve_tp4.sh
-```
-
-Per-rank logs land at `/tmp/dsv4_cpp_serve_rank{0..3}.log` by default (`LOG_DIR=/some/dir` to override). The API surface is the same OpenAI chat-completions subset described in [Quickstart](#quickstart); point clients at `http://<host>:$PORT/v1/chat/completions`.
-
-Common overrides for `scripts/run_cpp_serve_tp4.sh`:
-
-| Variable | Default | Meaning |
-| --- | --- | --- |
-| `CKPT` | local path | DeepSeek-V4-Flash FP4 safetensors directory. |
-| `PORT` | `8000` | HTTP port on rank 0. |
-| `MAX_CONTEXT` | `8192` | Maximum prompt + completion length; sizes the KV cache. |
-| `PYTHON` | `python` | Python for the tokenizer sidecar. |
-| `SIDECAR` | `src/server/cpp_sidecar.py` | Tokenizer / template sidecar script. |
-| `BIN` | `build/cpp_engine/dsv4_cpp_engine` | C++ engine binary path. |
-| `NCCL_ID` | `/tmp/dsv4_cpp_serve_nccl.id` | NCCL rendezvous file. |
-| `LOG_DIR` | `/tmp` | Per-rank log directory. |
-| `EXTRA_ENV` | unset | Extra env injected per rank, e.g. `EXTRA_ENV='DSV4_CPP_PREFILL_CHUNK_TOKENS=8192'`. |
-
-## Quickstart
-
-```bash
-python -m pip install -r requirements.txt
-python setup.py build_ext
-PYTHONPATH=$PWD python -m src.cli.convert_checkpoint \
-  --hf-ckpt-path /path/to/original/DeepSeek-V4-Flash \
-  --save-path checkpoints/DeepSeek-V4-Flash-w8a8
-CKPT_PATH=$PWD/checkpoints/DeepSeek-V4-Flash-w8a8 bash scripts/run_openai_server.sh
-```
-
-The server exposes an OpenAI-compatible chat-completions subset:
-
-- `GET /health`
-- `GET /v1/models`
-- `POST /v1/chat/completions`
-- `stream=false` non-streaming responses
-- `stream=true` token-level SSE responses
-- `stream_options.include_usage=true` final usage/timing chunk
-- common OpenAI request parameters: `max_tokens`, `max_completion_tokens`, `temperature`, `top_p`, `top_k`, `min_p`, `frequency_penalty`, `presence_penalty`, `repetition_penalty`, `seed`, `stop`, `n`, `logprobs`, `top_logprobs`, `user`, and `parallel_tool_calls`
-- standard OpenAI `tools`, `tool_choice`, assistant `tool_calls`, and `role=tool` continuation messages
-- `response_format` and reasoning effort prompt hints
-
-Notes: streaming currently supports `n=1`; streaming `logprobs` are rejected; tool-call streaming emits the parsed `delta.tool_calls` once near the end instead of character-by-character argument deltas.
-
-Useful runtime environment variables:
-
-| Variable | Default | Meaning |
-| --- | --- | --- |
-| `CKPT_PATH` | `checkpoints/DeepSeek-V4-Flash-w8a8` | Converted W8A8 runtime checkpoint. |
-| `TORCHRUN` | `torchrun` | Torch distributed launcher. |
-| `PYTHON` | `python` | Python executable used by utility scripts. |
-| `HOST` | `0.0.0.0` | Server bind host. |
-| `PORT` | `8000` | HTTP server port. |
-| `MASTER_PORT` | script-specific | Torch distributed rendezvous port. |
-| `NPROC_PER_NODE` | `4` | Number of local ranks / GPUs. |
-| `DSV4_TMP_DIR` | `.tmp` | Temporary benchmark and generated prompt directory. |
-| `CKPT_FORMAT` | `auto` | Checkpoint format passed to the server: `auto`, `safetensors`, or `gguf`. |
-| `TOKENIZER_PATH` | unset | Required for GGUF checkpoints; optional tokenizer override for other formats. |
-| `PARTITION_POLICY` | `legacy` | Runtime placement policy: `legacy`, `baseline_4gpu`, or `layer_pp_4gpu`. |
-| `SERVING_PROFILE` | `safe1` | Serving admission profile: `safe1`, `latency2`, or `throughput4`. |
-| `DEEPSEEK_GPU_MOE_CROSS_LAYER_PREFETCH` | `0` | Cross-layer decode MoE prefetch; default is off for the current long-prompt best path. |
-
-## How to run
-
-### 1. Install Python dependencies
-
-Use Python 3.11 with PyTorch/CUDA available. The validated environment uses Python 3.11:
-
-```bash
-python -m pip install -r requirements.txt
-```
-
-### 2. Build native extensions
-
-```bash
-python setup.py build_ext
-```
-
-### 3. Convert the checkpoint
-
-The runtime checkpoint `DeepSeek-V4-Flash-w8a8` is not the original upstream checkpoint. It is produced by converting the original Hugging Face/model checkpoint into this repo's W8A8 runtime format.
-
-```bash
-PYTHONPATH=$PWD python -m src.cli.convert_checkpoint \
-  --hf-ckpt-path /path/to/original/DeepSeek-V4-Flash \
-  --save-path checkpoints/DeepSeek-V4-Flash-w8a8
-```
-
-Then use the converted directory as `CKPT_PATH`:
-
-```bash
-export CKPT_PATH=$PWD/checkpoints/DeepSeek-V4-Flash-w8a8
-```
-
-### 4. Provide the checkpoint
-
-Either place the checkpoint at the default repo-relative location:
+The current C++ binary is still named:
 
 ```text
-checkpoints/DeepSeek-V4-Flash-w8a8
+build/cpp_engine/dsv4_cpp_engine
 ```
 
-or pass it explicitly:
+The name will be generalized after the PocketMoE model-spec layer stabilizes.
 
-```bash
-export CKPT_PATH=/path/to/DeepSeek-V4-Flash-w8a8
-```
+## Run the existing DeepSeek-V4 backend
 
-If `torchrun` or `python` are not on `PATH`, pass them explicitly:
-
-```bash
-export TORCHRUN=/path/to/torchrun
-export PYTHON=/path/to/python
-```
-
-### 5. Start the OpenAI-compatible server
+### PyTorch OpenAI-compatible server
 
 ```bash
 CKPT_PATH=/path/to/DeepSeek-V4-Flash-w8a8 \
 bash scripts/run_openai_server.sh
 ```
 
-Common overrides:
+Useful overrides:
 
 ```bash
 CKPT_PATH=/path/to/DeepSeek-V4-Flash-w8a8 \
@@ -271,9 +200,7 @@ NPROC_PER_NODE=4 \
 bash scripts/run_openai_server.sh
 ```
 
-### 6. Optional GGUF Q2 layer-pipeline run
-
-The runtime can also load the IQ2/Q2 GGUF checkpoint path used during development. Keep the GGUF file outside git, provide the tokenizer directory separately, and launch the layer-pipeline script:
+### GGUF Q2/IQ2 path
 
 ```bash
 CKPT_PATH=/path/to/DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2.gguf \
@@ -281,96 +208,69 @@ TOKENIZER_PATH=/path/to/DeepSeek-V4-Flash-tokenizer \
 bash scripts/run_gguf_q2_layer_pp.sh
 ```
 
-The OpenAI server path also accepts `--ckpt-format gguf --tokenizer-path /path/to/tokenizer` when launched manually.
-
-### 7. Call the API
-
-Health check:
+### C++ server
 
 ```bash
-curl -s http://127.0.0.1:8000/health
+CKPT=/path/to/DeepSeek-V4-Flash \
+PORT=8000 \
+MAX_CONTEXT=8192 \
+PYTHON=/path/to/python \
+bash scripts/run_cpp_serve_tp4.sh
 ```
 
-Non-streaming chat completion:
+## Inspect GGUF checkpoints
+
+PocketMoE adds sharded GGUF inspection for MoE model onboarding.
+
+DeepSeek-V4 legacy inspect:
 
 ```bash
-curl -s http://127.0.0.1:8000/v1/chat/completions \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model":"deepseek-v4-flash-w8a8",
-    "messages":[{"role":"user","content":"Hello"}],
-    "max_tokens":8,
-    "temperature":0,
-    "stream":false
-  }'
+PYTHONPATH=$PWD python -m src.cli.inspect_gguf \
+  --gguf-path /path/to/deepseek-v4.gguf \
+  --summary \
+  --validate-ds4-q2
 ```
 
-Token-level streaming:
+MiniMax-M2.7 spec/capability inspect:
 
 ```bash
-curl -N http://127.0.0.1:8000/v1/chat/completions \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model":"deepseek-v4-flash-w8a8",
-    "messages":[{"role":"user","content":"请从1数到10"}],
-    "max_tokens":64,
-    "temperature":0,
-    "stream":true
-  }'
+PYTHONPATH=$PWD python -m src.cli.inspect_gguf \
+  --gguf-path /mnt/data1/dsv4_inference/gguf_hfd/MiniMax-M2.7-GGUF/UD-IQ1_M \
+  --architecture auto \
+  --spec-summary \
+  --validate-spec \
+  --capability-report \
+  --placement-report
 ```
 
-### 7. Run benchmark smoke
+MiniMax generation is not enabled yet; the inspect path reports it as deferred.
 
-```bash
-CKPT_PATH=/path/to/DeepSeek-V4-Flash-w8a8 \
-DEEPSEEK_GPU_MOE_DECODE_ACTIVE=1 \
-PD_CASE=short_short \
-bash scripts/run_best_scheduler.sh
-```
+## Roadmap
 
-For longer runs, set `PD_CASE=all` or one of `short_short`, `short_long`, `long_short`, `long_long`.
-Temporary logs default to `.tmp/`; override with `DSV4_TMP_DIR=/path/to/tmp`.
+- [x] DeepSeek-V4 backend on 4×RTX 2080 Ti.
+- [x] FP4 and GGUF Q2/IQ2/IQ1 routed expert paths for DeepSeek-V4.
+- [ ] MoE model spec and architecture registry.
+- [ ] Sharded GGUF bundle inspection.
+- [ ] MiniMax-M2.7 tensor map validation and capability report.
+- [ ] q4_k/q5_k payload/kernels for MiniMax dense and attention weights.
+- [ ] MiniMax GQA attention runtime.
+- [ ] all-`iq2_xxs` MiniMax MoE resident path.
+- [ ] General high-bit heterogeneous routed expert policy for future MoE models.
 
-### 8. Run tests
+## Known limitations
 
-```bash
-PYTHONPATH=$PWD python tests/test_moe_single_token.py
-PYTHONPATH=$PWD python tests/test_fused_attn_prefuse.py
-PYTHONPATH=$PWD python tests/test_int8_gemm_imma.py
-PYTHONPATH=$PWD python tests/test_encoding_dsv4.py
-```
-
-## Known limitations and troubleshooting
-
-Known limitations:
-
-- The OpenAI API targets chat-completions compatibility for common clients, but it is not a complete OpenAI API implementation.
-- Fine-grained streaming tool-call deltas are not implemented; parsed tool calls are emitted once after final parsing.
-- The runtime is specialized for the converted `DeepSeek-V4-Flash-w8a8` checkpoint format.
-- Performance numbers are hardware- and NUMA-sensitive; short prefill timings are especially noisy.
-
-Troubleshooting:
-
-- `checkpoint not found`: set `CKPT_PATH` or convert/place the checkpoint under `checkpoints/DeepSeek-V4-Flash-w8a8`.
-- `ModuleNotFoundError: src`: run commands from the repository root, or set `PYTHONPATH=$PWD`.
-- Native extension unavailable: run `python setup.py build_ext` and check that `.so` files exist under `build/extensions/`.
-- `torchrun` not found: set `TORCHRUN=/path/to/torchrun`.
-- Port conflicts: change `PORT` for HTTP and `MASTER_PORT` for torch distributed.
-- Service hangs after client disconnect: the server may finish draining the in-flight generation to keep all ranks synchronized.
-
-## To do list
-
-- [ ] Support multi-request concurrency.
-- [ ] Add hot/cold expert statistics and caching.
-- [ ] Try MTP acceleration.
-- [ ] Try speculative decoding with a pruned draft model.
-- [ ] Try 1M context support.
+- The current generation runtime is still DeepSeek-V4-specific.
+- MiniMax-M2.7 support initially covers inspect/spec/validation/capability reporting only.
+- q4_k/q5_k execution kernels for MiniMax are not implemented yet.
+- Dense-only models are not a project target.
+- Performance is hardware-, NUMA-, and PCIe-topology-sensitive.
 
 ## License
 
 This repository's code is licensed under the [PolyForm Noncommercial License 1.0.0](LICENSE).
 
 Permitted uses include personal use, academic research, education, non-commercial benchmarking, and non-commercial deployment.
+
 Commercial use is not permitted without separate written permission from the copyright holder, including but not limited to:
 
 - selling hosted inference services based on this code;
@@ -378,12 +278,8 @@ Commercial use is not permitted without separate written permission from the cop
 - selling hardware/software bundles using this code;
 - using this code in paid consulting deliverables or commercial products.
 
-Model weights, tokenizer files, and third-party dependencies are governed by their respective licenses. This repository's code license does not grant any additional rights to DeepSeek model assets or other third-party materials.
-
-## Friendly links
-
-- [linux.do](https://linux.do/)
+Model weights, tokenizer files, and third-party dependencies are governed by their respective licenses. This repository's code license does not grant any additional rights to DeepSeek, MiniMax, or other third-party model assets.
 
 ## Acknowledgement
 
-This project builds on DeepSeek-V4-Flash model assets and the surrounding open-source PyTorch, CUDA, safetensors, and transformers ecosystem. The service/runtime organization and performance scripts in this repository are engineering work for deploying and benchmarking the standalone inference path.
+PocketMoE builds on the PyTorch, CUDA, safetensors, GGUF, transformers, and NCCL ecosystems. The runtime organization, quantized expert paths, CPU/GPU scheduling, and performance scripts in this repository are engineering work for local MoE inference on consumer GPUs.

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,260 +1,188 @@
-# DeepSeek-V4-Flash on 2080ti
+# PocketMoE（口袋 MoE）
 
 [English](README.md) | [中文](README_CN.md)
 
-## 项目描述
+PocketMoE 是一个面向消费级 GPU 的 **MoE-only 低 bit + 异构推理引擎**，目标是在家用/工作站硬件上做好 300B 以下 MoE 模型的本地化部署。
 
-手里有一台 2023 年组的 4 卡 RTX 2080 Ti 小服务器，整机成本小于 2 万元。之前尝试过用 ktransformers、llama.cpp 等方案做大模型推理部署，但低比特量化版本会带来模型效果或运行表现下降。同时，由于 Turing 架构 GPU 早已不被业界主流加速库支持，例如 FlashAttention、FlashInfer，或者最新 compiler 如 TileLang。此外，最新的 DeepSeek 模型使用了 FP4、FP8 等只有较新 GPU 才原生支持的数据格式，因此在 RTX 2080 Ti 上直接执行 DeepSeek 几乎不可行。
+“口袋 MoE”的含义是：把原本属于数据中心集群的千亿级 MoE 模型，通过低 bit 压缩、量化 expert kernel 和 CPU/GPU 异构调度，放进用户的“口袋”（消费级显卡）里。
 
-本项目就是在这个背景下，尝试通过 GPU+CPU 异构执行、自定义 FP4/FP8 unpack、自定义 sparse attention、自定义 indexer 等 DeepSeek-V4 组件，让 RTX 2080 Ti 这样的老卡也能运行 DeepSeek-V4。
+本项目最初来自“在 4×RTX 2080 Ti 上运行 DeepSeek-V4”的工程实践。DeepSeek-V4 仍然是第一个已验证 backend 和性能基线，但仓库现在会按更通用的 MoE 推理引擎方向组织。
 
-## 背景与目标
+## 项目定位
 
-DeepSeek-V4 是当前性能最好的国产模型之一，而 DeepSeek-V4-Flash 在保证较好性能的情况下，使用了较少的参数量：总参数量 284B，激活参数量只有 13B。RTX 2080 Ti 的理论算力仍然不低：单卡约 13.4 TFLOPS FP32、约 107.6 TFLOPS FP16 Tensor Core；4 卡合计约 53.8 TFLOPS FP32、约 430 TFLOPS FP16 Tensor Core。因此，其实完全可以尝试 DeepSeek-V4-Flash 的推理。
+PocketMoE 专注于 MoE 模型，以及以下消费级/工作站 GPU：
 
-对于 DeepSeek 这类 MoE 模型而言，大规模权重主要用于 routed experts。因此，只要想办法解决显存容量问题，就可以尝试进行推理部署。本项目尝试用 GPU+CPU 异构的方式，在支持 DeepSeek-V4-Flash 推理的同时，继续提高 prefill 和 decode 性能。
+- RTX 2080 Ti，包括 22 GiB 魔改卡；
+- RTX 3090；
+- RTX 4090；
+- 类似的 PCIe 消费级多卡机器，没有数据中心级显存容量，也没有 NVLink。
 
+项目要回答的问题很直接：
 
-## 硬件与限制
+> 怎么在原本放不下这些模型的消费级显卡上运行大 MoE？
 
-当前 README 中的性能数据来自以下机器：
+PocketMoE 的答案是两种执行模式。
 
-- GPU：4 x NVIDIA GeForce RTX 2080 Ti，每张 22 GiB，Turing 架构。
+### 1. 低 bit all-device 模式
+
+如果低 bit MoE checkpoint 能放进多卡总显存，就尽量让模型常驻 device：
+
+- dense / attention 权重在 GPU；
+- router / gate 权重在 GPU；
+- routed experts 在 GPU；
+- decode 不走 active-expert H2D；
+- prefill 使用 grouped resident MoE kernel；
+- 热路径直接消费 raw quantized blocks，不把权重展开成 fp32。
+
+这条路线适合 GGUF IQ1/IQ2/Q2/Q3 等能跨多张消费级显卡放下的 MoE checkpoint。
+
+### 2. 异构 routed-expert 模式
+
+如果 checkpoint 放不进 device，就把 routed experts 放在 CPU pinned/NUMA 内存中，只搬当前 token 或 prefill chunk 真正激活的 experts：
+
+- dense/router 计算尽量留在 GPU；
+- routed experts 常驻 CPU 内存；
+- decode 按 top-k active experts staging 到 GPU；
+- prefill 把 expert H2D 和 GPU compute overlap；
+- hot expert cache 和 layer-local prefetch 用于减少重复 PCIe 流量。
+
+这条路线适合高 bit MoE checkpoint，或者虽然是低 bit 但在预留 KV cache/workspace 后仍然放不下的模型。
+
+## 非目标
+
+PocketMoE 不是通用 dense 模型 serving 框架。
+
+Dense layer、attention、tokenizer、OpenAI 兼容服务会被支持，是因为 MoE 模型需要它们；但本项目不打算和 vLLM、SGLang、llama.cpp 在通用 dense LLM runtime 上正面竞争。核心关注点是：
+
+- routed expert 量化；
+- routed expert 放置策略；
+- active expert dispatch；
+- prefill/decode MoE kernel；
+- PCIe 消费级硬件上的 CPU/GPU 异构调度。
+
+## 当前 backend：DeepSeek-V4 / DSV4
+
+第一个已验证 backend 是 4×RTX 2080 Ti 上的 DeepSeek-V4-Flash。这个 backend 包含：
+
+- DeepSeek-V4 MLA、sparse attention、C4 indexer 路径；
+- DeepSeek 风格 hash routing 和 routed experts；
+- Turing GPU 上没有原生 FP4/FP8 Tensor Core 时的 FP4/FP8 风格 checkpoint 处理；
+- GGUF Q2/IQ2/IQ1 routed expert block 路径；
+- CPU/GPU active expert staging；
+- PyTorch runtime 和原生 C++/CUDA engine 两套路径。
+
+仓库里现有脚本和 benchmark 数字，除非特别说明，都是 DeepSeek-V4 backend 的结果。
+
+## 下一个 backend：MiniMax-M2.7
+
+下一个目标是 MiniMax-M2.7 GGUF。已经下载的 `UD-IQ1_M` bundle 是 3 分片 GGUF checkpoint，结构为：
+
+- `general.architecture = minimax-m2`；
+- 62 层；
+- hidden size 3072；
+- context length 196608；
+- 48 个 attention heads，8 个 KV heads；
+- 256 个 routed experts，top-k 8；
+- routed experts 是 `iq2_xxs`；
+- attention projection 是 `q5_k`；
+- embedding/head 是 `q4_k`；
+- router/norm/bias 是 `f32`。
+
+MiniMax-M2.7 支持会从以下能力开始：
+
+- sharded GGUF inspect；
+- architecture/spec 解析；
+- tensor schema validation；
+- quant capability report；
+- all-device 与异构 placement planning。
+
+MiniMax 的完整 generation 暂不启用；需要等 MiniMax GQA runtime、q4_k/q5_k kernel、以及 all-`iq2_xxs` MoE 路径实现后再打开。
+
+## 硬件基线
+
+原始 benchmark 机器为：
+
+- GPU：4× NVIDIA GeForce RTX 2080 Ti，每张 22 GiB，Turing 架构。
 - CPU：双路 Intel Xeon E5-2696 v4 @ 2.20 GHz。
 - CPU 拓扑：88 个逻辑 CPU，2 socket，每 socket 22 core，每 core 2 thread。
 - 系统内存：1 TiB。
 - 运行方式：`torchrun --nproc-per-node 4`，每张 GPU 一个 rank。
 
-指令集和数据类型限制：
+重要限制：
 
-- CPU 支持 AVX2/FMA/F16C，但不支持 AVX-512、AMX，也没有 BF16/FP16 矩阵指令。
-- RTX 2080 Ti 支持 FP16 CUDA Tensor Core，但没有原生 BF16、FP8、FP4 Tensor Core。
-- DeepSeek-V4 使用 FP4/FP8 风格格式，以及 sparse/indexed attention 等更偏向新 GPU 的路径，因此本项目需要自定义 unpack 和 kernel，而不能直接依赖现代加速库。
+- RTX 2080 Ti 没有原生 BF16、FP8、FP4 Tensor Core。
+- 机器没有 NVLink；GPU-GPU 通信需要经过 PCIe/host bridge。
+- PCIe Gen3 x16 带宽使 routed-expert staging 和 overlap 成为核心问题。
+- 单请求 latency 和 decode TPS 是主要优化目标。
 
-内存和互联限制：
+## DeepSeek-V4 backend 性能快照
 
-- 4 卡总显存约 88 GiB，但每个 rank 本地只有约 22 GiB。
-- 这台机器 GPU 之间没有 NVLink。`nvidia-smi topo -m` 显示同 socket 内 GPU 之间是 PHB，跨 socket GPU 之间是 SYS。
-- 每张 GPU 最大链路为 PCIe Gen3 x16，理论单向 PCIe payload 带宽约 15.75 GB/s。
-- GPU-GPU 通信需要经过 PCIe/host bridge，跨 socket 通信还要经过 CPU 互联。
-- GPU-CPU expert staging 受 PCIe 带宽和 NUMA 位置限制，因此 active-expert H2D staging 以及 CPU/GPU overlap 是本项目 runtime 的核心。
+### PyTorch FP4 异构路径
 
-## 当前性能
-
-当前验证过的最佳 FP4 resident 路径：
-
-- routed MoE expert 权重在 CPU。
-- decode 使用 active routed-expert H2D staging + GPU MoE compute。
-- decode 默认关闭 cross-layer MoE prefetch，因为最新 long-prompt A/B 中关闭更快。
-- shared experts 使用 paired INT8 GPU kernel，并启用 PD shared-expert FP16 路径。
-- 优化后的 FP4 resident 路径启用 sparse attention、C4 indexer、custom MoE finalize、async all-reduce、HC pre/post CUDA kernel。
-- 启用 logical PD scheduler。
-- OpenAI 服务默认使用与 best scheduler 脚本一致的优化环境变量。
-
-代表性 FP4 benchmark 结果：
+4×RTX 2080 Ti 上的代表性 FP4 结果：
 
 | 场景 | Prompt / prefill tokens | Decode tokens | Prefill | Decode TPS | 说明 |
 | --- | ---: | ---: | ---: | ---: | --- |
 | 已验证最大上下文 | 65,536 | 2 | 257.45s（约 255 tok/s） | n/a | OpenAI 路径，内容校验返回 `OK`。 |
-| 长 prompt decode | 2,148 | 63 | 6.69s（warmup 后约 321 tok/s） | 3.49 tok/s mean | FP4 resident OpenAI 路径，`scripts/run_fp4_resident_best.sh`，3 次 fresh run：3.464/3.500/3.507 tok/s。 |
-| 短 prompt decode | 29 | 127 | 实测约 1.7-3.2s | 3.16 tok/s mean | 早期 OpenAI 短 prompt 参考值；短 prompt prefill timing 比 long-prompt case 更容易波动。 |
+| 长 prompt decode | 2,148 | 63 | 6.69s（warmup 后约 321 tok/s） | 3.49 tok/s mean | FP4 resident OpenAI 路径，3 次 fresh run：3.464/3.500/3.507 tok/s。 |
+| 短 prompt decode | 29 | 127 | 实测约 1.7-3.2s | 3.16 tok/s mean | 短 prompt prefill timing 在这台机器上噪声较大。 |
 
-当前 runtime 已在这台 4 x RTX 2080 Ti 机器上验证 65,536-token prompt。服务脚本为了日常 serving 默认仍使用 `MAX_MODEL_LEN=4096`；测试最大上下文时需要显式设置 `MAX_MODEL_LEN=65536`。短 prompt 的 prefill 在这台机器上噪声较大，比较优化效果时建议优先看 decode TPS 和 long prompt case。
+### GGUF Q2/IQ2 异构路径
 
-### GGUF Q2 TP resident 路径
+GGUF IQ2_XXS/Q2_K 路径使用 4-GPU TP、grouped GPU prefill、active-expert decode、slot cache、async all-reduce/fused finalize，以及量化 block expert staging。Routed GGUF expert 权重常驻 CPU，并以量化 block 形式 staging 到 GPU，不在热路径中展开成 fp32。
 
-GGUF IQ2_XXS/Q2_K 路径也可以通过 `scripts/run_gguf_q2_tp_resident.sh` 运行。4 卡时脚本默认使用 `PARTITION_POLICY=baseline_4gpu`，并启用 grouped GPU prefill、IQ2_XXS W1/W3 DP4A expert-tile kernel、Q2_K W2 DP4A expert-tile kernel、active-expert decode、decode slot cache、async all-reduce/fused finalize，以及 4096-token prefill chunk。routed GGUF expert 权重仍常驻 CPU，并以量化 block 形式 staging 到 GPU，不在热路径中展开成 fp32 权重。
-
-Resident OpenAI-compatible benchmark，无显式 warmup，`CASE=all REPEAT=2`，4 x RTX 2080 Ti：
+OpenAI 兼容 benchmark，`CASE=all REPEAT=2`，4×RTX 2080 Ti：
 
 | Case | 请求 | Prompt tokens | 服务端 decode tokens | Prefill | Decode TPS | Wall time | 说明 |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
 | `short_short` | 1 | 5 | 7 | 3.17s（1.58 tok/s） | 2.94 | 5.64s | 冷 decode cache。 |
-| `short_short` | 2 | 5 | 7 | 2.46s（2.03 tok/s） | 4.83 | 3.98s | warm slot/cache 路径；达到 4.5 tok/s 短 decode 目标。 |
-| `short_long` | 1 | 5 | 9 | 2.46s（2.03 tok/s） | 4.49 | 4.53s | 即使冷请求也接近 decode 目标。 |
-| `short_long` | 2 | 5 | 9 | 2.46s（2.03 tok/s） | 4.89 | 4.37s | warm slot/cache 路径。 |
-| `long_short` | 1 | 2,148 | 7 | 14.17s（151.58 tok/s） | 3.26 | 16.47s | 冷长 prefill / decode-cache 路径。 |
-| `long_short` | 2 | 2,148 | 7 | 9.94s（216.17 tok/s） | 4.44 | 11.66s | warm prefill staging；略低于 4.5 tok/s decode 目标。 |
-| `long_long` | 1 | 2,148 | 63 | 10.01s（214.52 tok/s） | 3.71 | 27.29s | 较长 decode 仍低于短 decode 目标。 |
-| `long_long` | 2 | 2,148 | 63 | 10.08s（213.05 tok/s） | 3.75 | 27.18s | warm prefill 不能完全解决长 decode。 |
+| `short_short` | 2 | 5 | 7 | 2.46s（2.03 tok/s） | 4.83 | 3.98s | warm slot/cache 路径。 |
+| `long_short` | 2 | 2,148 | 7 | 9.94s（216.17 tok/s） | 4.44 | 11.66s | warm prefill staging。 |
+| `long_long` | 2 | 2,148 | 63 | 10.08s（213.05 tok/s） | 3.75 | 27.18s | 较长 decode 仍然更难。 |
 
-单卡 2080 Ti + host-memory 模式也可以通过设置 `NPROC_PER_NODE=1` 运行；这个模式主要用于 smoke/demo 和很短 prompt，不适合长 prompt serving。运行命令、内存占用、上下文边界和 benchmark 结果见 [GGUF_Q2_SINGLE_GPU.md](GGUF_Q2_SINGLE_GPU.md)。
+当前结论：在这套硬件和 checkpoint 上，prefill 已接近当前架构能达到的最好结果。Decode 仍主要受 active-expert cache miss/H2D copy、TP all-reduce/finalize 和长上下文 attention 成本限制。
 
-真实 HTTP `stream=true` SSE 测试，不同真实输入且无 warmup：
+### C++ engine
 
-| 顺序 | Prompt 类型 | Prompt tokens | 服务端 decode tokens | Client TTFC | Prefill | Decode TPS | Client wall time |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1 | 短中文问答 | 33 | 95 | 7.52s | 7.45s（4.43 tok/s） | 3.93 | 31.94s |
-| 2 | README 总结 | 918 | 159 | 7.40s | 7.32s（125.41 tok/s） | 3.82 | 49.44s |
-| 3 | 长技术背景总结 | 2,148 | 115 | 10.15s | 10.01s（214.64 tok/s） | 3.81 | 40.68s |
+`cpp_engine/` 下的原生 C++/CUDA engine 用于减少 DeepSeek-V4 backend 的 Python/PyTorch per-step overhead。Rank 0 内置 OpenAI 兼容 HTTP 服务，rank 1-3 是 NCCL workers。
 
-当前 GGUF Q2 结论：在这个 checkpoint 和硬件上，prefill 路径已经接近当前架构能达到的最好结果。重复请求或后续请求的 prefill/TTFC 会明显变快，因为 staged GGUF expert 路径以及 OS/GPU cache 已经变热；但 decode 仍受 active-expert cache miss/H2D copy、TP all-reduce/finalize 和长上下文 attention 成本限制。短请求 warm-cache decode 可以达到约 4.8 tok/s，而真实异构 streaming 和长输出 decode 通常在 3.7-3.9 tok/s。后续若要继续大幅提升，更可能需要优化 decode 侧 active-expert cache 调度或降低通信/copy 成本，而不是继续优化 prefill kernel。
-
-## C++ 引擎（cpp_engine）
-
-除了上面的 PyTorch runtime，本仓库还提供一个原生 C++/CUDA 推理引擎，位于 `cpp_engine/`。它加载同样的 DeepSeek-V4-Flash FP4 checkpoint，但用独立二进制驱动模型，避免 Python/PyTorch 的每步开销。rank 0 内置 OpenAI 兼容 HTTP 服务（cpp-httplib + SSE）；ranks 1-3 是 NCCL worker，通过 CPU 命令通道驱动。tokenize 和 chat template 在常驻 Python sidecar 中执行，sidecar 复用 `src/encoding/dsv4.py`，因此 prompt 模板、tool-call 格式和 reasoning-effort 行为与 Python 服务一致。
-
-同一台 4 x RTX 2080 Ti 机器上验证过的 FP4 性能（TP=4，全部使用默认值）：
+同一台 4×RTX 2080 Ti 机器上验证过的 FP4 结果：
 
 | 场景 | Prompt tokens | Prefill | Prefill TPS | Decode TPS | 单卡峰值显存 |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | 短 prompt | 2,101 | ~7.6s | ~275 tok/s | ~3.7 tok/s | ~7 GiB |
 | 32K 上下文 | 32,768 | ~82s | ~402 tok/s | n/a | ~11.2 GiB |
-| 64K 上下文（已验证最大） | 65,536 | ~164s | ~401 tok/s | ~3.7 tok/s | ~14.5 GiB |
+| 64K 上下文 | 65,536 | ~164s | ~401 tok/s | ~3.7 tok/s | ~14.5 GiB |
 
-目前已端到端验证的最大上下文是 64K；14.5 GiB 单卡峰值在 22 GiB 卡上仍有余量。在 64K 上，prefill 大约比上面的 PyTorch FP4 路径快 1.6 倍（164s vs 257s）。FP4 decode TPS 与 PyTorch 接近，因为 decode 瓶颈在 PCIe expert staging，而不是 host overhead。
+64K prefill 大约比 PyTorch FP4 路径快 1.6×。Decode TPS 接近，因为瓶颈主要是 PCIe expert staging，而不是 Python overhead。
 
-长上下文 prefill 默认启用两个路径：
+## 构建
 
-- **Chunked prefill**（`DSV4_CPP_PREFILL_CHUNK_TOKENS`，默认 `4096`）：把每层 body 包在 chunk loop 中，让 scratch buffer 是 chunk 大小而不是 `token_count` 大小。否则 64K prompt 会在约 22 GiB 的 attention scratch 分配处 OOM。
-- **Batched sparse attention**（`DSV4_CPP_PREFILL_BATCHED_ATTN`，默认 `1`）：把 per-token attention kernel 改为单个 batched kernel；64K 上快约 8.6 倍（1415s → 164s）。设 `=0` 切回 per-token 路径（仅用于调试）。
+Python extension：
 
-### 编译
+```bash
+python -m pip install -r requirements.txt
+python setup.py build_ext
+```
 
-需要 CUDA Toolkit 和 NCCL（NCCL 自动检测；如果不在默认搜索路径，通过 `-DNCCL_ROOT=/path/to/nccl` 显式指定）：
+C++ engine：
 
 ```bash
 cmake -S cpp_engine -B build/cpp_engine -DCMAKE_BUILD_TYPE=Release
 cmake --build build/cpp_engine -j
 ```
 
-生成的二进制位于 `build/cpp_engine/dsv4_cpp_engine`。
-
-### 启动 OpenAI 兼容服务
-
-启动脚本会 fork 4 个 rank（每卡一个），在 `$PORT` 暴露 OpenAI API：
-
-```bash
-CKPT=/path/to/DeepSeek-V4-Flash \
-PORT=8000 \
-MAX_CONTEXT=8192 \
-PYTHON=/path/to/python \
-bash scripts/run_cpp_serve_tp4.sh
-```
-
-`CKPT` 需要指向原始的 DeepSeek-V4-Flash FP4 safetensors 目录（不是 PyTorch 路径使用的 W8A8 转换版本）。`PYTHON` 只要装了 `transformers` 即可；sidecar 会直接从仓库 import `src/encoding/dsv4`。
-
-要支持 64K-token prompt，把 `MAX_CONTEXT` 提到至少 `65536 + max_completion_tokens`（例如 `73728`）：
-
-```bash
-CKPT=/path/to/DeepSeek-V4-Flash \
-MAX_CONTEXT=73728 \
-bash scripts/run_cpp_serve_tp4.sh
-```
-
-每个 rank 的日志默认在 `/tmp/dsv4_cpp_serve_rank{0..3}.log`（`LOG_DIR=/some/dir` 可覆盖）。API 接口与上面 [快速开始](#快速开始) 中的 OpenAI chat-completions 子集一致；客户端访问 `http://<host>:$PORT/v1/chat/completions`。
-
-`scripts/run_cpp_serve_tp4.sh` 接受的常用环境变量：
-
-| 变量 | 默认值 | 作用 |
-| --- | --- | --- |
-| `CKPT` | 本地路径 | DeepSeek-V4-Flash FP4 safetensors 目录。 |
-| `PORT` | `8000` | rank 0 HTTP 端口。 |
-| `MAX_CONTEXT` | `8192` | 最大 prompt+completion 长度（决定 KV cache 容量）。 |
-| `PYTHON` | `python` | tokenizer sidecar 使用的 Python。 |
-| `SIDECAR` | `src/server/cpp_sidecar.py` | tokenizer/template sidecar 脚本。 |
-| `BIN` | `build/cpp_engine/dsv4_cpp_engine` | C++ 引擎二进制路径。 |
-| `NCCL_ID` | `/tmp/dsv4_cpp_serve_nccl.id` | NCCL rendezvous 文件。 |
-| `LOG_DIR` | `/tmp` | 各 rank 日志目录。 |
-| `EXTRA_ENV` | 未设置 | 注入到每个 rank 的额外 env，例如 `EXTRA_ENV='DSV4_CPP_PREFILL_CHUNK_TOKENS=8192'`。 |
-
-## 快速开始
-
-```bash
-python -m pip install -r requirements.txt
-python setup.py build_ext
-PYTHONPATH=$PWD python -m src.cli.convert_checkpoint \
-  --hf-ckpt-path /path/to/original/DeepSeek-V4-Flash \
-  --save-path checkpoints/DeepSeek-V4-Flash-w8a8
-CKPT_PATH=$PWD/checkpoints/DeepSeek-V4-Flash-w8a8 bash scripts/run_openai_server.sh
-```
-
-服务暴露 OpenAI 兼容的 chat-completions 子集：
-
-- `GET /health`
-- `GET /v1/models`
-- `POST /v1/chat/completions`
-- `stream=false` 非流式响应
-- `stream=true` token-level SSE 响应
-- `stream_options.include_usage=true` 在最终 chunk 返回 usage/timing
-- 常用 OpenAI 请求参数：`max_tokens`、`max_completion_tokens`、`temperature`、`top_p`、`top_k`、`min_p`、`frequency_penalty`、`presence_penalty`、`repetition_penalty`、`seed`、`stop`、`n`、`logprobs`、`top_logprobs`、`user` 和 `parallel_tool_calls`
-- 标准 OpenAI `tools`、`tool_choice`、assistant `tool_calls` 以及 `role=tool` 续轮消息
-- `response_format` 和 reasoning effort prompt hint
-
-说明：streaming 当前支持 `n=1`；streaming `logprobs` 会被拒绝；tool-call streaming 会在末尾附近一次性返回解析后的 `delta.tool_calls`，不会逐字符流式输出 arguments。
-
-常用运行环境变量：
-
-| 变量 | 默认值 | 作用 |
-| --- | --- | --- |
-| `CKPT_PATH` | `checkpoints/DeepSeek-V4-Flash-w8a8` | 转换后的 W8A8 runtime checkpoint。 |
-| `TORCHRUN` | `torchrun` | Torch distributed launcher。 |
-| `PYTHON` | `python` | 工具脚本使用的 Python。 |
-| `HOST` | `0.0.0.0` | 服务监听地址。 |
-| `PORT` | `8000` | HTTP 服务端口。 |
-| `MASTER_PORT` | 脚本各自默认 | torch distributed rendezvous 端口。 |
-| `NPROC_PER_NODE` | `4` | 本机 rank / GPU 数量。 |
-| `DSV4_TMP_DIR` | `.tmp` | benchmark 临时文件和生成 prompt 目录。 |
-| `CKPT_FORMAT` | `auto` | 传给 server 的 checkpoint 格式：`auto`、`safetensors` 或 `gguf`。 |
-| `TOKENIZER_PATH` | 未设置 | GGUF checkpoint 必填；其它格式可作为 tokenizer 覆盖项。 |
-| `PARTITION_POLICY` | `legacy` | runtime 放置策略：`legacy`、`baseline_4gpu` 或 `layer_pp_4gpu`。 |
-| `SERVING_PROFILE` | `safe1` | serving admission profile：`safe1`、`latency2` 或 `throughput4`。 |
-| `DEEPSEEK_GPU_MOE_CROSS_LAYER_PREFETCH` | `0` | decode MoE 跨层预取；当前 long-prompt 最优路径默认关闭。 |
-
-## 如何运行
-
-### 1. 安装 Python 依赖
-
-使用 Python 3.11，并确保 PyTorch/CUDA 可用。当前验证环境使用 Python 3.11：
-
-```bash
-python -m pip install -r requirements.txt
-```
-
-### 2. 编译 native extensions
-
-```bash
-python setup.py build_ext
-```
-
-### 3. 转换 checkpoint
-
-运行时使用的 `DeepSeek-V4-Flash-w8a8` 不是原始 upstream checkpoint，而是由原始 Hugging Face/model checkpoint 转换出来的 W8A8 runtime 格式。
-
-```bash
-PYTHONPATH=$PWD python -m src.cli.convert_checkpoint \
-  --hf-ckpt-path /path/to/original/DeepSeek-V4-Flash \
-  --save-path checkpoints/DeepSeek-V4-Flash-w8a8
-```
-
-然后把转换后的目录作为 `CKPT_PATH`：
-
-```bash
-export CKPT_PATH=$PWD/checkpoints/DeepSeek-V4-Flash-w8a8
-```
-
-### 4. 提供 checkpoint 路径
-
-可以把 checkpoint 放在默认的仓库相对路径：
+当前 C++ binary 仍叫：
 
 ```text
-checkpoints/DeepSeek-V4-Flash-w8a8
+build/cpp_engine/dsv4_cpp_engine
 ```
 
-也可以显式传入：
+等 PocketMoE model-spec 层稳定后会再统一命名。
 
-```bash
-export CKPT_PATH=/path/to/DeepSeek-V4-Flash-w8a8
-```
+## 运行现有 DeepSeek-V4 backend
 
-如果 `torchrun` 或 `python` 不在 `PATH` 上，也可以显式传入：
-
-```bash
-export TORCHRUN=/path/to/torchrun
-export PYTHON=/path/to/python
-```
-
-### 5. 启动 OpenAI 兼容服务
+### PyTorch OpenAI 兼容服务
 
 ```bash
 CKPT_PATH=/path/to/DeepSeek-V4-Flash-w8a8 \
@@ -272,9 +200,7 @@ NPROC_PER_NODE=4 \
 bash scripts/run_openai_server.sh
 ```
 
-### 6. 可选：运行 GGUF Q2 layer-pipeline
-
-runtime 也支持开发过程中使用的 IQ2/Q2 GGUF checkpoint 路径。GGUF 文件不要提交到 git，tokenizer 目录需要单独提供，然后启动 layer-pipeline 脚本：
+### GGUF Q2/IQ2 路径
 
 ```bash
 CKPT_PATH=/path/to/DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2.gguf \
@@ -282,109 +208,78 @@ TOKENIZER_PATH=/path/to/DeepSeek-V4-Flash-tokenizer \
 bash scripts/run_gguf_q2_layer_pp.sh
 ```
 
-手动启动 OpenAI server 时也可以传入 `--ckpt-format gguf --tokenizer-path /path/to/tokenizer`。
-
-### 7. 调用 API
-
-健康检查：
+### C++ server
 
 ```bash
-curl -s http://127.0.0.1:8000/health
+CKPT=/path/to/DeepSeek-V4-Flash \
+PORT=8000 \
+MAX_CONTEXT=8192 \
+PYTHON=/path/to/python \
+bash scripts/run_cpp_serve_tp4.sh
 ```
 
-非流式 chat completion：
+## Inspect GGUF checkpoint
+
+PocketMoE 会为 MoE model onboarding 增加 sharded GGUF inspect 能力。
+
+DeepSeek-V4 legacy inspect：
 
 ```bash
-curl -s http://127.0.0.1:8000/v1/chat/completions \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model":"deepseek-v4-flash-w8a8",
-    "messages":[{"role":"user","content":"Hello"}],
-    "max_tokens":8,
-    "temperature":0,
-    "stream":false
-  }'
+PYTHONPATH=$PWD python -m src.cli.inspect_gguf \
+  --gguf-path /path/to/deepseek-v4.gguf \
+  --summary \
+  --validate-ds4-q2
 ```
 
-Token-level 流式输出：
+MiniMax-M2.7 spec/capability inspect：
 
 ```bash
-curl -N http://127.0.0.1:8000/v1/chat/completions \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model":"deepseek-v4-flash-w8a8",
-    "messages":[{"role":"user","content":"请从1数到10"}],
-    "max_tokens":64,
-    "temperature":0,
-    "stream":true
-  }'
+PYTHONPATH=$PWD python -m src.cli.inspect_gguf \
+  --gguf-path /mnt/data1/dsv4_inference/gguf_hfd/MiniMax-M2.7-GGUF/UD-IQ1_M \
+  --architecture auto \
+  --spec-summary \
+  --validate-spec \
+  --capability-report \
+  --placement-report
 ```
 
-### 7. 跑 benchmark smoke
+MiniMax generation 还未启用；inspect 路径会把它标记为 deferred。
 
-```bash
-CKPT_PATH=/path/to/DeepSeek-V4-Flash-w8a8 \
-DEEPSEEK_GPU_MOE_DECODE_ACTIVE=1 \
-PD_CASE=short_short \
-bash scripts/run_best_scheduler.sh
-```
+## Roadmap
 
-更完整的测试可以设置 `PD_CASE=all`，或者指定 `short_short`、`short_long`、`long_short`、`long_long`。
-临时日志默认写到 `.tmp/`，也可以通过 `DSV4_TMP_DIR=/path/to/tmp` 覆盖。
+- [x] 4×RTX 2080 Ti 上的 DeepSeek-V4 backend。
+- [x] DeepSeek-V4 FP4 和 GGUF Q2/IQ2/IQ1 routed expert 路径。
+- [ ] MoE model spec 和 architecture registry。
+- [ ] Sharded GGUF bundle inspect。
+- [ ] MiniMax-M2.7 tensor map validation 和 capability report。
+- [ ] MiniMax dense/attention 权重的 q4_k/q5_k payload/kernel。
+- [ ] MiniMax GQA attention runtime。
+- [ ] all-`iq2_xxs` MiniMax MoE resident path。
+- [ ] 面向未来 MoE 模型的高 bit 异构 routed expert 策略。
 
-### 8. 跑测试
+## 已知限制
 
-```bash
-PYTHONPATH=$PWD python tests/test_moe_single_token.py
-PYTHONPATH=$PWD python tests/test_fused_attn_prefuse.py
-PYTHONPATH=$PWD python tests/test_int8_gemm_imma.py
-PYTHONPATH=$PWD python tests/test_encoding_dsv4.py
-```
-
-## 已知限制与排障
-
-已知限制：
-
-- OpenAI API 现在主要兼容常见 chat-completions 客户端，但还不是完整的 OpenAI API 实现。
-- 还没有实现细粒度 tool-call delta streaming；解析后的 tool calls 会在最终解析后一次性返回。
-- runtime 专门面向转换后的 `DeepSeek-V4-Flash-w8a8` checkpoint 格式。
-- 性能对硬件和 NUMA 很敏感；短 prompt 的 prefill timing 尤其容易波动。
-
-常见排障：
-
-- `checkpoint not found`：设置 `CKPT_PATH`，或者把转换后的 checkpoint 放到 `checkpoints/DeepSeek-V4-Flash-w8a8`。
-- `ModuleNotFoundError: src`：从仓库根目录运行命令，或者设置 `PYTHONPATH=$PWD`。
-- native extension 不可用：运行 `python setup.py build_ext`，并检查 `build/extensions/` 下是否有 `.so`。
-- `torchrun` 找不到：设置 `TORCHRUN=/path/to/torchrun`。
-- 端口冲突：HTTP 使用 `PORT`，torch distributed 使用 `MASTER_PORT`，分别修改。
-- 客户端断开后服务仍在计算：服务可能会继续 drain 当前 generation，以保持所有 rank 同步。
-
-## To do list
-
-- [ ] 支持多请求并发。
-- [ ] 支持冷热专家统计和缓存。
-- [ ] 尝试支持 MTP 加速。
-- [ ] 尝试使用裁剪模型做投机推理。
-- [ ] 尝试 1M 上下文支持。
+- 当前 generation runtime 仍然是 DeepSeek-V4-specific。
+- MiniMax-M2.7 初期只支持 inspect/spec/validation/capability report。
+- MiniMax 的 q4_k/q5_k 执行 kernel 尚未实现。
+- Dense-only 模型不是本项目目标。
+- 性能对硬件、NUMA、PCIe 拓扑非常敏感。
 
 ## License
 
-本仓库代码采用 [PolyForm Noncommercial License 1.0.0](LICENSE)。
+This repository's code is licensed under the [PolyForm Noncommercial License 1.0.0](LICENSE).
 
-允许个人使用、学术研究、教学、非商业评测和非商业部署。
-未经版权所有者另行书面授权，不允许商业使用，包括但不限于：
+Permitted uses include personal use, academic research, education, non-commercial benchmarking, and non-commercial deployment.
 
-- 基于本代码销售托管推理服务；
-- 销售打包部署方案或一体机；
-- 将本代码用于硬件/软件捆绑销售；
-- 将本代码用于付费咨询交付物或商业产品。
+Commercial use is not permitted without separate written permission from the copyright holder, including but not limited to:
 
-模型权重、tokenizer 文件和第三方依赖遵循其各自许可证。本仓库代码许可证不会授予 DeepSeek 模型资产或其它第三方材料的额外权利。
+- selling hosted inference services based on this code;
+- selling packaged deployments or appliances;
+- selling hardware/software bundles using this code;
+- using this code in paid consulting deliverables or commercial products.
 
-## 友情链接
+Model weights, tokenizer files, and third-party dependencies are governed by their respective licenses. This repository's code license does not grant any additional rights to DeepSeek, MiniMax, or other third-party model assets.
 
-- [linux.do](https://linux.do/)
+## 致谢
 
-## Acknowledgement
-
-本项目基于 DeepSeek-V4-Flash 模型资产，以及 PyTorch、CUDA、safetensors、transformers 等开源生态。仓库中的服务化组织、运行时整理和性能脚本主要用于部署、验证和 benchmark standalone inference 路径。
+PocketMoE 基于 PyTorch、CUDA、safetensors、GGUF、transformers、NCCL 等生态。仓库中的 runtime 组织、量化 expert 路径、CPU/GPU 调度和性能脚本，是面向消费级 GPU 的本地 MoE 推理工程实践。

--- a/src/cli/inspect_gguf.py
+++ b/src/cli/inspect_gguf.py
@@ -5,16 +5,17 @@ import json
 import os
 from collections import Counter, defaultdict
 
-import torch
-
+from src.gguf.bundle import GGUFBundle, read_gguf_bundle
 from src.gguf.ds4_mapping import validate_ds4_tensor_mappings
-from src.gguf.reader import GGUFArraySummary, GGUFReader
-from src.runtime.transformer import ModelArgs, Transformer
+from src.gguf.reader import GGUFArraySummary
+from src.moe_model.registry import detect_spec, known_architectures
+from src.moe_model.spec import CapabilityReport, SpecValidation
 
 
 DS4_Q2_TYPES = {
     "q2_k",
     "iq2_xxs",
+    "iq1_m",
     "q4_k",
     "q8_0",
     "f16",
@@ -59,7 +60,7 @@ def _classify_tensor(name: str) -> str:
     return "other"
 
 
-def _summarize(ds4):
+def _summarize_file(ds4) -> None:
     print(f"path: {ds4.path}")
     print(f"size: {_format_bytes(ds4.size)}")
     print(f"version: {ds4.version}")
@@ -67,7 +68,31 @@ def _summarize(ds4):
     print(f"metadata_count: {ds4.metadata_count}")
     print(f"alignment: {ds4.alignment}")
     print(f"data_start: {ds4.data_start}")
-    for key in (
+    _summarize_metadata_and_tensors(ds4.metadata, ds4.tensors)
+
+
+def _summarize_bundle(bundle: GGUFBundle) -> None:
+    if len(bundle.shards) == 1:
+        _summarize_file(bundle.primary)
+        return
+    print(f"path: {bundle.path}")
+    print(f"size: {_format_bytes(bundle.size)}")
+    print(f"version: {bundle.version}")
+    print(f"shard_count: {len(bundle.shards)}")
+    print(f"tensor_count: {bundle.tensor_count}")
+    print(f"metadata_count: {bundle.metadata_count}")
+    print(f"primary_shard: {bundle.shards[bundle.primary_index].path}")
+    print("\nshards:")
+    for shard in bundle.shards:
+        print(
+            f"  [{shard.index}] {os.path.basename(shard.path)} "
+            f"size={_format_bytes(shard.file.size)} tensors={shard.file.tensor_count} metadata={shard.file.metadata_count}"
+        )
+    _summarize_metadata_and_tensors(bundle.metadata, bundle.tensors)
+
+
+def _summarize_metadata_and_tensors(metadata, tensors) -> None:
+    metadata_keys = (
         "general.architecture",
         "deepseek4.block_count",
         "deepseek4.embedding_length",
@@ -75,15 +100,26 @@ def _summarize(ds4):
         "deepseek4.expert_used_count",
         "deepseek4.expert_feed_forward_length",
         "deepseek4.context_length",
-    ):
-        if key in ds4.metadata:
-            print(f"metadata.{key}: {_metadata_value_text(ds4.metadata[key])}")
+        "minimax-m2.block_count",
+        "minimax-m2.embedding_length",
+        "minimax-m2.expert_count",
+        "minimax-m2.expert_used_count",
+        "minimax-m2.expert_feed_forward_length",
+        "minimax-m2.context_length",
+        "minimax-m2.attention.head_count",
+        "minimax-m2.attention.head_count_kv",
+        "minimax-m2.attention.key_length",
+        "minimax-m2.attention.value_length",
+    )
+    for key in metadata_keys:
+        if key in metadata:
+            print(f"metadata.{key}: {_metadata_value_text(metadata[key])}")
 
-    by_type = Counter(t.type_name for t in ds4.tensors)
-    by_class = Counter(_classify_tensor(t.name) for t in ds4.tensors)
+    by_type = Counter(t.type_name for t in tensors)
+    by_class = Counter(_classify_tensor(t.name) for t in tensors)
     bytes_by_type = defaultdict(int)
     bytes_by_class = defaultdict(int)
-    for tensor in ds4.tensors:
+    for tensor in tensors:
         if tensor.nbytes is not None:
             bytes_by_type[tensor.type_name] += tensor.nbytes
             bytes_by_class[_classify_tensor(tensor.name)] += tensor.nbytes
@@ -96,27 +132,28 @@ def _summarize(ds4):
     for class_name, count in sorted(by_class.items()):
         print(f"  {class_name:18s} {count:6d} {_format_bytes(bytes_by_class.get(class_name, 0))}")
 
-    routed = [t for t in ds4.tensors if _classify_tensor(t.name) == "routed_experts"]
+    routed = [t for t in tensors if _classify_tensor(t.name) == "routed_experts"]
     routed_types = Counter(t.type_name for t in routed)
     print("\nrouted expert types:")
     for type_name, count in sorted(routed_types.items()):
         print(f"  {type_name:12s} {count:6d}")
 
-    unknown_types = sorted({t.type_name for t in ds4.tensors if t.type_name.startswith("unknown_")})
+    unknown_types = sorted({t.type_name for t in tensors if t.type_name.startswith("unknown_")})
     if unknown_types:
         print("\nunknown tensor types:")
         for type_name in unknown_types:
             print(f"  {type_name}")
 
 
-def _print_tensors(ds4, limit: int, contains: str | None) -> None:
-    tensors = ds4.tensors
+def _print_tensors(bundle: GGUFBundle, limit: int, contains: str | None) -> None:
+    tensors = list(bundle.tensors)
     if contains:
         tensors = [t for t in tensors if contains in t.name]
     for tensor in tensors[:limit]:
+        shard_text = "" if len(bundle.shards) == 1 else f"\tshard={os.path.basename(tensor.shard_path)}"
         print(
             f"{tensor.name}\t{tensor.type_name}\t{tensor.dimensions}\t"
-            f"offset={tensor.offset}\tabs={tensor.absolute_offset}\tbytes={_format_bytes(tensor.nbytes)}"
+            f"offset={tensor.offset}\tabs={tensor.absolute_offset}\tbytes={_format_bytes(tensor.nbytes)}{shard_text}"
         )
     if len(tensors) > limit:
         print(f"... {len(tensors) - limit} more tensors")
@@ -178,6 +215,10 @@ def _validate_ds4_q2(ds4) -> int:
 
 
 def _runtime_state_shapes(config_path: str, routed_experts_device: str) -> dict[str, tuple[int, ...]]:
+    import torch
+
+    from src.runtime.transformer import ModelArgs, Transformer
+
     with open(config_path) as f:
         config_data = json.load(f)
     config_data["routed_experts_device"] = routed_experts_device
@@ -222,8 +263,75 @@ def _validate_runtime_mapping(ds4, config_path: str, routed_experts_device: str)
     return 0
 
 
+def _print_spec_summary(report: CapabilityReport) -> None:
+    p = report.params
+    print("\nspec summary:")
+    print(f"  architecture: {p.architecture}")
+    print(f"  layers: {p.n_layers}")
+    print(f"  hidden_size: {p.hidden_size}")
+    print(f"  vocab_size: {p.vocab_size}")
+    print(f"  context_length: {p.context_length}")
+    print(f"  attention_kind: {p.attention_kind}")
+    print(f"  n_heads: {p.n_heads}")
+    print(f"  n_kv_heads: {p.n_kv_heads}")
+    print(f"  head_dim: {p.head_dim}")
+    print(f"  rope_dim: {p.rope_dim}")
+    print(f"  rope_base: {p.rope_base}")
+    print(f"  n_routed_experts: {p.n_routed_experts}")
+    print(f"  top_k: {p.top_k}")
+    print(f"  expert_intermediate_size: {p.expert_intermediate_size}")
+    print(f"  n_shared_experts: {p.n_shared_experts}")
+    print(f"  gate_function: {p.gate_function}")
+
+
+def _print_validation(validation: SpecValidation) -> int:
+    print("\nspec validation:")
+    print(f"  ok: {validation.ok}")
+    print(f"  mapped_sources: {validation.mapped_sources}")
+    print(f"  unmapped_sources: {len(validation.unmapped_sources)}")
+    print("  role_counts:")
+    for role, count in sorted(validation.role_counts.items()):
+        print(f"    {role:16s} {count:6d}")
+    if validation.warnings:
+        print("  warnings:")
+        for warning in validation.warnings[:20]:
+            print(f"    - {warning}")
+    if validation.errors:
+        print("  errors:")
+        for error in validation.errors[:80]:
+            print(f"    - {error}")
+        if len(validation.errors) > 80:
+            print(f"    ... {len(validation.errors) - 80} more errors")
+        return 1
+    return 0
+
+
+def _print_capability_report(report: CapabilityReport) -> None:
+    print("\ncapability report:")
+    print("  tensor types:")
+    for type_name, count in sorted(report.tensor_type_counts.items()):
+        print(f"    {type_name:12s} {count:6d} {_format_bytes(report.bytes_by_type.get(type_name, 0))}")
+    print("  tensor roles:")
+    for role, count in sorted(report.tensor_role_counts.items()):
+        print(f"    {role:16s} {count:6d} {_format_bytes(report.bytes_by_role.get(role, 0))}")
+    print("  capabilities:")
+    for item in report.capabilities:
+        print(f"    [{item.status}] {item.name}: {item.reason}")
+
+
+def _print_placement_report(report: CapabilityReport) -> None:
+    print("\nplacement report:")
+    for decision in report.placements:
+        est = ""
+        if decision.estimated_bytes is not None:
+            est += f" total={_format_bytes(decision.estimated_bytes)}"
+        if decision.estimated_bytes_per_gpu is not None:
+            est += f" per_gpu={_format_bytes(decision.estimated_bytes_per_gpu)}"
+        print(f"  [{decision.status}] {decision.name}:{est} {decision.reason}")
+
+
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Inspect a GGUF file without loading tensor payloads.")
+    parser = argparse.ArgumentParser(description="Inspect a GGUF file or sharded GGUF bundle without loading tensor payloads.")
     parser.add_argument("--gguf-path", required=True)
     parser.add_argument("--summary", action="store_true")
     parser.add_argument("--list-tensors", action="store_true")
@@ -233,20 +341,60 @@ def main() -> int:
     parser.add_argument("--validate-runtime-mapping", action="store_true")
     parser.add_argument("--config", default="configs/config_w8a8.json")
     parser.add_argument("--routed-experts-device", choices=["gpu", "cpu"], default="cpu")
+    parser.add_argument("--architecture", default="auto", choices=["auto", *known_architectures()])
+    parser.add_argument("--spec-summary", action="store_true")
+    parser.add_argument("--validate-spec", action="store_true")
+    parser.add_argument("--capability-report", action="store_true")
+    parser.add_argument("--placement-report", action="store_true")
+    parser.add_argument("--gpu-count", type=int, default=4)
+    parser.add_argument("--gpu-memory-gib", type=float, default=22.0)
     args = parser.parse_args()
 
     if not os.path.exists(args.gguf_path):
         raise FileNotFoundError(args.gguf_path)
-    ds4 = GGUFReader(args.gguf_path).read()
-    if args.summary or not args.list_tensors:
-        _summarize(ds4)
+
+    bundle = read_gguf_bundle(args.gguf_path)
+    if args.summary or not (args.list_tensors or args.spec_summary or args.validate_spec or args.capability_report or args.placement_report):
+        _summarize_bundle(bundle)
     if args.list_tensors:
-        _print_tensors(ds4, args.limit, args.contains)
+        _print_tensors(bundle, args.limit, args.contains)
+
     status = 0
     if args.validate_ds4_q2:
-        status = max(status, _validate_ds4_q2(ds4))
+        status = max(status, _validate_ds4_q2(bundle if len(bundle.shards) > 1 else bundle.primary))
+
+    spec = None
+    report = None
+    if args.spec_summary or args.validate_spec or args.capability_report or args.placement_report or args.validate_runtime_mapping:
+        spec = detect_spec(bundle, args.architecture)
+
     if args.validate_runtime_mapping:
-        status = max(status, _validate_runtime_mapping(ds4, args.config, args.routed_experts_device))
+        assert spec is not None
+        if spec.architecture != "deepseek4":
+            print(
+                "runtime mapping: FAILED\n"
+                f"  - runtime mapping/generation is currently implemented for deepseek4 only, got {spec.architecture!r}; "
+                "use --validate-spec for header/logical tensor validation",
+                flush=True,
+            )
+            status = max(status, 1)
+        else:
+            status = max(status, _validate_runtime_mapping(bundle if len(bundle.shards) > 1 else bundle.primary, args.config, args.routed_experts_device))
+
+    if spec is not None and (args.spec_summary or args.capability_report or args.placement_report):
+        report = spec.capability_report(bundle, gpu_count=args.gpu_count, gpu_memory_gib=args.gpu_memory_gib)
+    if args.spec_summary:
+        assert report is not None
+        _print_spec_summary(report)
+    if args.validate_spec:
+        assert spec is not None
+        status = max(status, _print_validation(spec.validate_bundle(bundle)))
+    if args.capability_report:
+        assert report is not None
+        _print_capability_report(report)
+    if args.placement_report:
+        assert report is not None
+        _print_placement_report(report)
     return status
 
 

--- a/src/gguf/bundle.py
+++ b/src/gguf/bundle.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from src.gguf.reader import GGML_TYPES, GGUFFile, GGUFReader, GGUFTensorInfo
+
+
+_SHARD_RE = re.compile(r"^(?P<prefix>.+)-(?P<index>\d{5})-of-(?P<count>\d{5})\.gguf$")
+
+
+@dataclass(frozen=True)
+class GGUFTensorRef:
+    """Tensor header plus the shard that owns its payload.
+
+    Offsets remain shard-local: `absolute_offset` is valid only within
+    `shard_path`, exactly like `GGUFTensorInfo.absolute_offset` is valid within a
+    single `GGUFFile`.  The bundle is an index, not a concatenated virtual file.
+    """
+
+    name: str
+    dimensions: tuple[int, ...]
+    type_id: int
+    offset: int
+    absolute_offset: int
+    nbytes: int | None
+    shard_index: int
+    shard_path: str
+
+    @property
+    def type_name(self) -> str:
+        return GGML_TYPES.get(self.type_id, (f"unknown_{self.type_id}", 0, 0))[0]
+
+    @property
+    def elements(self) -> int:
+        total = 1
+        for dim in self.dimensions:
+            total *= int(dim)
+        return total
+
+
+@dataclass(frozen=True)
+class GGUFShard:
+    index: int
+    path: str
+    file: GGUFFile
+
+
+@dataclass(frozen=True)
+class GGUFBundle:
+    """Header-only unified view of one GGUF file or a sharded GGUF bundle."""
+
+    shards: tuple[GGUFShard, ...]
+    primary_index: int
+    metadata: dict[str, Any]
+    tensors: tuple[GGUFTensorRef, ...]
+    size: int
+
+    @property
+    def paths(self) -> tuple[str, ...]:
+        return tuple(shard.path for shard in self.shards)
+
+    @property
+    def path(self) -> str:
+        if len(self.shards) == 1:
+            return self.shards[0].path
+        return str(Path(self.shards[0].path).parent)
+
+    @property
+    def primary(self) -> GGUFFile:
+        return self.shards[self.primary_index].file
+
+    @property
+    def version(self) -> int:
+        return self.primary.version
+
+    @property
+    def tensor_count(self) -> int:
+        return len(self.tensors)
+
+    @property
+    def metadata_count(self) -> int:
+        return len(self.metadata)
+
+    @property
+    def tensors_by_name(self) -> dict[str, GGUFTensorRef]:
+        return {tensor.name: tensor for tensor in self.tensors}
+
+
+def _match_shard_name(path: Path) -> re.Match[str] | None:
+    return _SHARD_RE.match(path.name)
+
+
+def _sort_paths(paths: Iterable[Path]) -> list[Path]:
+    def key(path: Path):
+        match = _match_shard_name(path)
+        if match is not None:
+            return (match.group("prefix"), int(match.group("index")), path.name)
+        return (path.stem, 0, path.name)
+
+    return sorted(paths, key=key)
+
+
+def _expected_shard_paths(path: Path) -> list[Path] | None:
+    match = _match_shard_name(path)
+    if match is None:
+        return None
+    prefix = match.group("prefix")
+    count = int(match.group("count"))
+    return [path.with_name(f"{prefix}-{idx:05d}-of-{count:05d}.gguf") for idx in range(1, count + 1)]
+
+
+def resolve_gguf_bundle(path: str | Path) -> tuple[str, ...]:
+    """Resolve a single GGUF file, shard path, or directory into shard paths."""
+
+    root = Path(path).expanduser().resolve()
+    if not root.exists():
+        raise FileNotFoundError(str(root))
+
+    if root.is_dir():
+        ggufs = _sort_paths(p for p in root.iterdir() if p.is_file() and p.suffix == ".gguf")
+        if not ggufs:
+            raise FileNotFoundError(f"no .gguf files found in {root}")
+        shard_like = [p for p in ggufs if _match_shard_name(p) is not None]
+        if shard_like:
+            groups: dict[tuple[str, int], list[Path]] = {}
+            for item in shard_like:
+                match = _match_shard_name(item)
+                assert match is not None
+                groups.setdefault((match.group("prefix"), int(match.group("count"))), []).append(item)
+            if len(groups) != 1:
+                details = ", ".join(f"{prefix} of {count}" for prefix, count in sorted(groups))
+                raise ValueError(f"multiple GGUF shard groups found in {root}: {details}")
+            (prefix, count), _items = next(iter(groups.items()))
+            expected = [root / f"{prefix}-{idx:05d}-of-{count:05d}.gguf" for idx in range(1, count + 1)]
+            missing = [str(p) for p in expected if not p.exists()]
+            if missing:
+                raise FileNotFoundError("missing GGUF shard(s): " + ", ".join(missing))
+            return tuple(str(p) for p in expected)
+        return tuple(str(p) for p in ggufs)
+
+    if root.suffix != ".gguf":
+        raise ValueError(f"expected a .gguf file or directory, got {root}")
+
+    expected = _expected_shard_paths(root)
+    if expected is None:
+        return (str(root),)
+    missing = [str(p) for p in expected if not p.exists()]
+    if missing:
+        raise FileNotFoundError("missing GGUF shard(s): " + ", ".join(missing))
+    return tuple(str(p) for p in expected)
+
+
+def _primary_shard_index(shards: list[GGUFShard]) -> int:
+    for idx, shard in enumerate(shards):
+        if shard.file.metadata.get("split.no") == 0:
+            return idx
+    for idx, shard in enumerate(shards):
+        if "general.architecture" in shard.file.metadata:
+            return idx
+    return max(range(len(shards)), key=lambda i: shards[i].file.metadata_count)
+
+
+def read_gguf_bundle(path: str | Path) -> GGUFBundle:
+    paths = resolve_gguf_bundle(path)
+    shards: list[GGUFShard] = []
+    refs: list[GGUFTensorRef] = []
+    seen: dict[str, str] = {}
+    total_size = 0
+
+    for shard_index, shard_path in enumerate(paths):
+        gguf = GGUFReader(shard_path).read()
+        shards.append(GGUFShard(shard_index, shard_path, gguf))
+        total_size += int(gguf.size)
+        for tensor in gguf.tensors:
+            if tensor.name in seen:
+                raise ValueError(f"duplicate GGUF tensor {tensor.name!r} in {shard_path} and {seen[tensor.name]}")
+            seen[tensor.name] = shard_path
+            refs.append(
+                GGUFTensorRef(
+                    name=tensor.name,
+                    dimensions=tuple(int(dim) for dim in tensor.dimensions),
+                    type_id=int(tensor.type_id),
+                    offset=int(tensor.offset),
+                    absolute_offset=int(tensor.absolute_offset),
+                    nbytes=tensor.nbytes,
+                    shard_index=shard_index,
+                    shard_path=shard_path,
+                )
+            )
+
+    if not shards:
+        raise ValueError(f"no GGUF shards resolved from {path}")
+    primary_index = _primary_shard_index(shards)
+    metadata = dict(shards[primary_index].file.metadata)
+    return GGUFBundle(
+        shards=tuple(shards),
+        primary_index=primary_index,
+        metadata=metadata,
+        tensors=tuple(refs),
+        size=total_size,
+    )
+
+
+def bundle_from_file(file: GGUFFile) -> GGUFBundle:
+    refs = tuple(
+        GGUFTensorRef(
+            name=tensor.name,
+            dimensions=tuple(int(dim) for dim in tensor.dimensions),
+            type_id=int(tensor.type_id),
+            offset=int(tensor.offset),
+            absolute_offset=int(tensor.absolute_offset),
+            nbytes=tensor.nbytes,
+            shard_index=0,
+            shard_path=file.path,
+        )
+        for tensor in file.tensors
+    )
+    return GGUFBundle(
+        shards=(GGUFShard(0, file.path, file),),
+        primary_index=0,
+        metadata=dict(file.metadata),
+        tensors=refs,
+        size=int(file.size),
+    )

--- a/src/moe_model/__init__.py
+++ b/src/moe_model/__init__.py
@@ -1,0 +1,21 @@
+from src.moe_model.registry import detect_spec, get_spec, known_architectures
+from src.moe_model.spec import (
+    CapabilityItem,
+    CapabilityReport,
+    MoEArchitectureParams,
+    PlacementDecision,
+    SpecValidation,
+    TensorMapping,
+)
+
+__all__ = [
+    "CapabilityItem",
+    "CapabilityReport",
+    "MoEArchitectureParams",
+    "PlacementDecision",
+    "SpecValidation",
+    "TensorMapping",
+    "detect_spec",
+    "get_spec",
+    "known_architectures",
+]

--- a/src/moe_model/capability.py
+++ b/src/moe_model/capability.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class QuantCapability:
+    type_name: str
+    header_supported: bool
+    payload_reader_supported: bool
+    routed_raw_supported: bool
+    runtime_supported: bool
+    notes: str
+
+
+_CAPABILITIES = {
+    "f32": QuantCapability("f32", True, True, False, True, "dense scalar tensor payload supported"),
+    "f16": QuantCapability("f16", True, True, False, True, "dense scalar tensor payload supported"),
+    "bf16": QuantCapability("bf16", True, True, False, True, "dense scalar tensor payload supported"),
+    "i32": QuantCapability("i32", True, True, False, True, "dense scalar tensor payload supported"),
+    "q8_0": QuantCapability("q8_0", True, True, True, True, "raw q8_0 binding exists for supported modules"),
+    "q2_k": QuantCapability("q2_k", True, True, True, True, "routed expert raw blocks supported in existing DSV4 paths"),
+    "iq2_xxs": QuantCapability("iq2_xxs", True, True, True, True, "routed expert raw blocks supported; MiniMax full runtime is deferred"),
+    "iq1_m": QuantCapability("iq1_m", True, True, True, True, "routed expert raw blocks supported in existing DSV4 paths"),
+    "q4_k": QuantCapability("q4_k", True, False, False, False, "header known; payload/runtime kernels deferred"),
+    "q5_k": QuantCapability("q5_k", True, False, False, False, "header known; payload/runtime kernels deferred"),
+}
+
+
+def quant_capability(type_name: str) -> QuantCapability:
+    return _CAPABILITIES.get(
+        type_name,
+        QuantCapability(type_name, False, False, False, False, "unknown GGUF tensor type"),
+    )
+
+
+def capability_status_for_role(role: str, type_name: str, *, architecture: str) -> tuple[str, str]:
+    cap = quant_capability(type_name)
+    if architecture == "minimax-m2":
+        if role in {"routed_w1", "routed_w2", "routed_w3"} and type_name == "iq2_xxs":
+            return "deferred", "iq2_xxs routed blocks are readable and low-bit resident candidates; MiniMax MoE runtime/fast path is not implemented yet"
+        if role in {"attn_q", "attn_k", "attn_v", "attn_o"} and type_name == "q5_k":
+            return "deferred", "q5_k attention kernels and MiniMax GQA runtime are deferred"
+        if role in {"embedding", "lm_head"} and type_name == "q4_k":
+            return "deferred", "q4_k embedding/head kernels are deferred"
+        if type_name == "f32":
+            return "deferred", "f32 tensor payload is supported, but full MiniMax runtime/generation is deferred"
+    if cap.runtime_supported:
+        return "supported", cap.notes
+    if cap.header_supported:
+        return "deferred", cap.notes
+    return "unsupported", cap.notes

--- a/src/moe_model/ds4_spec.py
+++ b/src/moe_model/ds4_spec.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+
+from src.gguf.bundle import GGUFBundle
+from src.moe_model.capability import capability_status_for_role
+from src.moe_model.placement import HardwareProfile, heterogeneous_expert_decision, lowbit_device_resident_decision
+from src.moe_model.spec import (
+    CapabilityItem,
+    CapabilityReport,
+    MoEArchitectureParams,
+    PlacementDecision,
+    SpecValidation,
+    TensorMapping,
+    bytes_by,
+    counts_by,
+    metadata_float,
+    metadata_int,
+)
+
+
+class DeepSeekV4Spec:
+    architecture = "deepseek4"
+    display_name = "DeepSeek-V4"
+
+    def parse_params(self, bundle: GGUFBundle) -> MoEArchitectureParams:
+        md = bundle.metadata
+        vocab = metadata_int(md, "tokenizer.ggml.tokens", metadata_int(md, "deepseek4.vocab_size", 0))
+        head_dim = metadata_int(md, "deepseek4.attention.key_length", 0)
+        return MoEArchitectureParams(
+            architecture=self.architecture,
+            n_layers=metadata_int(md, "deepseek4.block_count", 0),
+            hidden_size=metadata_int(md, "deepseek4.embedding_length", 0),
+            vocab_size=vocab,
+            context_length=metadata_int(md, "deepseek4.context_length", 0),
+            n_heads=metadata_int(md, "deepseek4.attention.head_count", 0),
+            n_kv_heads=metadata_int(md, "deepseek4.attention.head_count_kv", 0),
+            head_dim=head_dim,
+            rope_dim=metadata_int(md, "deepseek4.rope.dimension_count", 0) or None,
+            rope_base=metadata_float(md, "deepseek4.rope.freq_base", 0.0) or None,
+            n_routed_experts=metadata_int(md, "deepseek4.expert_count", 0),
+            top_k=metadata_int(md, "deepseek4.expert_used_count", 0),
+            expert_intermediate_size=metadata_int(md, "deepseek4.expert_feed_forward_length", 0),
+            n_shared_experts=metadata_int(md, "deepseek4.expert_shared_count", 1),
+            gate_function="hash+sqrtsoftplus",
+            attention_kind="dsv4_mla_compressed_sparse",
+            routed_expert_layout="packed_3d",
+            norm_eps=metadata_float(md, "deepseek4.attention.layer_norm_rms_epsilon", 0.0) or None,
+        )
+
+    def classify_tensor(self, name: str) -> str:
+        if "ffn_gate_exps" in name:
+            return "routed_w1"
+        if "ffn_down_exps" in name:
+            return "routed_w2"
+        if "ffn_up_exps" in name:
+            return "routed_w3"
+        if "ffn_gate_shexp" in name or "ffn_up_shexp" in name or "ffn_down_shexp" in name:
+            return "shared_experts"
+        if "ffn_gate_inp" in name:
+            return "gate"
+        if "exp_probs_b" in name:
+            return "gate_bias"
+        if ".attn" in name or "attn_" in name or "indexer" in name:
+            return "attention"
+        if name == "token_embd.weight":
+            return "embedding"
+        if name == "output.weight":
+            return "lm_head"
+        if name == "output_norm.weight":
+            return "final_norm"
+        if "hc_" in name or name.startswith("output_hc"):
+            return "hyper_connection"
+        if "ffn" in name:
+            return "ffn_other"
+        return "other"
+
+    def build_tensor_mappings(self, bundle: GGUFBundle) -> list[TensorMapping]:
+        from src.gguf.ds4_mapping import build_ds4_tensor_mappings
+
+        mappings = []
+        for item in build_ds4_tensor_mappings(bundle):
+            mappings.append(
+                TensorMapping(
+                    source_name=item.gguf_name,
+                    logical_name=item.target_key,
+                    role=item.role or self.classify_tensor(item.gguf_name),
+                    transform=item.transform,
+                    expert=item.expert,
+                )
+            )
+        return mappings
+
+    def validate_bundle(self, bundle: GGUFBundle) -> SpecValidation:
+        params = self.parse_params(bundle)
+        errors: list[str] = []
+        warnings: list[str] = []
+        if bundle.metadata.get("general.architecture") != self.architecture:
+            errors.append(f"general.architecture expected {self.architecture!r}, got {bundle.metadata.get('general.architecture')!r}")
+        if params.n_layers <= 0:
+            errors.append("missing or invalid deepseek4.block_count")
+        role_counts = Counter(self.classify_tensor(t.name) for t in bundle.tensors)
+        return SpecValidation(
+            ok=not errors,
+            errors=errors,
+            warnings=warnings,
+            mapped_sources=sum(role_counts.values()),
+            unmapped_sources=[],
+            role_counts=dict(role_counts),
+        )
+
+    def capability_report(self, bundle: GGUFBundle, *, gpu_count: int = 4, gpu_memory_gib: float = 22.0) -> CapabilityReport:
+        params = self.parse_params(bundle)
+        role_by_name = {t.name: self.classify_tensor(t.name) for t in bundle.tensors}
+        tensor_role_counts = counts_by(bundle.tensors, lambda t: role_by_name[t.name])
+        tensor_type_counts = counts_by(bundle.tensors, lambda t: t.type_name)
+        bytes_by_type = bytes_by(bundle.tensors, lambda t: t.type_name)
+        bytes_by_role = bytes_by(bundle.tensors, lambda t: role_by_name[t.name])
+        caps: list[CapabilityItem] = []
+        seen: set[tuple[str, str]] = set()
+        for t in bundle.tensors:
+            role = role_by_name[t.name]
+            key = (role, t.type_name)
+            if key in seen:
+                continue
+            seen.add(key)
+            status, reason = capability_status_for_role(role, t.type_name, architecture=self.architecture)
+            caps.append(CapabilityItem(f"{role}:{t.type_name}", status, reason))
+        routed_bytes = sum(int(t.nbytes or 0) for t in bundle.tensors if role_by_name[t.name] in {"routed_w1", "routed_w2", "routed_w3"})
+        hardware = HardwareProfile(gpu_count=gpu_count, gpu_memory_gib=gpu_memory_gib)
+        placements: list[PlacementDecision] = [
+            lowbit_device_resident_decision(bundle.size, hardware),
+            heterogeneous_expert_decision(routed_bytes),
+        ]
+        return CapabilityReport(
+            architecture=self.architecture,
+            params=params,
+            tensor_type_counts=tensor_type_counts,
+            tensor_role_counts=tensor_role_counts,
+            bytes_by_type=bytes_by_type,
+            bytes_by_role=bytes_by_role,
+            capabilities=caps,
+            placements=placements,
+        )

--- a/src/moe_model/minimax_m2_spec.py
+++ b/src/moe_model/minimax_m2_spec.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from collections import Counter
+
+from src.gguf.bundle import GGUFBundle
+from src.moe_model.capability import capability_status_for_role
+from src.moe_model.placement import HardwareProfile, heterogeneous_expert_decision, lowbit_device_resident_decision
+from src.moe_model.spec import (
+    CapabilityItem,
+    CapabilityReport,
+    MoEArchitectureParams,
+    PlacementDecision,
+    SpecValidation,
+    TensorMapping,
+    bytes_by,
+    counts_by,
+    metadata_float,
+    metadata_int,
+)
+
+
+class MiniMaxM2Spec:
+    architecture = "minimax-m2"
+    display_name = "MiniMax-M2"
+
+    _GLOBAL_TENSORS = {
+        "token_embd.weight": ("embed_tokens.weight", "embedding", "transpose", "q4_k"),
+        "output.weight": ("lm_head.weight", "lm_head", "transpose", "q4_k"),
+        "output_norm.weight": ("final_norm.weight", "final_norm", "direct", "f32"),
+    }
+
+    _LAYER_TENSORS = {
+        "attn_q.weight": ("self_attn.q_proj.weight", "attn_q", "transpose", "q5_k"),
+        "attn_q_norm.weight": ("self_attn.q_norm.weight", "attn_norm", "direct", "f32"),
+        "attn_k.weight": ("self_attn.k_proj.weight", "attn_k", "transpose", "q5_k"),
+        "attn_k_norm.weight": ("self_attn.k_norm.weight", "attn_norm", "direct", "f32"),
+        "attn_v.weight": ("self_attn.v_proj.weight", "attn_v", "transpose", "q5_k"),
+        "attn_output.weight": ("self_attn.o_proj.weight", "attn_o", "transpose", "q5_k"),
+        "attn_norm.weight": ("input_layernorm.weight", "attn_norm", "direct", "f32"),
+        "ffn_gate_inp.weight": ("mlp.router.weight", "gate", "transpose", "f32"),
+        "exp_probs_b.bias": ("mlp.router.bias", "gate_bias", "direct", "f32"),
+        "ffn_gate_exps.weight": ("mlp.experts.routed.w1", "routed_w1", "routed_expert_transpose", "iq2_xxs"),
+        "ffn_up_exps.weight": ("mlp.experts.routed.w3", "routed_w3", "routed_expert_transpose", "iq2_xxs"),
+        "ffn_down_exps.weight": ("mlp.experts.routed.w2", "routed_w2", "routed_expert_transpose", "iq2_xxs"),
+        "ffn_norm.weight": ("post_attention_layernorm.weight", "ffn_norm", "direct", "f32"),
+    }
+
+    def parse_params(self, bundle: GGUFBundle) -> MoEArchitectureParams:
+        md = bundle.metadata
+        head_dim = metadata_int(md, "minimax-m2.attention.key_length", 0)
+        return MoEArchitectureParams(
+            architecture=self.architecture,
+            n_layers=metadata_int(md, "minimax-m2.block_count", 0),
+            hidden_size=metadata_int(md, "minimax-m2.embedding_length", 0),
+            vocab_size=metadata_int(md, "tokenizer.ggml.tokens", metadata_int(md, "minimax-m2.vocab_size", 0)),
+            context_length=metadata_int(md, "minimax-m2.context_length", 0),
+            n_heads=metadata_int(md, "minimax-m2.attention.head_count", 0),
+            n_kv_heads=metadata_int(md, "minimax-m2.attention.head_count_kv", 0),
+            head_dim=head_dim,
+            rope_dim=metadata_int(md, "minimax-m2.rope.dimension_count", 0) or None,
+            rope_base=metadata_float(md, "minimax-m2.rope.freq_base", 0.0) or None,
+            n_routed_experts=metadata_int(md, "minimax-m2.expert_count", 0),
+            top_k=metadata_int(md, "minimax-m2.expert_used_count", 0),
+            expert_intermediate_size=metadata_int(md, "minimax-m2.expert_feed_forward_length", 0),
+            n_shared_experts=0,
+            gate_function=f"gguf_enum:{metadata_int(md, 'minimax-m2.expert_gating_func', 0)}",
+            attention_kind="gqa_separate_qkv",
+            routed_expert_layout="packed_3d",
+            norm_eps=metadata_float(md, "minimax-m2.attention.layer_norm_rms_epsilon", 0.0) or None,
+        )
+
+    def classify_tensor(self, name: str) -> str:
+        if name in self._GLOBAL_TENSORS:
+            return self._GLOBAL_TENSORS[name][1]
+        if not name.startswith("blk."):
+            return "other"
+        suffix = name.split(".", 2)[2] if len(name.split(".", 2)) == 3 else ""
+        return self._LAYER_TENSORS.get(suffix, ("", "other", "", ""))[1]
+
+    def build_tensor_mappings(self, bundle: GGUFBundle) -> list[TensorMapping]:
+        params = self.parse_params(bundle)
+        mappings: list[TensorMapping] = []
+        for source_name, (logical, role, transform, _expected_type) in self._GLOBAL_TENSORS.items():
+            mappings.append(TensorMapping(source_name, logical, role, transform))
+        for layer in range(params.n_layers):
+            for suffix, (logical_suffix, role, transform, _expected_type) in self._LAYER_TENSORS.items():
+                source = f"blk.{layer}.{suffix}"
+                logical = f"layers.{layer}.{logical_suffix}"
+                if role in {"routed_w1", "routed_w2", "routed_w3"}:
+                    mappings.append(TensorMapping(source, logical, role, transform, layer=layer))
+                else:
+                    mappings.append(TensorMapping(source, logical, role, transform, layer=layer))
+        return mappings
+
+    def _expected_shape_ok(self, source_name: str, dims: tuple[int, ...], params: MoEArchitectureParams) -> bool:
+        h = params.hidden_size
+        e = params.n_routed_experts
+        i = params.expert_intermediate_size
+        q = params.n_heads * params.head_dim
+        kv = params.n_kv_heads * params.head_dim
+        v = params.vocab_size
+        if source_name == "token_embd.weight" or source_name == "output.weight":
+            return dims == (h, v)
+        if source_name == "output_norm.weight":
+            return dims == (h,)
+        suffix = source_name.split(".", 2)[2]
+        expected = {
+            "attn_q.weight": (h, q),
+            "attn_q_norm.weight": (q,),
+            "attn_k.weight": (h, kv),
+            "attn_k_norm.weight": (kv,),
+            "attn_v.weight": (h, kv),
+            "attn_output.weight": (q, h),
+            "attn_norm.weight": (h,),
+            "ffn_gate_inp.weight": (h, e),
+            "exp_probs_b.bias": (e,),
+            "ffn_gate_exps.weight": (h, i, e),
+            "ffn_up_exps.weight": (h, i, e),
+            "ffn_down_exps.weight": (i, h, e),
+            "ffn_norm.weight": (h,),
+        }.get(suffix)
+        return expected is None or dims == expected
+
+    def validate_bundle(self, bundle: GGUFBundle) -> SpecValidation:
+        params = self.parse_params(bundle)
+        errors: list[str] = []
+        warnings: list[str] = []
+        names = bundle.tensors_by_name
+        mapped_sources: set[str] = set()
+        role_counts: Counter[str] = Counter()
+
+        if bundle.metadata.get("general.architecture") != self.architecture:
+            errors.append(f"general.architecture expected {self.architecture!r}, got {bundle.metadata.get('general.architecture')!r}")
+        for key in (
+            "minimax-m2.block_count",
+            "minimax-m2.embedding_length",
+            "minimax-m2.expert_count",
+            "minimax-m2.expert_used_count",
+            "minimax-m2.expert_feed_forward_length",
+        ):
+            if key not in bundle.metadata:
+                errors.append(f"missing metadata {key}")
+        if params.n_layers <= 0:
+            errors.append("minimax-m2.block_count must be positive")
+
+        for source_name, (_logical, role, _transform, expected_type) in self._GLOBAL_TENSORS.items():
+            tensor = names.get(source_name)
+            if tensor is None:
+                errors.append(f"missing tensor {source_name}")
+                continue
+            mapped_sources.add(source_name)
+            role_counts[role] += 1
+            if tensor.type_name != expected_type:
+                errors.append(f"{source_name} expected {expected_type}, got {tensor.type_name}")
+            if not self._expected_shape_ok(source_name, tuple(tensor.dimensions), params):
+                errors.append(f"{source_name} unexpected shape {tuple(tensor.dimensions)}")
+
+        for layer in range(params.n_layers):
+            for suffix, (_logical, role, _transform, expected_type) in self._LAYER_TENSORS.items():
+                source_name = f"blk.{layer}.{suffix}"
+                tensor = names.get(source_name)
+                if tensor is None:
+                    errors.append(f"missing tensor {source_name}")
+                    continue
+                mapped_sources.add(source_name)
+                role_counts[role] += 1
+                if tensor.type_name != expected_type:
+                    errors.append(f"{source_name} expected {expected_type}, got {tensor.type_name}")
+                if not self._expected_shape_ok(source_name, tuple(tensor.dimensions), params):
+                    errors.append(f"{source_name} unexpected shape {tuple(tensor.dimensions)}")
+
+        unmapped = sorted(set(names) - mapped_sources)
+        if unmapped:
+            warnings.append(f"{len(unmapped)} unmapped tensors, e.g. {unmapped[:10]}")
+        return SpecValidation(
+            ok=not errors,
+            errors=errors,
+            warnings=warnings,
+            mapped_sources=len(mapped_sources),
+            unmapped_sources=unmapped,
+            role_counts=dict(role_counts),
+        )
+
+    def capability_report(self, bundle: GGUFBundle, *, gpu_count: int = 4, gpu_memory_gib: float = 22.0) -> CapabilityReport:
+        params = self.parse_params(bundle)
+        role_by_name = {t.name: self.classify_tensor(t.name) for t in bundle.tensors}
+        tensor_role_counts = counts_by(bundle.tensors, lambda t: role_by_name[t.name])
+        tensor_type_counts = counts_by(bundle.tensors, lambda t: t.type_name)
+        bytes_by_type = bytes_by(bundle.tensors, lambda t: t.type_name)
+        bytes_by_role = bytes_by(bundle.tensors, lambda t: role_by_name[t.name])
+
+        caps: list[CapabilityItem] = []
+        seen: set[tuple[str, str]] = set()
+        for tensor in bundle.tensors:
+            role = role_by_name[tensor.name]
+            key = (role, tensor.type_name)
+            if key in seen:
+                continue
+            seen.add(key)
+            status, reason = capability_status_for_role(role, tensor.type_name, architecture=self.architecture)
+            caps.append(CapabilityItem(f"{role}:{tensor.type_name}", status, reason))
+        caps.append(CapabilityItem("generation", "deferred", "MiniMax-M2 generation is not implemented yet"))
+
+        tensor_bytes = sum(int(t.nbytes or 0) for t in bundle.tensors)
+        routed_bytes = sum(
+            int(t.nbytes or 0)
+            for t in bundle.tensors
+            if role_by_name[t.name] in {"routed_w1", "routed_w2", "routed_w3"}
+        )
+        hardware = HardwareProfile(gpu_count=gpu_count, gpu_memory_gib=gpu_memory_gib)
+        placements: list[PlacementDecision] = [
+            lowbit_device_resident_decision(tensor_bytes, hardware),
+            heterogeneous_expert_decision(routed_bytes),
+        ]
+        return CapabilityReport(
+            architecture=self.architecture,
+            params=params,
+            tensor_type_counts=tensor_type_counts,
+            tensor_role_counts=tensor_role_counts,
+            bytes_by_type=bytes_by_type,
+            bytes_by_role=bytes_by_role,
+            capabilities=caps,
+            placements=placements,
+        )

--- a/src/moe_model/placement.py
+++ b/src/moe_model/placement.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.moe_model.spec import PlacementDecision
+
+
+@dataclass(frozen=True)
+class HardwareProfile:
+    gpu_count: int = 4
+    gpu_memory_gib: float = 22.0
+    name: str = "consumer-gpu-box"
+
+    @property
+    def total_gpu_bytes(self) -> int:
+        return int(self.gpu_count * self.gpu_memory_gib * (1024 ** 3))
+
+    @property
+    def per_gpu_bytes(self) -> int:
+        return int(self.gpu_memory_gib * (1024 ** 3))
+
+
+def estimate_even_shard(total_bytes: int, gpu_count: int) -> int:
+    if gpu_count <= 0:
+        return int(total_bytes)
+    return (int(total_bytes) + int(gpu_count) - 1) // int(gpu_count)
+
+
+def lowbit_device_resident_decision(total_bytes: int, hardware: HardwareProfile, *, reserve_fraction: float = 0.15) -> PlacementDecision:
+    per_gpu = estimate_even_shard(total_bytes, hardware.gpu_count)
+    usable = int(hardware.per_gpu_bytes * (1.0 - reserve_fraction))
+    if per_gpu <= usable:
+        return PlacementDecision(
+            name="all_device_lowbit",
+            status="candidate",
+            reason=f"even sharding uses {per_gpu} bytes/GPU within reserved budget {usable} bytes/GPU",
+            estimated_bytes=int(total_bytes),
+            estimated_bytes_per_gpu=per_gpu,
+        )
+    return PlacementDecision(
+        name="all_device_lowbit",
+        status="deferred",
+        reason=f"even sharding uses {per_gpu} bytes/GPU above reserved budget {usable} bytes/GPU",
+        estimated_bytes=int(total_bytes),
+        estimated_bytes_per_gpu=per_gpu,
+    )
+
+
+def heterogeneous_expert_decision(routed_bytes: int) -> PlacementDecision:
+    return PlacementDecision(
+        name="heterogeneous_routed_experts",
+        status="candidate",
+        reason="routed experts can be kept in CPU pinned/NUMA memory and staged by active routes when all-device placement is not practical",
+        estimated_bytes=int(routed_bytes),
+        estimated_bytes_per_gpu=None,
+    )

--- a/src/moe_model/registry.py
+++ b/src/moe_model/registry.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from src.gguf.bundle import GGUFBundle
+from src.moe_model.spec import MoEModelSpec
+
+
+_SPECS: dict[str, MoEModelSpec] | None = None
+
+
+def _init_specs() -> dict[str, MoEModelSpec]:
+    from src.moe_model.ds4_spec import DeepSeekV4Spec
+    from src.moe_model.minimax_m2_spec import MiniMaxM2Spec
+
+    return {
+        DeepSeekV4Spec.architecture: DeepSeekV4Spec(),
+        MiniMaxM2Spec.architecture: MiniMaxM2Spec(),
+    }
+
+
+def _specs() -> dict[str, MoEModelSpec]:
+    global _SPECS
+    if _SPECS is None:
+        _SPECS = _init_specs()
+    return _SPECS
+
+
+def known_architectures() -> list[str]:
+    return sorted(_specs())
+
+
+def get_spec(architecture: str) -> MoEModelSpec:
+    key = architecture.strip().lower()
+    try:
+        return _specs()[key]
+    except KeyError as exc:
+        raise ValueError(f"unsupported MoE architecture {architecture!r}; known: {', '.join(known_architectures())}") from exc
+
+
+def detect_spec(bundle: GGUFBundle, override: str = "auto") -> MoEModelSpec:
+    if override != "auto":
+        return get_spec(override)
+    arch = bundle.metadata.get("general.architecture")
+    if not isinstance(arch, str) or not arch:
+        raise ValueError("GGUF metadata does not contain general.architecture; pass --architecture explicitly")
+    return get_spec(arch)

--- a/src/moe_model/spec.py
+++ b/src/moe_model/spec.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from src.gguf.bundle import GGUFBundle
+
+
+@dataclass(frozen=True)
+class MoEArchitectureParams:
+    architecture: str
+    n_layers: int
+    hidden_size: int
+    vocab_size: int
+    context_length: int
+    n_heads: int
+    n_kv_heads: int
+    head_dim: int
+    rope_dim: int | None
+    rope_base: float | None
+    n_routed_experts: int
+    top_k: int
+    expert_intermediate_size: int
+    n_shared_experts: int = 0
+    gate_function: str | None = None
+    attention_kind: str = "unknown"
+    routed_expert_layout: str = "packed_3d"
+    norm_eps: float | None = None
+
+
+@dataclass(frozen=True)
+class TensorMapping:
+    source_name: str
+    logical_name: str
+    role: str
+    transform: str = "direct"
+    layer: int | None = None
+    expert: int | None = None
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class SpecValidation:
+    ok: bool
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    mapped_sources: int = 0
+    unmapped_sources: list[str] = field(default_factory=list)
+    role_counts: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CapabilityItem:
+    name: str
+    status: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class PlacementDecision:
+    name: str
+    status: str
+    reason: str
+    estimated_bytes: int | None = None
+    estimated_bytes_per_gpu: int | None = None
+
+
+@dataclass(frozen=True)
+class CapabilityReport:
+    architecture: str
+    params: MoEArchitectureParams
+    tensor_type_counts: dict[str, int]
+    tensor_role_counts: dict[str, int]
+    bytes_by_type: dict[str, int]
+    bytes_by_role: dict[str, int]
+    capabilities: list[CapabilityItem]
+    placements: list[PlacementDecision]
+
+
+class MoEModelSpec(Protocol):
+    architecture: str
+    display_name: str
+
+    def parse_params(self, bundle: GGUFBundle) -> MoEArchitectureParams:
+        ...
+
+    def classify_tensor(self, name: str) -> str:
+        ...
+
+    def build_tensor_mappings(self, bundle: GGUFBundle) -> list[TensorMapping]:
+        ...
+
+    def validate_bundle(self, bundle: GGUFBundle) -> SpecValidation:
+        ...
+
+    def capability_report(self, bundle: GGUFBundle, *, gpu_count: int = 4, gpu_memory_gib: float = 22.0) -> CapabilityReport:
+        ...
+
+
+def metadata_value(metadata: dict[str, Any], key: str, default: Any = None) -> Any:
+    return metadata.get(key, default)
+
+
+def metadata_int(metadata: dict[str, Any], key: str, default: int = 0) -> int:
+    value = metadata.get(key, default)
+    try:
+        if hasattr(value, "length"):
+            return int(value.length)
+        return int(value)
+    except Exception:
+        return int(default)
+
+
+def metadata_float(metadata: dict[str, Any], key: str, default: float = 0.0) -> float:
+    value = metadata.get(key, default)
+    try:
+        return float(value)
+    except Exception:
+        return float(default)
+
+
+def bytes_by(items, key_fn) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for item in items:
+        key = str(key_fn(item))
+        result[key] = result.get(key, 0) + int(item.nbytes or 0)
+    return result
+
+
+def counts_by(items, key_fn) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for item in items:
+        key = str(key_fn(item))
+        result[key] = result.get(key, 0) + 1
+    return result

--- a/tests/gguf_test_utils.py
+++ b/tests/gguf_test_utils.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+from typing import Any
+
+from src.gguf.reader import GGUF_MAGIC, align_up, tensor_nbytes
+
+GGUF_VERSION = 3
+GGML_F32 = 0
+GGML_F16 = 1
+GGML_Q4_K = 12
+GGML_Q5_K = 13
+GGML_IQ2_XXS = 16
+GGML_IQ1_M = 29
+GGML_BF16 = 30
+
+
+def pack_string(value: str) -> bytes:
+    data = value.encode("utf-8")
+    return struct.pack("<Q", len(data)) + data
+
+
+def pack_metadata_value(value: Any) -> bytes:
+    if isinstance(value, str):
+        return struct.pack("<I", 8) + pack_string(value)
+    if isinstance(value, bool):
+        return struct.pack("<I", 7) + struct.pack("<?", value)
+    if isinstance(value, int):
+        return struct.pack("<I", 5) + struct.pack("<i", int(value))
+    if isinstance(value, float):
+        return struct.pack("<I", 6) + struct.pack("<f", float(value))
+    if isinstance(value, tuple) and len(value) == 2 and value[0] == "array_strings":
+        values = list(value[1])
+        buf = bytearray()
+        buf.extend(struct.pack("<I", 9))  # array
+        buf.extend(struct.pack("<I", 8))  # string item type
+        buf.extend(struct.pack("<Q", len(values)))
+        for item in values:
+            buf.extend(pack_string(str(item)))
+        return bytes(buf)
+    raise TypeError(f"unsupported GGUF test metadata value: {value!r}")
+
+
+def write_gguf(
+    path: Path,
+    *,
+    metadata: dict[str, Any] | None = None,
+    tensors: list[tuple[str, tuple[int, ...], int]] | None = None,
+    alignment: int = 32,
+) -> None:
+    """Write a tiny valid GGUF file for header-only tests.
+
+    Tensor payloads are zero-filled and only sized according to GGML block
+    metadata.  This helper intentionally implements the subset needed by the
+    spec/bundle tests, not a general GGUF writer.
+    """
+
+    metadata = dict(metadata or {})
+    tensors = list(tensors or [])
+    if alignment != 32:
+        metadata.setdefault("general.alignment", alignment)
+
+    payloads: list[bytes] = []
+    offsets: list[int] = []
+    cursor = 0
+    for _name, dims, type_id in tensors:
+        nbytes = tensor_nbytes(type_id, dims)
+        if nbytes is None:
+            raise ValueError(f"unknown test tensor type id {type_id}")
+        offsets.append(cursor)
+        payloads.append(b"\0" * nbytes)
+        cursor += nbytes
+
+    buf = bytearray()
+    buf.extend(GGUF_MAGIC)
+    buf.extend(struct.pack("<I", GGUF_VERSION))
+    buf.extend(struct.pack("<Q", len(tensors)))
+    buf.extend(struct.pack("<Q", len(metadata)))
+
+    for key, value in metadata.items():
+        buf.extend(pack_string(key))
+        buf.extend(pack_metadata_value(value))
+
+    for (name, dims, type_id), offset in zip(tensors, offsets):
+        buf.extend(pack_string(name))
+        buf.extend(struct.pack("<I", len(dims)))
+        for dim in dims:
+            buf.extend(struct.pack("<Q", int(dim)))
+        buf.extend(struct.pack("<I", int(type_id)))
+        buf.extend(struct.pack("<Q", int(offset)))
+
+    padded = align_up(len(buf), alignment)
+    if padded > len(buf):
+        buf.extend(b"\0" * (padded - len(buf)))
+    for payload in payloads:
+        buf.extend(payload)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(bytes(buf))
+
+
+def minimax_metadata(*, n_layers: int = 2, hidden: int = 8, vocab: int = 16, experts: int = 4) -> dict[str, Any]:
+    return {
+        "general.architecture": "minimax-m2",
+        "minimax-m2.block_count": n_layers,
+        "minimax-m2.embedding_length": hidden,
+        "minimax-m2.vocab_size": vocab,
+        "minimax-m2.context_length": 128,
+        "minimax-m2.attention.head_count": 2,
+        "minimax-m2.attention.head_count_kv": 1,
+        "minimax-m2.attention.key_length": 4,
+        "minimax-m2.attention.value_length": 4,
+        "minimax-m2.rope.dimension_count": 4,
+        "minimax-m2.rope.freq_base": 5000000.0,
+        "minimax-m2.expert_count": experts,
+        "minimax-m2.expert_used_count": 2,
+        "minimax-m2.expert_feed_forward_length": 4,
+        "minimax-m2.expert_gating_func": 2,
+        "minimax-m2.attention.layer_norm_rms_epsilon": 0.00001,
+    }
+
+
+def minimax_tensors(*, n_layers: int = 2, hidden: int = 8, vocab: int = 16, experts: int = 4) -> list[tuple[str, tuple[int, ...], int]]:
+    q = 8
+    kv = 4
+    inter = 4
+    tensors: list[tuple[str, tuple[int, ...], int]] = [
+        ("token_embd.weight", (hidden, vocab), GGML_Q4_K),
+        ("output.weight", (hidden, vocab), GGML_Q4_K),
+        ("output_norm.weight", (hidden,), GGML_F32),
+    ]
+    for layer in range(n_layers):
+        prefix = f"blk.{layer}"
+        tensors.extend(
+            [
+                (f"{prefix}.attn_q.weight", (hidden, q), GGML_Q5_K),
+                (f"{prefix}.attn_q_norm.weight", (q,), GGML_F32),
+                (f"{prefix}.attn_k.weight", (hidden, kv), GGML_Q5_K),
+                (f"{prefix}.attn_k_norm.weight", (kv,), GGML_F32),
+                (f"{prefix}.attn_v.weight", (hidden, kv), GGML_Q5_K),
+                (f"{prefix}.attn_output.weight", (q, hidden), GGML_Q5_K),
+                (f"{prefix}.attn_norm.weight", (hidden,), GGML_F32),
+                (f"{prefix}.ffn_gate_inp.weight", (hidden, experts), GGML_F32),
+                (f"{prefix}.exp_probs_b.bias", (experts,), GGML_F32),
+                (f"{prefix}.ffn_gate_exps.weight", (hidden, inter, experts), GGML_IQ2_XXS),
+                (f"{prefix}.ffn_up_exps.weight", (hidden, inter, experts), GGML_IQ2_XXS),
+                (f"{prefix}.ffn_down_exps.weight", (inter, hidden, experts), GGML_IQ2_XXS),
+                (f"{prefix}.ffn_norm.weight", (hidden,), GGML_F32),
+            ]
+        )
+    return tensors
+
+
+def write_minimax_bundle(root: Path, *, n_layers: int = 2) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    write_gguf(
+        root / "tiny-minimax-00001-of-00002.gguf",
+        metadata={**minimax_metadata(n_layers=n_layers), "split.no": 0, "split.count": 2},
+        tensors=[],
+    )
+    write_gguf(
+        root / "tiny-minimax-00002-of-00002.gguf",
+        metadata={"split.no": 1, "split.count": 2},
+        tensors=minimax_tensors(n_layers=n_layers),
+    )
+    return root

--- a/tests/test_gguf_bundle.py
+++ b/tests/test_gguf_bundle.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.gguf.bundle import read_gguf_bundle, resolve_gguf_bundle
+from tests.gguf_test_utils import GGML_F32, write_gguf, write_minimax_bundle
+
+
+def test_single_file_bundle(tmp_path: Path) -> None:
+    path = tmp_path / "single.gguf"
+    write_gguf(
+        path,
+        metadata={"general.architecture": "deepseek4", "deepseek4.block_count": 1},
+        tensors=[("token_embd.weight", (4, 8), GGML_F32)],
+    )
+
+    bundle = read_gguf_bundle(path)
+
+    assert bundle.paths == (str(path.resolve()),)
+    assert bundle.path == str(path.resolve())
+    assert bundle.version == 3
+    assert bundle.tensor_count == 1
+    assert bundle.metadata["general.architecture"] == "deepseek4"
+    assert bundle.tensors_by_name["token_embd.weight"].shard_index == 0
+
+
+def test_directory_shard_resolution_and_metadata_only_primary(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1)
+
+    paths = resolve_gguf_bundle(root)
+    bundle = read_gguf_bundle(root)
+
+    assert len(paths) == 2
+    assert paths[0].endswith("tiny-minimax-00001-of-00002.gguf")
+    assert bundle.primary_index == 0
+    assert bundle.metadata["general.architecture"] == "minimax-m2"
+    assert bundle.tensor_count == 16
+    assert "blk.0.ffn_gate_exps.weight" in bundle.tensors_by_name
+    assert bundle.tensors_by_name["blk.0.ffn_gate_exps.weight"].shard_index == 1
+
+
+def test_shard_path_resolves_all_shards(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1)
+    second = root / "tiny-minimax-00002-of-00002.gguf"
+
+    paths = resolve_gguf_bundle(second)
+
+    assert len(paths) == 2
+    assert paths[0].endswith("tiny-minimax-00001-of-00002.gguf")
+    assert paths[1].endswith("tiny-minimax-00002-of-00002.gguf")
+
+
+def test_missing_shard_is_reported(tmp_path: Path) -> None:
+    root = tmp_path / "bundle"
+    root.mkdir()
+    write_gguf(
+        root / "broken-00001-of-00002.gguf",
+        metadata={"general.architecture": "minimax-m2", "split.no": 0, "split.count": 2},
+        tensors=[],
+    )
+
+    with pytest.raises(FileNotFoundError, match="missing GGUF shard"):
+        resolve_gguf_bundle(root)
+
+
+def test_duplicate_tensor_detection(tmp_path: Path) -> None:
+    root = tmp_path / "bundle"
+    root.mkdir()
+    for idx in (1, 2):
+        write_gguf(
+            root / f"dup-{idx:05d}-of-00002.gguf",
+            metadata={"general.architecture": "minimax-m2", "split.no": idx - 1, "split.count": 2},
+            tensors=[("same.weight", (4,), GGML_F32)],
+        )
+
+    with pytest.raises(ValueError, match="duplicate GGUF tensor"):
+        read_gguf_bundle(root)

--- a/tests/test_inspect_gguf_specs.py
+++ b/tests/test_inspect_gguf_specs.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.gguf_test_utils import write_gguf, write_minimax_bundle
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_inspect(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        [sys.executable, "-m", "src.cli.inspect_gguf", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def test_inspect_minimax_spec_summary_validation_and_reports(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1)
+
+    result = _run_inspect(
+        "--gguf-path",
+        str(root),
+        "--architecture",
+        "auto",
+        "--spec-summary",
+        "--validate-spec",
+        "--capability-report",
+        "--placement-report",
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "architecture: minimax-m2" in result.stdout
+    assert "layers: 1" in result.stdout
+    assert "hidden_size: 8" in result.stdout
+    assert "n_routed_experts: 4" in result.stdout
+    assert "top_k: 2" in result.stdout
+    assert "ok: True" in result.stdout
+    assert "[deferred] embedding:q4_k" in result.stdout
+    assert "[deferred] attn_q:q5_k" in result.stdout
+    assert "[deferred] routed_w1:iq2_xxs" in result.stdout
+    assert "[candidate] all_device_lowbit" in result.stdout
+    assert "[candidate] heterogeneous_routed_experts" in result.stdout
+
+
+def test_inspect_minimax_runtime_mapping_fails_clearly(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1)
+
+    result = _run_inspect("--gguf-path", str(root), "--validate-runtime-mapping")
+
+    assert result.returncode == 1
+    assert "runtime mapping: FAILED" in result.stdout
+    assert "MiniMax" in result.stdout or "minimax" in result.stdout
+    assert "--validate-spec" in result.stdout
+
+
+def test_inspect_legacy_ds4_summary_and_q2_validation_still_work(tmp_path: Path) -> None:
+    path = tmp_path / "ds4-empty.gguf"
+    write_gguf(
+        path,
+        metadata={
+            "general.architecture": "deepseek4",
+            "deepseek4.block_count": 0,
+            "deepseek4.embedding_length": 8,
+            "deepseek4.expert_count": 4,
+            "deepseek4.expert_used_count": 2,
+            "deepseek4.expert_feed_forward_length": 4,
+        },
+        tensors=[],
+    )
+
+    result = _run_inspect("--gguf-path", str(path), "--summary", "--validate-ds4-q2")
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "metadata.general.architecture: 'deepseek4'" in result.stdout
+    assert "tensor_count: 0" in result.stdout
+    assert "validation: OK" in result.stdout

--- a/tests/test_minimax_m2_spec.py
+++ b/tests/test_minimax_m2_spec.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.gguf.bundle import read_gguf_bundle
+from src.moe_model.minimax_m2_spec import MiniMaxM2Spec
+from tests.gguf_test_utils import GGML_F32, write_gguf, write_minimax_bundle
+
+
+REAL_MINIMAX_PATH = Path("/mnt/data1/dsv4_inference/gguf_hfd/MiniMax-M2.7-GGUF/UD-IQ1_M")
+
+
+def test_minimax_spec_parses_tiny_bundle_and_validates_schema(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=2)
+    bundle = read_gguf_bundle(root)
+    spec = MiniMaxM2Spec()
+
+    params = spec.parse_params(bundle)
+    validation = spec.validate_bundle(bundle)
+
+    assert params.architecture == "minimax-m2"
+    assert params.n_layers == 2
+    assert params.hidden_size == 8
+    assert params.vocab_size == 16
+    assert params.n_heads == 2
+    assert params.n_kv_heads == 1
+    assert params.head_dim == 4
+    assert params.n_routed_experts == 4
+    assert params.top_k == 2
+    assert params.expert_intermediate_size == 4
+    assert params.attention_kind == "gqa_separate_qkv"
+    assert params.gate_function == "gguf_enum:2"
+    assert validation.ok, validation.errors
+    assert validation.mapped_sources == 29
+    assert validation.role_counts["routed_w1"] == 2
+    assert validation.role_counts["routed_w2"] == 2
+    assert validation.role_counts["routed_w3"] == 2
+
+
+def test_minimax_capability_marks_runtime_deferred_but_placement_candidate(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1)
+    bundle = read_gguf_bundle(root)
+    report = MiniMaxM2Spec().capability_report(bundle, gpu_count=4, gpu_memory_gib=22.0)
+
+    caps = {item.name: item for item in report.capabilities}
+    placements = {item.name: item for item in report.placements}
+
+    assert caps["embedding:q4_k"].status == "deferred"
+    assert caps["attn_q:q5_k"].status == "deferred"
+    assert caps["routed_w1:iq2_xxs"].status == "deferred"
+    assert caps["generation"].status == "deferred"
+    assert "MiniMax" in caps["generation"].reason
+    assert report.tensor_type_counts["iq2_xxs"] == 3
+    assert report.tensor_type_counts["q5_k"] == 4
+    assert placements["all_device_lowbit"].status == "candidate"
+    assert placements["heterogeneous_routed_experts"].status == "candidate"
+
+
+def test_minimax_spec_does_not_require_dsv4_only_tensors(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1)
+    bundle = read_gguf_bundle(root)
+    validation = MiniMaxM2Spec().validate_bundle(bundle)
+
+    assert validation.ok, validation.errors
+    joined = "\n".join(validation.errors)
+    assert "attn_q_a" not in joined
+    assert "attn_kv" not in joined
+    assert "ffn_gate_tid2eid" not in joined
+    assert "ffn_gate_shexp" not in joined
+    assert "hc_" not in joined
+    assert "indexer" not in joined
+
+
+def test_minimax_shape_validation_catches_wrong_tensor_shape(tmp_path: Path) -> None:
+    path = tmp_path / "bad.gguf"
+    metadata = {
+        "general.architecture": "minimax-m2",
+        "minimax-m2.block_count": 1,
+        "minimax-m2.embedding_length": 8,
+        "minimax-m2.vocab_size": 16,
+        "minimax-m2.context_length": 128,
+        "minimax-m2.attention.head_count": 2,
+        "minimax-m2.attention.head_count_kv": 1,
+        "minimax-m2.attention.key_length": 4,
+        "minimax-m2.expert_count": 4,
+        "minimax-m2.expert_used_count": 2,
+        "minimax-m2.expert_feed_forward_length": 4,
+    }
+    write_gguf(path, metadata=metadata, tensors=[("token_embd.weight", (7, 16), GGML_F32)])
+    bundle = read_gguf_bundle(path)
+
+    validation = MiniMaxM2Spec().validate_bundle(bundle)
+
+    assert not validation.ok
+    assert any("token_embd.weight unexpected shape" in error for error in validation.errors)
+
+
+@pytest.mark.skipif(not REAL_MINIMAX_PATH.exists(), reason="local MiniMax-M2.7 GGUF bundle not present")
+def test_real_minimax_m27_bundle_validates_when_available() -> None:
+    bundle = read_gguf_bundle(REAL_MINIMAX_PATH)
+    spec = MiniMaxM2Spec()
+    params = spec.parse_params(bundle)
+    validation = spec.validate_bundle(bundle)
+    report = spec.capability_report(bundle)
+
+    assert params.n_layers == 62
+    assert params.hidden_size == 3072
+    assert params.vocab_size == 200064
+    assert params.n_routed_experts == 256
+    assert params.top_k == 8
+    assert bundle.tensor_count == 809
+    assert validation.ok, validation.errors[:20]
+    assert report.tensor_type_counts["iq2_xxs"] == 62 * 3
+    assert any(item.name == "generation" and item.status == "deferred" for item in report.capabilities)

--- a/tests/test_moe_model_registry.py
+++ b/tests/test_moe_model_registry.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.gguf.bundle import read_gguf_bundle
+from src.moe_model.registry import detect_spec, get_spec, known_architectures
+from tests.gguf_test_utils import write_gguf, write_minimax_bundle
+
+
+def test_known_architectures_include_dsv4_and_minimax() -> None:
+    assert "deepseek4" in known_architectures()
+    assert "minimax-m2" in known_architectures()
+
+
+def test_get_spec_normalizes_architecture() -> None:
+    assert get_spec("MiniMax-M2").architecture == "minimax-m2"
+    assert get_spec("deepseek4").architecture == "deepseek4"
+
+
+def test_detect_spec_from_minimax_bundle(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1)
+    bundle = read_gguf_bundle(root)
+
+    spec = detect_spec(bundle)
+
+    assert spec.architecture == "minimax-m2"
+
+
+def test_detect_spec_from_deepseek_metadata(tmp_path: Path) -> None:
+    path = tmp_path / "ds4.gguf"
+    write_gguf(
+        path,
+        metadata={"general.architecture": "deepseek4", "deepseek4.block_count": 1},
+        tensors=[],
+    )
+    bundle = read_gguf_bundle(path)
+
+    spec = detect_spec(bundle)
+
+    assert spec.architecture == "deepseek4"
+
+
+def test_unknown_architecture_error(tmp_path: Path) -> None:
+    path = tmp_path / "unknown.gguf"
+    write_gguf(path, metadata={"general.architecture": "dense-thing"}, tensors=[])
+    bundle = read_gguf_bundle(path)
+
+    with pytest.raises(ValueError, match="unsupported MoE architecture"):
+        detect_spec(bundle)


### PR DESCRIPTION
## Summary
- Reposition README/README_CN around PocketMoE as a MoE-only low-bit + heterogeneous inference engine for consumer GPUs.
- Add header-only sharded GGUF bundle support and a MoE model spec/registry layer for DeepSeek-V4 and MiniMax-M2.7.
- Extend inspect_gguf with spec summary, validation, capability, and placement reports; add tests for bundle/spec/CLI behavior.

## Validation
- PYTHONPATH=$PWD python -m pytest tests/test_gguf_bundle.py tests/test_moe_model_registry.py tests/test_minimax_m2_spec.py tests/test_inspect_gguf_specs.py tests/test_gguf_iq1m_reader.py tests/test_partition_policy.py -q
- PYTHONPATH=$PWD python -m src.cli.inspect_gguf --gguf-path /mnt/data1/dsv4_inference/gguf_hfd/MiniMax-M2.7-GGUF/UD-IQ1_M --architecture auto --spec-summary --validate-spec --capability-report --placement-report
- PYTHONPATH=$PWD python -m src.cli.inspect_gguf --gguf-path /mnt/data1/dsv4_inference/DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2.gguf --summary --validate-ds4-q2

🤖 Generated with [Claude Code](https://claude.com/claude-code)