### PR TITLE
Add MiniMax MoE runtime readiness checks

### DIFF
--- a/src/cli/inspect_gguf.py
+++ b/src/cli/inspect_gguf.py
@@ -330,6 +330,73 @@ def _print_placement_report(report: CapabilityReport) -> None:
         print(f"  [{decision.status}] {decision.name}:{est} {decision.reason}")
 
 
+def _print_moe_runtime_report(bundle: GGUFBundle, *, gpu_count: int, gpu_memory_gib: float):
+    from src.runtime.minimax_m2_moe import build_minimax_m2_moe_runtime_plan
+
+    plan = build_minimax_m2_moe_runtime_plan(bundle, gpu_count=gpu_count, gpu_memory_gib=gpu_memory_gib)
+    print("\nmoe runtime report:")
+    print(f"  architecture: {plan.architecture}")
+    print(f"  minimax_moe_runtime: {plan.status}")
+    print(f"  ok: {plan.ok}")
+    print(f"  layers: {plan.params.n_layers}")
+    print(f"  routed tensors: {plan.routed_tensor_count} / expected {plan.expected_routed_tensor_count}")
+    print(f"  moe tensors: {plan.moe_tensor_count} / expected {plan.expected_moe_tensor_count}")
+    print(f"  routed bytes: {_format_bytes(plan.routed_bytes)}")
+    print(f"  moe bytes: {_format_bytes(plan.moe_bytes)}")
+    print("  role counts:")
+    for role, count in sorted(plan.tensor_role_counts.items()):
+        print(f"    {role:16s} {count:6d} {_format_bytes(plan.bytes_by_role.get(role, 0))}")
+    print("  routed types:")
+    for type_name, count in sorted(plan.routed_type_counts.items()):
+        print(f"    {type_name:12s} {count:6d}")
+    print("  skipped/deferred dense components:")
+    skipped_by_role = Counter((item.role, item.type_name, item.reason) for item in plan.skipped_tensors)
+    for (role, type_name, reason), count in sorted(skipped_by_role.items()):
+        print(f"    [{type_name}] {role:16s} {count:6d}: {reason}")
+    print("  placements:")
+    for decision in plan.placements:
+        est = ""
+        if decision.estimated_bytes is not None:
+            est += f" total={_format_bytes(decision.estimated_bytes)}"
+        if decision.estimated_bytes_per_gpu is not None:
+            est += f" per_gpu={_format_bytes(decision.estimated_bytes_per_gpu)}"
+        print(f"    [{decision.status}] {decision.name}:{est} {decision.reason}")
+    print("  generation: deferred (MiniMax-M2 full attention/q4/q5 runtime is not implemented yet)")
+    if plan.warnings:
+        print("  warnings:")
+        for warning in plan.warnings[:20]:
+            print(f"    - {warning}")
+    if plan.errors:
+        print("  errors:")
+        for error in plan.errors[:80]:
+            print(f"    - {error}")
+    return plan
+
+
+def _check_minimax_routed_blocks(bundle: GGUFBundle, *, layer_limit: int, expert: int, row_count: int) -> int:
+    from src.runtime.minimax_m2_moe import MiniMaxM2RoutedBlockLoader, ROUTED_ROLES, build_minimax_m2_moe_runtime_plan
+
+    plan = build_minimax_m2_moe_runtime_plan(bundle)
+    if not plan.ok:
+        print("\nrouted block check: FAILED")
+        for error in plan.errors[:20]:
+            print(f"  - {error}")
+        return 1
+    layers = min(max(int(layer_limit), 0), plan.params.n_layers)
+    rows = max(int(row_count), 1)
+    print("\nrouted block check:")
+    print(f"  layers_checked: {layers}")
+    print(f"  expert: {expert}")
+    print(f"  row_count: {rows}")
+    with MiniMaxM2RoutedBlockLoader(bundle, plan=plan) as loader:
+        for layer in range(layers):
+            for role in sorted(ROUTED_ROLES):
+                blocks, type_name, in_dim = loader.read_expert_role_blocks(layer, role, expert=int(expert), row_count=rows)
+                print(f"  layer={layer} role={role} type={type_name} in_dim={in_dim} blocks_shape={tuple(blocks.shape)}")
+    print("routed block check: OK")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Inspect a GGUF file or sharded GGUF bundle without loading tensor payloads.")
     parser.add_argument("--gguf-path", required=True)
@@ -346,6 +413,11 @@ def main() -> int:
     parser.add_argument("--validate-spec", action="store_true")
     parser.add_argument("--capability-report", action="store_true")
     parser.add_argument("--placement-report", action="store_true")
+    parser.add_argument("--moe-runtime-report", action="store_true", help="Report MiniMax-M2 MoE-only runtime readiness")
+    parser.add_argument("--check-routed-blocks", action="store_true", help="Read a tiny MiniMax-M2 routed expert block slice to validate payload offsets")
+    parser.add_argument("--check-layer-limit", type=int, default=1, help="Number of layers to sample for --check-routed-blocks")
+    parser.add_argument("--check-expert", type=int, default=0, help="Expert id to sample for --check-routed-blocks")
+    parser.add_argument("--check-row-count", type=int, default=1, help="Output rows to sample for --check-routed-blocks")
     parser.add_argument("--gpu-count", type=int, default=4)
     parser.add_argument("--gpu-memory-gib", type=float, default=22.0)
     args = parser.parse_args()
@@ -354,7 +426,15 @@ def main() -> int:
         raise FileNotFoundError(args.gguf_path)
 
     bundle = read_gguf_bundle(args.gguf_path)
-    if args.summary or not (args.list_tensors or args.spec_summary or args.validate_spec or args.capability_report or args.placement_report):
+    if args.summary or not (
+        args.list_tensors
+        or args.spec_summary
+        or args.validate_spec
+        or args.capability_report
+        or args.placement_report
+        or args.moe_runtime_report
+        or args.check_routed_blocks
+    ):
         _summarize_bundle(bundle)
     if args.list_tensors:
         _print_tensors(bundle, args.limit, args.contains)
@@ -365,7 +445,15 @@ def main() -> int:
 
     spec = None
     report = None
-    if args.spec_summary or args.validate_spec or args.capability_report or args.placement_report or args.validate_runtime_mapping:
+    if (
+        args.spec_summary
+        or args.validate_spec
+        or args.capability_report
+        or args.placement_report
+        or args.validate_runtime_mapping
+        or args.moe_runtime_report
+        or args.check_routed_blocks
+    ):
         spec = detect_spec(bundle, args.architecture)
 
     if args.validate_runtime_mapping:
@@ -374,7 +462,7 @@ def main() -> int:
             print(
                 "runtime mapping: FAILED\n"
                 f"  - runtime mapping/generation is currently implemented for deepseek4 only, got {spec.architecture!r}; "
-                "use --validate-spec for header/logical tensor validation",
+                "use --validate-spec for header/logical tensor validation or --moe-runtime-report for MiniMax-M2 MoE-only readiness",
                 flush=True,
             )
             status = max(status, 1)
@@ -395,6 +483,26 @@ def main() -> int:
     if args.placement_report:
         assert report is not None
         _print_placement_report(report)
+    if args.moe_runtime_report or args.check_routed_blocks:
+        assert spec is not None
+        if spec.architecture != "minimax-m2":
+            print(
+                "\nmoe runtime report: FAILED\n"
+                f"  - MoE runtime readiness report is currently implemented for minimax-m2 only, got {spec.architecture!r}",
+                flush=True,
+            )
+            status = max(status, 1)
+        else:
+            plan = _print_moe_runtime_report(bundle, gpu_count=args.gpu_count, gpu_memory_gib=args.gpu_memory_gib)
+            if not plan.ok:
+                status = max(status, 1)
+            if args.check_routed_blocks:
+                status = max(status, _check_minimax_routed_blocks(
+                    bundle,
+                    layer_limit=args.check_layer_limit,
+                    expert=args.check_expert,
+                    row_count=args.check_row_count,
+                ))
     return status
 
 

--- a/src/runtime/minimax_m2_moe.py
+++ b/src/runtime/minimax_m2_moe.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from src.gguf.bundle import GGUFBundle, read_gguf_bundle
+from src.gguf.tensor_reader import GGUFTensorDataReader
+from src.moe_model.minimax_m2_spec import MiniMaxM2Spec
+from src.moe_model.placement import HardwareProfile, heterogeneous_expert_decision, lowbit_device_resident_decision
+from src.moe_model.spec import MoEArchitectureParams, PlacementDecision
+
+
+MINIMAX_M2_ARCHITECTURE = "minimax-m2"
+ROUTED_ROLES = frozenset({"routed_w1", "routed_w2", "routed_w3"})
+MOE_RUNTIME_ROLES = frozenset({"gate", "gate_bias", "ffn_norm", *ROUTED_ROLES})
+_REQUIRED_LAYER_ROLES = tuple(sorted(MOE_RUNTIME_ROLES))
+_EXPECTED_ROUTED_TYPE = "iq2_xxs"
+_EXPECTED_DENSE_MOE_TYPE = "f32"
+
+
+@dataclass(frozen=True)
+class MiniMaxM2MoETensorPlan:
+    source_name: str
+    role: str
+    layer: int | None
+    type_name: str
+    dimensions: tuple[int, ...]
+    nbytes: int | None
+    shard_path: str
+    status: str = "candidate"
+    reason: str = "available for MiniMax-M2 MoE-only runtime"
+
+
+@dataclass(frozen=True)
+class MiniMaxM2SkippedTensorPlan:
+    source_name: str
+    role: str
+    layer: int | None
+    type_name: str
+    dimensions: tuple[int, ...]
+    nbytes: int | None
+    shard_path: str
+    status: str = "deferred"
+    reason: str = "not part of MiniMax-M2 MoE-only runtime readiness check"
+
+
+@dataclass(frozen=True)
+class MiniMaxM2MoERuntimePlan:
+    architecture: str
+    status: str
+    ok: bool
+    params: MoEArchitectureParams
+    tensor_plans: tuple[MiniMaxM2MoETensorPlan, ...]
+    skipped_tensors: tuple[MiniMaxM2SkippedTensorPlan, ...]
+    tensor_role_counts: dict[str, int]
+    tensor_type_counts: dict[str, int]
+    routed_type_counts: dict[str, int]
+    bytes_by_role: dict[str, int]
+    bytes_by_type: dict[str, int]
+    placements: tuple[PlacementDecision, ...]
+    errors: tuple[str, ...] = field(default_factory=tuple)
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def moe_tensor_count(self) -> int:
+        return len(self.tensor_plans)
+
+    @property
+    def expected_moe_tensor_count(self) -> int:
+        return int(self.params.n_layers) * len(_REQUIRED_LAYER_ROLES)
+
+    @property
+    def routed_tensor_count(self) -> int:
+        return sum(1 for item in self.tensor_plans if item.role in ROUTED_ROLES)
+
+    @property
+    def expected_routed_tensor_count(self) -> int:
+        return int(self.params.n_layers) * len(ROUTED_ROLES)
+
+    @property
+    def routed_bytes(self) -> int:
+        return sum(int(item.nbytes or 0) for item in self.tensor_plans if item.role in ROUTED_ROLES)
+
+    @property
+    def moe_bytes(self) -> int:
+        return sum(int(item.nbytes or 0) for item in self.tensor_plans)
+
+    def tensor_for(self, layer: int, role: str) -> MiniMaxM2MoETensorPlan:
+        for item in self.tensor_plans:
+            if item.layer == layer and item.role == role:
+                return item
+        raise KeyError(f"MiniMax-M2 MoE tensor not planned for layer={layer} role={role}")
+
+
+def _skip_reason(role: str, type_name: str) -> str:
+    if role in {"embedding", "lm_head"} and type_name == "q4_k":
+        return "q4_k embedding/head payload and MiniMax generation runtime are deferred"
+    if role in {"attn_q", "attn_k", "attn_v", "attn_o"} and type_name == "q5_k":
+        return "q5_k attention kernels and MiniMax GQA runtime are deferred"
+    if role == "attn_norm":
+        return "attention normalization belongs to deferred MiniMax GQA runtime"
+    if role == "final_norm":
+        return "final norm belongs to deferred MiniMax generation runtime"
+    return "not required by the MiniMax-M2 MoE-only routed expert readiness path"
+
+
+def _counts(items: Iterable[MiniMaxM2MoETensorPlan], attr: str) -> dict[str, int]:
+    counter: Counter[str] = Counter(str(getattr(item, attr)) for item in items)
+    return dict(counter)
+
+
+def _bytes_by(items: Iterable[MiniMaxM2MoETensorPlan], attr: str) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for item in items:
+        key = str(getattr(item, attr))
+        result[key] = result.get(key, 0) + int(item.nbytes or 0)
+    return result
+
+
+def _layer_role_counts(items: Iterable[MiniMaxM2MoETensorPlan]) -> dict[tuple[int, str], int]:
+    counts: Counter[tuple[int, str]] = Counter()
+    for item in items:
+        if item.layer is not None:
+            counts[(int(item.layer), item.role)] += 1
+    return dict(counts)
+
+
+def build_minimax_m2_moe_runtime_plan(
+    bundle: GGUFBundle,
+    *,
+    gpu_count: int = 4,
+    gpu_memory_gib: float = 22.0,
+) -> MiniMaxM2MoERuntimePlan:
+    spec = MiniMaxM2Spec()
+    params = spec.parse_params(bundle)
+    errors: list[str] = []
+    warnings: list[str] = []
+    tensor_plans: list[MiniMaxM2MoETensorPlan] = []
+    skipped: list[MiniMaxM2SkippedTensorPlan] = []
+    names = bundle.tensors_by_name
+
+    if bundle.metadata.get("general.architecture") != MINIMAX_M2_ARCHITECTURE:
+        errors.append(
+            f"general.architecture expected {MINIMAX_M2_ARCHITECTURE!r}, got {bundle.metadata.get('general.architecture')!r}"
+        )
+
+    for mapping in spec.build_tensor_mappings(bundle):
+        tensor = names.get(mapping.source_name)
+        if tensor is None:
+            if mapping.role in MOE_RUNTIME_ROLES:
+                errors.append(f"missing MiniMax-M2 MoE tensor {mapping.source_name}")
+            continue
+        if mapping.role in MOE_RUNTIME_ROLES:
+            if mapping.layer is None:
+                errors.append(f"MiniMax-M2 MoE tensor {mapping.source_name} has no layer id")
+            expected_type = _EXPECTED_ROUTED_TYPE if mapping.role in ROUTED_ROLES else _EXPECTED_DENSE_MOE_TYPE
+            status = "candidate"
+            reason = "available for MiniMax-M2 MoE-only runtime"
+            if tensor.type_name != expected_type:
+                status = "unsupported"
+                reason = f"expected {expected_type}, got {tensor.type_name}"
+                errors.append(f"{mapping.source_name} expected {expected_type}, got {tensor.type_name}")
+            tensor_plans.append(
+                MiniMaxM2MoETensorPlan(
+                    source_name=mapping.source_name,
+                    role=mapping.role,
+                    layer=mapping.layer,
+                    type_name=tensor.type_name,
+                    dimensions=tuple(int(dim) for dim in tensor.dimensions),
+                    nbytes=tensor.nbytes,
+                    shard_path=tensor.shard_path,
+                    status=status,
+                    reason=reason,
+                )
+            )
+        else:
+            skipped.append(
+                MiniMaxM2SkippedTensorPlan(
+                    source_name=mapping.source_name,
+                    role=mapping.role,
+                    layer=mapping.layer,
+                    type_name=tensor.type_name,
+                    dimensions=tuple(int(dim) for dim in tensor.dimensions),
+                    nbytes=tensor.nbytes,
+                    shard_path=tensor.shard_path,
+                    reason=_skip_reason(mapping.role, tensor.type_name),
+                )
+            )
+
+    layer_counts = _layer_role_counts(tensor_plans)
+    for layer in range(params.n_layers):
+        for role in _REQUIRED_LAYER_ROLES:
+            count = layer_counts.get((layer, role), 0)
+            if count != 1:
+                errors.append(f"layer {layer} role {role} expected 1 tensor, got {count}")
+
+    if params.n_layers <= 0:
+        errors.append("minimax-m2.block_count must be positive for MoE runtime planning")
+    if params.n_routed_experts <= 0:
+        errors.append("minimax-m2.expert_count must be positive for MoE runtime planning")
+    if params.top_k <= 0:
+        errors.append("minimax-m2.expert_used_count must be positive for MoE runtime planning")
+
+    role_counts = _counts(tensor_plans, "role")
+    type_counts = _counts(tensor_plans, "type_name")
+    routed_type_counts = dict(Counter(item.type_name for item in tensor_plans if item.role in ROUTED_ROLES))
+    bytes_by_role = _bytes_by(tensor_plans, "role")
+    bytes_by_type = _bytes_by(tensor_plans, "type_name")
+    moe_bytes = sum(int(item.nbytes or 0) for item in tensor_plans)
+    routed_bytes = sum(int(item.nbytes or 0) for item in tensor_plans if item.role in ROUTED_ROLES)
+    hardware = HardwareProfile(gpu_count=gpu_count, gpu_memory_gib=gpu_memory_gib)
+    placements = (
+        lowbit_device_resident_decision(moe_bytes, hardware),
+        heterogeneous_expert_decision(routed_bytes),
+    )
+    status = "candidate" if not errors else "failed"
+    if skipped:
+        warnings.append(
+            f"{len(skipped)} dense/non-MoE tensors are intentionally skipped for MiniMax-M2 MoE-only readiness"
+        )
+    return MiniMaxM2MoERuntimePlan(
+        architecture=MINIMAX_M2_ARCHITECTURE,
+        status=status,
+        ok=not errors,
+        params=params,
+        tensor_plans=tuple(tensor_plans),
+        skipped_tensors=tuple(skipped),
+        tensor_role_counts=role_counts,
+        tensor_type_counts=type_counts,
+        routed_type_counts=routed_type_counts,
+        bytes_by_role=bytes_by_role,
+        bytes_by_type=bytes_by_type,
+        placements=placements,
+        errors=tuple(errors),
+        warnings=tuple(warnings),
+    )
+
+
+class MiniMaxM2RoutedBlockLoader:
+    """Lazy raw-block reader for MiniMax-M2 routed expert tensors.
+
+    This loader is intentionally MoE-only.  It never attempts to read q4_k/q5_k
+    dense tensors and it opens each GGUF shard lazily only when a routed block
+    read is requested.
+    """
+
+    def __init__(self, bundle_or_path: GGUFBundle | str | Path, *, plan: MiniMaxM2MoERuntimePlan | None = None):
+        self.bundle = read_gguf_bundle(bundle_or_path) if not isinstance(bundle_or_path, GGUFBundle) else bundle_or_path
+        self.plan = plan or build_minimax_m2_moe_runtime_plan(self.bundle)
+        if not self.plan.ok:
+            raise ValueError(f"MiniMax-M2 MoE runtime plan is not valid: {list(self.plan.errors[:10])}")
+        self._readers: dict[str, GGUFTensorDataReader] = {}
+
+    def close(self) -> None:
+        for reader in self._readers.values():
+            reader.close()
+        self._readers.clear()
+
+    def __enter__(self) -> "MiniMaxM2RoutedBlockLoader":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def _reader(self, shard_path: str) -> GGUFTensorDataReader:
+        reader = self._readers.get(shard_path)
+        if reader is None:
+            reader = GGUFTensorDataReader(shard_path)
+            self._readers[shard_path] = reader
+        return reader
+
+    def _tensor_plan(self, layer: int, role: str) -> MiniMaxM2MoETensorPlan:
+        if role not in ROUTED_ROLES:
+            raise ValueError(f"role must be one of {sorted(ROUTED_ROLES)}, got {role!r}")
+        if layer < 0 or layer >= self.plan.params.n_layers:
+            raise ValueError(f"layer {layer} outside MiniMax-M2 range [0, {self.plan.params.n_layers})")
+        return self.plan.tensor_for(layer, role)
+
+    def read_layer_role_blocks(
+        self,
+        layer: int,
+        role: str,
+        *,
+        expert_start: int = 0,
+        expert_count: int | None = None,
+    ):
+        item = self._tensor_plan(int(layer), role)
+        return self._reader(item.shard_path).read_routed_layer_blocks(
+            item.source_name,
+            expert_start=int(expert_start),
+            expert_count=expert_count,
+        )
+
+    def read_expert_role_blocks(
+        self,
+        layer: int,
+        role: str,
+        *,
+        expert: int,
+        row_start: int = 0,
+        row_count: int | None = None,
+    ):
+        item = self._tensor_plan(int(layer), role)
+        return self._reader(item.shard_path).read_routed_expert_blocks(
+            item.source_name,
+            expert=int(expert),
+            row_start=int(row_start),
+            row_count=row_count,
+        )

--- a/tests/gguf_test_utils.py
+++ b/tests/gguf_test_utils.py
@@ -100,7 +100,14 @@ def write_gguf(
     path.write_bytes(bytes(buf))
 
 
-def minimax_metadata(*, n_layers: int = 2, hidden: int = 8, vocab: int = 16, experts: int = 4) -> dict[str, Any]:
+def minimax_metadata(
+    *,
+    n_layers: int = 2,
+    hidden: int = 8,
+    vocab: int = 16,
+    experts: int = 4,
+    inter: int = 4,
+) -> dict[str, Any]:
     return {
         "general.architecture": "minimax-m2",
         "minimax-m2.block_count": n_layers,
@@ -115,16 +122,22 @@ def minimax_metadata(*, n_layers: int = 2, hidden: int = 8, vocab: int = 16, exp
         "minimax-m2.rope.freq_base": 5000000.0,
         "minimax-m2.expert_count": experts,
         "minimax-m2.expert_used_count": 2,
-        "minimax-m2.expert_feed_forward_length": 4,
+        "minimax-m2.expert_feed_forward_length": inter,
         "minimax-m2.expert_gating_func": 2,
         "minimax-m2.attention.layer_norm_rms_epsilon": 0.00001,
     }
 
 
-def minimax_tensors(*, n_layers: int = 2, hidden: int = 8, vocab: int = 16, experts: int = 4) -> list[tuple[str, tuple[int, ...], int]]:
+def minimax_tensors(
+    *,
+    n_layers: int = 2,
+    hidden: int = 8,
+    vocab: int = 16,
+    experts: int = 4,
+    inter: int = 4,
+) -> list[tuple[str, tuple[int, ...], int]]:
     q = 8
     kv = 4
-    inter = 4
     tensors: list[tuple[str, tuple[int, ...], int]] = [
         ("token_embd.weight", (hidden, vocab), GGML_Q4_K),
         ("output.weight", (hidden, vocab), GGML_Q4_K),
@@ -152,16 +165,28 @@ def minimax_tensors(*, n_layers: int = 2, hidden: int = 8, vocab: int = 16, expe
     return tensors
 
 
-def write_minimax_bundle(root: Path, *, n_layers: int = 2) -> Path:
+def write_minimax_bundle(
+    root: Path,
+    *,
+    n_layers: int = 2,
+    hidden: int = 8,
+    vocab: int = 16,
+    experts: int = 4,
+    inter: int = 4,
+) -> Path:
     root.mkdir(parents=True, exist_ok=True)
     write_gguf(
         root / "tiny-minimax-00001-of-00002.gguf",
-        metadata={**minimax_metadata(n_layers=n_layers), "split.no": 0, "split.count": 2},
+        metadata={
+            **minimax_metadata(n_layers=n_layers, hidden=hidden, vocab=vocab, experts=experts, inter=inter),
+            "split.no": 0,
+            "split.count": 2,
+        },
         tensors=[],
     )
     write_gguf(
         root / "tiny-minimax-00002-of-00002.gguf",
         metadata={"split.no": 1, "split.count": 2},
-        tensors=minimax_tensors(n_layers=n_layers),
+        tensors=minimax_tensors(n_layers=n_layers, hidden=hidden, vocab=vocab, experts=experts, inter=inter),
     )
     return root

--- a/tests/test_inspect_gguf_specs.py
+++ b/tests/test_inspect_gguf_specs.py
@@ -64,6 +64,54 @@ def test_inspect_minimax_runtime_mapping_fails_clearly(tmp_path: Path) -> None:
     assert "--validate-spec" in result.stdout
 
 
+
+
+def test_inspect_minimax_moe_runtime_report(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1)
+
+    result = _run_inspect(
+        "--gguf-path",
+        str(root),
+        "--architecture",
+        "minimax-m2",
+        "--moe-runtime-report",
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "moe runtime report:" in result.stdout
+    assert "minimax_moe_runtime: candidate" in result.stdout
+    assert "layers: 1" in result.stdout
+    assert "routed tensors: 3 / expected 3" in result.stdout
+    assert "moe tensors: 6 / expected 6" in result.stdout
+    assert "q4_k embedding/head" in result.stdout
+    assert "q5_k attention" in result.stdout
+    assert "generation: deferred" in result.stdout
+
+
+def test_inspect_minimax_check_routed_blocks(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1, hidden=256, inter=256)
+
+    result = _run_inspect(
+        "--gguf-path",
+        str(root),
+        "--architecture",
+        "minimax-m2",
+        "--check-routed-blocks",
+        "--check-layer-limit",
+        "1",
+        "--check-row-count",
+        "1",
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "routed block check:" in result.stdout
+    assert "layer=0 role=routed_w1 type=iq2_xxs" in result.stdout
+    assert "layer=0 role=routed_w2 type=iq2_xxs" in result.stdout
+    assert "layer=0 role=routed_w3 type=iq2_xxs" in result.stdout
+    assert "blocks_shape=(1, 1, 66)" in result.stdout
+    assert "routed block check: OK" in result.stdout
+
+
 def test_inspect_legacy_ds4_summary_and_q2_validation_still_work(tmp_path: Path) -> None:
     path = tmp_path / "ds4-empty.gguf"
     write_gguf(

--- a/tests/test_minimax_m2_moe_runtime.py
+++ b/tests/test_minimax_m2_moe_runtime.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.gguf.bundle import read_gguf_bundle
+from src.runtime.minimax_m2_moe import (
+    MiniMaxM2RoutedBlockLoader,
+    ROUTED_ROLES,
+    build_minimax_m2_moe_runtime_plan,
+)
+from tests.gguf_test_utils import write_minimax_bundle
+
+
+REAL_MINIMAX_PATH = Path("/mnt/data1/dsv4_inference/gguf_hfd/MiniMax-M2.7-GGUF/UD-IQ1_M")
+
+
+def test_minimax_moe_runtime_plan_validates_tiny_bundle(tmp_path: Path) -> None:
+    # Use inter=256 so IQ2_XXS routed rows have one full 256-element block and
+    # can be used by raw block smoke tests without requiring huge fixtures.
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=2, hidden=256, inter=256)
+    bundle = read_gguf_bundle(root)
+
+    plan = build_minimax_m2_moe_runtime_plan(bundle)
+
+    assert plan.ok, plan.errors
+    assert plan.status == "candidate"
+    assert plan.params.n_layers == 2
+    assert plan.moe_tensor_count == 12
+    assert plan.expected_moe_tensor_count == 12
+    assert plan.routed_tensor_count == 6
+    assert plan.expected_routed_tensor_count == 6
+    assert plan.tensor_role_counts["gate"] == 2
+    assert plan.tensor_role_counts["gate_bias"] == 2
+    assert plan.tensor_role_counts["ffn_norm"] == 2
+    assert plan.routed_type_counts == {"iq2_xxs": 6}
+    assert plan.placements[0].name == "all_device_lowbit"
+    assert plan.placements[0].status == "candidate"
+
+
+def test_minimax_moe_runtime_plan_reports_dense_skips(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1, hidden=256, inter=256)
+    bundle = read_gguf_bundle(root)
+    plan = build_minimax_m2_moe_runtime_plan(bundle)
+
+    skipped = {(item.role, item.type_name): item.reason for item in plan.skipped_tensors}
+
+    assert plan.ok, plan.errors
+    assert ("embedding", "q4_k") in skipped
+    assert ("lm_head", "q4_k") in skipped
+    assert ("attn_q", "q5_k") in skipped
+    assert ("attn_k", "q5_k") in skipped
+    assert ("attn_v", "q5_k") in skipped
+    assert ("attn_o", "q5_k") in skipped
+    assert "deferred" in skipped[("embedding", "q4_k")]
+    assert "GQA runtime" in skipped[("attn_q", "q5_k")]
+
+
+def test_minimax_routed_block_loader_reads_small_slice(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1, hidden=256, inter=256)
+    bundle = read_gguf_bundle(root)
+    plan = build_minimax_m2_moe_runtime_plan(bundle)
+
+    with MiniMaxM2RoutedBlockLoader(bundle, plan=plan) as loader:
+        for role in sorted(ROUTED_ROLES):
+            blocks, type_name, in_dim = loader.read_expert_role_blocks(0, role, expert=0, row_count=1)
+            assert type_name == "iq2_xxs"
+            assert in_dim == 256
+            assert tuple(blocks.shape) == (1, 1, 66)
+
+            layer_blocks, layer_type_name, layer_in_dim = loader.read_layer_role_blocks(0, role, expert_start=0, expert_count=1)
+            assert layer_type_name == "iq2_xxs"
+            assert layer_in_dim == in_dim
+            assert tuple(layer_blocks.shape) == (1, 256, 1, 66)
+
+
+@pytest.mark.skipif(not REAL_MINIMAX_PATH.exists(), reason="local MiniMax-M2.7 GGUF bundle not present")
+def test_real_minimax_moe_runtime_plan_does_not_read_payload() -> None:
+    bundle = read_gguf_bundle(REAL_MINIMAX_PATH)
+    plan = build_minimax_m2_moe_runtime_plan(bundle)
+
+    assert plan.ok, plan.errors[:20]
+    assert plan.params.n_layers == 62
+    assert plan.routed_tensor_count == 62 * 3
+    assert plan.expected_routed_tensor_count == 62 * 3
+    assert plan.tensor_role_counts["gate"] == 62
+    assert plan.tensor_role_counts["gate_bias"] == 62
+    assert plan.tensor_role_counts["ffn_norm"] == 62
+    assert plan.routed_type_counts == {"iq2_xxs": 62 * 3}
+    assert plan.routed_bytes > 50 * 1024**3
+    assert any(item.type_name == "q4_k" for item in plan.skipped_tensors)
+    assert any(item.type_name == "q5_k" for item in plan.skipped_tensors)
+
+
+@pytest.mark.skipif(not REAL_MINIMAX_PATH.exists(), reason="local MiniMax-M2.7 GGUF bundle not present")
+def test_real_minimax_routed_block_loader_reads_tiny_slice() -> None:
+    bundle = read_gguf_bundle(REAL_MINIMAX_PATH)
+    plan = build_minimax_m2_moe_runtime_plan(bundle)
+
+    with MiniMaxM2RoutedBlockLoader(bundle, plan=plan) as loader:
+        blocks, type_name, in_dim = loader.read_expert_role_blocks(0, "routed_w1", expert=0, row_count=1)
+
+    assert type_name == "iq2_xxs"
+    assert in_dim == 3072
+    assert tuple(blocks.shape) == (1, 12, 66)


### PR DESCRIPTION
## Summary
- Add a MiniMax-M2 MoE-only runtime readiness planner and lazy routed expert raw block loader.
- Extend inspect_gguf with --moe-runtime-report and tiny --check-routed-blocks payload smoke checks.
- Add tests for MiniMax MoE runtime planning, routed block loading, and CLI readiness reporting.

## Validation
- PYTHONPATH=$PWD python -m pytest tests/test_gguf_bundle.py tests/test_moe_model_registry.py tests/test_minimax_m2_spec.py tests/test_minimax_m2_moe_runtime.py tests/test_inspect_gguf_specs.py tests/test_gguf_iq1m_reader.py tests/test_partition_policy.py -q
- PYTHONPATH=$PWD python -m src.cli.inspect_gguf --gguf-path /mnt/data1/dsv4_inference/gguf_hfd/MiniMax-M2.7-GGUF/UD-IQ1_M --architecture minimax-m2 --spec-summary --validate-spec --capability-report --placement-report --moe-runtime-report
- PYTHONPATH=$PWD python -m src.cli.inspect_gguf --gguf-path /mnt/data1/dsv4_inference/gguf_hfd/MiniMax-M2.7-GGUF/UD-IQ1_M --architecture minimax-m2 --moe-runtime-report --check-routed-blocks --check-layer-limit 1 --check-row-count 1
- PYTHONPATH=$PWD python -m src.cli.inspect_gguf --gguf-path /mnt/data1/dsv4_inference/DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2.gguf --summary --validate-ds4-q2

🤖 Generated with [Claude Code](https://claude.com/claude-code)