### PR TITLE
Add MiniMax all-device routed cache

### DIFF
--- a/src/cli/inspect_gguf.py
+++ b/src/cli/inspect_gguf.py
@@ -331,7 +331,7 @@ def _print_placement_report(report: CapabilityReport) -> None:
 
 
 def _print_moe_runtime_report(bundle: GGUFBundle, *, gpu_count: int, gpu_memory_gib: float):
-    from src.runtime.minimax_m2_moe import build_minimax_m2_moe_runtime_plan
+    from src.moe_model.minimax_m2_moe import build_minimax_m2_moe_runtime_plan
 
     plan = build_minimax_m2_moe_runtime_plan(bundle, gpu_count=gpu_count, gpu_memory_gib=gpu_memory_gib)
     print("\nmoe runtime report:")
@@ -374,7 +374,7 @@ def _print_moe_runtime_report(bundle: GGUFBundle, *, gpu_count: int, gpu_memory_
 
 
 def _check_minimax_routed_blocks(bundle: GGUFBundle, *, layer_limit: int, expert: int, row_count: int) -> int:
-    from src.runtime.minimax_m2_moe import MiniMaxM2RoutedBlockLoader, ROUTED_ROLES, build_minimax_m2_moe_runtime_plan
+    from src.moe_model.minimax_m2_moe import MiniMaxM2RoutedBlockLoader, ROUTED_ROLES, build_minimax_m2_moe_runtime_plan
 
     plan = build_minimax_m2_moe_runtime_plan(bundle)
     if not plan.ok:
@@ -394,6 +394,68 @@ def _check_minimax_routed_blocks(bundle: GGUFBundle, *, layer_limit: int, expert
                 blocks, type_name, in_dim = loader.read_expert_role_blocks(layer, role, expert=int(expert), row_count=rows)
                 print(f"  layer={layer} role={role} type={type_name} in_dim={in_dim} blocks_shape={tuple(blocks.shape)}")
     print("routed block check: OK")
+    return 0
+
+
+def _cuda_smoke_minimax_routed_blocks(
+    bundle: GGUFBundle,
+    *,
+    layer: int,
+    role: str,
+    expert: int,
+    expert_count: int,
+    tokens: int,
+    device: str,
+) -> int:
+    import torch
+
+    from src.moe_model.minimax_m2_moe import MiniMaxM2DeviceResidentCache, build_minimax_m2_moe_runtime_plan
+
+    if not torch.cuda.is_available():
+        print("\ncuda routed block smoke: FAILED")
+        print("  - CUDA is not available")
+        return 1
+    plan = build_minimax_m2_moe_runtime_plan(bundle)
+    if not plan.ok:
+        print("\ncuda routed block smoke: FAILED")
+        for error in plan.errors[:20]:
+            print(f"  - {error}")
+        return 1
+    layer = int(layer)
+    expert = int(expert)
+    expert_count = int(expert_count)
+    tokens = int(tokens)
+    if expert_count <= 0:
+        print("\ncuda routed block smoke: FAILED")
+        print(f"  - expert_count must be positive, got {expert_count}")
+        return 1
+    print("\ncuda routed block smoke:")
+    print(f"  device: {device}")
+    print(f"  layer: {layer}")
+    print(f"  role: {role}")
+    print(f"  expert_range: [{expert}, {expert + expert_count})")
+    print(f"  tokens: {tokens}")
+    try:
+        with MiniMaxM2DeviceResidentCache(
+            bundle,
+            plan=plan,
+            device=device,
+            expert_start=expert,
+            expert_count=expert_count,
+        ) as cache:
+            _output, result = cache.cuda_gemm_smoke(layer=layer, role=role, expert=expert, tokens=tokens)
+            print(f"  type: {result.type_name} type_id={result.type_id}")
+            print(f"  blocks_shape: {result.blocks_shape}")
+            print(f"  input_shape: {result.input_shape}")
+            print(f"  output_shape: {result.output_shape}")
+            print(f"  output_dtype: {result.output_dtype}")
+            print(f"  finite: {result.finite}")
+            print(f"  resident_bytes: {_format_bytes(result.resident_bytes)}")
+    except Exception as exc:
+        print("cuda routed block smoke: FAILED")
+        print(f"  - {type(exc).__name__}: {exc}")
+        return 1
+    print("cuda routed block smoke: OK")
     return 0
 
 
@@ -418,6 +480,13 @@ def main() -> int:
     parser.add_argument("--check-layer-limit", type=int, default=1, help="Number of layers to sample for --check-routed-blocks")
     parser.add_argument("--check-expert", type=int, default=0, help="Expert id to sample for --check-routed-blocks")
     parser.add_argument("--check-row-count", type=int, default=1, help="Output rows to sample for --check-routed-blocks")
+    parser.add_argument("--cuda-smoke-routed-blocks", action="store_true", help="Load a small MiniMax-M2 routed expert slice to CUDA and run raw GGUF GEMM smoke")
+    parser.add_argument("--cuda-smoke-layer", type=int, default=0, help="MiniMax-M2 layer id for --cuda-smoke-routed-blocks")
+    parser.add_argument("--cuda-smoke-role", choices=["routed_w1", "routed_w2", "routed_w3"], default="routed_w1", help="Routed role for --cuda-smoke-routed-blocks")
+    parser.add_argument("--cuda-smoke-expert", type=int, default=0, help="Expert id for --cuda-smoke-routed-blocks")
+    parser.add_argument("--cuda-smoke-expert-count", type=int, default=1, help="Number of experts to load into the CUDA resident cache for smoke")
+    parser.add_argument("--cuda-smoke-tokens", type=int, default=1, help="Token rows for the raw GGUF GEMM smoke input")
+    parser.add_argument("--cuda-smoke-device", default="cuda", help="CUDA device for --cuda-smoke-routed-blocks, e.g. cuda or cuda:0")
     parser.add_argument("--gpu-count", type=int, default=4)
     parser.add_argument("--gpu-memory-gib", type=float, default=22.0)
     args = parser.parse_args()
@@ -434,6 +503,7 @@ def main() -> int:
         or args.placement_report
         or args.moe_runtime_report
         or args.check_routed_blocks
+        or args.cuda_smoke_routed_blocks
     ):
         _summarize_bundle(bundle)
     if args.list_tensors:
@@ -453,6 +523,7 @@ def main() -> int:
         or args.validate_runtime_mapping
         or args.moe_runtime_report
         or args.check_routed_blocks
+        or args.cuda_smoke_routed_blocks
     ):
         spec = detect_spec(bundle, args.architecture)
 
@@ -483,7 +554,7 @@ def main() -> int:
     if args.placement_report:
         assert report is not None
         _print_placement_report(report)
-    if args.moe_runtime_report or args.check_routed_blocks:
+    if args.moe_runtime_report or args.check_routed_blocks or args.cuda_smoke_routed_blocks:
         assert spec is not None
         if spec.architecture != "minimax-m2":
             print(
@@ -493,9 +564,11 @@ def main() -> int:
             )
             status = max(status, 1)
         else:
-            plan = _print_moe_runtime_report(bundle, gpu_count=args.gpu_count, gpu_memory_gib=args.gpu_memory_gib)
-            if not plan.ok:
-                status = max(status, 1)
+            plan = None
+            if args.moe_runtime_report or args.check_routed_blocks:
+                plan = _print_moe_runtime_report(bundle, gpu_count=args.gpu_count, gpu_memory_gib=args.gpu_memory_gib)
+                if not plan.ok:
+                    status = max(status, 1)
             if args.check_routed_blocks:
                 status = max(status, _check_minimax_routed_blocks(
                     bundle,
@@ -503,6 +576,19 @@ def main() -> int:
                     expert=args.check_expert,
                     row_count=args.check_row_count,
                 ))
+            if args.cuda_smoke_routed_blocks:
+                if plan is not None and not plan.ok:
+                    status = max(status, 1)
+                else:
+                    status = max(status, _cuda_smoke_minimax_routed_blocks(
+                        bundle,
+                        layer=args.cuda_smoke_layer,
+                        role=args.cuda_smoke_role,
+                        expert=args.cuda_smoke_expert,
+                        expert_count=args.cuda_smoke_expert_count,
+                        tokens=args.cuda_smoke_tokens,
+                        device=args.cuda_smoke_device,
+                    ))
     return status
 
 

--- a/src/moe_model/minimax_m2_moe.py
+++ b/src/moe_model/minimax_m2_moe.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
+
+import torch
 
 from src.gguf.bundle import GGUFBundle, read_gguf_bundle
 from src.gguf.tensor_reader import GGUFTensorDataReader
@@ -18,6 +20,18 @@ MOE_RUNTIME_ROLES = frozenset({"gate", "gate_bias", "ffn_norm", *ROUTED_ROLES})
 _REQUIRED_LAYER_ROLES = tuple(sorted(MOE_RUNTIME_ROLES))
 _EXPECTED_ROUTED_TYPE = "iq2_xxs"
 _EXPECTED_DENSE_MOE_TYPE = "f32"
+
+GGUF_DEVICE_TYPE_IDS = {
+    "iq2_xxs": 0,
+    "q2_k": 1,
+    "iq1_m": 2,
+}
+SUPPORTED_DEVICE_ROUTED_TYPES = frozenset(GGUF_DEVICE_TYPE_IDS)
+_ROUTED_ROLE_ATTRS = {
+    "routed_w1": "w1",
+    "routed_w2": "w2",
+    "routed_w3": "w3",
+}
 
 
 @dataclass(frozen=True)
@@ -44,6 +58,66 @@ class MiniMaxM2SkippedTensorPlan:
     shard_path: str
     status: str = "deferred"
     reason: str = "not part of MiniMax-M2 MoE-only runtime readiness check"
+
+
+@dataclass(frozen=True)
+class MiniMaxM2DeviceRoutedTensor:
+    source_name: str
+    role: str
+    layer: int
+    blocks: torch.Tensor
+    type_name: str
+    type_id: int
+    in_dim: int
+    out_dim: int
+    expert_start: int
+    expert_count: int
+    device: torch.device
+
+    @property
+    def nbytes(self) -> int:
+        return int(self.blocks.numel() * self.blocks.element_size())
+
+
+@dataclass(frozen=True)
+class MiniMaxM2DeviceRoutedLayer:
+    layer: int
+    w1: MiniMaxM2DeviceRoutedTensor
+    w3: MiniMaxM2DeviceRoutedTensor
+    w2: MiniMaxM2DeviceRoutedTensor
+    device: torch.device
+
+
+@dataclass(frozen=True)
+class MiniMaxM2CudaGemmSmokeResult:
+    layer: int
+    role: str
+    expert: int
+    type_name: str
+    type_id: int
+    device: torch.device
+    input_shape: tuple[int, ...]
+    blocks_shape: tuple[int, ...]
+    output_shape: tuple[int, ...]
+    output_dtype: torch.dtype
+    finite: bool
+    resident_bytes: int
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "layer": self.layer,
+            "role": self.role,
+            "expert": self.expert,
+            "type_name": self.type_name,
+            "type_id": self.type_id,
+            "device": str(self.device),
+            "input_shape": self.input_shape,
+            "blocks_shape": self.blocks_shape,
+            "output_shape": self.output_shape,
+            "output_dtype": str(self.output_dtype),
+            "finite": self.finite,
+            "resident_bytes": self.resident_bytes,
+        }
 
 
 @dataclass(frozen=True)
@@ -309,3 +383,235 @@ class MiniMaxM2RoutedBlockLoader:
             row_start=int(row_start),
             row_count=row_count,
         )
+
+
+def _canonical_cuda_device(device: str | torch.device) -> torch.device:
+    resolved = torch.device(device)
+    if resolved.type != "cuda":
+        raise ValueError(f"MiniMax-M2 device-resident cache requires a CUDA device, got {resolved}")
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is not available for MiniMax-M2 device-resident cache")
+    if resolved.index is None:
+        resolved = torch.device("cuda", torch.cuda.current_device())
+    return resolved
+
+
+def _gguf_cuda_quant_grid(type_name: str, device: torch.device) -> torch.Tensor:
+    if type_name == "iq2_xxs":
+        from src.gguf.tensor_reader import get_iq2xxs_signed_grid_tensor
+
+        return get_iq2xxs_signed_grid_tensor().to(device=device, non_blocking=False).contiguous()
+    if type_name == "iq1_m":
+        from src.gguf.tensor_reader import get_iq1_grid_tensor
+
+        return get_iq1_grid_tensor().to(device=device, non_blocking=False).contiguous()
+    return torch.empty(0, dtype=torch.int8, device=device)
+
+
+class MiniMaxM2DeviceResidentCache:
+    """CUDA-resident MiniMax-M2 routed expert block cache.
+
+    This is a deliberately small all-device building block: it copies raw GGUF
+    routed expert blocks into CUDA memory and exposes a smoke path that feeds
+    those blocks into the existing raw GGUF GEMM extension.  It does not run
+    MiniMax attention, routing, or generation.
+    """
+
+    def __init__(
+        self,
+        bundle_or_path: GGUFBundle | str | Path,
+        *,
+        device: str | torch.device = "cuda",
+        plan: MiniMaxM2MoERuntimePlan | None = None,
+        expert_start: int = 0,
+        expert_count: int | None = None,
+    ):
+        self.device = _canonical_cuda_device(device)
+        self.bundle = read_gguf_bundle(bundle_or_path) if not isinstance(bundle_or_path, GGUFBundle) else bundle_or_path
+        self.plan = plan or build_minimax_m2_moe_runtime_plan(self.bundle)
+        if not self.plan.ok:
+            raise ValueError(f"MiniMax-M2 MoE runtime plan is not valid: {list(self.plan.errors[:10])}")
+        self.expert_start = int(expert_start)
+        if self.expert_start < 0:
+            raise ValueError(f"expert_start must be non-negative, got {expert_start}")
+        available = int(self.plan.params.n_routed_experts) - self.expert_start
+        if available < 0:
+            raise ValueError(
+                f"expert_start {self.expert_start} outside MiniMax-M2 expert count {self.plan.params.n_routed_experts}"
+            )
+        self.expert_count = available if expert_count is None else int(expert_count)
+        if self.expert_count <= 0 or self.expert_count > available:
+            raise ValueError(
+                f"expert range [{self.expert_start}, {self.expert_start + self.expert_count}) is outside "
+                f"MiniMax-M2 expert count {self.plan.params.n_routed_experts}"
+            )
+        self._loader = MiniMaxM2RoutedBlockLoader(self.bundle, plan=self.plan)
+        self._cache: dict[tuple[int, str], MiniMaxM2DeviceRoutedTensor] = {}
+        self._grid_cache: dict[str, torch.Tensor] = {}
+
+    @classmethod
+    def from_path(
+        cls,
+        bundle_or_path: GGUFBundle | str | Path,
+        *,
+        device: str | torch.device = "cuda",
+        plan: MiniMaxM2MoERuntimePlan | None = None,
+        expert_start: int = 0,
+        expert_count: int | None = None,
+    ) -> "MiniMaxM2DeviceResidentCache":
+        return cls(
+            bundle_or_path,
+            device=device,
+            plan=plan,
+            expert_start=expert_start,
+            expert_count=expert_count,
+        )
+
+    def close(self) -> None:
+        self.clear()
+        self._loader.close()
+
+    def __enter__(self) -> "MiniMaxM2DeviceResidentCache":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def clear(self) -> None:
+        self._cache.clear()
+        self._grid_cache.clear()
+
+    def _type_id(self, type_name: str) -> int:
+        try:
+            return GGUF_DEVICE_TYPE_IDS[type_name]
+        except KeyError as exc:
+            raise NotImplementedError(f"MiniMax-M2 device cache does not support routed type {type_name!r}") from exc
+
+    def _quant_grid(self, type_name: str) -> torch.Tensor:
+        cached = self._grid_cache.get(type_name)
+        if cached is None or cached.device != self.device:
+            cached = _gguf_cuda_quant_grid(type_name, self.device)
+            self._grid_cache[type_name] = cached
+        return cached
+
+    def load_role(self, layer: int, role: str) -> MiniMaxM2DeviceRoutedTensor:
+        layer = int(layer)
+        if role not in ROUTED_ROLES:
+            raise ValueError(f"role must be one of {sorted(ROUTED_ROLES)}, got {role!r}")
+        key = (layer, role)
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+
+        item = self.plan.tensor_for(layer, role)
+        if item.type_name not in SUPPORTED_DEVICE_ROUTED_TYPES:
+            raise NotImplementedError(f"MiniMax-M2 routed type {item.type_name!r} is not supported by the CUDA device cache")
+        cpu_blocks, type_name, in_dim = self._loader.read_layer_role_blocks(
+            layer,
+            role,
+            expert_start=self.expert_start,
+            expert_count=self.expert_count,
+        )
+        if type_name != item.type_name:
+            raise RuntimeError(f"routed type mismatch for {item.source_name}: plan={item.type_name}, reader={type_name}")
+        blocks = cpu_blocks.to(device=self.device, non_blocking=False).contiguous()
+        device_tensor = MiniMaxM2DeviceRoutedTensor(
+            source_name=item.source_name,
+            role=role,
+            layer=layer,
+            blocks=blocks,
+            type_name=type_name,
+            type_id=self._type_id(type_name),
+            in_dim=int(in_dim),
+            out_dim=int(blocks.shape[1]),
+            expert_start=self.expert_start,
+            expert_count=self.expert_count,
+            device=self.device,
+        )
+        self._cache[key] = device_tensor
+        return device_tensor
+
+    def layer(self, layer: int) -> MiniMaxM2DeviceRoutedLayer:
+        layer = int(layer)
+        return MiniMaxM2DeviceRoutedLayer(
+            layer=layer,
+            w1=self.load_role(layer, "routed_w1"),
+            w3=self.load_role(layer, "routed_w3"),
+            w2=self.load_role(layer, "routed_w2"),
+            device=self.device,
+        )
+
+    def preload_layers(self, layer_start: int = 0, layer_count: int | None = None) -> int:
+        layer_start = int(layer_start)
+        layer_count = self.plan.params.n_layers - layer_start if layer_count is None else int(layer_count)
+        if layer_start < 0 or layer_count < 0 or layer_start + layer_count > self.plan.params.n_layers:
+            raise ValueError(
+                f"layer range [{layer_start}, {layer_start + layer_count}) is outside MiniMax-M2 range [0, {self.plan.params.n_layers})"
+            )
+        loaded = 0
+        for layer_id in range(layer_start, layer_start + layer_count):
+            before = len(self._cache)
+            self.layer(layer_id)
+            loaded += len(self._cache) - before
+        return loaded
+
+    def memory_bytes(self) -> int:
+        return sum(tensor.nbytes for tensor in self._cache.values())
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "architecture": MINIMAX_M2_ARCHITECTURE,
+            "device": str(self.device),
+            "expert_start": self.expert_start,
+            "expert_count": self.expert_count,
+            "cached_tensors": len(self._cache),
+            "resident_bytes": self.memory_bytes(),
+            "cached_roles": sorted(f"{layer}:{role}" for (layer, role) in self._cache),
+        }
+
+    def cuda_gemm_smoke(
+        self,
+        *,
+        layer: int = 0,
+        role: str = "routed_w1",
+        expert: int | None = None,
+        tokens: int = 1,
+        dtype: torch.dtype = torch.float16,
+    ) -> tuple[torch.Tensor, MiniMaxM2CudaGemmSmokeResult]:
+        from src.kernels.cuda_loader import load_cuda_kernel
+
+        tensor = self.load_role(int(layer), role)
+        expert = self.expert_start if expert is None else int(expert)
+        local_expert = expert - tensor.expert_start
+        if local_expert < 0 or local_expert >= tensor.expert_count:
+            raise ValueError(
+                f"expert {expert} is outside cached range [{tensor.expert_start}, {tensor.expert_start + tensor.expert_count})"
+            )
+        tokens = int(tokens)
+        if tokens <= 0:
+            raise ValueError(f"tokens must be positive, got {tokens}")
+        cuda_mod = load_cuda_kernel()
+        if cuda_mod is None or not hasattr(cuda_mod, "gguf_quant_gemm_forward"):
+            raise RuntimeError("built CUDA extension with gguf_quant_gemm_forward is not available")
+        expert_blocks = tensor.blocks[local_expert].contiguous()
+        x = torch.zeros((tokens, tensor.in_dim), device=self.device, dtype=dtype)
+        grid = self._quant_grid(tensor.type_name)
+        y = cuda_mod.gguf_quant_gemm_forward(x.contiguous(), expert_blocks, int(tensor.in_dim), int(tensor.type_id), grid)
+        finite = bool(torch.isfinite(y).all().item())
+        result = MiniMaxM2CudaGemmSmokeResult(
+            layer=int(layer),
+            role=role,
+            expert=expert,
+            type_name=tensor.type_name,
+            type_id=tensor.type_id,
+            device=self.device,
+            input_shape=tuple(int(dim) for dim in x.shape),
+            blocks_shape=tuple(int(dim) for dim in expert_blocks.shape),
+            output_shape=tuple(int(dim) for dim in y.shape),
+            output_dtype=y.dtype,
+            finite=finite,
+            resident_bytes=self.memory_bytes(),
+        )
+        if not finite:
+            raise RuntimeError(f"MiniMax-M2 CUDA GEMM smoke produced non-finite values: {result.as_dict()}")
+        return y, result

--- a/tests/test_inspect_gguf_specs.py
+++ b/tests/test_inspect_gguf_specs.py
@@ -5,10 +5,22 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+import torch
+
 from tests.gguf_test_utils import write_gguf, write_minimax_bundle
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _cuda_gguf_ext_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    from src.kernels.cuda_loader import load_cuda_kernel
+
+    cuda_mod = load_cuda_kernel()
+    return cuda_mod is not None and hasattr(cuda_mod, "gguf_quant_gemm_forward")
 
 
 def _run_inspect(*args: str) -> subprocess.CompletedProcess[str]:
@@ -110,6 +122,56 @@ def test_inspect_minimax_check_routed_blocks(tmp_path: Path) -> None:
     assert "layer=0 role=routed_w3 type=iq2_xxs" in result.stdout
     assert "blocks_shape=(1, 1, 66)" in result.stdout
     assert "routed block check: OK" in result.stdout
+
+
+@pytest.mark.skipif(torch.cuda.is_available(), reason="negative CUDA-unavailable CLI check only runs on CPU-only hosts")
+def test_inspect_minimax_cuda_smoke_reports_missing_cuda(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1, hidden=256, inter=256)
+
+    result = _run_inspect(
+        "--gguf-path",
+        str(root),
+        "--architecture",
+        "minimax-m2",
+        "--cuda-smoke-routed-blocks",
+    )
+
+    assert result.returncode == 1
+    assert "cuda routed block smoke: FAILED" in result.stdout
+    assert "CUDA is not available" in result.stdout
+
+
+@pytest.mark.skipif(not _cuda_gguf_ext_available(), reason="CUDA GGUF extension is not available")
+def test_inspect_minimax_cuda_smoke_routed_blocks(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1, hidden=256, inter=256)
+
+    result = _run_inspect(
+        "--gguf-path",
+        str(root),
+        "--architecture",
+        "minimax-m2",
+        "--cuda-smoke-routed-blocks",
+        "--cuda-smoke-layer",
+        "0",
+        "--cuda-smoke-role",
+        "routed_w1",
+        "--cuda-smoke-expert",
+        "0",
+        "--cuda-smoke-expert-count",
+        "1",
+        "--cuda-smoke-tokens",
+        "2",
+        "--cuda-smoke-device",
+        "cuda:0",
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "cuda routed block smoke:" in result.stdout
+    assert "type: iq2_xxs type_id=0" in result.stdout
+    assert "blocks_shape: (256, 1, 66)" in result.stdout
+    assert "input_shape: (2, 256)" in result.stdout
+    assert "output_shape: (2, 256)" in result.stdout
+    assert "cuda routed block smoke: OK" in result.stdout
 
 
 def test_inspect_legacy_ds4_summary_and_q2_validation_still_work(tmp_path: Path) -> None:

--- a/tests/test_minimax_m2_moe_runtime.py
+++ b/tests/test_minimax_m2_moe_runtime.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import torch
 
 from src.gguf.bundle import read_gguf_bundle
-from src.runtime.minimax_m2_moe import (
+from src.moe_model.minimax_m2_moe import (
+    GGUF_DEVICE_TYPE_IDS,
+    MiniMaxM2DeviceResidentCache,
     MiniMaxM2RoutedBlockLoader,
     ROUTED_ROLES,
     build_minimax_m2_moe_runtime_plan,
@@ -14,6 +17,15 @@ from tests.gguf_test_utils import write_minimax_bundle
 
 
 REAL_MINIMAX_PATH = Path("/mnt/data1/dsv4_inference/gguf_hfd/MiniMax-M2.7-GGUF/UD-IQ1_M")
+
+
+def _cuda_gguf_ext_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    from src.kernels.cuda_loader import load_cuda_kernel
+
+    cuda_mod = load_cuda_kernel()
+    return cuda_mod is not None and hasattr(cuda_mod, "gguf_quant_gemm_forward")
 
 
 def test_minimax_moe_runtime_plan_validates_tiny_bundle(tmp_path: Path) -> None:
@@ -73,6 +85,77 @@ def test_minimax_routed_block_loader_reads_small_slice(tmp_path: Path) -> None:
             assert layer_type_name == "iq2_xxs"
             assert layer_in_dim == in_dim
             assert tuple(layer_blocks.shape) == (1, 256, 1, 66)
+
+
+
+def test_minimax_routed_layer_blocks_full_expert_shape(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1, hidden=256, inter=256, experts=3)
+    bundle = read_gguf_bundle(root)
+    plan = build_minimax_m2_moe_runtime_plan(bundle)
+
+    with MiniMaxM2RoutedBlockLoader(bundle, plan=plan) as loader:
+        w1, type_name, in_dim = loader.read_layer_role_blocks(0, "routed_w1")
+        assert type_name == "iq2_xxs"
+        assert in_dim == 256
+        assert tuple(w1.shape) == (3, 256, 1, 66)
+
+        w2, type_name, in_dim = loader.read_layer_role_blocks(0, "routed_w2")
+        assert type_name == "iq2_xxs"
+        assert in_dim == 256
+        assert tuple(w2.shape) == (3, 256, 1, 66)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_minimax_device_resident_cache_loads_tiny_layer_cuda(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1, hidden=256, inter=256, experts=2)
+    bundle = read_gguf_bundle(root)
+    plan = build_minimax_m2_moe_runtime_plan(bundle)
+
+    with MiniMaxM2DeviceResidentCache(bundle, plan=plan, device="cuda:0", expert_start=0, expert_count=1) as cache:
+        layer = cache.layer(0)
+        assert layer.device.type == "cuda"
+        assert layer.w1.blocks.is_cuda
+        assert layer.w1.blocks.dtype == torch.uint8
+        assert layer.w1.type_id == GGUF_DEVICE_TYPE_IDS["iq2_xxs"]
+        assert tuple(layer.w1.blocks.shape) == (1, 256, 1, 66)
+        assert tuple(layer.w2.blocks.shape) == (1, 256, 1, 66)
+        assert cache.memory_bytes() == 3 * 256 * 1 * 66
+        summary = cache.summary()
+        assert summary["cached_tensors"] == 3
+        assert summary["resident_bytes"] == cache.memory_bytes()
+
+
+@pytest.mark.skipif(not _cuda_gguf_ext_available(), reason="CUDA GGUF extension is not available")
+def test_minimax_device_resident_cache_cuda_gemm_smoke_tiny(tmp_path: Path) -> None:
+    root = write_minimax_bundle(tmp_path / "bundle", n_layers=1, hidden=256, inter=256, experts=2)
+    bundle = read_gguf_bundle(root)
+    plan = build_minimax_m2_moe_runtime_plan(bundle)
+
+    with MiniMaxM2DeviceResidentCache(bundle, plan=plan, device="cuda:0", expert_start=0, expert_count=1) as cache:
+        output, result = cache.cuda_gemm_smoke(layer=0, role="routed_w1", expert=0, tokens=2)
+
+    assert output.is_cuda
+    assert tuple(output.shape) == (2, 256)
+    assert result.finite
+    assert result.input_shape == (2, 256)
+    assert result.output_shape == (2, 256)
+    assert result.blocks_shape == (256, 1, 66)
+    assert result.type_name == "iq2_xxs"
+
+
+@pytest.mark.skipif(not (REAL_MINIMAX_PATH.exists() and _cuda_gguf_ext_available()), reason="local MiniMax-M2.7 GGUF bundle or CUDA GGUF extension not present")
+def test_real_minimax_device_resident_cache_cuda_gemm_smoke_tiny_slice() -> None:
+    bundle = read_gguf_bundle(REAL_MINIMAX_PATH)
+    plan = build_minimax_m2_moe_runtime_plan(bundle)
+
+    with MiniMaxM2DeviceResidentCache(bundle, plan=plan, device="cuda:0", expert_start=0, expert_count=1) as cache:
+        output, result = cache.cuda_gemm_smoke(layer=0, role="routed_w1", expert=0, tokens=1)
+
+    assert output.is_cuda
+    assert result.finite
+    assert result.input_shape == (1, 3072)
+    assert result.output_shape == (1, 1536)
+    assert result.blocks_shape == (1536, 12, 66)
 
 
 @pytest.mark.skipif(not REAL_MINIMAX_PATH.exists(), reason="local MiniMax-M2.7 GGUF bundle not present")


### PR DESCRIPTION
## Summary
- add a MiniMax-M2 device-resident routed expert cache for all-device low-bit placement
- add an explicit inspect_gguf CUDA routed-block smoke path using the existing raw GGUF GEMM extension
- add CPU/CUDA tests for MiniMax routed block cache and CLI smoke behavior

## Validation
- `PYTHONPATH=$PWD python -m pytest tests/test_minimax_m2_moe_runtime.py tests/test_inspect_gguf_specs.py tests/test_minimax_m2_spec.py tests/test_gguf_bundle.py tests/test_moe_model_registry.py -q` → 27 passed, 4 skipped in base env
- `PYTHONPATH=$PWD python -m pytest tests/test_gguf_iq1m_reader.py tests/test_partition_policy.py -q` → 14 passed in base env
- `conda run -n deepseek bash -lc 'PYTHONPATH=$PWD python -m pytest tests/test_minimax_m2_moe_runtime.py tests/test_inspect_gguf_specs.py tests/test_minimax_m2_spec.py tests/test_gguf_bundle.py tests/test_moe_model_registry.py -q'` → 30 passed, 1 skipped\n- `conda run -n deepseek bash -lc 'PYTHONPATH=$PWD python -m pytest tests/test_gguf_iq1m_reader.py tests/test_partition_policy.py -q'` → 14 passed\n- real MiniMax-M2.7 CPU readiness + routed block check OK\n- real MiniMax-M2.7 CUDA smoke OK: layer 0 routed_w1 expert 0, output shape (1, 1536), finite=True\n- DSV4 inspect regression OK: validation OK\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)