### PR TITLE
FlashMemory retriever plugin: async KV swap, GPU weight load, mock smoke

### DIFF
--- a/cpp_engine/include/safetensors_reader.hpp
+++ b/cpp_engine/include/safetensors_reader.hpp
@@ -13,6 +13,7 @@ namespace dsv4 {
 
 enum class SafeDType {
     BF16,
+    F16,
     F32,
     I64,
     I8,

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -82,6 +82,62 @@ struct FlashMemoryPluginMetadata {
     uint64_t total_weight_bytes = 0;
 };
 
+struct FlashMemoryLayerDeviceWeights {
+    std::string layer;
+    void* wq_a = nullptr;
+    void* wq_b = nullptr;
+    void* q_norm_weight = nullptr;
+    void* weights_proj = nullptr;
+    SafeDType wq_a_dtype = SafeDType::Unknown;
+    SafeDType wq_b_dtype = SafeDType::Unknown;
+    SafeDType q_norm_dtype = SafeDType::Unknown;
+    SafeDType weights_proj_dtype = SafeDType::Unknown;
+    uint64_t bytes = 0;
+};
+
+struct FlashMemoryDeviceWeights {
+    std::vector<FlashMemoryLayerDeviceWeights> layers;
+    uint64_t total_device_bytes = 0;
+    uint64_t device_probe_checksum = 0;
+    bool loaded = false;
+
+    FlashMemoryDeviceWeights() = default;
+    FlashMemoryDeviceWeights(const FlashMemoryDeviceWeights&) = delete;
+    FlashMemoryDeviceWeights& operator=(const FlashMemoryDeviceWeights&) = delete;
+    FlashMemoryDeviceWeights(FlashMemoryDeviceWeights&& other) noexcept { *this = std::move(other); }
+    FlashMemoryDeviceWeights& operator=(FlashMemoryDeviceWeights&& other) noexcept {
+        if (this == &other) return *this;
+        release();
+        layers = std::move(other.layers);
+        total_device_bytes = other.total_device_bytes;
+        device_probe_checksum = other.device_probe_checksum;
+        loaded = other.loaded;
+        other.total_device_bytes = 0;
+        other.device_probe_checksum = 0;
+        other.loaded = false;
+        return *this;
+    }
+    ~FlashMemoryDeviceWeights() { release(); }
+
+    void release() {
+        for (auto& l : layers) {
+            cudaFree(l.wq_a);
+            cudaFree(l.wq_b);
+            cudaFree(l.q_norm_weight);
+            cudaFree(l.weights_proj);
+            l.wq_a = nullptr;
+            l.wq_b = nullptr;
+            l.q_norm_weight = nullptr;
+            l.weights_proj = nullptr;
+        }
+        layers.clear();
+        total_device_bytes = 0;
+        device_probe_checksum = 0;
+        loaded = false;
+    }
+};
+
+
 FlashMemoryPluginMetadata inspect_flashmemory_checkpoint_metadata(const std::string& ckpt_path) {
     SafeTensorsShard shard(ckpt_path);
     std::map<std::string, std::vector<std::string>> by_layer;
@@ -137,6 +193,85 @@ FlashMemoryPluginMetadata inspect_flashmemory_checkpoint_metadata(const std::str
         meta.layers.push_back(layer);
     }
     return meta;
+}
+
+void* upload_flashmemory_tensor(const SafeTensorsShard& shard, const SafeTensorInfo& info) {
+    if (!flashmemory_dtype_allowed(info.dtype)) {
+        throw std::runtime_error("FlashMemory plugin unsupported dtype for upload: " + info.name + " dtype=" + safe_dtype_name(info.dtype));
+    }
+    void* d = nullptr;
+    check_cuda(cudaMalloc(&d, info.nbytes), ("alloc FlashMemory tensor " + info.name).c_str());
+    check_cuda(cudaMemcpy(d, shard.tensor_data(info), info.nbytes, cudaMemcpyHostToDevice),
+               ("copy FlashMemory tensor " + info.name).c_str());
+    return d;
+}
+
+FlashMemoryDeviceWeights load_flashmemory_device_weights(const std::string& ckpt_path) {
+    SafeTensorsShard shard(ckpt_path);
+    FlashMemoryPluginMetadata meta = inspect_flashmemory_checkpoint_metadata(ckpt_path);
+    FlashMemoryDeviceWeights out;
+    out.layers.reserve(meta.layers.size());
+    auto require_info = [&](const std::string& tensor) -> const SafeTensorInfo& {
+        const SafeTensorInfo* info = shard.find_tensor(tensor);
+        if (info == nullptr) throw std::runtime_error("FlashMemory plugin missing tensor during device load: " + tensor);
+        return *info;
+    };
+    for (const std::string& layer : meta.layers) {
+        FlashMemoryLayerDeviceWeights lw;
+        lw.layer = layer;
+        const auto& wq_a = require_info("retrievers." + layer + ".wq_a.weight");
+        const auto& wq_b = require_info("retrievers." + layer + ".wq_b.weight");
+        const auto& q_norm = require_info("retrievers." + layer + ".q_norm_weight");
+        const auto& weights_proj = require_info("retrievers." + layer + ".weights_proj.weight");
+        lw.wq_a_dtype = wq_a.dtype;
+        lw.wq_b_dtype = wq_b.dtype;
+        lw.q_norm_dtype = q_norm.dtype;
+        lw.weights_proj_dtype = weights_proj.dtype;
+        lw.wq_a = upload_flashmemory_tensor(shard, wq_a);
+        lw.wq_b = upload_flashmemory_tensor(shard, wq_b);
+        lw.q_norm_weight = upload_flashmemory_tensor(shard, q_norm);
+        lw.weights_proj = upload_flashmemory_tensor(shard, weights_proj);
+        lw.bytes = wq_a.nbytes + wq_b.nbytes + q_norm.nbytes + weights_proj.nbytes;
+        out.total_device_bytes += lw.bytes;
+        out.layers.push_back(std::move(lw));
+    }
+    out.loaded = true;
+    return out;
+}
+
+// Mock scorer smoke: read back a small prefix from each layer's device weight
+// pointers and fold the bytes into a checksum. This does NOT run the FlashMemory
+// retriever; it only proves the device-loaded weights are addressable/readable
+// (round-trip D2H) so the isolated plugin path stays runtime_scoring=0 while
+// validating the GPU upload. Returns the number of probed pointers.
+uint64_t flashmemory_device_weight_smoke(FlashMemoryDeviceWeights& weights, uint64_t probe_bytes) {
+    if (!weights.loaded) throw std::runtime_error("FlashMemory mock scorer smoke requires loaded device weights");
+    std::vector<uint8_t> host;
+    uint64_t checksum = 1469598103934665603ULL;  // FNV-1a offset basis
+    uint64_t probed = 0;
+    auto probe_ptr = [&](void* ptr, SafeDType dtype, uint64_t tensor_bytes) {
+        if (ptr == nullptr) throw std::runtime_error("FlashMemory mock scorer smoke hit null device pointer");
+        const uint64_t n = std::min<uint64_t>(probe_bytes, tensor_bytes);
+        if (n == 0) return;
+        host.resize(static_cast<size_t>(n));
+        check_cuda(cudaMemcpy(host.data(), ptr, n, cudaMemcpyDeviceToHost), "FlashMemory mock scorer probe D2H");
+        checksum ^= static_cast<uint64_t>(dtype);
+        checksum *= 1099511628211ULL;
+        for (uint64_t i = 0; i < n; ++i) {
+            checksum ^= host[static_cast<size_t>(i)];
+            checksum *= 1099511628211ULL;  // FNV-1a prime
+        }
+        ++probed;
+    };
+    for (auto& l : weights.layers) {
+        const uint64_t per_tensor = l.bytes / 4;  // approximate even split for the probe cap
+        probe_ptr(l.wq_a, l.wq_a_dtype, per_tensor == 0 ? l.bytes : per_tensor);
+        probe_ptr(l.wq_b, l.wq_b_dtype, per_tensor == 0 ? l.bytes : per_tensor);
+        probe_ptr(l.q_norm_weight, l.q_norm_dtype, per_tensor == 0 ? l.bytes : per_tensor);
+        probe_ptr(l.weights_proj, l.weights_proj_dtype, per_tensor == 0 ? l.bytes : per_tensor);
+    }
+    weights.device_probe_checksum = checksum;
+    return probed;
 }
 
 
@@ -6779,14 +6914,22 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
         env_int_or_default("DSV4_GGUF_KV_SWAP_TEST_ALLOW_TOPK_REDUCTION", 0) != 0;
     const bool gguf_flashmemory_plugin = env_int_or_default("DSV4_GGUF_FLASHMEMORY_PLUGIN", 0) != 0;
     const int gguf_flashmemory_metadata_only = env_int_or_default("DSV4_GGUF_FLASHMEMORY_METADATA_ONLY", 1);
+    const int gguf_flashmemory_load_device = env_int_or_default("DSV4_GGUF_FLASHMEMORY_LOAD_DEVICE", 0);
+    const int gguf_flashmemory_mock_smoke = env_int_or_default("DSV4_GGUF_FLASHMEMORY_MOCK_SCORER_SMOKE", 0);
     const char* gguf_flashmemory_ckpt_env = std::getenv("DSV4_GGUF_FLASHMEMORY_CKPT");
     const std::string gguf_flashmemory_ckpt = gguf_flashmemory_ckpt_env == nullptr ? std::string() : std::string(gguf_flashmemory_ckpt_env);
     if (gguf_flashmemory_plugin && gguf_flashmemory_metadata_only != 0 && gguf_flashmemory_metadata_only != 1)
         throw std::runtime_error("DSV4_GGUF_FLASHMEMORY_METADATA_ONLY must be 0 or 1");
+    if (gguf_flashmemory_plugin && gguf_flashmemory_load_device != 0 && gguf_flashmemory_load_device != 1)
+        throw std::runtime_error("DSV4_GGUF_FLASHMEMORY_LOAD_DEVICE must be 0 or 1");
+    if (gguf_flashmemory_plugin && gguf_flashmemory_mock_smoke != 0 && gguf_flashmemory_mock_smoke != 1)
+        throw std::runtime_error("DSV4_GGUF_FLASHMEMORY_MOCK_SCORER_SMOKE must be 0 or 1");
     if (gguf_flashmemory_plugin && gguf_flashmemory_ckpt.empty())
         throw std::runtime_error("DSV4_GGUF_FLASHMEMORY_PLUGIN requires DSV4_GGUF_FLASHMEMORY_CKPT=/path/flashmemory_ds_v4.safetensors");
+    if (gguf_flashmemory_plugin && gguf_flashmemory_mock_smoke && !gguf_flashmemory_load_device)
+        throw std::runtime_error("DSV4_GGUF_FLASHMEMORY_MOCK_SCORER_SMOKE requires DSV4_GGUF_FLASHMEMORY_LOAD_DEVICE=1");
     if (gguf_flashmemory_plugin && gguf_flashmemory_metadata_only == 0)
-        throw std::runtime_error("FlashMemory retriever runtime scoring is not wired yet; use DSV4_GGUF_FLASHMEMORY_METADATA_ONLY=1 for the paper-reproduction plugin skeleton");
+        throw std::runtime_error("FlashMemory retriever runtime scoring is not wired yet; keep DSV4_GGUF_FLASHMEMORY_METADATA_ONLY=1 for the isolated paper-reproduction plugin path");
     if (gguf_kv_swap_requested && !gguf_sparse_compressor)
         throw std::runtime_error("DSV4_GGUF_KV_SWAP requires DSV4_GGUF_SPARSE_COMPRESSOR=1");
     if (gguf_kv_swap_requested && gguf_kv_swap_pinned_mib <= 0)
@@ -6810,15 +6953,30 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
         throw std::runtime_error("DSV4_GGUF_SPARSE_WINDOW must be > 0");
     if (gguf_sparse_compressor && (gguf_sparse_attn_threshold < 0 || gguf_sparse_attn_threshold > gguf_sparse_window))
         throw std::runtime_error("DSV4_GGUF_SPARSE_ATTN_THRESHOLD must be in [0, DSV4_GGUF_SPARSE_WINDOW]");
+    std::unique_ptr<FlashMemoryDeviceWeights> flashmemory_device_weights;
     if (gguf_flashmemory_plugin) {
         FlashMemoryPluginMetadata fm = inspect_flashmemory_checkpoint_metadata(gguf_flashmemory_ckpt);
+        uint64_t flashmemory_probed = 0;
+        if (gguf_flashmemory_load_device) {
+            flashmemory_device_weights = std::make_unique<FlashMemoryDeviceWeights>(
+                load_flashmemory_device_weights(gguf_flashmemory_ckpt));
+            check_cuda(cudaDeviceSynchronize(), "sync FlashMemory device weight load");
+            if (gguf_flashmemory_mock_smoke) {
+                flashmemory_probed = flashmemory_device_weight_smoke(*flashmemory_device_weights, /*probe_bytes=*/64);
+            }
+        }
         if (tp_rank == 0) {
             std::ostringstream layers;
             for (size_t i = 0; i < fm.layers.size(); ++i) {
                 if (i) layers << ",";
                 layers << fm.layers[i];
             }
-            std::cout << "gguf_flashmemory_plugin=1 metadata_only=1"
+            const double device_mib = flashmemory_device_weights && flashmemory_device_weights->loaded
+                ? static_cast<double>(flashmemory_device_weights->total_device_bytes) / (1024.0 * 1024.0)
+                : 0.0;
+            std::cout << "gguf_flashmemory_plugin=1 metadata_only=" << gguf_flashmemory_metadata_only
+                      << " load_device=" << gguf_flashmemory_load_device
+                      << " mock_scorer_smoke=" << gguf_flashmemory_mock_smoke
                       << " ckpt=" << gguf_flashmemory_ckpt
                       << " layers=" << layers.str()
                       << " n_heads=" << fm.n_heads
@@ -6827,7 +6985,12 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
                       << " hidden_dim=" << fm.hidden_dim
                       << " rope_dim=" << fm.rope_dim
                       << " weight_mib=" << (static_cast<double>(fm.total_weight_bytes) / (1024.0 * 1024.0))
-                      << " runtime_scoring=0"
+                      << " device_mib=" << device_mib;
+            if (gguf_flashmemory_mock_smoke) {
+                std::cout << " mock_probed_ptrs=" << flashmemory_probed
+                          << " mock_probe_checksum=" << flashmemory_device_weights->device_probe_checksum;
+            }
+            std::cout << " runtime_scoring=0"
                       << "\n";
         }
     }

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -3851,10 +3851,16 @@ void gguf_kv_swap_in_selected(GgufKvSwapLayerState* st,
                               float* d_kv_cache,
                               int* d_kv_indices,
                               int window_len,
-                              int extra_count) {
+                              int extra_count,
+                              cudaStream_t copy_stream,
+                              cudaEvent_t stage_event,
+                              bool async_h2d) {
     if (st == nullptr || !st->enabled || extra_count <= 0) return;
     if (extra_count > st->gpu_chunks) {
         throw std::runtime_error("GGUF KV swap selected more chunks than GPU staging capacity");
+    }
+    if (async_h2d && (copy_stream == nullptr || stage_event == nullptr)) {
+        throw std::runtime_error("GGUF KV swap async H2D requested without copy stream/event");
     }
     std::vector<int> h_indices(static_cast<size_t>(extra_count));
     check_cuda(cudaMemcpy(h_indices.data(), d_kv_indices + window_len,
@@ -3862,6 +3868,7 @@ void gguf_kv_swap_in_selected(GgufKvSwapLayerState* st,
                           cudaMemcpyDeviceToHost),
                "GGUF KV swap copy selected indices");
     const size_t bytes = static_cast<size_t>(st->kv_dim) * sizeof(float);
+    bool queued_async_work = false;
     for (int i = 0; i < extra_count; ++i) {
         const int logical = h_indices[static_cast<size_t>(i)] - st->window;
         if (logical < 0 || logical >= st->compressed_cap) {
@@ -3880,16 +3887,37 @@ void gguf_kv_swap_in_selected(GgufKvSwapLayerState* st,
             physical = gguf_kv_swap_acquire_slot(*st, logical);
             const float* h_src = st->h_compressed_kv + static_cast<size_t>(logical) * st->kv_dim;
             float* d_dst = d_kv_cache + static_cast<size_t>(st->window + physical) * st->kv_dim;
-            check_cuda(cudaMemcpy(d_dst, h_src, bytes, cudaMemcpyHostToDevice),
-                       "GGUF KV swap load compressed chunk");
+            if (async_h2d) {
+                check_cuda(cudaMemcpyAsync(d_dst, h_src, bytes, cudaMemcpyHostToDevice, copy_stream),
+                           "GGUF KV swap async load compressed chunk");
+                queued_async_work = true;
+            } else {
+                check_cuda(cudaMemcpy(d_dst, h_src, bytes, cudaMemcpyHostToDevice),
+                           "GGUF KV swap load compressed chunk");
+            }
             st->h2d_bytes += bytes;
         }
         h_indices[static_cast<size_t>(i)] = st->window + physical;
     }
-    check_cuda(cudaMemcpy(d_kv_indices + window_len, h_indices.data(),
-                          static_cast<size_t>(extra_count) * sizeof(int),
-                          cudaMemcpyHostToDevice),
-               "GGUF KV swap rewrite selected indices");
+    if (async_h2d) {
+        if (queued_async_work) {
+            check_cuda(cudaEventRecord(stage_event, copy_stream),
+                       "record GGUF KV swap stage event");
+        }
+        check_cuda(cudaMemcpy(d_kv_indices + window_len, h_indices.data(),
+                              static_cast<size_t>(extra_count) * sizeof(int),
+                              cudaMemcpyHostToDevice),
+                   "GGUF KV swap rewrite selected indices");
+        if (queued_async_work) {
+            check_cuda(cudaStreamWaitEvent(nullptr, stage_event, 0),
+                       "default stream wait GGUF KV swap stage event");
+        }
+    } else {
+        check_cuda(cudaMemcpy(d_kv_indices + window_len, h_indices.data(),
+                              static_cast<size_t>(extra_count) * sizeof(int),
+                              cudaMemcpyHostToDevice),
+                   "GGUF KV swap rewrite selected indices");
+    }
 }
 
 struct GgufLayerDeviceWeights {
@@ -3931,6 +3959,9 @@ struct GgufLayerDeviceWeights {
     const GgufIndexerDeviceWeights* indexer = nullptr;
     GgufSparseLayerState* sparse_state = nullptr;
     GgufKvSwapLayerState* kv_swap = nullptr;
+    cudaStream_t kv_swap_stream = nullptr;
+    cudaEvent_t kv_swap_stage_event = nullptr;
+    bool kv_swap_async_h2d = false;
     int compress_ratio = 0;
     int sparse_window_size = 0;
     int sparse_attn_threshold = 0;
@@ -4221,7 +4252,10 @@ void gguf_layer_forward_attn_to_gate(const GgufLayerDeviceWeights& w,
                 }
             }
             gguf_kv_swap_in_selected(w.kv_swap, s.d_kv_cache, s.d_kv_indices,
-                                     window_len, extra_count);
+                                     window_len, extra_count,
+                                     w.kv_swap_stream,
+                                     w.kv_swap_stage_event,
+                                     w.kv_swap_async_h2d);
             const int index_count = window_len + extra_count;
             s.sparse_kv_index_count = index_count;
             s.sparse_attn_used = true;
@@ -6664,6 +6698,8 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
         throw std::runtime_error("DSV4_GGUF_KV_SWAP_PINNED_MIB must be > 0");
     if (gguf_kv_swap_requested && gguf_kv_swap_gpu_chunks_env < 0)
         throw std::runtime_error("DSV4_GGUF_KV_SWAP_GPU_CHUNKS must be >= 0");
+    if (gguf_kv_swap_requested && gguf_kv_swap_sync != 0 && gguf_kv_swap_sync != 1)
+        throw std::runtime_error("DSV4_GGUF_KV_SWAP_SYNC must be 0 or 1");
     const int gguf_sparse_window = env_int_or_default(
         "DSV4_GGUF_SPARSE_WINDOW",
         static_cast<int>(ctx.config.window_size == 0 ? 128 : ctx.config.window_size));
@@ -7326,6 +7362,18 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
     if (gguf_mem_profile) gguf_log_mem("after_scratch", tp_rank);
     gguf_check_min_free("after_scratch", tp_rank, gguf_min_free_mib);
 
+    // Optional GGUF KV swap copy stream. Only used when the plugin is enabled
+    // and DSV4_GGUF_KV_SWAP_SYNC=0; the default sync=1 path is unchanged.
+    const bool gguf_kv_swap_async_h2d = gguf_kv_swap_enabled && gguf_kv_swap_sync == 0;
+    cudaStream_t gguf_kv_swap_copy_stream = nullptr;
+    cudaEvent_t gguf_kv_swap_stage_event = nullptr;
+    if (gguf_kv_swap_async_h2d) {
+        check_cuda(cudaStreamCreateWithFlags(&gguf_kv_swap_copy_stream, cudaStreamNonBlocking),
+                   "create gguf kv swap copy stream");
+        check_cuda(cudaEventCreateWithFlags(&gguf_kv_swap_stage_event, cudaEventDisableTiming),
+                   "create gguf kv swap stage event");
+    }
+
     // Dedicated copy stream for staging (H2D for routed Q2 experts). Currently
     // neutral in wall-time (staging is on the critical path between gate D2H
     // and MoE compute; nothing on default stream can overlap with it within a
@@ -7513,6 +7561,9 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
             lw.indexer = (layer_sparse_enabled && d_indexer_w[L].present) ? &d_indexer_w[L] : nullptr;
             lw.sparse_state = (layer_sparse_enabled && d_sparse_state[L].compressor_kv != nullptr) ? &d_sparse_state[L] : nullptr;
             lw.kv_swap = (layer_sparse_enabled && d_kv_swap_state[L].enabled) ? &d_kv_swap_state[L] : nullptr;
+            lw.kv_swap_stream = (lw.kv_swap != nullptr && gguf_kv_swap_async_h2d) ? gguf_kv_swap_copy_stream : nullptr;
+            lw.kv_swap_stage_event = (lw.kv_swap != nullptr && gguf_kv_swap_async_h2d) ? gguf_kv_swap_stage_event : nullptr;
+            lw.kv_swap_async_h2d = (lw.kv_swap != nullptr && gguf_kv_swap_async_h2d);
             lw.compress_ratio = layer_sparse_enabled ? d_compressor_w[L].ratio : 0;
             lw.sparse_window_size = layer_sparse_enabled ? gguf_sparse_window : 0;
             lw.sparse_attn_threshold = layer_sparse_enabled ? gguf_sparse_attn_threshold : 0;
@@ -8326,6 +8377,10 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
         cudaEventDestroy(gguf_moe_stage_event);
         cudaEventDestroy(gguf_moe_consume_event);
         cudaStreamDestroy(gguf_moe_copy_stream);
+    }
+    if (gguf_kv_swap_async_h2d) {
+        cudaEventDestroy(gguf_kv_swap_stage_event);
+        cudaStreamDestroy(gguf_kv_swap_copy_stream);
     }
     if (gguf_registered) cudaHostUnregister(gguf_base);
     return r;

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -25,6 +25,8 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <memory>
+#include <map>
+#include <fstream>
 #include <vector>
 
 namespace dsv4 {
@@ -54,6 +56,89 @@ const std::string& check_safetensors_path(const std::string& dir) {
     }
     return dir;
 }
+
+std::string shape_to_string(const std::vector<uint64_t>& shape) {
+    std::ostringstream oss;
+    oss << "[";
+    for (size_t i = 0; i < shape.size(); ++i) {
+        if (i) oss << ",";
+        oss << shape[i];
+    }
+    oss << "]";
+    return oss.str();
+}
+
+bool flashmemory_dtype_allowed(SafeDType dtype) {
+    return dtype == SafeDType::F32 || dtype == SafeDType::BF16 || dtype == SafeDType::F16;
+}
+
+struct FlashMemoryPluginMetadata {
+    std::vector<std::string> layers;
+    int n_heads = 128;
+    int head_dim = 128;
+    int q_lora_rank = 2048;
+    int hidden_dim = 4096;
+    int rope_dim = 64;
+    uint64_t total_weight_bytes = 0;
+};
+
+FlashMemoryPluginMetadata inspect_flashmemory_checkpoint_metadata(const std::string& ckpt_path) {
+    SafeTensorsShard shard(ckpt_path);
+    std::map<std::string, std::vector<std::string>> by_layer;
+    const std::string prefix = "retrievers.";
+    for (const auto& [name, info] : shard.tensors()) {
+        if (name.rfind(prefix, 0) != 0) continue;
+        const size_t layer_start = prefix.size();
+        const size_t dot = name.find('.', layer_start);
+        if (dot == std::string::npos || dot == layer_start) continue;
+        const std::string layer = name.substr(layer_start, dot - layer_start);
+        by_layer[layer].push_back(name.substr(dot + 1));
+    }
+    if (by_layer.empty()) {
+        throw std::runtime_error("FlashMemory plugin checkpoint is not in retrievers.l{ID}.* format: " + ckpt_path);
+    }
+
+    FlashMemoryPluginMetadata meta;
+    const std::vector<std::string> required = {
+        "wq_a.weight",
+        "wq_b.weight",
+        "q_norm_weight",
+        "weights_proj.weight",
+    };
+    auto require_info = [&](const std::string& tensor) -> const SafeTensorInfo& {
+        const SafeTensorInfo* info = shard.find_tensor(tensor);
+        if (info == nullptr) throw std::runtime_error("FlashMemory plugin missing tensor: " + tensor);
+        if (!flashmemory_dtype_allowed(info->dtype)) {
+            throw std::runtime_error("FlashMemory plugin unsupported dtype for " + tensor + ": " + safe_dtype_name(info->dtype));
+        }
+        return *info;
+    };
+    auto require_shape = [&](const SafeTensorInfo& info, const std::vector<uint64_t>& expected) {
+        if (info.shape != expected) {
+            throw std::runtime_error("FlashMemory plugin tensor shape mismatch for " + info.name +
+                                     ": got " + shape_to_string(info.shape) +
+                                     " expected " + shape_to_string(expected));
+        }
+        meta.total_weight_bytes += info.nbytes;
+    };
+
+    for (const auto& [layer, _names] : by_layer) {
+        for (const std::string& suffix : required) {
+            (void)require_info("retrievers." + layer + "." + suffix);
+        }
+        const auto& wq_a = require_info("retrievers." + layer + ".wq_a.weight");
+        const auto& wq_b = require_info("retrievers." + layer + ".wq_b.weight");
+        const auto& q_norm = require_info("retrievers." + layer + ".q_norm_weight");
+        const auto& weights_proj = require_info("retrievers." + layer + ".weights_proj.weight");
+        require_shape(wq_a, {static_cast<uint64_t>(meta.q_lora_rank), static_cast<uint64_t>(meta.hidden_dim)});
+        require_shape(wq_b, {static_cast<uint64_t>(meta.n_heads * meta.head_dim), static_cast<uint64_t>(meta.q_lora_rank)});
+        require_shape(q_norm, {static_cast<uint64_t>(meta.q_lora_rank)});
+        require_shape(weights_proj, {static_cast<uint64_t>(meta.n_heads), static_cast<uint64_t>(meta.hidden_dim)});
+        meta.layers.push_back(layer);
+    }
+    return meta;
+}
+
 
 struct Fp4Handle {
     SafeTensorsShard shard;
@@ -6692,6 +6777,16 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
     const int gguf_kv_swap_validate = env_int_or_default("DSV4_GGUF_KV_SWAP_VALIDATE", 0);
     const bool gguf_kv_swap_test_allow_topk_reduction =
         env_int_or_default("DSV4_GGUF_KV_SWAP_TEST_ALLOW_TOPK_REDUCTION", 0) != 0;
+    const bool gguf_flashmemory_plugin = env_int_or_default("DSV4_GGUF_FLASHMEMORY_PLUGIN", 0) != 0;
+    const int gguf_flashmemory_metadata_only = env_int_or_default("DSV4_GGUF_FLASHMEMORY_METADATA_ONLY", 1);
+    const char* gguf_flashmemory_ckpt_env = std::getenv("DSV4_GGUF_FLASHMEMORY_CKPT");
+    const std::string gguf_flashmemory_ckpt = gguf_flashmemory_ckpt_env == nullptr ? std::string() : std::string(gguf_flashmemory_ckpt_env);
+    if (gguf_flashmemory_plugin && gguf_flashmemory_metadata_only != 0 && gguf_flashmemory_metadata_only != 1)
+        throw std::runtime_error("DSV4_GGUF_FLASHMEMORY_METADATA_ONLY must be 0 or 1");
+    if (gguf_flashmemory_plugin && gguf_flashmemory_ckpt.empty())
+        throw std::runtime_error("DSV4_GGUF_FLASHMEMORY_PLUGIN requires DSV4_GGUF_FLASHMEMORY_CKPT=/path/flashmemory_ds_v4.safetensors");
+    if (gguf_flashmemory_plugin && gguf_flashmemory_metadata_only == 0)
+        throw std::runtime_error("FlashMemory retriever runtime scoring is not wired yet; use DSV4_GGUF_FLASHMEMORY_METADATA_ONLY=1 for the paper-reproduction plugin skeleton");
     if (gguf_kv_swap_requested && !gguf_sparse_compressor)
         throw std::runtime_error("DSV4_GGUF_KV_SWAP requires DSV4_GGUF_SPARSE_COMPRESSOR=1");
     if (gguf_kv_swap_requested && gguf_kv_swap_pinned_mib <= 0)
@@ -6715,6 +6810,27 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
         throw std::runtime_error("DSV4_GGUF_SPARSE_WINDOW must be > 0");
     if (gguf_sparse_compressor && (gguf_sparse_attn_threshold < 0 || gguf_sparse_attn_threshold > gguf_sparse_window))
         throw std::runtime_error("DSV4_GGUF_SPARSE_ATTN_THRESHOLD must be in [0, DSV4_GGUF_SPARSE_WINDOW]");
+    if (gguf_flashmemory_plugin) {
+        FlashMemoryPluginMetadata fm = inspect_flashmemory_checkpoint_metadata(gguf_flashmemory_ckpt);
+        if (tp_rank == 0) {
+            std::ostringstream layers;
+            for (size_t i = 0; i < fm.layers.size(); ++i) {
+                if (i) layers << ",";
+                layers << fm.layers[i];
+            }
+            std::cout << "gguf_flashmemory_plugin=1 metadata_only=1"
+                      << " ckpt=" << gguf_flashmemory_ckpt
+                      << " layers=" << layers.str()
+                      << " n_heads=" << fm.n_heads
+                      << " head_dim=" << fm.head_dim
+                      << " q_lora_rank=" << fm.q_lora_rank
+                      << " hidden_dim=" << fm.hidden_dim
+                      << " rope_dim=" << fm.rope_dim
+                      << " weight_mib=" << (static_cast<double>(fm.total_weight_bytes) / (1024.0 * 1024.0))
+                      << " runtime_scoring=0"
+                      << "\n";
+        }
+    }
     if (gguf_mem_profile) gguf_log_mem("after_context_init", tp_rank);
 
     auto upload_u8 = [](const void* src, size_t bytes) {

--- a/cpp_engine/src/safetensors_reader.cpp
+++ b/cpp_engine/src/safetensors_reader.cpp
@@ -168,6 +168,7 @@ const uint8_t* SafeTensorsShard::tensor_data(const SafeTensorInfo& info) const {
 std::string safe_dtype_name(SafeDType dtype) {
     switch (dtype) {
         case SafeDType::BF16: return "BF16";
+        case SafeDType::F16: return "F16";
         case SafeDType::F32: return "F32";
         case SafeDType::I64: return "I64";
         case SafeDType::I8: return "I8";
@@ -180,6 +181,7 @@ std::string safe_dtype_name(SafeDType dtype) {
 
 SafeDType safe_dtype_from_string(const std::string& dtype) {
     if (dtype == "BF16") return SafeDType::BF16;
+    if (dtype == "F16") return SafeDType::F16;
     if (dtype == "F32") return SafeDType::F32;
     if (dtype == "I64") return SafeDType::I64;
     if (dtype == "I8") return SafeDType::I8;
@@ -191,6 +193,7 @@ SafeDType safe_dtype_from_string(const std::string& dtype) {
 uint64_t safe_dtype_size(SafeDType dtype) {
     switch (dtype) {
         case SafeDType::BF16: return 2;
+        case SafeDType::F16: return 2;
         case SafeDType::F32: return 4;
         case SafeDType::I64: return 8;
         case SafeDType::I8: return 1;


### PR DESCRIPTION
## Summary

Builds on the isolated FlashMemory paper-reproduction plugin (default OFF) on the C++ GGUF/IQ1M decode path. Three commits:

1. **Async H2D mode for GGUF KV swap** (`e364034`) — `DSV4_GGUF_KV_SWAP_SYNC=0` overlaps compressed-chunk H2D on a dedicated copy stream + event; default sync path unchanged.
2. **FlashMemory retriever plugin metadata loader** (`6fb6bb8`) — parse/validate `retrievers.l{ID}.*` checkpoint shapes (wq_a/wq_b/q_norm/weights_proj); adds F16 to the safetensors reader.
3. **FlashMemory plugin GPU weight load + mock scorer smoke** (`ae115d3`) — move-only `FlashMemoryDeviceWeights` RAII holder uploads the 4 retriever tensors per layer to device; `DSV4_GGUF_FLASHMEMORY_MOCK_SCORER_SMOKE=1` reads back a 64B prefix per tensor (D2H) into an FNV-1a checksum, proving device weights are addressable **without** running any scoring.

All FlashMemory behavior is gated behind `DSV4_GGUF_FLASHMEMORY_PLUGIN=1` (default OFF). `runtime_scoring` stays 0; the DeepSeek sparse indexer/attention path is untouched.

## Verification (TP4 + NCCL, DeepSeek-V4-Flash IQ2XXS-w2Q2K)

Identical tokens across all three configs — proves isolation:

| Config | Result | Tokens |
|--------|--------|--------|
| Plugin OFF (default) | no plugin line | `[91096, 120682, 12272, 55889]` |
| metadata-only | `device_mib=0 runtime_scoring=0` | same |
| GPU-load + mock-smoke | `device_mib=81.0 mock_probed_ptrs=4 runtime_scoring=0` | same |

- FP4/Q2 MoE grouped unit tests: `test_fp4_matvec`, `test_moe_grouped_fp4`, `test_moe_grouped_q2` all PASS (keeps the FP4-must-work constraint).
- F16 reader path exercised end-to-end by the F16 retriever checkpoint.

## Not in this PR

Real scorer kernel (RoPE + Hadamard + FP8 dequant + relu/sigmoid) and `compressed_k [N,132]` generation — `runtime_scoring` remains 0 until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)