### PR TITLE
Add iq2_xxs w2 DP4A prefill kernel for MiniMax (+100% prefill TPS)

### DIFF
--- a/src/csrc/cuda_kernel_impl.cu
+++ b/src/csrc/cuda_kernel_impl.cu
@@ -6935,6 +6935,102 @@ __global__ void gguf_moe_w2_scatter_q2k_dp4a_kernel(
     }
 }
 
+// iq2_xxs w2 (ffn_down) DP4A scatter for prefill.  Mirrors the parity-validated
+// grid decode of gguf_moe_w13_iq2_xxs_dp4a_kernel (symmetric, no dmin term) and
+// the scatter output of gguf_moe_w2_scatter_q2k_dp4a_kernel.  Contraction is over
+// inter_dim; hidden activation must be Q8_1 quantized in 32-element groups (one
+// group per iq2_xxs sub-block), so hidden_groups == ceil(inter_dim/32).
+__global__ void gguf_moe_w2_scatter_iq2_xxs_dp4a_kernel(
+    const int8_t* __restrict__ hidden_q,
+    const float* __restrict__ hidden_scale,
+    const int64_t* __restrict__ route_tokens,
+    const int32_t* __restrict__ route_experts,
+    const uint8_t* __restrict__ w2_blocks,
+    const int8_t* __restrict__ signed_grid,
+    float* __restrict__ y,
+    int routes,
+    int dim,
+    int inter_dim,
+    int w2_blocks_per_row,
+    int hidden_groups) {
+    const int route = blockIdx.y;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int out_col = blockIdx.x * kGGUFQuantTileN + warp;
+    if (route >= routes || warp >= kGGUFQuantTileN) return;
+
+    const int64_t token = route_tokens[route];
+    const int expert = route_experts[route];
+    const int8_t* hidden_row = hidden_q + static_cast<int64_t>(route) * inter_dim;
+    const float* hs_row = hidden_scale + static_cast<int64_t>(route) * hidden_groups;
+    const uint8_t* w2_row = w2_blocks + (static_cast<int64_t>(expert) * dim + out_col) * w2_blocks_per_row * 66;
+
+    __shared__ int h_shared_q[64];
+    __shared__ float h_shared_scale[8];
+
+    float acc = 0.0f;
+
+    for (int block_idx = 0; block_idx < w2_blocks_per_row; ++block_idx) {
+        const int k_base = block_idx * 256;
+        const int tid = threadIdx.x;
+        if (tid < 64) {
+            const int byte_off = tid * 4;
+            int v = 0;
+            if (k_base + byte_off + 4 <= inter_dim) {
+                v = *reinterpret_cast<const int*>(hidden_row + k_base + byte_off);
+            }
+            h_shared_q[tid] = v;
+        }
+        if (tid < 8) {
+            const int sg_idx = block_idx * 8 + tid;
+            h_shared_scale[tid] = sg_idx < hidden_groups ? hs_row[sg_idx] : 0.0f;
+        }
+        __syncthreads();
+
+        if (out_col < dim) {
+            const int sub = lane >> 2;
+            const int part = lane & 3;
+            const uint8_t* w2_block = w2_row + static_cast<int64_t>(block_idx) * 66;
+            const uint8_t* chunk = w2_block + 2 + sub * 8;
+            const float d = gguf_block_scale_f16(w2_block);
+
+            const uint32_t aux = static_cast<uint32_t>(chunk[4]) |
+                (static_cast<uint32_t>(chunk[5]) << 8) |
+                (static_cast<uint32_t>(chunk[6]) << 16) |
+                (static_cast<uint32_t>(chunk[7]) << 24);
+
+            const int grid_id = chunk[part];
+            const int sign_idx = static_cast<int>((aux >> (7 * part)) & 127);
+            const float s = 0.125f * d * static_cast<float>(2 * (aux >> 28) + 1);
+
+            const int8_t* vals = signed_grid + (grid_id * 128 + sign_idx) * 8;
+            const int v_p0 = *reinterpret_cast<const int*>(vals);
+            const int v_p1 = *reinterpret_cast<const int*>(vals + 4);
+
+            const int hq_base = sub * 8 + part * 2;
+            const int h_p0 = h_shared_q[hq_base];
+            const int h_p1 = h_shared_q[hq_base + 1];
+
+            int sumi = __dp4a(v_p0, h_p0, 0);
+            sumi = __dp4a(v_p1, h_p1, sumi);
+
+            const float hs = h_shared_scale[sub];
+            float local = s * hs * static_cast<float>(sumi);
+
+            #pragma unroll
+            for (int offset = 16; offset > 0; offset >>= 1) {
+                local += __shfl_down_sync(0xffffffff, local, offset);
+            }
+            if (lane == 0) acc += local;
+        }
+        __syncthreads();
+    }
+
+    if (lane == 0 && out_col < dim) {
+        atomicAdd(y + token * dim + out_col, acc);
+    }
+}
+
 __global__ void gguf_moe_w2_scatter_q2k_dp4a_subwarp_kernel(
     const int8_t* __restrict__ hidden_q,
     const float* __restrict__ hidden_scale,
@@ -7790,11 +7886,57 @@ torch::Tensor gguf_moe_prefill_grouped_forward_cuda(
     }
 
     const dim3 w2_grid(ceil_div(dim, kGGUFQuantTileN), routes);
+    const bool use_iq2_xxs_w2_dp4a =
+        w2_type_id == 0 &&
+        w2_block_bytes == 66 &&
+        env_enabled_explicit("DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A");
     const bool use_q2k_w2_dp4a =
         w2_type_id == 1 &&
         w2_block_bytes == 84 &&
         env_enabled_explicit("DEEPSEEK_GGUF_Q2K_W2_DP4A");
-    if (use_q2k_w2_dp4a) {
+    if (use_iq2_xxs_w2_dp4a) {
+        // iq2_xxs w2: hidden quantized in 32-element groups (one per iq2_xxs
+        // sub-block), matching the w13 activation quantizer.  Decode reuses the
+        // parity-validated grid lookup from gguf_moe_w13_iq2_xxs_dp4a_kernel.
+        const int hidden_groups = ceil_div(inter_dim, 32);
+        auto hidden = torch::empty({routes, inter_dim}, x.options().dtype(torch::kFloat32));
+        auto hidden_q = torch::empty({routes, inter_dim}, x.options().dtype(torch::kInt8));
+        auto hidden_scale = torch::empty({routes, hidden_groups}, x.options().dtype(torch::kFloat32));
+        const int hidden_threads = 256;
+        const int hidden_blocks = static_cast<int>((static_cast<int64_t>(routes) * inter_dim + hidden_threads - 1) / hidden_threads);
+        route_swiglu_cast_kernel<float><<<hidden_blocks, hidden_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            gate.data_ptr<float>(),
+            up.data_ptr<float>(),
+            route_weights_contig.data_ptr<float>(),
+            hidden.data_ptr<float>(),
+            routes,
+            inter_dim,
+            static_cast<float>(swiglu_limit));
+        const dim3 quant_grid(routes, hidden_groups);
+        gguf_q8_1_quantize_x_32_kernel<float><<<quant_grid, 32, 0, at::cuda::getCurrentCUDAStream()>>>(
+            hidden.data_ptr<float>(),
+            hidden_q.data_ptr<int8_t>(),
+            hidden_scale.data_ptr<float>(),
+            routes,
+            inter_dim);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        if (emit_profile) {
+            check_cuda(cudaEventRecord(ev_hidden, at::cuda::getCurrentCUDAStream()), "record gguf prefill profile hidden event");
+        }
+        gguf_moe_w2_scatter_iq2_xxs_dp4a_kernel<<<w2_grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+            hidden_q.data_ptr<int8_t>(),
+            hidden_scale.data_ptr<float>(),
+            route_tokens_contig.data_ptr<int64_t>(),
+            route_experts.data_ptr<int32_t>(),
+            w2_contig.data_ptr<uint8_t>(),
+            grid_ptr,
+            y.data_ptr<float>(),
+            routes,
+            dim,
+            inter_dim,
+            w2_blocks_per_row,
+            hidden_groups);
+    } else if (use_q2k_w2_dp4a) {
         const int hidden_groups = ceil_div(inter_dim, 16);
         auto hidden_q = torch::empty({routes, inter_dim}, x.options().dtype(torch::kInt8));
         auto hidden_scale = torch::empty({routes, hidden_groups}, x.options().dtype(torch::kFloat32));
@@ -7926,7 +8068,7 @@ torch::Tensor gguf_moe_prefill_grouped_forward_cuda(
             dim,
             inter_dim,
             static_cast<int>(use_iq2_xxs_w13_dp4a),
-            static_cast<int>(use_q2k_w2_dp4a),
+            static_cast<int>(use_iq2_xxs_w2_dp4a || use_q2k_w2_dp4a),
             w13_ms,
             hidden_ms,
             w2_ms,
@@ -7969,8 +8111,10 @@ torch::Tensor gguf_moe_single_token_iq2_q2k_forward_cuda(
 
     const int w1_blocks_per_row = static_cast<int>(w1_contig.size(2));
     const int w2_blocks_per_row = static_cast<int>(w2_contig.size(2));
+    const int w2_block_bytes = static_cast<int>(w2_contig.size(3));
+    const bool w2_is_iq2_xxs = (w2_block_bytes == 66);
     const int x_groups = ceil_div(dim, 32);
-    const int hidden_groups = ceil_div(inter_dim, 16);
+    const int hidden_groups = w2_is_iq2_xxs ? ceil_div(inter_dim, 32) : ceil_div(inter_dim, 16);
 
     auto x_q = torch::empty({1, dim}, x.options().dtype(torch::kInt8));
     auto x_scale = torch::empty({1, x_groups}, x.options().dtype(torch::kFloat32));
@@ -8009,7 +8153,26 @@ torch::Tensor gguf_moe_single_token_iq2_q2k_forward_cuda(
     auto hidden_q = torch::empty({routes, inter_dim}, x.options().dtype(torch::kInt8));
     auto hidden_scale = torch::empty({routes, hidden_groups}, x.options().dtype(torch::kFloat32));
     const dim3 quant_h_grid(routes, hidden_groups);
-    if (env_enabled_explicit("DEEPSEEK_GGUF_Q2K_FUSED_SWIGLU_QUANT")) {
+    if (w2_is_iq2_xxs) {
+        // iq2_xxs w2: hidden quantized in 32-element groups (matches sub-block size).
+        auto hidden = torch::empty({routes, inter_dim}, x.options().dtype(torch::kFloat32));
+        const int hidden_threads = 256;
+        const int hidden_blocks = static_cast<int>((static_cast<int64_t>(routes) * inter_dim + hidden_threads - 1) / hidden_threads);
+        route_swiglu_cast_kernel<float><<<hidden_blocks, hidden_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            gate.data_ptr<float>(),
+            up.data_ptr<float>(),
+            route_weights_contig.data_ptr<float>(),
+            hidden.data_ptr<float>(),
+            routes,
+            inter_dim,
+            static_cast<float>(swiglu_limit));
+        gguf_q8_1_quantize_x_32_kernel<float><<<quant_h_grid, 32, 0, at::cuda::getCurrentCUDAStream()>>>(
+            hidden.data_ptr<float>(),
+            hidden_q.data_ptr<int8_t>(),
+            hidden_scale.data_ptr<float>(),
+            routes,
+            inter_dim);
+    } else if (env_enabled_explicit("DEEPSEEK_GGUF_Q2K_FUSED_SWIGLU_QUANT")) {
         gguf_route_swiglu_quantize_hidden_16_kernel<<<quant_h_grid, 16, 0, at::cuda::getCurrentCUDAStream()>>>(
             gate.data_ptr<float>(),
             up.data_ptr<float>(),
@@ -8041,18 +8204,36 @@ torch::Tensor gguf_moe_single_token_iq2_q2k_forward_cuda(
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 
     const dim3 w2_grid(ceil_div(dim, kGGUFQuantTileN), routes);
-    gguf_moe_single_w2_q2k_dp4a_kernel<<<w2_grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
-        hidden_q.data_ptr<int8_t>(),
-        hidden_scale.data_ptr<float>(),
-        route_slots_contig.data_ptr<int64_t>(),
-        w2_contig.data_ptr<uint8_t>(),
-        y.data_ptr<float>(),
-        routes,
-        n_experts,
-        dim,
-        inter_dim,
-        w2_blocks_per_row,
-        hidden_groups);
+    if (w2_is_iq2_xxs) {
+        auto route_tokens = torch::zeros({routes}, route_slots_contig.options());
+        auto route_experts = route_slots_contig.to(torch::kInt32);
+        gguf_moe_w2_scatter_iq2_xxs_dp4a_kernel<<<w2_grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+            hidden_q.data_ptr<int8_t>(),
+            hidden_scale.data_ptr<float>(),
+            route_tokens.data_ptr<int64_t>(),
+            route_experts.data_ptr<int32_t>(),
+            w2_contig.data_ptr<uint8_t>(),
+            grid_contig.data_ptr<int8_t>(),
+            y.data_ptr<float>(),
+            routes,
+            dim,
+            inter_dim,
+            w2_blocks_per_row,
+            hidden_groups);
+    } else {
+        gguf_moe_single_w2_q2k_dp4a_kernel<<<w2_grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+            hidden_q.data_ptr<int8_t>(),
+            hidden_scale.data_ptr<float>(),
+            route_slots_contig.data_ptr<int64_t>(),
+            w2_contig.data_ptr<uint8_t>(),
+            y.data_ptr<float>(),
+            routes,
+            n_experts,
+            dim,
+            inter_dim,
+            w2_blocks_per_row,
+            hidden_groups);
+    }
     C10_CUDA_KERNEL_LAUNCH_CHECK();
     return y;
 }

--- a/src/models/minimax_m2/spec.py
+++ b/src/models/minimax_m2/spec.py
@@ -235,12 +235,17 @@ class MiniMaxM2Spec:
 
         t_load = time.perf_counter()
 
-        # Enable GGUF Q2 DP4A for MoE prefill acceleration (validated +35~55% on long prompts)
-        # MiniMax routed experts are ALL iq2_xxs (w1/w3/w2), so these gates directly accelerate
-        # the 66% MoE bottleneck. Short prompts may regress 1~2% due to quantization overhead.
-        # Can be disabled by setting env var to "0" before importing.
+        # Enable GGUF iq2_xxs/Q2 DP4A for MoE prefill acceleration.
+        # MiniMax routed experts are ALL iq2_xxs (w1/w3/w2), so these gates directly
+        # accelerate the MoE bottleneck. Measured on UD-IQ1_M TP4 (256-tok prefill):
+        #   - w13 DP4A: float 12.24 -> 24.46 TPS (+100%)
+        #   - w2  DP4A: 24.46 -> ~49 TPS (+100%), w2 kernel ~75ms -> ~10ms (8x)
+        # Combined ~4x over float baseline; token parity exact in both cases.
+        # Short prompts may regress slightly; disable via env var "0" before importing.
         if os.environ.get("DEEPSEEK_GGUF_IQ2_XXS_W13_DP4A") is None:
             os.environ["DEEPSEEK_GGUF_IQ2_XXS_W13_DP4A"] = "1"
+        if os.environ.get("DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A") is None:
+            os.environ["DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A"] = "1"
         if os.environ.get("DEEPSEEK_GGUF_Q2K_W2_DP4A") is None:
             os.environ["DEEPSEEK_GGUF_Q2K_W2_DP4A"] = "1"
 

--- a/tests/test_minimax_iq2xxs_w2_dp4a.py
+++ b/tests/test_minimax_iq2xxs_w2_dp4a.py
@@ -1,0 +1,297 @@
+"""Test iq2_xxs w2 DP4A grouped prefill kernel numerical correctness vs float baseline."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+from src.loader.gguf.bundle import read_gguf_bundle
+from src.models.minimax_m2.moe_runtime import MiniMaxM2DeviceResidentCache
+from src.models.minimax_m2.moe_planning import build_minimax_m2_moe_runtime_plan
+
+
+REAL_MINIMAX_PATH = Path("/mnt/data1/dsv4_inference/gguf_hfd/MiniMax-M2.7-GGUF/UD-IQ1_M")
+
+
+def _cuda_gguf_ext_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    from src.kernels.cuda_loader import load_cuda_kernel
+
+    cuda_mod = load_cuda_kernel()
+    return cuda_mod is not None and hasattr(cuda_mod, "gguf_moe_prefill_grouped_forward")
+
+
+@pytest.mark.skipif(not (REAL_MINIMAX_PATH.exists() and _cuda_gguf_ext_available()), reason="real MiniMax-M2.7 GGUF bundle or CUDA extension not available")
+def test_iq2_xxs_w2_dp4a_vs_float_small_fixture() -> None:
+    """Numerical correctness of iq2_xxs w2 DP4A grouped kernel vs float baseline."""
+    from src.kernels.cuda_loader import load_cuda_kernel
+
+    cuda_mod = load_cuda_kernel()
+    bundle = read_gguf_bundle(REAL_MINIMAX_PATH)
+    plan = build_minimax_m2_moe_runtime_plan(bundle)
+    assert plan.ok, plan.errors[:5]
+
+    # Use first 2 experts from layer 0 as test slice
+    device = torch.device("cuda:0")
+    with MiniMaxM2DeviceResidentCache(bundle, plan=plan, device=device, expert_start=0, expert_count=2) as cache:
+        layer = cache.layer(0)
+        dim = int(layer.w1.in_dim)  # 3072
+        inter_dim = int(layer.w1.out_dim)  # 1536
+        n_experts = int(layer.w1.expert_count)  # 2
+        assert layer.w1.type_name == "iq2_xxs"
+        assert layer.w2.type_name == "iq2_xxs"
+
+        # Synthetic test case: 4 tokens, each routes top-2, all 8 routes hit our 2 experts
+        tokens = 4
+        topk = 2
+        # Route pattern: token0->[expert0,expert1], token1->[expert1,expert0], ...
+        # to exercise both experts in mixed order
+        indices = torch.tensor([
+            [0, 1],
+            [1, 0],
+            [0, 1],
+            [1, 0],
+        ], device=device, dtype=torch.long)
+        weights = torch.rand(tokens, topk, device=device, dtype=torch.float32)
+        weights = weights / weights.sum(dim=-1, keepdim=True)
+
+        # Group routes
+        grouped = cuda_mod.moe_group_routes(indices, weights, 0, n_experts)
+        _local_ids, route_tokens, route_weights, seg_starts = grouped
+        routes = int(route_tokens.numel())
+        assert routes == tokens * topk
+
+        # Input: random float16
+        torch.manual_seed(1234)
+        x = torch.randn(tokens, dim, device=device, dtype=torch.float16)
+        grid = cache._quant_grid("iq2_xxs")
+
+        # --- Float baseline: env var OFF ---
+        env_backup = os.environ.get("DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A")
+        os.environ.pop("DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A", None)
+        y_float = cuda_mod.gguf_moe_prefill_grouped_forward(
+            x,
+            route_tokens,
+            route_weights,
+            seg_starts,
+            layer.w1.blocks,
+            layer.w3.blocks,
+            layer.w2.blocks,
+            int(dim),
+            int(layer.w1.type_id),
+            int(dim),
+            int(layer.w3.type_id),
+            int(inter_dim),
+            int(layer.w2.type_id),
+            grid,
+            0.0,
+        )
+
+        # --- iq2_xxs w2 DP4A: env var ON ---
+        os.environ["DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A"] = "1"
+        y_dp4a = cuda_mod.gguf_moe_prefill_grouped_forward(
+            x,
+            route_tokens,
+            route_weights,
+            seg_starts,
+            layer.w1.blocks,
+            layer.w3.blocks,
+            layer.w2.blocks,
+            int(dim),
+            int(layer.w1.type_id),
+            int(dim),
+            int(layer.w3.type_id),
+            int(inter_dim),
+            int(layer.w2.type_id),
+            grid,
+            0.0,
+        )
+
+        # Restore env
+        if env_backup is not None:
+            os.environ["DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A"] = env_backup
+        else:
+            os.environ.pop("DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A", None)
+
+        # --- Compare ---
+        assert y_float.shape == y_dp4a.shape == (tokens, dim)
+        assert y_float.dtype == y_dp4a.dtype == torch.float32
+
+        # int8 activation quantization + DP4A accumulation introduces small
+        # approximation error versus the float hidden baseline.  Avoid max-relative
+        # on near-zero outputs; gate on absolute error and p99 relative error.
+        abs_diff = (y_dp4a - y_float).abs()
+        max_abs = float(abs_diff.max().item())
+        mean_abs = float(abs_diff.mean().item())
+        mask = y_float.abs() > 1e-2
+        rel_err = abs_diff[mask] / (y_float[mask].abs() + 1e-8)
+        p99_rel = float(torch.quantile(rel_err, 0.99).item()) if rel_err.numel() else 0.0
+        mean_rel = float(rel_err.mean().item()) if rel_err.numel() else 0.0
+
+        # Sanity: outputs are finite and not all-zero
+        assert torch.isfinite(y_float).all(), "float baseline has non-finite values"
+        assert torch.isfinite(y_dp4a).all(), "DP4A output has non-finite values"
+        assert y_float.abs().sum() > 0.0, "float baseline is all-zero"
+        assert y_dp4a.abs().sum() > 0.0, "DP4A output is all-zero"
+
+        assert max_abs < 0.35, f"max_abs={max_abs:.4e}, mean_abs={mean_abs:.4e}, p99_rel={p99_rel:.4e}, mean_rel={mean_rel:.4e}"
+        assert mean_abs < 2.0e-2, f"max_abs={max_abs:.4e}, mean_abs={mean_abs:.4e}, p99_rel={p99_rel:.4e}, mean_rel={mean_rel:.4e}"
+        assert p99_rel < 0.30, f"max_abs={max_abs:.4e}, mean_abs={mean_abs:.4e}, p99_rel={p99_rel:.4e}, mean_rel={mean_rel:.4e}"
+
+        print(
+            "✓ iq2_xxs w2 DP4A numerical match: "
+            f"max_abs={max_abs:.4e}, mean_abs={mean_abs:.4e}, p99_rel={p99_rel:.4e}, mean_rel={mean_rel:.4e}"
+        )
+
+
+@pytest.mark.skipif(not (REAL_MINIMAX_PATH.exists() and _cuda_gguf_ext_available()), reason="real MiniMax-M2.7 GGUF bundle or CUDA extension not available")
+def test_iq2_xxs_w2_dp4a_env_gate() -> None:
+    """Verify DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A env gate toggles the DP4A branch."""
+    from src.kernels.cuda_loader import load_cuda_kernel
+
+    cuda_mod = load_cuda_kernel()
+    bundle = read_gguf_bundle(REAL_MINIMAX_PATH)
+    plan = build_minimax_m2_moe_runtime_plan(bundle)
+    device = torch.device("cuda:0")
+
+    with MiniMaxM2DeviceResidentCache(bundle, plan=plan, device=device, expert_start=0, expert_count=1) as cache:
+        layer = cache.layer(0)
+        dim = int(layer.w1.in_dim)
+        inter_dim = int(layer.w1.out_dim)
+
+        tokens = 2
+        indices = torch.tensor([[0], [0]], device=device, dtype=torch.long)
+        weights = torch.ones(tokens, 1, device=device, dtype=torch.float32)
+        grouped = cuda_mod.moe_group_routes(indices, weights, 0, 1)
+        _local_ids, route_tokens, route_weights, seg_starts = grouped
+
+        x = torch.randn(tokens, dim, device=device, dtype=torch.float16)
+        grid = cache._quant_grid("iq2_xxs")
+
+        # OFF
+        env_backup = os.environ.get("DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A")
+        os.environ.pop("DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A", None)
+        y_off = cuda_mod.gguf_moe_prefill_grouped_forward(
+            x, route_tokens, route_weights, seg_starts,
+            layer.w1.blocks, layer.w3.blocks, layer.w2.blocks,
+            int(dim), int(layer.w1.type_id), int(dim), int(layer.w3.type_id),
+            int(inter_dim), int(layer.w2.type_id), grid, 0.0)
+
+        # ON
+        os.environ["DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A"] = "1"
+        y_on = cuda_mod.gguf_moe_prefill_grouped_forward(
+            x, route_tokens, route_weights, seg_starts,
+            layer.w1.blocks, layer.w3.blocks, layer.w2.blocks,
+            int(dim), int(layer.w1.type_id), int(dim), int(layer.w3.type_id),
+            int(inter_dim), int(layer.w2.type_id), grid, 0.0)
+
+        if env_backup is not None:
+            os.environ["DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A"] = env_backup
+        else:
+            os.environ.pop("DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A", None)
+
+        # OFF = float baseline, ON = DP4A; outputs differ but both finite
+        assert torch.isfinite(y_off).all()
+        assert torch.isfinite(y_on).all()
+        # They should differ (DP4A quantization path vs float)
+        # but be close enough (already covered by numerical test)
+        diff_norm = (y_on - y_off).norm().item()
+        assert diff_norm > 0.0, "DP4A and float baseline are identical (env gate not working)"
+
+
+@pytest.mark.skipif(not (REAL_MINIMAX_PATH.exists() and _cuda_gguf_ext_available()), reason="real MiniMax-M2.7 GGUF bundle or CUDA extension not available")
+def test_iq2_xxs_single_token_decode_dp4a_vs_grouped_float_baseline() -> None:
+    """Single-token iq2_xxs w13+w2 DP4A decode path matches grouped float baseline."""
+    from src.kernels.cuda_loader import load_cuda_kernel
+
+    cuda_mod = load_cuda_kernel()
+    bundle = read_gguf_bundle(REAL_MINIMAX_PATH)
+    plan = build_minimax_m2_moe_runtime_plan(bundle)
+    device = torch.device("cuda:0")
+
+    with MiniMaxM2DeviceResidentCache(bundle, plan=plan, device=device, expert_start=0, expert_count=2) as cache:
+        layer = cache.layer(0)
+        dim = int(layer.w1.in_dim)
+        inter_dim = int(layer.w1.out_dim)
+
+        # Single decode token routes to both local experts.
+        indices = torch.tensor([[0, 1]], device=device, dtype=torch.long)
+        weights = torch.tensor([[0.625, 0.375]], device=device, dtype=torch.float32)
+        grouped = cuda_mod.moe_group_routes(indices, weights, 0, 2)
+        _local_ids, route_tokens, route_weights, seg_starts = grouped
+
+        torch.manual_seed(5678)
+        x = torch.randn(1, dim, device=device, dtype=torch.float16)
+        grid = cache._quant_grid("iq2_xxs")
+
+        env_w13 = os.environ.get("DEEPSEEK_GGUF_IQ2_XXS_W13_DP4A")
+        env_w2 = os.environ.get("DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A")
+        try:
+            # Grouped float baseline: both env gates OFF.
+            os.environ.pop("DEEPSEEK_GGUF_IQ2_XXS_W13_DP4A", None)
+            os.environ.pop("DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A", None)
+            y_float = cuda_mod.gguf_moe_prefill_grouped_forward(
+                x,
+                route_tokens,
+                route_weights,
+                seg_starts,
+                layer.w1.blocks,
+                layer.w3.blocks,
+                layer.w2.blocks,
+                int(dim),
+                int(layer.w1.type_id),
+                int(dim),
+                int(layer.w3.type_id),
+                int(inter_dim),
+                int(layer.w2.type_id),
+                grid,
+                0.0,
+            )
+
+            # Single-token decode path: iq2_xxs w13+w2 DP4A.
+            os.environ["DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A"] = "1"
+            route_slots = indices.reshape(-1).contiguous()
+            route_weights_flat = weights.reshape(-1).contiguous()
+            y_decode = cuda_mod.gguf_moe_single_token_iq2_q2k_forward(
+                x,
+                route_slots,
+                route_weights_flat,
+                layer.w1.blocks,
+                layer.w3.blocks,
+                layer.w2.blocks,
+                grid,
+                0.0,
+            )
+        finally:
+            if env_w13 is None:
+                os.environ.pop("DEEPSEEK_GGUF_IQ2_XXS_W13_DP4A", None)
+            else:
+                os.environ["DEEPSEEK_GGUF_IQ2_XXS_W13_DP4A"] = env_w13
+            if env_w2 is None:
+                os.environ.pop("DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A", None)
+            else:
+                os.environ["DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A"] = env_w2
+
+        assert y_float.shape == y_decode.shape == (1, dim)
+        assert torch.isfinite(y_float).all()
+        assert torch.isfinite(y_decode).all()
+
+        diff = (y_decode - y_float).abs()
+        max_abs = float(diff.max().item())
+        mean_abs = float(diff.mean().item())
+        mask = y_float.abs() > 1e-2
+        rel_err = diff[mask] / (y_float[mask].abs() + 1e-8)
+        p99_rel = float(torch.quantile(rel_err, 0.99).item()) if rel_err.numel() else 0.0
+        mean_rel = float(rel_err.mean().item()) if rel_err.numel() else 0.0
+
+        # This includes both w13 input q8 quantization and w2 hidden q8 quantization.
+        assert max_abs < 0.75, f"max_abs={max_abs:.4e}, mean_abs={mean_abs:.4e}, p99_rel={p99_rel:.4e}, mean_rel={mean_rel:.4e}"
+        assert mean_abs < 5.0e-2, f"max_abs={max_abs:.4e}, mean_abs={mean_abs:.4e}, p99_rel={p99_rel:.4e}, mean_rel={mean_rel:.4e}"
+        assert p99_rel < 0.50, f"max_abs={max_abs:.4e}, mean_abs={mean_abs:.4e}, p99_rel={p99_rel:.4e}, mean_rel={mean_rel:.4e}"
+        print(
+            "✓ iq2_xxs single-token decode DP4A match: "
+            f"max_abs={max_abs:.4e}, mean_abs={mean_abs:.4e}, p99_rel={p99_rel:.4e}, mean_rel={mean_rel:.4e}"
+        )


### PR DESCRIPTION
## Summary

Adds an **iq2_xxs w2 DP4A prefill kernel** for MiniMax-M2, doubling prefill throughput on top of the already-merged w13 DP4A work (PR #34).

Profiling the post-#34 prefill exposed the real MoE bottleneck: **w2 (`ffn_down`) was silently running the float kernel.** MiniMax-M2 routed experts are *all* `iq2_xxs` (66-byte blocks), but the only w2 DP4A prefill path required `q2_k` (84-byte). The gate never matched, so w2 fell back to float — about **80% of MoE time**.

## Per-kernel profile (UD-IQ1_M TP4, 256-tok prefill, before this PR)

```
gguf_prefill_kernel_profile ... w13_dp4a=1 w2_dp4a=0 w13=20.0ms hidden=0.02ms w2=92.1ms total=112.2ms
```

`w13` (DP4A) was already fast; `w2` (float) dominated at ~4-5× the w13 cost.

## Change

Add `gguf_moe_w2_scatter_iq2_xxs_dp4a_kernel`, reusing two already-validated pieces:
- the **iq2_xxs grid decode** from `gguf_moe_w13_iq2_xxs_dp4a_kernel` (symmetric signed-grid lookup, scale `0.125·d·(2·(aux>>28)+1)`, no min term)
- the **scatter output** structure from `gguf_moe_w2_scatter_q2k_dp4a_kernel` (`atomicAdd` to `y[token·dim + col]`)

Hidden activation is Q8_1-quantized in **32-element groups** (one per iq2_xxs sub-block), via the existing `gguf_q8_1_quantize_x_32_kernel`. Gated by `DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A`, **default-on** in `MiniMaxM2Spec.build_token_runtime`.

Also fixes a latent bug: `gguf_moe_single_token_iq2_q2k_forward` hardcoded the q2_k 84-byte w2 stride, producing non-finite output on iq2_xxs w2 models. It is now w2-type-aware (32-group hidden quant + the new scatter kernel for iq2_xxs). This path is not used by the live decode dispatch (guarded by `w2_type == "q2_k"`), but is now correct for direct callers and tests.

## Performance (UD-IQ1_M TP4, 4×RTX 2080Ti)

| Metric | Phase 1 (w13 DP4A) | This PR (+ w2 DP4A) | Improvement |
|--------|--------------------|--------------------:|-------------|
| Prefill TPS (256 tok) | 24.47 | **49.0** | **+100% (2.0×)** |
| w2 kernel / call | ~75 ms (float) | **~10 ms** | ~8× |
| Prefill TPS (8 tok) | 11.04 | **13.8** | +25% |
| Decode TPS | ~5.5 | ~5.5 | unchanged (NCCL-bound) |
| Memory / card | 15.85 GiB | 15.85 GiB | unchanged |

Cumulative vs the true float baseline (12.24 TPS): **4.0× prefill**.

### Token parity — exact match (greedy)

```
Long  (256 tok): 32,48,32,49,32,50,32,51   (ON == OFF)
Short (8 tok):   9,9,16474,9,16474,9,16474,9   (ON == OFF)
```

## Testing

`tests/test_minimax_iq2xxs_w2_dp4a.py` (3 tests, all pass on real MiniMax-M2.7 weights):
- `test_iq2_xxs_w2_dp4a_vs_float_small_fixture` — DP4A vs float: `max_abs=0.21, mean_abs=0.009, p99_rel=0.24`
- `test_iq2_xxs_w2_dp4a_env_gate` — env gate toggles the branch
- `test_iq2_xxs_single_token_decode_dp4a_vs_grouped_float_baseline` — single-token decode now finite & matches: `max_abs=0.028, mean_abs=0.006`

End-to-end TP4 short + long validated (default-on, no env vars set). FP4 kernel source is untouched.

## Configuration

Default-on. To disable:
```bash
DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A=0 python ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
