### PR TITLE
Add serial headpair GGUF prefill attention

### DIFF
--- a/cpp_engine/cuda/cuda_ops.cu
+++ b/cpp_engine/cuda/cuda_ops.cu
@@ -1035,6 +1035,129 @@ __global__ void prefill_sparse_attention_headpair_kernel(
     }
 }
 
+__global__ void prefill_sparse_attention_headpair_serial_kernel(
+    const float* __restrict__ q,
+    const float* __restrict__ kv,
+    const float* __restrict__ attn_sink,
+    const int32_t* __restrict__ topk_idxs,
+    float* __restrict__ out,
+    int seqlen,
+    int heads,
+    int kv_len,
+    int topk,
+    int dim,
+    float softmax_scale) {
+    const int head_pairs = (heads + 1) / 2;
+    const int bsp = blockIdx.x;
+    const int pair = bsp % head_pairs;
+    const int s = (bsp / head_pairs) % seqlen;
+    const int h0 = pair * 2;
+    const int h1 = h0 + 1;
+    const bool has_h1 = h1 < heads;
+    const int tid = threadIdx.x;
+
+    extern __shared__ float smem[];
+    float* scores0 = smem;
+    float* scores1 = scores0 + topk;
+    float* q0_shared = scores1 + topk;
+    float* q1_shared = q0_shared + dim;
+    int32_t* idx_shared = reinterpret_cast<int32_t*>(q1_shared + dim);
+    float* reduce0 = reinterpret_cast<float*>(idx_shared + topk);
+    float* reduce1 = reduce0 + blockDim.x;
+
+    const float* q0_ptr = q + (static_cast<size_t>(s) * heads + h0) * dim;
+    const float* q1_ptr = has_h1 ? q + (static_cast<size_t>(s) * heads + h1) * dim : q0_ptr;
+    const int32_t* idx_base = topk_idxs + static_cast<size_t>(s) * topk;
+    for (int d = tid; d < dim; d += blockDim.x) {
+        q0_shared[d] = q0_ptr[d];
+        if (has_h1) q1_shared[d] = q1_ptr[d];
+    }
+    for (int t = tid; t < topk; t += blockDim.x) idx_shared[t] = idx_base[t];
+    __syncthreads();
+
+    const float sink0 = attn_sink == nullptr ? -INFINITY : attn_sink[h0];
+    const float sink1 = (has_h1 && attn_sink != nullptr) ? attn_sink[h1] : -INFINITY;
+    float local_max0 = sink0;
+    float local_max1 = sink1;
+    for (int t = tid; t < topk; t += blockDim.x) {
+        const int idx = idx_shared[t];
+        float score0 = -INFINITY;
+        float score1 = -INFINITY;
+        if (idx >= 0 && idx < kv_len) {
+            const float* kv_ptr = kv + static_cast<size_t>(idx) * dim;
+            float acc0 = 0.0f;
+            float acc1 = 0.0f;
+            for (int d = 0; d < dim; ++d) {
+                const float v = kv_ptr[d];
+                acc0 += q0_shared[d] * v;
+                if (has_h1) acc1 += q1_shared[d] * v;
+            }
+            score0 = acc0 * softmax_scale;
+            if (has_h1) score1 = acc1 * softmax_scale;
+            local_max0 = fmaxf(local_max0, score0);
+            if (has_h1) local_max1 = fmaxf(local_max1, score1);
+        }
+        scores0[t] = score0;
+        if (has_h1) scores1[t] = score1;
+    }
+    reduce0[tid] = local_max0;
+    if (has_h1) reduce1[tid] = local_max1;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            reduce0[tid] = fmaxf(reduce0[tid], reduce0[tid + stride]);
+            if (has_h1) reduce1[tid] = fmaxf(reduce1[tid], reduce1[tid + stride]);
+        }
+        __syncthreads();
+    }
+    const float max0 = reduce0[0];
+    const float max1 = has_h1 ? reduce1[0] : -INFINITY;
+
+    float local_denom0 = 0.0f;
+    float local_denom1 = 0.0f;
+    for (int t = tid; t < topk; t += blockDim.x) {
+        const float w0 = expf(scores0[t] - max0);
+        scores0[t] = w0;
+        local_denom0 += w0;
+        if (has_h1) {
+            const float w1 = expf(scores1[t] - max1);
+            scores1[t] = w1;
+            local_denom1 += w1;
+        }
+    }
+    reduce0[tid] = local_denom0;
+    if (has_h1) reduce1[tid] = local_denom1;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            reduce0[tid] += reduce0[tid + stride];
+            if (has_h1) reduce1[tid] += reduce1[tid + stride];
+        }
+        __syncthreads();
+    }
+    const float denom0 = reduce0[0] + (attn_sink == nullptr ? 0.0f : expf(sink0 - max0));
+    const float denom1 = has_h1 ? reduce1[0] + (attn_sink == nullptr ? 0.0f : expf(sink1 - max1)) : 1.0f;
+    const float inv0 = 1.0f / denom0;
+    const float inv1 = has_h1 ? 1.0f / denom1 : 0.0f;
+
+    float* out0_ptr = out + (static_cast<size_t>(s) * heads + h0) * dim;
+    float* out1_ptr = has_h1 ? out + (static_cast<size_t>(s) * heads + h1) * dim : out0_ptr;
+    for (int d = tid; d < dim; d += blockDim.x) {
+        float acc0 = 0.0f;
+        float acc1 = 0.0f;
+        for (int t = 0; t < topk; ++t) {
+            const int idx = idx_shared[t];
+            if (idx >= 0 && idx < kv_len) {
+                const float v = kv[static_cast<size_t>(idx) * dim + d];
+                acc0 += scores0[t] * v;
+                if (has_h1) acc1 += scores1[t] * v;
+            }
+        }
+        out0_ptr[d] = acc0 * inv0;
+        if (has_h1) out1_ptr[d] = acc1 * inv1;
+    }
+}
+
 __global__ void single_token_sparse_attention_kernel(
     const float* q,
     const float* kv,
@@ -1834,6 +1957,29 @@ bool prefill_sparse_attention_headpair_cuda(
     const size_t shared_bytes = (static_cast<size_t>(2) * topk + static_cast<size_t>(2) * head_dim + static_cast<size_t>(topk) * sizeof(int32_t) / sizeof(float) + static_cast<size_t>(2) * threads + 8) * sizeof(float);
     auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
     prefill_sparse_attention_headpair_kernel<<<tokens * head_pairs, threads, shared_bytes, cuda_stream>>>(d_q, d_kv, d_attn_sink, d_topk_indices, d_y, tokens, heads, kv_len, topk, head_dim, scale);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool prefill_sparse_attention_headpair_serial_cuda(
+    const float* d_q,
+    const float* d_kv,
+    const float* d_attn_sink,
+    const int32_t* d_topk_indices,
+    float* d_y,
+    int tokens,
+    int heads,
+    int kv_len,
+    int topk,
+    int head_dim,
+    float scale,
+    void* stream) {
+    if (d_q == nullptr || d_kv == nullptr || d_attn_sink == nullptr || d_topk_indices == nullptr || d_y == nullptr) return false;
+    if (tokens <= 0 || heads <= 0 || kv_len <= 0 || topk <= 0 || head_dim <= 0) return false;
+    const int head_pairs = (heads + 1) / 2;
+    const int threads = 256;
+    const size_t shared_bytes = (static_cast<size_t>(2) * topk + static_cast<size_t>(2) * head_dim + static_cast<size_t>(topk) * sizeof(int32_t) / sizeof(float) + static_cast<size_t>(2) * threads + 8) * sizeof(float);
+    auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
+    prefill_sparse_attention_headpair_serial_kernel<<<tokens * head_pairs, threads, shared_bytes, cuda_stream>>>(d_q, d_kv, d_attn_sink, d_topk_indices, d_y, tokens, heads, kv_len, topk, head_dim, scale);
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/include/cuda_ops.hpp
+++ b/cpp_engine/include/cuda_ops.hpp
@@ -759,6 +759,20 @@ bool prefill_sparse_attention_headpair_cuda(
     float scale,
     void* stream = nullptr);
 
+bool prefill_sparse_attention_headpair_serial_cuda(
+    const float* d_q,
+    const float* d_kv,
+    const float* d_attn_sink,
+    const int32_t* d_topk_indices,
+    float* d_y,
+    int tokens,
+    int heads,
+    int kv_len,
+    int topk,
+    int head_dim,
+    float scale,
+    void* stream = nullptr);
+
 bool single_token_sparse_attention_cuda(
     const float* d_q,
     const float* d_kv,

--- a/cpp_engine/src/dsv4_engine.cpp
+++ b/cpp_engine/src/dsv4_engine.cpp
@@ -8496,7 +8496,9 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
             prefill_attn_topk > 0 && prefill_attn_index_elems > 0 &&
             (prefill_attn_max_index_topk <= 0 || prefill_attn_topk <= prefill_attn_max_index_topk) &&
             (prefill_attn_max_index_elems <= 0 || prefill_attn_index_elems <= prefill_attn_max_index_elems);
-        const bool use_prefill_headpair_attn = use_prefill_indexed_attn &&
+        const bool use_prefill_headpair_serial_attn = use_prefill_indexed_attn &&
+            env_int_or_default("DSV4_GGUF_PREFILL_HEADPAIR_SERIAL_ATTN", 1) != 0;
+        const bool use_prefill_headpair_attn = use_prefill_indexed_attn && !use_prefill_headpair_serial_attn &&
             env_int_or_default("DSV4_GGUF_PREFILL_HEADPAIR_ATTN", 0) != 0;
         const bool iq1_grouped_w2_q8_enabled = env_int_or_default("DSV4_IQ1_GROUPED_W2_Q8", 1) != 0;
         const bool iq1_grouped_gemm_enabled = env_int_or_default("DSV4_IQ1_GROUPED_GEMM", 1) != 0;
@@ -8690,7 +8692,9 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
                 if (!head_rmsnorm_rope_rows_cuda(d_kv_rows, cn, 1, head_dim, rope_dim, cs, ld.rope_theta, false, 0.0f)) throw std::runtime_error("GGUF prefill kv rope rows failed");
                 if (!copy_rows_to_kv_cache_cuda(d_kv_rows, d_kv_cache[L], cn, head_dim, layer_cache_capacity[L], cs)) throw std::runtime_error("GGUF prefill kv cache rows copy failed");
                 if (use_prefill_indexed_attn) {
-                    if (use_prefill_headpair_attn) {
+                    if (use_prefill_headpair_serial_attn) {
+                        if (!prefill_sparse_attention_headpair_serial_cuda(d_q_rows, d_kv_cache[L], d_attn_sink[L], d_prefill_attn_indices + static_cast<size_t>(cs) * prefill_attn_topk, d_attn_value_rows, cn, heads, ce, prefill_attn_topk, head_dim, 1.0f / std::sqrt(static_cast<float>(head_dim)))) throw std::runtime_error("GGUF prefill headpair serial indexed attention rows failed");
+                    } else if (use_prefill_headpair_attn) {
                         if (!prefill_sparse_attention_headpair_cuda(d_q_rows, d_kv_cache[L], d_attn_sink[L], d_prefill_attn_indices + static_cast<size_t>(cs) * prefill_attn_topk, d_attn_value_rows, cn, heads, ce, prefill_attn_topk, head_dim, 1.0f / std::sqrt(static_cast<float>(head_dim)))) throw std::runtime_error("GGUF prefill headpair indexed attention rows failed");
                     } else {
                         if (!prefill_sparse_attention_indexed_cuda(d_q_rows, d_kv_cache[L], d_attn_sink[L], d_prefill_attn_indices + static_cast<size_t>(cs) * prefill_attn_topk, d_attn_value_rows, cn, heads, ce, prefill_attn_topk, head_dim, 1.0f / std::sqrt(static_cast<float>(head_dim)))) throw std::runtime_error("GGUF prefill indexed attention rows failed");
@@ -8920,6 +8924,7 @@ GgufDecodeResult run_gguf_generate_smoke(const std::string& ckpt_path,
                       << " iq1_route_major=" << (iq1_grouped_route_major_enabled ? 1 : 0)
                       << " indexed_attn=" << (use_prefill_indexed_attn ? 1 : 0)
                       << " headpair_attn=" << (use_prefill_headpair_attn ? 1 : 0)
+                      << " headpair_serial_attn=" << (use_prefill_headpair_serial_attn ? 1 : 0)
                       << " attn_topk=" << prefill_attn_topk
                       << " attn_ms=" << prof_prefill_attn_ms
                       << " gate_ms=" << prof_prefill_gate_ms

--- a/cpp_engine/tests/test_attention_projection.cpp
+++ b/cpp_engine/tests/test_attention_projection.cpp
@@ -189,6 +189,59 @@ void test_cached_attention_kernel() {
     }
 }
 
+void test_prefill_headpair_serial_matches_indexed() {
+    constexpr int tokens = 4;
+    constexpr int heads = 5;
+    constexpr int head_dim = 64;
+    constexpr int topk = 4;
+    constexpr int kv_len = 4;
+    const float scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+    std::vector<float> q(static_cast<size_t>(tokens) * heads * head_dim);
+    std::vector<float> kv(static_cast<size_t>(kv_len) * head_dim);
+    std::vector<float> sink(heads);
+    std::vector<int32_t> indices(static_cast<size_t>(tokens) * topk, -1);
+    for (size_t i = 0; i < q.size(); ++i) q[i] = std::sin(static_cast<float>(i) * 0.013f) * 0.25f;
+    for (size_t i = 0; i < kv.size(); ++i) kv[i] = std::cos(static_cast<float>(i) * 0.017f) * 0.2f;
+    for (int h = 0; h < heads; ++h) sink[h] = -0.15f + 0.07f * static_cast<float>(h);
+    for (int t = 0; t < tokens; ++t) {
+        for (int k = 0; k < topk; ++k) indices[static_cast<size_t>(t) * topk + k] = (k <= t) ? k : -1;
+    }
+
+    float* d_q = nullptr;
+    float* d_kv = nullptr;
+    float* d_sink = nullptr;
+    float* d_indexed = nullptr;
+    float* d_serial = nullptr;
+    int32_t* d_indices = nullptr;
+    const size_t out_elems = q.size();
+    check_cuda(cudaMalloc(&d_q, q.size() * sizeof(float)), "cudaMalloc prefill q");
+    check_cuda(cudaMalloc(&d_kv, kv.size() * sizeof(float)), "cudaMalloc prefill kv");
+    check_cuda(cudaMalloc(&d_sink, sink.size() * sizeof(float)), "cudaMalloc prefill sink");
+    check_cuda(cudaMalloc(&d_indices, indices.size() * sizeof(int32_t)), "cudaMalloc prefill indices");
+    check_cuda(cudaMalloc(&d_indexed, out_elems * sizeof(float)), "cudaMalloc prefill indexed");
+    check_cuda(cudaMalloc(&d_serial, out_elems * sizeof(float)), "cudaMalloc prefill serial");
+    check_cuda(cudaMemcpy(d_q, q.data(), q.size() * sizeof(float), cudaMemcpyHostToDevice), "copy prefill q");
+    check_cuda(cudaMemcpy(d_kv, kv.data(), kv.size() * sizeof(float), cudaMemcpyHostToDevice), "copy prefill kv");
+    check_cuda(cudaMemcpy(d_sink, sink.data(), sink.size() * sizeof(float), cudaMemcpyHostToDevice), "copy prefill sink");
+    check_cuda(cudaMemcpy(d_indices, indices.data(), indices.size() * sizeof(int32_t), cudaMemcpyHostToDevice), "copy prefill indices");
+    if (!dsv4::prefill_sparse_attention_indexed_cuda(d_q, d_kv, d_sink, d_indices, d_indexed, tokens, heads, kv_len, topk, head_dim, scale)) throw std::runtime_error("prefill indexed attention launch failed");
+    if (!dsv4::prefill_sparse_attention_headpair_serial_cuda(d_q, d_kv, d_sink, d_indices, d_serial, tokens, heads, kv_len, topk, head_dim, scale)) throw std::runtime_error("prefill headpair serial attention launch failed");
+    check_cuda(cudaDeviceSynchronize(), "sync prefill attention compare");
+    std::vector<float> indexed(out_elems);
+    std::vector<float> serial(out_elems);
+    check_cuda(cudaMemcpy(indexed.data(), d_indexed, out_elems * sizeof(float), cudaMemcpyDeviceToHost), "copy indexed attention");
+    check_cuda(cudaMemcpy(serial.data(), d_serial, out_elems * sizeof(float), cudaMemcpyDeviceToHost), "copy serial attention");
+    cudaFree(d_q);
+    cudaFree(d_kv);
+    cudaFree(d_sink);
+    cudaFree(d_indices);
+    cudaFree(d_indexed);
+    cudaFree(d_serial);
+    float max_abs = 0.0f;
+    for (size_t i = 0; i < out_elems; ++i) max_abs = std::max(max_abs, std::fabs(indexed[i] - serial[i]));
+    if (max_abs > 1e-7f) throw std::runtime_error("prefill headpair serial mismatch vs indexed");
+}
+
 void test_single_token_attention_kernel() {
     constexpr int heads = 3;
     constexpr int head_dim = 4;
@@ -245,6 +298,7 @@ int main(int argc, char** argv) {
         test_head_rmsnorm_rope_kernel();
         test_single_token_attention_kernel();
         test_cached_attention_kernel();
+        test_prefill_headpair_serial_matches_indexed();
         Args args = parse_args(argc, argv);
         if (args.ckpt.empty()) throw std::runtime_error("--ckpt is required");
         dsv4::SafeTensorsIndex index(args.ckpt);


### PR DESCRIPTION
## Summary

- Add a serial-score headpair sparse prefill attention CUDA kernel for GGUF Q2 chunked prefill.
- Enable it by default behind `DSV4_GGUF_PREFILL_HEADPAIR_SERIAL_ATTN=1`, while keeping the older warp-dot headpair path available via `DSV4_GGUF_PREFILL_HEADPAIR_ATTN=1` when the serial path is disabled.
- Add a CUDA regression in `test_attention_projection` that compares the serial headpair output against the existing indexed prefill attention path.

## Why

The older headpair path improved prefill speed but changed dot-product reduction order enough to perturb short-prompt outputs. This variant preserves the indexed path's per-score serial dot accumulation order while still sharing a block across two heads, making it safer as a default prefill optimization.

## Validation

- `cd /mnt/data1/dsv4_inference/build/cpp_engine && make dsv4_cpp_core test_attention_projection test_gguf_generate -j16`
- `/mnt/data1/dsv4_inference/build/cpp_engine/tests/test_attention_projection --ckpt /mnt/data1/modelscope/deepseek-ai/DeepSeek-V4-Flash --rows 128`
- `/mnt/data1/dsv4_inference/build/cpp_engine/tests/test_moe_grouped_q2`
- `/mnt/data1/dsv4_inference/build/cpp_engine/tests/test_moe_grouped_fp4`
- `/mnt/data1/dsv4_inference/build/cpp_engine/tests/test_persistent_engine /mnt/data1/modelscope/deepseek-ai/DeepSeek-V4-Flash 1 2`
- `LOG_DIR=/tmp/dsv4_pr_eval conda run -n deepseek bash scripts/run_gguf_q2_tp_generate.sh`
- `rg -n "cudaHostRegister|cudaHostUnregister" cpp_engine/src cpp_engine/include cpp_engine/tests` — only guard/comment references, no real whole-GGUF mmap pinning calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
