### PR TITLE
Add GLM-DSA raw-block MoE runtime (iq2_xs/iq3_xxs/q6_k)

### DIFF
--- a/src/csrc/cuda_kernel.cpp
+++ b/src/csrc/cuda_kernel.cpp
@@ -390,7 +390,15 @@ int64_t gguf_quant_block_bytes_for_type(int64_t type_id) {
     if (type_id == 2) return 56;    // iq1_m
     if (type_id == 3) return 144;   // q4_k
     if (type_id == 4) return 176;   // q5_k
-    TORCH_CHECK(false, "type_id must be 0 (iq2_xxs), 1 (q2_k), 2 (iq1_m), 3 (q4_k), or 4 (q5_k)");
+    if (type_id == 5) return 74;    // iq2_xs
+    if (type_id == 6) return 98;    // iq3_xxs
+    if (type_id == 8) return 210;   // q6_k
+    TORCH_CHECK(false, "unsupported GGUF quant type_id: ", type_id);
+}
+
+bool gguf_quant_type_supported(int64_t type_id) {
+    return type_id == 0 || type_id == 1 || type_id == 2 || type_id == 3 ||
+           type_id == 4 || type_id == 5 || type_id == 6 || type_id == 8;
 }
 
 void check_gguf_quant_grid(const torch::Tensor& grid, int64_t type_id, const char* name) {
@@ -404,6 +412,11 @@ void check_gguf_quant_grid(const torch::Tensor& grid, int64_t type_id, const cha
         TORCH_CHECK(grid.scalar_type() == torch::kInt8, name, " must be int8");
         TORCH_CHECK(grid.is_contiguous(), name, " must be contiguous");
         TORCH_CHECK(grid.numel() == 2048 * 8, name, " must contain 2048*8 entries for iq1_m");
+    } else if (type_id == 5 || type_id == 6) {
+        TORCH_CHECK(grid.is_cuda(), name, " must be CUDA for iq2_xs/iq3_xxs");
+        TORCH_CHECK(grid.scalar_type() == torch::kInt8, name, " must be int8");
+        TORCH_CHECK(grid.is_contiguous(), name, " must be contiguous");
+        TORCH_CHECK(grid.numel() >= (512 * 128 * 8 + 256 * 128 * 8), name, " must contain packed iq2_xs and iq3_xxs signed grids");
     }
 }
 
@@ -542,7 +555,7 @@ torch::Tensor gguf_quant_gemm_forward(
     const torch::Tensor& signed_grid) {
     TORCH_CHECK(x.dim() == 2 || x.dim() == 3, "x must have shape [M, K] or [B, S, K]");
     TORCH_CHECK(blocks.dim() == 3, "blocks must have shape [N, K_blocks, block_bytes]");
-    TORCH_CHECK(type_id >= 0 && type_id <= 4, "type_id must be 0 (iq2_xxs), 1 (q2_k), 2 (iq1_m), 3 (q4_k), or 4 (q5_k)");
+    TORCH_CHECK(gguf_quant_type_supported(type_id), "unsupported GGUF quant type_id: ", type_id);
     TORCH_CHECK(row_elems > 0, "row_elems must be positive");
     TORCH_CHECK(x.size(-1) == row_elems, "inner dimension mismatch");
     TORCH_CHECK(blocks.size(1) * 256 >= row_elems, "blocks do not cover row_elems");
@@ -567,7 +580,7 @@ torch::Tensor gguf_quant_gemm_prefill_forward(
     const torch::Tensor& signed_grid) {
     TORCH_CHECK(x.dim() == 2 || x.dim() == 3, "x must have shape [M, K] or [B, S, K]");
     TORCH_CHECK(blocks.dim() == 3, "blocks must have shape [N, K_blocks, block_bytes]");
-    TORCH_CHECK(type_id >= 0 && type_id <= 4, "type_id must be 0 (iq2_xxs), 1 (q2_k), 2 (iq1_m), 3 (q4_k), or 4 (q5_k)");
+    TORCH_CHECK(gguf_quant_type_supported(type_id), "unsupported GGUF quant type_id: ", type_id);
     TORCH_CHECK(row_elems > 0, "row_elems must be positive");
     TORCH_CHECK(x.size(-1) == row_elems, "inner dimension mismatch");
     TORCH_CHECK(blocks.size(1) * 256 >= row_elems, "blocks do not cover row_elems");
@@ -594,9 +607,14 @@ torch::Tensor gguf_quant_gemm_pair_forward(
     const torch::Tensor& signed_grid) {
     TORCH_CHECK(x.dim() == 2 || x.dim() == 3, "x must have shape [M, K] or [B, S, K]");
     TORCH_CHECK(blocks0.dim() == 3 && blocks1.dim() == 3, "blocks must have shape [N, K_blocks, block_bytes]");
-    TORCH_CHECK(type_id0 >= 0 && type_id0 <= 4, "type_id0 must be 0..4");
-    TORCH_CHECK(type_id1 >= 0 && type_id1 <= 4, "type_id1 must be 0..4");
-    TORCH_CHECK(!(type_id0 == 0 && type_id1 == 2) && !(type_id0 == 2 && type_id1 == 0), "paired GEMM cannot mix iq2_xxs and iq1_m because they require different grids");
+    TORCH_CHECK(gguf_quant_type_supported(type_id0), "unsupported GGUF quant type_id0: ", type_id0);
+    TORCH_CHECK(gguf_quant_type_supported(type_id1), "unsupported GGUF quant type_id1: ", type_id1);
+    const bool uses_iq2_grid = (type_id0 == 0 || type_id1 == 0);
+    const bool uses_iq1_grid = (type_id0 == 2 || type_id1 == 2);
+    const bool uses_iq2_xs_iq3_xxs_grid = (type_id0 == 5 || type_id1 == 5 || type_id0 == 6 || type_id1 == 6);
+    TORCH_CHECK(!(uses_iq2_grid && uses_iq1_grid), "paired GEMM cannot mix iq2_xxs and iq1_m because they require different grids");
+    TORCH_CHECK(!(uses_iq2_grid && uses_iq2_xs_iq3_xxs_grid), "paired GEMM cannot mix iq2_xxs with iq2_xs/iq3_xxs because they require different grids");
+    TORCH_CHECK(!(uses_iq1_grid && uses_iq2_xs_iq3_xxs_grid), "paired GEMM cannot mix iq1_m with iq2_xs/iq3_xxs because they require different grids");
     TORCH_CHECK(row_elems0 > 0 && row_elems1 > 0, "row_elems must be positive");
     TORCH_CHECK(row_elems0 == row_elems1, "paired GGUF GEMM requires matching input dimensions");
     TORCH_CHECK(x.size(-1) == row_elems0, "inner dimension mismatch");
@@ -613,10 +631,12 @@ torch::Tensor gguf_quant_gemm_pair_forward(
         x.scalar_type() == torch::kBFloat16 ||
         x.scalar_type() == torch::kFloat32,
         "x must be float16, bfloat16, or float32");
-    if (type_id0 == 0 || type_id1 == 0) {
+    if (uses_iq2_grid) {
         check_gguf_quant_grid(signed_grid, 0, "signed_grid");
-    } else if (type_id0 == 2 || type_id1 == 2) {
+    } else if (uses_iq1_grid) {
         check_gguf_quant_grid(signed_grid, 2, "signed_grid");
+    } else if (uses_iq2_xs_iq3_xxs_grid) {
+        check_gguf_quant_grid(signed_grid, 5, "signed_grid");
     }
     return gguf_quant_gemm_pair_forward_cuda(
         x,
@@ -675,12 +695,15 @@ torch::Tensor gguf_moe_prefill_grouped_forward(
     TORCH_CHECK(seg_starts.size(0) == w1_blocks.size(0) + 1, "seg_starts/expert count mismatch");
     TORCH_CHECK(w1_blocks.size(0) == w3_blocks.size(0) && w1_blocks.size(0) == w2_blocks.size(0), "expert count mismatch");
     TORCH_CHECK(w1_blocks.size(2) * 256 >= w1_row_elems && w3_blocks.size(2) * 256 >= w3_row_elems && w2_blocks.size(2) * 256 >= w2_row_elems, "blocks do not cover row_elems");
-    TORCH_CHECK(w1_type_id == 0 || w1_type_id == 1 || w1_type_id == 2, "w1_type_id must be 0, 1, or 2");
-    TORCH_CHECK(w3_type_id == 0 || w3_type_id == 1 || w3_type_id == 2, "w3_type_id must be 0, 1, or 2");
-    TORCH_CHECK(w2_type_id == 0 || w2_type_id == 1 || w2_type_id == 2, "w2_type_id must be 0, 1, or 2");
+    TORCH_CHECK(gguf_quant_type_supported(w1_type_id), "unsupported w1 GGUF type: ", w1_type_id);
+    TORCH_CHECK(gguf_quant_type_supported(w3_type_id), "unsupported w3 GGUF type: ", w3_type_id);
+    TORCH_CHECK(gguf_quant_type_supported(w2_type_id), "unsupported w2 GGUF type: ", w2_type_id);
     const bool uses_iq2_grid = (w1_type_id == 0 || w3_type_id == 0 || w2_type_id == 0);
     const bool uses_iq1_grid = (w1_type_id == 2 || w3_type_id == 2 || w2_type_id == 2);
+    const bool uses_iq2_xs_iq3_xxs_grid = (w1_type_id == 5 || w3_type_id == 5 || w2_type_id == 5 || w1_type_id == 6 || w3_type_id == 6 || w2_type_id == 6);
     TORCH_CHECK(!(uses_iq2_grid && uses_iq1_grid), "grouped GGUF kernel cannot mix iq2_xxs and iq1_m because they require different grids");
+    TORCH_CHECK(!(uses_iq2_grid && uses_iq2_xs_iq3_xxs_grid), "grouped GGUF kernel cannot mix iq2_xxs with iq2_xs/iq3_xxs because they require different grids");
+    TORCH_CHECK(!(uses_iq1_grid && uses_iq2_xs_iq3_xxs_grid), "grouped GGUF kernel cannot mix iq1_m with iq2_xs/iq3_xxs because they require different grids");
     TORCH_CHECK(w1_blocks.size(3) == gguf_quant_block_bytes_for_type(w1_type_id), "unexpected w1 GGUF block size");
     TORCH_CHECK(w3_blocks.size(3) == gguf_quant_block_bytes_for_type(w3_type_id), "unexpected w3 GGUF block size");
     TORCH_CHECK(w2_blocks.size(3) == gguf_quant_block_bytes_for_type(w2_type_id), "unexpected w2 GGUF block size");
@@ -706,6 +729,8 @@ torch::Tensor gguf_moe_prefill_grouped_forward(
         check_gguf_quant_grid(signed_grid, 0, "signed_grid");
     } else if (uses_iq1_grid) {
         check_gguf_quant_grid(signed_grid, 2, "signed_grid");
+    } else if (uses_iq2_xs_iq3_xxs_grid) {
+        check_gguf_quant_grid(signed_grid, 5, "signed_grid");
     }
     return gguf_moe_prefill_grouped_forward_cuda(
         x,

--- a/src/csrc/cuda_kernel_impl.cu
+++ b/src/csrc/cuda_kernel_impl.cu
@@ -6129,6 +6129,121 @@ __global__ void gguf_quant_gemm_pair_kernel(
     }
 }
 
+constexpr int kIQ2XSSignedGridEntries = 512 * 128 * 8;
+
+__device__ __forceinline__ float iq2xs_block_dot_256(
+    const float* __restrict__ x_shared,
+    const uint8_t* __restrict__ block,
+    const int8_t* __restrict__ signed_grid,
+    int lane) {
+    const float d = gguf_block_scale_f16(block);
+    const uint8_t* qs = block + 2;
+    const uint8_t* scales = block + 66;
+    float acc = 0.0f;
+    #pragma unroll
+    for (int sub = 0; sub < 8; ++sub) {
+        const uint8_t* chunk = qs + sub * 8;
+        const int ls0 = static_cast<int>(scales[sub] & 0x0F);
+        const int ls1 = static_cast<int>(scales[sub] >> 4);
+        #pragma unroll
+        for (int part = 0; part < 4; ++part) {
+            const uint16_t q = static_cast<uint16_t>(chunk[part * 2]) |
+                (static_cast<uint16_t>(chunk[part * 2 + 1]) << 8);
+            const int grid_id = static_cast<int>(q & 0x01FFu);
+            const int sign_idx = static_cast<int>(q >> 9);
+            const int8_t* vals = signed_grid + ((grid_id * 128 + sign_idx) * 8);
+            const float scale = 0.25f * d * (static_cast<float>(part < 2 ? ls0 : ls1) + 0.5f);
+            const int k_start = sub * 32 + part * 8;
+            float local = 0.0f;
+            if (lane < 8) {
+                local = x_shared[k_start + lane] * static_cast<float>(vals[lane]) * scale;
+                #pragma unroll
+                for (int offset = 4; offset > 0; offset >>= 1) {
+                    local += __shfl_down_sync(0xff, local, offset);
+                }
+                if (lane == 0) acc += local;
+            }
+        }
+    }
+    return acc;
+}
+
+__device__ __forceinline__ float iq3xxs_block_dot_256(
+    const float* __restrict__ x_shared,
+    const uint8_t* __restrict__ block,
+    const int8_t* __restrict__ signed_grid,
+    int lane) {
+    const float d = gguf_block_scale_f16(block);
+    const uint8_t* qs = block + 2;
+    const int8_t* iq3_grid = signed_grid + kIQ2XSSignedGridEntries;
+    float acc = 0.0f;
+    #pragma unroll
+    for (int sub = 0; sub < 8; ++sub) {
+        const uint8_t* qbytes = qs + sub * 12;
+        const uint32_t aux = static_cast<uint32_t>(qbytes[8]) |
+            (static_cast<uint32_t>(qbytes[9]) << 8) |
+            (static_cast<uint32_t>(qbytes[10]) << 16) |
+            (static_cast<uint32_t>(qbytes[11]) << 24);
+        const float scale = 0.5f * d * (static_cast<float>(aux >> 28) + 0.5f);
+        #pragma unroll
+        for (int part = 0; part < 8; ++part) {
+            const int grid_id = static_cast<int>(qbytes[part]);
+            const int sign_idx = static_cast<int>((aux >> (7 * (part >> 1))) & 127);
+            const int val_offset = (part & 1) * 4;
+            const int8_t* vals = iq3_grid + ((grid_id * 128 + sign_idx) * 8 + val_offset);
+            const int k_start = sub * 32 + part * 4;
+            float local = 0.0f;
+            if (lane < 4) {
+                local = x_shared[k_start + lane] * static_cast<float>(vals[lane]) * scale;
+                #pragma unroll
+                for (int offset = 2; offset > 0; offset >>= 1) {
+                    local += __shfl_down_sync(0x0f, local, offset);
+                }
+                if (lane == 0) acc += local;
+            }
+        }
+    }
+    return acc;
+}
+
+__device__ __forceinline__ float q6k_block_dot_256(
+    const float* __restrict__ x_shared,
+    const uint8_t* __restrict__ block,
+    int lane) {
+    const uint8_t* ql_base = block;
+    const uint8_t* qh_base = block + 128;
+    const int8_t* scales = reinterpret_cast<const int8_t*>(block + 192);
+    const float d = gguf_block_scale_f16(block + 208);
+    // ggml dequantize_row_q6_K layout: two 128-wide halves per super-block.
+    // lane == l in 0..31 within each half; is = l/16 selects sc[is+0/2/4/6].
+    const int l = lane;
+    const int is = l >> 4;
+    float local = 0.0f;
+    #pragma unroll
+    for (int half = 0; half < 2; ++half) {
+        const uint8_t* ql = ql_base + half * 64;
+        const uint8_t* qh = qh_base + half * 32;
+        const int8_t* sc = scales + half * 8;
+        const int base = half * 128;
+        const uint8_t ql0 = ql[l];
+        const uint8_t ql32 = ql[l + 32];
+        const uint8_t qhb = qh[l];
+        const int q1 = static_cast<int>((ql0 & 0x0F) | (((qhb >> 0) & 0x03) << 4)) - 32;
+        const int q2 = static_cast<int>((ql32 & 0x0F) | (((qhb >> 2) & 0x03) << 4)) - 32;
+        const int q3 = static_cast<int>((ql0 >> 4) | (((qhb >> 4) & 0x03) << 4)) - 32;
+        const int q4 = static_cast<int>((ql32 >> 4) | (((qhb >> 6) & 0x03) << 4)) - 32;
+        local += x_shared[base + l +  0] * d * static_cast<float>(sc[is + 0]) * static_cast<float>(q1);
+        local += x_shared[base + l + 32] * d * static_cast<float>(sc[is + 2]) * static_cast<float>(q2);
+        local += x_shared[base + l + 64] * d * static_cast<float>(sc[is + 4]) * static_cast<float>(q3);
+        local += x_shared[base + l + 96] * d * static_cast<float>(sc[is + 6]) * static_cast<float>(q4);
+    }
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        local += __shfl_down_sync(0xffffffff, local, offset);
+    }
+    return local;
+}
+
 __device__ __forceinline__ float gguf_quant_block_dot_256(
     const float* __restrict__ x_shared,
     const uint8_t* __restrict__ block,
@@ -6170,6 +6285,15 @@ __device__ __forceinline__ float gguf_quant_block_dot_256(
         if (lane == 0) acc += blk;
     } else if (type_id == 4) {
         const float blk = q5k_block_dot_256(x_shared, block, lane);
+        if (lane == 0) acc += blk;
+    } else if (type_id == 5) {
+        const float blk = iq2xs_block_dot_256(x_shared, block, signed_grid, lane);
+        if (lane == 0) acc += blk;
+    } else if (type_id == 6) {
+        const float blk = iq3xxs_block_dot_256(x_shared, block, signed_grid, lane);
+        if (lane == 0) acc += blk;
+    } else if (type_id == 8) {
+        const float blk = q6k_block_dot_256(x_shared, block, lane);
         if (lane == 0) acc += blk;
     } else {
         const uint8_t* scales = block;
@@ -6250,6 +6374,23 @@ __device__ __forceinline__ void gguf_quant_block_dot_256_rows4(
         q4k_block_dot_256_rows4(x_shared, block, lane, valid_rows, acc);
     } else if (type_id == 4) {
         q5k_block_dot_256_rows4(x_shared, block, lane, valid_rows, acc);
+    } else if (type_id == 5 || type_id == 6 || type_id == 8) {
+        if (valid_rows > 0) {
+            float blk = gguf_quant_block_dot_256(x_shared, block, signed_grid, type_id, lane);
+            if (lane == 0) acc[0] += blk;
+        }
+        if (valid_rows > 1) {
+            float blk = gguf_quant_block_dot_256(x_shared + 256, block, signed_grid, type_id, lane);
+            if (lane == 0) acc[1] += blk;
+        }
+        if (valid_rows > 2) {
+            float blk = gguf_quant_block_dot_256(x_shared + 512, block, signed_grid, type_id, lane);
+            if (lane == 0) acc[2] += blk;
+        }
+        if (valid_rows > 3) {
+            float blk = gguf_quant_block_dot_256(x_shared + 768, block, signed_grid, type_id, lane);
+            if (lane == 0) acc[3] += blk;
+        }
     } else {
         const uint8_t* scales = block;
         const uint8_t* qs = block + 16;
@@ -7561,7 +7702,7 @@ torch::Tensor gguf_quant_gemm_forward_cuda(
     auto out = torch::empty({rows, n}, x.options().dtype(torch::kBFloat16));
     const int8_t* grid_ptr = nullptr;
     torch::Tensor grid_contig;
-    if (type_id == 0 || type_id == 2) {
+    if (type_id == 0 || type_id == 2 || type_id == 5 || type_id == 6) {
         grid_contig = signed_grid.contiguous();
         grid_ptr = grid_contig.data_ptr<int8_t>();
     }
@@ -7612,7 +7753,7 @@ torch::Tensor gguf_quant_gemm_prefill_forward_cuda(
     auto out = torch::empty({rows, n}, x.options().dtype(torch::kBFloat16));
     const int8_t* grid_ptr = nullptr;
     torch::Tensor grid_contig;
-    if (type_id == 0 || type_id == 2) {
+    if (type_id == 0 || type_id == 2 || type_id == 5 || type_id == 6) {
         grid_contig = signed_grid.contiguous();
         grid_ptr = grid_contig.data_ptr<int8_t>();
     }
@@ -7661,7 +7802,7 @@ torch::Tensor gguf_quant_gemm_pair_forward_cuda(
     auto out1 = torch::empty({rows, n}, x.options().dtype(torch::kBFloat16));
     const int8_t* grid_ptr = nullptr;
     torch::Tensor grid_contig;
-    if (type_id0 == 0 || type_id1 == 0 || type_id0 == 2 || type_id1 == 2) {
+    if (type_id0 == 0 || type_id1 == 0 || type_id0 == 2 || type_id1 == 2 || type_id0 == 5 || type_id1 == 5 || type_id0 == 6 || type_id1 == 6) {
         grid_contig = signed_grid.contiguous();
         grid_ptr = grid_contig.data_ptr<int8_t>();
     }
@@ -7775,7 +7916,10 @@ torch::Tensor gguf_moe_prefill_grouped_forward_cuda(
 
     const int8_t* grid_ptr = nullptr;
     torch::Tensor grid_contig;
-    if (w1_type_id == 0 || w3_type_id == 0 || w2_type_id == 0 || w1_type_id == 2 || w3_type_id == 2 || w2_type_id == 2) {
+    if (w1_type_id == 0 || w3_type_id == 0 || w2_type_id == 0 ||
+        w1_type_id == 2 || w3_type_id == 2 || w2_type_id == 2 ||
+        w1_type_id == 5 || w3_type_id == 5 || w2_type_id == 5 ||
+        w1_type_id == 6 || w3_type_id == 6 || w2_type_id == 6) {
         grid_contig = signed_grid.contiguous();
         grid_ptr = grid_contig.data_ptr<int8_t>();
     }

--- a/src/loader/gguf/quant_types.py
+++ b/src/loader/gguf/quant_types.py
@@ -6,6 +6,9 @@ GGUF_DENSE_TYPE_IDS = {
     "iq1_m": 2,
     "q4_k": 3,
     "q5_k": 4,
+    "iq2_xs": 5,
+    "iq3_xxs": 6,
+    "q6_k": 8,
 }
 
 GGUF_DENSE_TYPE_NAMES = {value: key for key, value in GGUF_DENSE_TYPE_IDS.items()}

--- a/src/loader/gguf/tensor_reader.py
+++ b/src/loader/gguf/tensor_reader.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import math
 import mmap
 import os
+import re
 import time
 from functools import lru_cache
+from pathlib import Path
 from typing import Iterable
 
 import numpy as np
@@ -97,11 +99,15 @@ _DENSE_DTYPES = {
 # raw blocks in runtime and use reference dequant only in tests.
 _QUANT_BLOCK_META = {
     "q2_k": (256, 84),
+    "q3_k": (256, 110),
     "iq2_xxs": (256, 66),
+    "iq2_xs": (256, 74),
+    "iq3_xxs": (256, 98),
     "iq1_m": (256, 56),
     "q4_k": (256, 144),
     "q5_k": (256, 176),
     "q6_k": (256, 210),
+    "iq4_xs": (256, 136),
 }
 
 
@@ -140,6 +146,62 @@ def _get_scale_min_k4(scales: np.ndarray, idx: int) -> tuple[np.ndarray, np.ndar
     )
 
 
+def _extract_ggml_table(table_name: str, *, dtype: str, expected: int) -> np.ndarray:
+    """Parse a vendored llama.cpp IQ lookup table without duplicating constants."""
+    header = Path(__file__).parents[2] / "csrc" / "llama_mmq" / "ggml-common.h"
+    text = header.read_text(encoding="utf-8")
+    match = re.search(
+        rf"GGML_TABLE_BEGIN\([^,]+,\s*{re.escape(table_name)},\s*{expected}\)(.*?)GGML_TABLE_END\(\)",
+        text,
+        flags=re.S,
+    )
+    if match is None:
+        raise RuntimeError(f"failed to locate {table_name} in {header}")
+    values = [int(item, 16) for item in re.findall(r"0x[0-9a-fA-F]+", match.group(1))]
+    if len(values) != int(expected):
+        raise RuntimeError(f"{table_name} expected {expected} entries, got {len(values)}")
+    return np.asarray(values, dtype=np.dtype(dtype))
+
+
+@lru_cache(maxsize=1)
+def _iq2xs_grid() -> np.ndarray:
+    return _extract_ggml_table("iq2xs_grid", dtype="<u8", expected=512)
+
+
+@lru_cache(maxsize=1)
+def _iq3xxs_grid() -> np.ndarray:
+    return _extract_ggml_table("iq3xxs_grid", dtype="<u4", expected=256)
+
+
+@lru_cache(maxsize=1)
+def _iq2xs_signed_grid() -> np.ndarray:
+    base = np.empty((512, 8), dtype=np.int8)
+    for idx, value in enumerate(_iq2xs_grid()):
+        base[idx] = np.frombuffer(int(value).to_bytes(8, "little"), dtype=np.uint8).astype(np.int8)
+    signs = np.empty((128, 8), dtype=np.int8)
+    masks = np.array([1, 2, 4, 8, 16, 32, 64, 128], dtype=np.uint8)
+    for idx in range(128):
+        sign_mask = idx | ((int(idx).bit_count() & 1) << 7)
+        signs[idx] = np.where((sign_mask & masks) != 0, -1, 1).astype(np.int8)
+    return (base[:, None, :].astype(np.int16) * signs[None, :, :].astype(np.int16)).astype(np.int8)
+
+
+@lru_cache(maxsize=1)
+def _iq3xxs_signed_grid() -> np.ndarray:
+    base = np.empty((256, 4), dtype=np.int8)
+    for idx, value in enumerate(_iq3xxs_grid()):
+        base[idx] = np.frombuffer(int(value).to_bytes(4, "little"), dtype=np.uint8).astype(np.int8)
+    signs = np.empty((128, 8), dtype=np.int8)
+    masks = np.array([1, 2, 4, 8, 16, 32, 64, 128], dtype=np.uint8)
+    for idx in range(128):
+        sign_mask = idx | ((int(idx).bit_count() & 1) << 7)
+        signs[idx] = np.where((sign_mask & masks) != 0, -1, 1).astype(np.int8)
+    expanded = np.empty((256, 128, 8), dtype=np.int8)
+    expanded[:, :, 0:4] = (base[:, None, :].astype(np.int16) * signs[None, :, 0:4].astype(np.int16)).astype(np.int8)
+    expanded[:, :, 4:8] = (base[:, None, :].astype(np.int16) * signs[None, :, 4:8].astype(np.int16)).astype(np.int8)
+    return expanded
+
+
 @lru_cache(maxsize=1)
 def _iq2xxs_signed_grid() -> np.ndarray:
     base = np.empty((256, 8), dtype=np.int8)
@@ -156,6 +218,29 @@ def _iq2xxs_signed_grid() -> np.ndarray:
 @lru_cache(maxsize=1)
 def get_iq2xxs_signed_grid_tensor() -> torch.Tensor:
     return torch.from_numpy(_iq2xxs_signed_grid().copy()).contiguous().to(device="cpu")
+
+
+@lru_cache(maxsize=1)
+def get_iq2xs_signed_grid_tensor() -> torch.Tensor:
+    return torch.from_numpy(_iq2xs_signed_grid().copy()).contiguous().to(device="cpu")
+
+
+@lru_cache(maxsize=1)
+def get_iq3xxs_signed_grid_tensor() -> torch.Tensor:
+    return torch.from_numpy(_iq3xxs_signed_grid().copy()).contiguous().to(device="cpu")
+
+
+@lru_cache(maxsize=1)
+def get_iq2xs_iq3xxs_signed_grid_tensor() -> torch.Tensor:
+    # GLM MoE uses IQ2_XS for routed w1/w3 and IQ3_XXS for routed w2.  Keep a
+    # single packed tensor for that runtime, but preserve per-format helpers
+    # above so other callers can fetch the exact table they need.
+    return torch.cat(
+        [
+            get_iq2xs_signed_grid_tensor().reshape(-1),
+            get_iq3xxs_signed_grid_tensor().reshape(-1),
+        ]
+    ).contiguous()
 
 
 @lru_cache(maxsize=1)
@@ -214,7 +299,7 @@ class GGUFTensorDataReader:
             return self._read_dense_tensor(tensor)
         if tensor.type_name == "q8_0":
             return self._read_q8_0_tensor(tensor)
-        if tensor.type_name in {"q2_k", "iq2_xxs", "iq1_m", "q4_k", "q5_k", "q6_k"} and len(tensor.dimensions) == 2:
+        if tensor.type_name in _QUANT_BLOCK_META and len(tensor.dimensions) == 2:
             return self._read_quantized_matrix(tensor, tensor.absolute_offset, int(tensor.dimensions[0]), int(tensor.dimensions[1]), tensor.type_name)
         raise NotImplementedError(f"payload decode for {tensor.name} ({tensor.type_name}) is not supported by read_tensor")
 
@@ -482,8 +567,14 @@ class GGUFTensorDataReader:
         blocks_per_row = math.ceil(in_dim / 256)
         if type_name == "q2_k":
             values = self._read_q2_k_rows(offset, out_dim, blocks_per_row)
+        elif type_name == "q3_k":
+            values = self._read_q3_k_rows(offset, out_dim, blocks_per_row)
         elif type_name == "iq2_xxs":
             values = self._read_iq2_xxs_rows(offset, out_dim, blocks_per_row)
+        elif type_name == "iq2_xs":
+            values = self._read_iq2_xs_rows(offset, out_dim, blocks_per_row)
+        elif type_name == "iq3_xxs":
+            values = self._read_iq3_xxs_rows(offset, out_dim, blocks_per_row)
         elif type_name == "iq1_m":
             values = self._read_iq1_m_rows(offset, out_dim, blocks_per_row)
         elif type_name == "q4_k":
@@ -492,6 +583,8 @@ class GGUFTensorDataReader:
             values = self._read_q5_k_rows(offset, out_dim, blocks_per_row)
         elif type_name == "q6_k":
             values = self._read_q6_k_rows(offset, out_dim, blocks_per_row)
+        elif type_name == "iq4_xs":
+            values = self._read_iq4_xs_rows(offset, out_dim, blocks_per_row)
         else:
             raise NotImplementedError(type_name)
         return torch.from_numpy(values.reshape(out_dim, blocks_per_row * 256)[:, :in_dim].copy())
@@ -562,6 +655,122 @@ class GGUFTensorDataReader:
             _GGUF_READER_PROFILE_COUNT += 1
             print(
                 f"gguf_reader_profile type=iq2_xxs rows={rows} blocks_per_row={blocks_per_row} bytes={nbytes} "
+                f"read={t_read - t0:.6f}s decode={t_done - t_read:.6f}s total={t_done - t0:.6f}s",
+                flush=True,
+            )
+        return out
+
+    def _read_iq2_xs_rows(self, offset: int, rows: int, blocks_per_row: int) -> np.ndarray:
+        """Reference-decode IQ2_XS rows using llama.cpp grid/sign layout."""
+        global _GGUF_READER_PROFILE_COUNT
+        profile = _GGUF_READER_PROFILE and _GGUF_READER_PROFILE_COUNT < _GGUF_READER_PROFILE_LIMIT
+        t0 = time.perf_counter() if profile else 0.0
+        nbytes = rows * blocks_per_row * 74
+        data = self._read_at(offset, nbytes)
+        if profile:
+            t_read = time.perf_counter()
+        blocks = np.frombuffer(data, dtype=np.uint8).reshape(rows, blocks_per_row, 74)
+        d = _f16_bytes_to_f32(blocks[:, :, 0:2])
+        qs = blocks[:, :, 2:66]
+        scales = blocks[:, :, 66:74]
+        signed_grid = _iq2xs_signed_grid()
+        out = np.empty((rows, blocks_per_row, 256), dtype=np.float32)
+        for sub in range(8):
+            chunk = qs[:, :, sub * 8:(sub + 1) * 8]
+            ls0 = (scales[:, :, sub] & 0x0F).astype(np.float32)
+            ls1 = (scales[:, :, sub] >> 4).astype(np.float32)
+            for part in range(4):
+                q = chunk[:, :, part * 2].astype(np.uint16) | (chunk[:, :, part * 2 + 1].astype(np.uint16) << 8)
+                grid_ids = (q & 0x01FF).astype(np.int64)
+                sign_idx = (q >> 9).astype(np.int64)
+                values = signed_grid[grid_ids, sign_idx].astype(np.float32)
+                start = sub * 32 + part * 8
+                scale = (ls0 if part < 2 else ls1) + 0.5
+                out[:, :, start:start + 8] = 0.25 * d[:, :, None] * scale[:, :, None] * values
+        if profile:
+            t_done = time.perf_counter()
+            _GGUF_READER_PROFILE_COUNT += 1
+            print(
+                f"gguf_reader_profile type=iq2_xs rows={rows} blocks_per_row={blocks_per_row} bytes={nbytes} "
+                f"read={t_read - t0:.6f}s decode={t_done - t_read:.6f}s total={t_done - t0:.6f}s",
+                flush=True,
+            )
+        return out
+
+    def _read_iq3_xxs_rows(self, offset: int, rows: int, blocks_per_row: int) -> np.ndarray:
+        """Reference-decode IQ3_XXS rows using llama.cpp grid/sign layout."""
+        global _GGUF_READER_PROFILE_COUNT
+        profile = _GGUF_READER_PROFILE and _GGUF_READER_PROFILE_COUNT < _GGUF_READER_PROFILE_LIMIT
+        t0 = time.perf_counter() if profile else 0.0
+        nbytes = rows * blocks_per_row * 98
+        data = self._read_at(offset, nbytes)
+        if profile:
+            t_read = time.perf_counter()
+        blocks = np.frombuffer(data, dtype=np.uint8).reshape(rows, blocks_per_row, 98)
+        d = _f16_bytes_to_f32(blocks[:, :, 0:2])
+        qs = blocks[:, :, 2:98]
+        signed_grid = _iq3xxs_signed_grid()
+        out = np.empty((rows, blocks_per_row, 256), dtype=np.float32)
+        for sub in range(8):
+            qbytes = qs[:, :, sub * 12:sub * 12 + 8]
+            aux = (
+                qs[:, :, sub * 12 + 8].astype(np.uint32)
+                | (qs[:, :, sub * 12 + 9].astype(np.uint32) << 8)
+                | (qs[:, :, sub * 12 + 10].astype(np.uint32) << 16)
+                | (qs[:, :, sub * 12 + 11].astype(np.uint32) << 24)
+            )
+            ls = (aux >> 28).astype(np.float32)
+            for part in range(8):
+                grid_ids = qbytes[:, :, part].astype(np.int64)
+                sign_idx = ((aux >> (7 * (part // 2))) & 127).astype(np.int64)
+                values = signed_grid[grid_ids, sign_idx, part % 2 * 4:part % 2 * 4 + 4].astype(np.float32)
+                start = sub * 32 + part * 4
+                out[:, :, start:start + 4] = 0.5 * d[:, :, None] * (ls[:, :, None] + 0.5) * values
+        if profile:
+            t_done = time.perf_counter()
+            _GGUF_READER_PROFILE_COUNT += 1
+            print(
+                f"gguf_reader_profile type=iq3_xxs rows={rows} blocks_per_row={blocks_per_row} bytes={nbytes} "
+                f"read={t_read - t0:.6f}s decode={t_done - t_read:.6f}s total={t_done - t0:.6f}s",
+                flush=True,
+            )
+        return out
+
+    def _read_q3_k_rows(self, offset: int, rows: int, blocks_per_row: int) -> np.ndarray:
+        """Reference-decode Q3_K rows to float32 using llama.cpp/ggml layout."""
+        global _GGUF_READER_PROFILE_COUNT
+        profile = _GGUF_READER_PROFILE and _GGUF_READER_PROFILE_COUNT < _GGUF_READER_PROFILE_LIMIT
+        t0 = time.perf_counter() if profile else 0.0
+        nbytes = rows * blocks_per_row * 110
+        data = self._read_at(offset, nbytes)
+        if profile:
+            t_read = time.perf_counter()
+        blocks = np.frombuffer(data, dtype=np.uint8).reshape(rows, blocks_per_row, 110)
+        hmask = blocks[:, :, 0:32]
+        qs = blocks[:, :, 32:96]
+        scales = blocks[:, :, 96:108]
+        d = _f16_bytes_to_f32(blocks[:, :, 108:110])
+        out = np.empty((rows, blocks_per_row, 256), dtype=np.float32)
+        for group in range(16):
+            if group < 8:
+                scale = (scales[:, :, group] & 0x0F).astype(np.int16)
+            else:
+                scale = (scales[:, :, group - 8] >> 4).astype(np.int16)
+            scale = (scale - 8).astype(np.float32)
+            qbytes = qs[:, :, group * 4:(group + 1) * 4]
+            qlow = np.empty((rows, blocks_per_row, 16), dtype=np.uint8)
+            qlow[:, :, 0:4] = qbytes & 0x03
+            qlow[:, :, 4:8] = (qbytes >> 2) & 0x03
+            qlow[:, :, 8:12] = (qbytes >> 4) & 0x03
+            qlow[:, :, 12:16] = (qbytes >> 6) & 0x03
+            bits = ((hmask[:, :, group * 2:group * 2 + 2][:, :, :, None] >> np.arange(8, dtype=np.uint8)) & 1).reshape(rows, blocks_per_row, 16)
+            q = qlow.astype(np.int16) - np.where(bits == 0, 4, 0).astype(np.int16)
+            out[:, :, group * 16:(group + 1) * 16] = d[:, :, None] * scale[:, :, None] * q.astype(np.float32)
+        if profile:
+            t_done = time.perf_counter()
+            _GGUF_READER_PROFILE_COUNT += 1
+            print(
+                f"gguf_reader_profile type=q3_k rows={rows} blocks_per_row={blocks_per_row} bytes={nbytes} "
                 f"read={t_read - t0:.6f}s decode={t_done - t_read:.6f}s total={t_done - t0:.6f}s",
                 flush=True,
             )
@@ -664,32 +873,73 @@ class GGUFTensorDataReader:
         scales = blocks[:, :, 192:208].view(np.int8).astype(np.float32)
         d = _f16_bytes_to_f32(blocks[:, :, 208:210])
         out = np.empty((rows, blocks_per_row, 256), dtype=np.float32)
-        for group in range(16):
-            ql_part = ql[:, :, group * 8:(group + 1) * 8]
-            qh_part = qh[:, :, group * 4:(group + 1) * 4]
-            if group % 2 == 0:
-                low = ql_part & 0x0F
-            else:
-                low = ql_part >> 4
-            high_lo = qh_part & 0x03
-            high_hi = (qh_part >> 2) & 0x03
-            high = np.empty((rows, blocks_per_row, 8), dtype=np.uint8)
-            high[:, :, 0:4] = high_lo
-            high[:, :, 4:8] = high_hi
-            q = (low | (high << 4)).astype(np.int16) - 32
-            out[:, :, group * 16:group * 16 + 8] = d[:, :, None] * scales[:, :, group, None] * q.astype(np.float32)
-            # ql stores 8 bytes per group, i.e. 16 packed low nibbles.
-            if group % 2 == 0:
-                low2 = ql_part >> 4
-            else:
-                low2 = ql_part & 0x0F
-            q2 = (low2 | (high << 4)).astype(np.int16) - 32
-            out[:, :, group * 16 + 8:(group + 1) * 16] = d[:, :, None] * scales[:, :, group, None] * q2.astype(np.float32)
+        d_ = d[:, :, None]
+        # ggml dequantize_row_q6_K layout: two 128-wide halves per super-block.
+        # For l in 0..31 within a half: is = l // 16, and the four sub-lanes use
+        # scales sc[is+0], sc[is+2], sc[is+4], sc[is+6].
+        is_idx = np.concatenate([np.zeros(16, dtype=np.int64), np.ones(16, dtype=np.int64)])
+        for half in range(2):
+            base = half * 128
+            ql_h = ql[:, :, half * 64:(half + 1) * 64]
+            qh_h = qh[:, :, half * 32:(half + 1) * 32]
+            sc_h = scales[:, :, half * 8:(half + 1) * 8]
+            ql_l = ql_h[:, :, 0:32].astype(np.uint8)
+            ql_l32 = ql_h[:, :, 32:64].astype(np.uint8)
+            qh_l = qh_h[:, :, 0:32].astype(np.uint8)
+            q1 = ((ql_l & 0x0F) | (((qh_l >> 0) & 0x03) << 4)).astype(np.int16) - 32
+            q2 = ((ql_l32 & 0x0F) | (((qh_l >> 2) & 0x03) << 4)).astype(np.int16) - 32
+            q3 = ((ql_l >> 4) | (((qh_l >> 4) & 0x03) << 4)).astype(np.int16) - 32
+            q4 = ((ql_l32 >> 4) | (((qh_l >> 6) & 0x03) << 4)).astype(np.int16) - 32
+            sc1 = sc_h[:, :, is_idx + 0]
+            sc2 = sc_h[:, :, is_idx + 2]
+            sc3 = sc_h[:, :, is_idx + 4]
+            sc4 = sc_h[:, :, is_idx + 6]
+            out[:, :, base + 0:base + 32] = d_ * sc1 * q1.astype(np.float32)
+            out[:, :, base + 32:base + 64] = d_ * sc2 * q2.astype(np.float32)
+            out[:, :, base + 64:base + 96] = d_ * sc3 * q3.astype(np.float32)
+            out[:, :, base + 96:base + 128] = d_ * sc4 * q4.astype(np.float32)
         if profile:
             t_done = time.perf_counter()
             _GGUF_READER_PROFILE_COUNT += 1
             print(
                 f"gguf_reader_profile type=q6_k rows={rows} blocks_per_row={blocks_per_row} bytes={nbytes} "
+                f"read={t_read - t0:.6f}s decode={t_done - t_read:.6f}s total={t_done - t0:.6f}s",
+                flush=True,
+            )
+        return out
+
+    def _read_iq4_xs_rows(self, offset: int, rows: int, blocks_per_row: int) -> np.ndarray:
+        """Reference-decode IQ4_XS rows to float32."""
+        global _GGUF_READER_PROFILE_COUNT
+        profile = _GGUF_READER_PROFILE and _GGUF_READER_PROFILE_COUNT < _GGUF_READER_PROFILE_LIMIT
+        t0 = time.perf_counter() if profile else 0.0
+        nbytes = rows * blocks_per_row * 136
+        data = self._read_at(offset, nbytes)
+        if profile:
+            t_read = time.perf_counter()
+        blocks = np.frombuffer(data, dtype=np.uint8).reshape(rows, blocks_per_row, 136)
+        d = _f16_bytes_to_f32(blocks[:, :, 0:2])
+        scales_h = blocks[:, :, 2:4].view("<u2")
+        scales_l = blocks[:, :, 4:8]
+        qs = blocks[:, :, 8:136]
+        kvalues = np.array([-127, -104, -83, -65, -49, -35, -22, -10, 1, 13, 25, 38, 53, 69, 89, 113], dtype=np.float32)
+        out = np.empty((rows, blocks_per_row, 256), dtype=np.float32)
+        for group in range(8):
+            scale = ((scales_l[:, :, group // 2] >> (4 if group & 1 else 0)) & 0x0F).astype(np.int16)
+            scale |= (((scales_h >> (2 * group)) & 0x03).astype(np.int16) << 4)
+            scale = (scale - 32).astype(np.float32)
+            q = qs[:, :, group * 16:(group + 1) * 16]
+            lo = kvalues[q & 0x0F]
+            hi = kvalues[q >> 4]
+            values = np.empty((rows, blocks_per_row, 32), dtype=np.float32)
+            values[:, :, 0::2] = lo
+            values[:, :, 1::2] = hi
+            out[:, :, group * 32:(group + 1) * 32] = d[:, :, None] * scale[:, :, None] * values
+        if profile:
+            t_done = time.perf_counter()
+            _GGUF_READER_PROFILE_COUNT += 1
+            print(
+                f"gguf_reader_profile type=iq4_xs rows={rows} blocks_per_row={blocks_per_row} bytes={nbytes} "
                 f"read={t_read - t0:.6f}s decode={t_done - t_read:.6f}s total={t_done - t0:.6f}s",
                 flush=True,
             )

--- a/src/models/glm_dsa/architecture.py
+++ b/src/models/glm_dsa/architecture.py
@@ -4,6 +4,7 @@ import math
 from dataclasses import dataclass
 
 import torch
+import torch.distributed as dist
 import torch.nn.functional as F
 
 from src.components.gguf.tp_logits import distributed_argmax_local_logits, gather_sharded_logits
@@ -269,6 +270,273 @@ class GLMDSADenseMLP:
     def __call__(self, x: torch.Tensor) -> torch.Tensor:
         hidden = F.silu(self.gate_proj(x).float()) * self.up_proj(x).float()
         return self.down_proj(hidden.to(self.dtype))
+
+
+class GLMDSAMoE:
+    """Reference GLM-DSA routed+shared MoE.
+
+    This is deliberately a correctness bring-up path: selected experts are
+    dequantized on CPU by the GGUF loader, moved to CUDA, and evaluated with
+    PyTorch matmuls.  It enables small-layer full-model smoke tests before the
+    optimized PocketMoE active-expert kernels are wired in.
+    """
+
+    def __init__(
+        self,
+        args: GLMDSAArgs,
+        layer_id: int,
+        gate_weight: torch.Tensor,
+        gate_bias: torch.Tensor | None,
+        shared_gate_proj: ReferenceLinear | None,
+        shared_up_proj: ReferenceLinear | None,
+        shared_down_proj: ReferenceLinear | None,
+        expert_loader,
+        *,
+        device: torch.device,
+        dtype: torch.dtype = torch.float16,
+        expert_start: int = 0,
+        expert_count: int | None = None,
+    ):
+        self.args = args
+        self.layer_id = int(layer_id)
+        self.gate_weight = gate_weight.float().contiguous()
+        self.gate_bias = gate_bias.float().contiguous() if gate_bias is not None else None
+        self.shared_gate_proj = shared_gate_proj
+        self.shared_up_proj = shared_up_proj
+        self.shared_down_proj = shared_down_proj
+        self.expert_loader = expert_loader
+        self.device = device
+        self.dtype = dtype
+        self.expert_start = int(expert_start)
+        available = max(0, int(args.n_routed_experts) - self.expert_start)
+        self.expert_count = available if expert_count is None else int(expert_count)
+        if self.expert_start < 0 or self.expert_count < 0 or self.expert_start + self.expert_count > int(args.n_routed_experts):
+            raise ValueError(
+                f"invalid GLM-DSA local expert range [{self.expert_start}, {self.expert_start + self.expert_count}) "
+                f"for expert_count={args.n_routed_experts}"
+            )
+        self._expert_cache: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
+
+    def route(self, x_flat: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        logits = x_flat.float() @ self.gate_weight.t()
+        probs = torch.sigmoid(logits)
+        select_scores = probs if self.gate_bias is None else probs + self.gate_bias
+        _, indices = torch.topk(select_scores, k=int(self.args.top_k), dim=-1)
+        weights = torch.gather(probs, dim=-1, index=indices)
+        if self.args.expert_weights_norm:
+            weights = weights / weights.sum(dim=-1, keepdim=True).clamp_min(1.0e-20)
+        weights = weights * float(self.args.expert_weights_scale)
+        return indices.to(torch.long).contiguous(), weights.float().contiguous()
+
+    def _expert_weights(self, expert: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        expert = int(expert)
+        cached = self._expert_cache.get(expert)
+        if cached is not None:
+            return cached
+        w1, w3, w2 = self.expert_loader(expert)
+        cached = (
+            w1.to(device=self.device, dtype=torch.float32, non_blocking=False).contiguous(),
+            w3.to(device=self.device, dtype=torch.float32, non_blocking=False).contiguous(),
+            w2.to(device=self.device, dtype=torch.float32, non_blocking=False).contiguous(),
+        )
+        self._expert_cache[expert] = cached
+        return cached
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        original_shape = x.shape
+        x_flat = x.reshape(-1, original_shape[-1]).contiguous()
+        indices, weights = self.route(x_flat)
+        out = torch.zeros((x_flat.size(0), self.args.dim), device=x.device, dtype=torch.float32)
+        try:
+            local_start = self.expert_start
+            local_end = self.expert_start + self.expert_count
+            for expert in torch.unique(indices).tolist():
+                expert = int(expert)
+                if expert < local_start or expert >= local_end:
+                    continue
+                mask = indices == expert
+                route_pos = mask.nonzero(as_tuple=False)
+                if route_pos.numel() == 0:
+                    continue
+                token_ids = route_pos[:, 0]
+                route_ids = route_pos[:, 1]
+                x_sel = x_flat.index_select(0, token_ids).float()
+                w1, w3, w2 = self._expert_weights(expert)
+                hidden = F.silu(F.linear(x_sel, w1)) * F.linear(x_sel, w3)
+                y = F.linear(hidden, w2) * weights[token_ids, route_ids, None]
+                out.index_add_(0, token_ids, y.float())
+        finally:
+            # Keep this reference path heterogeneous/active-expert: do not retain
+            # dequantized routed experts across layers or decode calls.
+            self._expert_cache.clear()
+
+        if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
+            dist.all_reduce(out)
+
+        if self.shared_gate_proj is not None and self.shared_up_proj is not None and self.shared_down_proj is not None:
+            shared = F.silu(self.shared_gate_proj(x_flat).float()) * self.shared_up_proj(x_flat).float()
+            out = out + self.shared_down_proj(shared.to(self.dtype)).float()
+        return out.reshape(original_shape).to(self.dtype)
+
+
+class GLMDSARawBlockMoE:
+    """GLM-DSA routed+shared MoE over raw GGUF quantized blocks.
+
+    Routed experts (iq2_xs w1/w3, iq3_xxs w2) are staged per active expert and
+    evaluated with the CUDA grouped MoE kernel; no fp32 weight expansion happens
+    on the hot path.  Shared experts run through raw quantized GGUF linears
+    (q5_k gate/up, q6_k down).  Router math matches ``GLMDSAMoE.route``.
+    """
+
+    def __init__(
+        self,
+        args: GLMDSAArgs,
+        layer_id: int,
+        gate_weight: torch.Tensor,
+        gate_bias: torch.Tensor | None,
+        shared_gate_proj,
+        shared_up_proj,
+        shared_down_proj,
+        *,
+        gguf_path: str,
+        w1_name: str,
+        w3_name: str,
+        w2_name: str,
+        signed_grid: torch.Tensor,
+        device: torch.device,
+        dtype: torch.dtype = torch.float16,
+        expert_start: int = 0,
+        expert_count: int | None = None,
+        swiglu_limit: float = -1.0,
+    ):
+        self.args = args
+        self.layer_id = int(layer_id)
+        self.gate_weight = gate_weight.float().contiguous()
+        self.gate_bias = gate_bias.float().contiguous() if gate_bias is not None else None
+        self.shared_gate_proj = shared_gate_proj
+        self.shared_up_proj = shared_up_proj
+        self.shared_down_proj = shared_down_proj
+        self.gguf_path = str(gguf_path)
+        self.w1_name = str(w1_name)
+        self.w3_name = str(w3_name)
+        self.w2_name = str(w2_name)
+        self.device = device
+        self.dtype = dtype
+        self.swiglu_limit = float(swiglu_limit)
+        self.expert_start = int(expert_start)
+        available = max(0, int(args.n_routed_experts) - self.expert_start)
+        self.expert_count = available if expert_count is None else int(expert_count)
+        if self.expert_start < 0 or self.expert_count < 0 or self.expert_start + self.expert_count > int(args.n_routed_experts):
+            raise ValueError(
+                f"invalid GLM-DSA local expert range [{self.expert_start}, {self.expert_start + self.expert_count}) "
+                f"for expert_count={args.n_routed_experts}"
+            )
+        self._grid = signed_grid.to(device=device, dtype=torch.int8).contiguous()
+        from src.loader.gguf.quant_types import GGUF_DENSE_TYPE_IDS
+
+        self._type_ids = GGUF_DENSE_TYPE_IDS
+
+    def route(self, x_flat: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        logits = x_flat.float() @ self.gate_weight.t()
+        probs = torch.sigmoid(logits)
+        select_scores = probs if self.gate_bias is None else probs + self.gate_bias
+        _, indices = torch.topk(select_scores, k=int(self.args.top_k), dim=-1)
+        weights = torch.gather(probs, dim=-1, index=indices)
+        if self.args.expert_weights_norm:
+            weights = weights / weights.sum(dim=-1, keepdim=True).clamp_min(1.0e-20)
+        weights = weights * float(self.args.expert_weights_scale)
+        return indices.to(torch.long).contiguous(), weights.float().contiguous()
+
+    def _stage_active_experts(self, reader, local_ids_cpu: list[int]):
+        """Read and stack raw blocks for the active local experts.
+
+        Returns stacked ``[E_active, N, K_blocks, block_bytes]`` tensors for
+        w1/w3/w2 plus their (type_id, in_dim) metadata.
+        """
+        w1_vals, w3_vals, w2_vals = [], [], []
+        for local_id in local_ids_cpu:
+            expert_id = int(local_id) + self.expert_start
+            w1_b, w1_tn, w1_in = reader.read_routed_expert_blocks(self.w1_name, expert_id)
+            w3_b, w3_tn, w3_in = reader.read_routed_expert_blocks(self.w3_name, expert_id)
+            w2_b, w2_tn, w2_in = reader.read_routed_expert_blocks(self.w2_name, expert_id)
+            w1_vals.append((w1_b, w1_tn, w1_in))
+            w3_vals.append((w3_b, w3_tn, w3_in))
+            w2_vals.append((w2_b, w2_tn, w2_in))
+        w1_blocks = torch.stack([v[0] for v in w1_vals], dim=0).to(self.device, non_blocking=True).contiguous()
+        w3_blocks = torch.stack([v[0] for v in w3_vals], dim=0).to(self.device, non_blocking=True).contiguous()
+        w2_blocks = torch.stack([v[0] for v in w2_vals], dim=0).to(self.device, non_blocking=True).contiguous()
+        meta = (
+            (self._type_ids[w1_vals[0][1]], int(w1_vals[0][2])),
+            (self._type_ids[w3_vals[0][1]], int(w3_vals[0][2])),
+            (self._type_ids[w2_vals[0][1]], int(w2_vals[0][2])),
+        )
+        return w1_blocks, w3_blocks, w2_blocks, meta
+
+    def _routed_forward(self, x_flat: torch.Tensor, indices: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
+        from src.kernels.cuda_loader import load_cuda_kernel
+        from src.loader.gguf.tensor_reader import get_cached_gguf_tensor_reader
+
+        cuda_mod = load_cuda_kernel()
+        if cuda_mod is None or not hasattr(cuda_mod, "gguf_moe_prefill_grouped_forward"):
+            raise RuntimeError("CUDA grouped MoE kernel is required for GLMDSARawBlockMoE")
+
+        out = torch.zeros((x_flat.size(0), self.args.dim), device=x_flat.device, dtype=torch.float32)
+        grouped = cuda_mod.moe_group_routes(
+            indices.contiguous(),
+            weights.contiguous().to(torch.float32),
+            int(self.expert_start),
+            int(self.expert_count),
+        )
+        if grouped is None:
+            return out
+        local_ids, route_tokens, route_weights, seg_starts = grouped
+        if local_ids.numel() == 0:
+            return out
+        local_ids_cpu = local_ids.detach().cpu().to(torch.long).tolist()
+
+        reader = get_cached_gguf_tensor_reader(self.gguf_path)
+        w1_blocks, w3_blocks, w2_blocks, meta = self._stage_active_experts(reader, local_ids_cpu)
+        (w1_type_id, w1_in_dim), (w3_type_id, w3_in_dim), (w2_type_id, w2_in_dim) = meta
+
+        seg_i32 = seg_starts if seg_starts.dtype == torch.int32 else seg_starts.to(torch.int32)
+        compact_starts = torch.cat(
+            [seg_i32[local_ids.to(seg_i32.device)], seg_i32[-1:]], dim=0
+        ).contiguous()
+
+        y = cuda_mod.gguf_moe_prefill_grouped_forward(
+            x_flat.to(torch.float16).contiguous(),
+            route_tokens,
+            route_weights.contiguous(),
+            compact_starts,
+            w1_blocks,
+            w3_blocks,
+            w2_blocks,
+            w1_in_dim,
+            w1_type_id,
+            w3_in_dim,
+            w3_type_id,
+            w2_in_dim,
+            w2_type_id,
+            self._grid,
+            float(self.swiglu_limit),
+        )
+        # The grouped kernel already scatter-adds each route into y[token] and
+        # multiplies route weights internally, so y is the [T, D] routed output.
+        return y.float()
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        original_shape = x.shape
+        x_flat = x.reshape(-1, original_shape[-1]).contiguous()
+        indices, weights = self.route(x_flat)
+        out = self._routed_forward(x_flat, indices, weights)
+
+        if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
+            dist.all_reduce(out)
+
+        if self.shared_gate_proj is not None and self.shared_up_proj is not None and self.shared_down_proj is not None:
+            shared = F.silu(self.shared_gate_proj(x_flat).float()) * self.shared_up_proj(x_flat).float()
+            out = out + self.shared_down_proj(shared.to(self.dtype)).float()
+        return out.reshape(original_shape).to(self.dtype)
 
 
 class GLMDSAMoEPlaceholder:

--- a/src/models/glm_dsa/gguf_model.py
+++ b/src/models/glm_dsa/gguf_model.py
@@ -13,7 +13,9 @@ from src.models.glm_dsa.architecture import (
     GLMDSAAttention,
     GLMDSABlock,
     GLMDSADenseMLP,
+    GLMDSAMoE,
     GLMDSAMoEPlaceholder,
+    GLMDSARawBlockMoE,
     GLMDSATransformer,
     ReferenceEmbedding,
     ReferenceLinear,
@@ -37,6 +39,9 @@ class GLMDSAGGUFModelLoader:
         dtype: torch.dtype = torch.float16,
         n_layers: int | None = None,
         allow_moe_layers: bool = False,
+        expert_start: int = 0,
+        expert_count: int | None = None,
+        use_raw_block_moe: bool = True,
     ):
         self.bundle = read_gguf_bundle(bundle_or_path) if not isinstance(bundle_or_path, GGUFBundle) else bundle_or_path
         resolved = torch.device(device)
@@ -48,6 +53,15 @@ class GLMDSAGGUFModelLoader:
         self.dtype = dtype
         self.args = GLMDSAArgs.from_bundle(self.bundle, n_layers=n_layers)
         self.allow_moe_layers = bool(allow_moe_layers)
+        self.use_raw_block_moe = bool(use_raw_block_moe)
+        self.expert_start = int(expert_start)
+        available = max(0, int(self.args.n_routed_experts) - self.expert_start)
+        self.expert_count = available if expert_count is None else int(expert_count)
+        if self.expert_start < 0 or self.expert_count < 0 or self.expert_start + self.expert_count > int(self.args.n_routed_experts):
+            raise ValueError(
+                f"invalid GLM-DSA expert range [{self.expert_start}, {self.expert_start + self.expert_count}) "
+                f"for expert_count={self.args.n_routed_experts}"
+            )
         self._readers: dict[str, GGUFTensorDataReader] = {}
 
     def close(self) -> None:
@@ -97,6 +111,128 @@ class GLMDSAGGUFModelLoader:
             raise ValueError(f"{name} expected shape {expected_shape}, got {tuple(tensor.shape)}")
         return tensor
 
+    def _read_routed_expert_cpu(self, name: str, expert: int) -> torch.Tensor:
+        tensor = self._tensor_ref(name)
+        return self._reader_for(tensor).read_routed_expert(tensor.name, expert=int(expert)).float().contiguous()
+
+    def _glm_moe_expert_loader(self, prefix: str):
+        def load_expert(expert: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            return (
+                self._read_routed_expert_cpu(f"{prefix}.ffn_gate_exps.weight", expert),
+                self._read_routed_expert_cpu(f"{prefix}.ffn_up_exps.weight", expert),
+                self._read_routed_expert_cpu(f"{prefix}.ffn_down_exps.weight", expert),
+            )
+
+        return load_expert
+
+    def _quant_linear(self, name: str):
+        """Build a raw-block CUDA linear over a 2D quantized GGUF tensor.
+
+        Used for GLM shared experts (q5_k gate/up, q6_k down) so the shared
+        path also avoids fp32 weight expansion.
+        """
+        from src.components.gguf.quantized_ops import QuantizedGGUFLinear
+        from src.loader.gguf.quant_types import GGUF_DENSE_TYPE_IDS
+        from src.loader.gguf.quantized_tensor import QuantizedGGUFTensor
+
+        tensor = self._tensor_ref(name)
+        blocks, type_name, row_elems = self._reader_for(tensor).read_quantized_matrix_blocks(tensor.name)
+        try:
+            type_id = GGUF_DENSE_TYPE_IDS[type_name]
+        except KeyError as exc:
+            raise NotImplementedError(
+                f"GLM shared expert weight {name} type {type_name!r} is not supported by the raw-block runtime"
+            ) from exc
+        cuda_blocks = blocks.to(device=self.device, non_blocking=False).contiguous()
+        quant = QuantizedGGUFTensor(
+            source_name=name,
+            blocks=cuda_blocks,
+            type_name=type_name,
+            type_id=int(type_id),
+            row_elems=int(row_elems),
+            out_dim=int(cuda_blocks.shape[0]),
+            row_start=0,
+        )
+        return QuantizedGGUFLinear(quant, out_dtype=self.dtype)
+
+    def _glm_routed_type_names(self, prefix: str) -> tuple[str, str, str]:
+        w1 = self._tensor_ref(f"{prefix}.ffn_gate_exps.weight").type_name
+        w3 = self._tensor_ref(f"{prefix}.ffn_up_exps.weight").type_name
+        w2 = self._tensor_ref(f"{prefix}.ffn_down_exps.weight").type_name
+        return w1, w3, w2
+
+    def _routed_grid_for(self, type_names: tuple[str, str, str]) -> torch.Tensor:
+        """Pick the signed grid for the routed dtypes, or an empty tensor.
+
+        GLM routed experts use iq2_xs (w1/w3) + iq3_xxs (w2), which share a
+        single packed codebook.  Non-grid dtypes get an empty grid.
+        """
+        from src.loader.gguf.tensor_reader import get_iq2xs_iq3xxs_signed_grid_tensor
+
+        if any(tn in ("iq2_xs", "iq3_xxs") for tn in type_names):
+            return get_iq2xs_iq3xxs_signed_grid_tensor()
+        return torch.empty(0, dtype=torch.int8)
+
+    def _routed_dtypes_raw_supported(self, type_names: tuple[str, str, str]) -> bool:
+        from src.loader.gguf.quant_types import GGUF_DENSE_TYPE_IDS
+
+        return all(tn in GGUF_DENSE_TYPE_IDS for tn in type_names)
+
+    def _routed_blocks_256_aligned(self, prefix: str) -> bool:
+        """Raw-block/CUDA grouped kernels require 256-element block alignment.
+
+        Tiny synthetic test bundles use non-aligned dims (e.g. in_dim=12); those
+        must fall back to the fp32 reference MoE instead of the raw-block path.
+        """
+        for suffix in ("ffn_gate_exps.weight", "ffn_up_exps.weight", "ffn_down_exps.weight"):
+            tensor = self._tensor_ref(f"{prefix}.{suffix}")
+            in_dim = int(tensor.dimensions[0])
+            if in_dim % 256 != 0:
+                return False
+        return True
+
+    def _build_moe_layer(self, prefix: str, layer_id: int):
+        routed_types = self._glm_routed_type_names(prefix)
+        use_raw = (
+            self.use_raw_block_moe
+            and self._routed_dtypes_raw_supported(routed_types)
+            and self._routed_blocks_256_aligned(prefix)
+        )
+        if use_raw:
+            gate = self._tensor_ref(f"{prefix}.ffn_gate_exps.weight")
+            return GLMDSARawBlockMoE(
+                self.args,
+                layer_id,
+                self._read_dense(f"{prefix}.ffn_gate_inp.weight"),
+                self._read_dense(f"{prefix}.exp_probs_b.bias"),
+                self._quant_linear(f"{prefix}.ffn_gate_shexp.weight"),
+                self._quant_linear(f"{prefix}.ffn_up_shexp.weight"),
+                self._quant_linear(f"{prefix}.ffn_down_shexp.weight"),
+                gguf_path=gate.shard_path,
+                w1_name=f"{prefix}.ffn_gate_exps.weight",
+                w3_name=f"{prefix}.ffn_up_exps.weight",
+                w2_name=f"{prefix}.ffn_down_exps.weight",
+                signed_grid=self._routed_grid_for(routed_types),
+                device=self.device,
+                dtype=self.dtype,
+                expert_start=self.expert_start,
+                expert_count=self.expert_count,
+            )
+        return GLMDSAMoE(
+            self.args,
+            layer_id,
+            self._read_dense(f"{prefix}.ffn_gate_inp.weight"),
+            self._read_dense(f"{prefix}.exp_probs_b.bias"),
+            self._linear(f"{prefix}.ffn_gate_shexp.weight"),
+            self._linear(f"{prefix}.ffn_up_shexp.weight"),
+            self._linear(f"{prefix}.ffn_down_shexp.weight"),
+            self._glm_moe_expert_loader(prefix),
+            device=self.device,
+            dtype=self.dtype,
+            expert_start=self.expert_start,
+            expert_count=self.expert_count,
+        )
+
     def load(self) -> GLMDSATransformer:
         if self.args.n_layers > self.args.leading_dense_layers and not self.allow_moe_layers:
             raise NotImplementedError(
@@ -140,7 +276,10 @@ class GLMDSAGGUFModelLoader:
                     dtype=self.dtype,
                 )
             else:
-                mlp = GLMDSAMoEPlaceholder(layer_id)
+                if self.allow_moe_layers:
+                    mlp = self._build_moe_layer(prefix, layer_id)
+                else:
+                    mlp = GLMDSAMoEPlaceholder(layer_id)
             layers.append(
                 GLMDSABlock(
                     self.args,
@@ -175,6 +314,8 @@ def load_glm_dsa_gguf_model(
     dtype: torch.dtype = torch.float16,
     n_layers: int | None = None,
     allow_moe_layers: bool = False,
+    expert_start: int = 0,
+    expert_count: int | None = None,
 ) -> tuple[GLMDSATransformer, dict[str, Any]]:
     start = time.perf_counter()
     loader = GLMDSAGGUFModelLoader(
@@ -183,6 +324,8 @@ def load_glm_dsa_gguf_model(
         dtype=dtype,
         n_layers=n_layers,
         allow_moe_layers=allow_moe_layers,
+        expert_start=expert_start,
+        expert_count=expert_count,
     )
     try:
         model = loader.load()
@@ -200,5 +343,7 @@ def load_glm_dsa_gguf_model(
         "device": str(model.device),
         "dtype": str(dtype),
         "allow_moe_layers": bool(allow_moe_layers),
+        "expert_start": int(loader.expert_start),
+        "expert_count": int(loader.expert_count),
     }
     return model, info

--- a/src/models/glm_dsa/spec.py
+++ b/src/models/glm_dsa/spec.py
@@ -273,14 +273,18 @@ class GLMDSASpec:
         from src.runtime.generation import GGUFTokenRuntime
         from src.models.glm_dsa.gguf_model import load_glm_dsa_gguf_model
 
-        _ = (world, rank, gpu_memory_gib)
+        _ = gpu_memory_gib
         leading_dense = self.leading_dense_layers(bundle)
         effective_layers = int(leading_dense if n_layers is None else n_layers)
-        if effective_layers > leading_dense:
-            raise NotImplementedError(
-                f"GLM-DSA reference generation currently supports dense-prefix only: "
-                f"n_layers={effective_layers}, leading_dense_layers={leading_dense}"
-            )
+        allow_moe_layers = effective_layers > leading_dense
+        expert_total = int(self.parse_params(bundle).n_routed_experts)
+        if allow_moe_layers:
+            expert_start = (expert_total * int(rank)) // int(world)
+            expert_end = (expert_total * (int(rank) + 1)) // int(world)
+            expert_count = expert_end - expert_start
+        else:
+            expert_start = 0
+            expert_count = 0
 
         t_load = time.perf_counter()
         model, _info = load_glm_dsa_gguf_model(
@@ -288,15 +292,17 @@ class GLMDSASpec:
             device=device,
             dtype=dtype,
             n_layers=effective_layers,
-            allow_moe_layers=False,
+            allow_moe_layers=allow_moe_layers,
+            expert_start=expert_start,
+            expert_count=expert_count,
         )
         load_seconds = time.perf_counter() - t_load
         eos = bundle.metadata.get("tokenizer.ggml.eos_token_id")
         eos_id = int(eos) if isinstance(eos, int) else None
         return GGUFTokenRuntime(
             model=model,
-            expert_start=0,
-            expert_count=0,
+            expert_start=int(expert_start),
+            expert_count=int(expert_count),
             eos_token_id=eos_id,
             load_seconds=float(load_seconds),
         )

--- a/src/models/minimax_m2/moe_runtime.py
+++ b/src/models/minimax_m2/moe_runtime.py
@@ -177,6 +177,10 @@ def _gguf_cuda_quant_grid(type_name: str, device: torch.device) -> torch.Tensor:
         from src.loader.gguf.tensor_reader import get_iq2xxs_signed_grid_tensor
 
         return get_iq2xxs_signed_grid_tensor().to(device=device, non_blocking=False).contiguous()
+    if type_name in {"iq2_xs", "iq3_xxs"}:
+        from src.loader.gguf.tensor_reader import get_iq2xs_iq3xxs_signed_grid_tensor
+
+        return get_iq2xs_iq3xxs_signed_grid_tensor().to(device=device, non_blocking=False).contiguous()
     if type_name == "iq1_m":
         from src.loader.gguf.tensor_reader import get_iq1_grid_tensor
 

--- a/tests/test_glm_dsa_quant_cuda.py
+++ b/tests/test_glm_dsa_quant_cuda.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from src.kernels.cuda_loader import load_cuda_kernel
+from src.loader.gguf.bundle import read_gguf_bundle
+from src.loader.gguf.tensor_reader import (
+    GGUFTensorDataReader,
+    get_iq2xs_iq3xxs_signed_grid_tensor,
+)
+
+
+REAL_GLM_PATH = Path("/mnt/data3/GLM-5.2-GGUF/UD-Q2_K_XL")
+
+# Representative tensors per GLM GGUF dtype (read-only /mnt/data3).
+IQ2_XS_ROUTED = "blk.3.ffn_gate_exps.weight"   # type_id 5
+IQ3_XXS_ROUTED = "blk.3.ffn_down_exps.weight"  # type_id 6
+Q6_K_DENSE = "blk.0.ffn_down.weight"           # type_id 8
+
+
+def _cuda_gemm_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    mod = load_cuda_kernel()
+    return mod is not None and hasattr(mod, "gguf_quant_gemm_forward")
+
+
+def _merged_grid_cuda() -> torch.Tensor:
+    return get_iq2xs_iq3xxs_signed_grid_tensor().to(device="cuda", dtype=torch.int8).contiguous()
+
+
+def _empty_grid_cuda() -> torch.Tensor:
+    return torch.empty((0,), device="cuda", dtype=torch.int8)
+
+
+@pytest.mark.skipif(
+    not (REAL_GLM_PATH.exists() and _cuda_gemm_available()),
+    reason="real GLM GGUF or CUDA extension not available",
+)
+@pytest.mark.parametrize(
+    ("name", "type_id", "type_name", "routed"),
+    [
+        (IQ2_XS_ROUTED, 5, "iq2_xs", True),
+        (IQ3_XXS_ROUTED, 6, "iq3_xxs", True),
+        (Q6_K_DENSE, 8, "q6_k", False),
+    ],
+)
+def test_glm_quant_gemm_matches_reference(name: str, type_id: int, type_name: str, routed: bool) -> None:
+    bundle = read_gguf_bundle(REAL_GLM_PATH)
+    tensor = bundle.tensors_by_name[name]
+    reader = GGUFTensorDataReader(tensor.shard_path)
+    rows = 16
+    try:
+        if routed:
+            blocks, tn, in_dim = reader.read_routed_expert_blocks(tensor.name, 0, 0, rows)
+            ref = reader.read_routed_expert(tensor.name, 0, 0, rows).float()
+        else:
+            blocks, tn, in_dim = reader.read_quantized_matrix_block_rows(tensor.name, 0, rows)
+            ref = reader.read_quantized_matrix_rows_reference(tensor.name, 0, rows).float()
+    finally:
+        reader.close()
+
+    assert tn == type_name
+    assert ref.shape == (rows, in_dim)
+
+    mod = load_cuda_kernel()
+    grid = _merged_grid_cuda() if type_id in (5, 6) else _empty_grid_cuda()
+    blocks_cuda = blocks.cuda()
+    ref_cuda = ref.cuda()
+
+    x = torch.randn((5, in_dim), device="cuda", dtype=torch.float16)
+    expected = x.float() @ ref_cuda.t()
+
+    y = mod.gguf_quant_gemm_forward(x, blocks_cuda, in_dim, type_id, grid).float()
+    yp = mod.gguf_quant_gemm_prefill_forward(x, blocks_cuda, in_dim, type_id, grid).float()
+
+    assert bool(torch.isfinite(y).all().item())
+    assert bool(torch.isfinite(yp).all().item())
+
+    scale = expected.abs().max().clamp_min(1.0e-3)
+    rel_decode = (y - expected).abs().max() / scale
+    rel_prefill = (yp - expected).abs().max() / scale
+    assert float(rel_decode.item()) < 2.0e-2, f"{type_name} decode rel err {rel_decode.item()}"
+    assert float(rel_prefill.item()) < 2.0e-2, f"{type_name} prefill rel err {rel_prefill.item()}"

--- a/tests/test_glm_dsa_spec.py
+++ b/tests/test_glm_dsa_spec.py
@@ -75,7 +75,8 @@ def test_glm_dsa_capability_is_inventory_supported_but_generation_deferred(tmp_p
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for GLM-DSA reference runtime smoke")
-def test_glm_dsa_dense_prefix_reference_runtime_forward(tmp_path: Path) -> None:
+@pytest.mark.parametrize("n_layers", [1, 2])
+def test_glm_dsa_reference_runtime_forward(tmp_path: Path, n_layers: int) -> None:
     root = write_glm_dsa_bundle(tmp_path / "bundle", n_layers=4, leading_dense=1)
     bundle = read_gguf_bundle(root)
     spec = GLMDSASpec()
@@ -85,7 +86,7 @@ def test_glm_dsa_dense_prefix_reference_runtime_forward(tmp_path: Path) -> None:
         rank=0,
         device=torch.device("cuda", 0),
         dtype=torch.float16,
-        n_layers=1,
+        n_layers=n_layers,
         gpu_memory_gib=22.0,
     )
 


### PR DESCRIPTION
## Summary

Implements GLM-5.2 (glm-dsa) full-model MoE inference over **raw GGUF quantized blocks**, replacing the fp32-dequant reference path as the default routed-expert runtime. Weights are consumed in their native GGUF dtype; no fp32 weight expansion on the hot path.

## What changed

**Fixed CUDA/reference numerical bugs (new GLM dtypes)**
- `iq3_xxs`: added missing `+0.5` scale offset in reference decode and CUDA block-dot (matching llama.cpp).
- `q6_k`: rewrote reference decode and CUDA block-dot to the ggml `dequantize_row_q6_K` two-128-half layout (`sc[is+0/2/4/6]`, `is=l//16`). CUDA now uses all 32 lanes for the warp reduce.

**New raw-block runtime**
- `GLMDSARawBlockMoE`: GLM sigmoid router → `moe_group_routes` → per-active-expert `read_routed_expert_blocks` → stacked compact blocks + compact `seg_starts` → `gguf_moe_prefill_grouped_forward`. Preserves TP `all_reduce` and shared-expert add.
- Shared experts run through `QuantizedGGUFLinear` (q5_k gate/up, q6_k down) — no fp32 expansion.
- Loader defaults to `use_raw_block_moe=True`; tiny non-256-aligned bundles auto-fall back to fp32 reference.
- `spec.build_token_runtime` wires rank-local expert sharding + enables MoE layers.

## Testing (deepseek env, read-only /mnt/data3 GLM-5.2 UD-Q2_K_XL)
- New tests/test_glm_dsa_quant_cuda.py: iq2_xs/iq3_xxs/q6_k CUDA vs reference parity — all pass.
- Real GLM-5.2 end-to-end smoke: takes GLMDSARawBlockMoE path, logits (1,1,154880), finite, next token produced.
- Full GLM suite (10) pass; MiniMax + q4/q5 regression (15) pass — no regression.
- No cudaHostRegister introduced (respects mmap-pin ban).

## Not in this PR
- TP4 multi-GPU smoke (next step).
- Decode-specialized GLM kernels / perf tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)