### PR TITLE
Load GLM-DSA dense/embedding/lm_head as raw GGUF blocks

### DIFF
--- a/src/components/gguf/quantized_ops.py
+++ b/src/components/gguf/quantized_ops.py
@@ -25,6 +25,10 @@ class QuantizedGGUFLinear:
     def out_dim(self) -> int:
         return int(self.tensor.out_dim)
 
+    @property
+    def row_start(self) -> int:
+        return int(self.tensor.row_start)
+
     def __call__(self, x: torch.Tensor) -> torch.Tensor:
         if x.size(-1) != self.in_dim:
             raise ValueError(f"{self.tensor.source_name}: expected input dim {self.in_dim}, got {x.size(-1)}")

--- a/src/models/glm_dsa/gguf_model.py
+++ b/src/models/glm_dsa/gguf_model.py
@@ -125,35 +125,54 @@ class GLMDSAGGUFModelLoader:
 
         return load_expert
 
-    def _quant_linear(self, name: str):
-        """Build a raw-block CUDA linear over a 2D quantized GGUF tensor.
+    def _quant_tensor(self, name: str, *, row_start: int = 0, row_count: int | None = None):
+        """Read a 2D quantized GGUF tensor into device-resident raw blocks.
 
-        Used for GLM shared experts (q5_k gate/up, q6_k down) so the shared
-        path also avoids fp32 weight expansion.
+        Avoids fp32 weight expansion for dense/attention/shared weights.  When
+        ``row_count`` is given, only that output-row slice is read (TP sharding
+        of vocab/lm_head).
         """
-        from src.components.gguf.quantized_ops import QuantizedGGUFLinear
         from src.loader.gguf.quant_types import GGUF_DENSE_TYPE_IDS
         from src.loader.gguf.quantized_tensor import QuantizedGGUFTensor
 
         tensor = self._tensor_ref(name)
-        blocks, type_name, row_elems = self._reader_for(tensor).read_quantized_matrix_blocks(tensor.name)
+        reader = self._reader_for(tensor)
+        if row_count is None:
+            blocks, type_name, row_elems = reader.read_quantized_matrix_blocks(tensor.name)
+        else:
+            blocks, type_name, row_elems = reader.read_quantized_matrix_block_rows(
+                tensor.name, int(row_start), int(row_count)
+            )
         try:
             type_id = GGUF_DENSE_TYPE_IDS[type_name]
         except KeyError as exc:
             raise NotImplementedError(
-                f"GLM shared expert weight {name} type {type_name!r} is not supported by the raw-block runtime"
+                f"GLM weight {name} type {type_name!r} is not supported by the raw-block runtime"
             ) from exc
         cuda_blocks = blocks.to(device=self.device, non_blocking=False).contiguous()
-        quant = QuantizedGGUFTensor(
+        return QuantizedGGUFTensor(
             source_name=name,
             blocks=cuda_blocks,
             type_name=type_name,
             type_id=int(type_id),
             row_elems=int(row_elems),
             out_dim=int(cuda_blocks.shape[0]),
-            row_start=0,
+            row_start=int(row_start),
         )
+
+    def _quant_linear(self, name: str, *, row_start: int = 0, row_count: int | None = None):
+        """Build a raw-block CUDA linear over a 2D quantized GGUF tensor."""
+        from src.components.gguf.quantized_ops import QuantizedGGUFLinear
+
+        quant = self._quant_tensor(name, row_start=row_start, row_count=row_count)
         return QuantizedGGUFLinear(quant, out_dtype=self.dtype)
+
+    def _quant_embedding(self, name: str):
+        """Build a raw-block CUDA embedding over a 2D quantized GGUF tensor."""
+        from src.components.gguf.quantized_ops import QuantizedGGUFEmbedding
+
+        quant = self._quant_tensor(name)
+        return QuantizedGGUFEmbedding(quant, out_dtype=self.dtype)
 
     def _glm_routed_type_names(self, prefix: str) -> tuple[str, str, str]:
         w1 = self._tensor_ref(f"{prefix}.ffn_gate_exps.weight").type_name
@@ -240,8 +259,8 @@ class GLMDSAGGUFModelLoader:
                 f"requested n_layers={self.args.n_layers}, leading_dense_layers={self.args.leading_dense_layers}"
             )
 
-        embedding = self._embedding("token_embd.weight")
-        lm_head = self._linear("output.weight")
+        embedding = self._quant_embedding("token_embd.weight")
+        lm_head = self._quant_linear("output.weight")
         final_norm = self._read_dense("output_norm.weight")
 
         layers: list[GLMDSABlock] = []
@@ -251,7 +270,7 @@ class GLMDSAGGUFModelLoader:
             attention = GLMDSAAttention(
                 self.args,
                 layer_id,
-                self._linear(f"{prefix}.attn_q_a.weight"),
+                self._quant_linear(f"{prefix}.attn_q_a.weight"),
                 self._read_dense(f"{prefix}.attn_q_a_norm.weight"),
                 self._linear(f"{prefix}.attn_q_b.weight"),
                 self._linear(f"{prefix}.attn_kv_a_mqa.weight"),
@@ -264,15 +283,15 @@ class GLMDSAGGUFModelLoader:
                     f"{prefix}.attn_v_b.weight",
                     expected_shape=(self.args.value_dim, self.args.value_mla_dim, self.args.n_heads),
                 ),
-                self._linear(f"{prefix}.attn_output.weight"),
+                self._quant_linear(f"{prefix}.attn_output.weight"),
                 device=self.device,
                 dtype=self.dtype,
             )
             if layer_id < self.args.leading_dense_layers:
                 mlp = GLMDSADenseMLP(
-                    self._linear(f"{prefix}.ffn_gate.weight"),
-                    self._linear(f"{prefix}.ffn_up.weight"),
-                    self._linear(f"{prefix}.ffn_down.weight"),
+                    self._quant_linear(f"{prefix}.ffn_gate.weight"),
+                    self._quant_linear(f"{prefix}.ffn_up.weight"),
+                    self._quant_linear(f"{prefix}.ffn_down.weight"),
                     dtype=self.dtype,
                 )
             else:


### PR DESCRIPTION
## Summary

Switches the GLM-DSA GGUF runtime's non-MoE weights from fp32 dequantization to device-resident raw quantized blocks, eliminating the fp32 weight-expansion that dominated model load time.

Weights moved to raw blocks (`QuantizedGGUFEmbedding` / `QuantizedGGUFLinear`):
- `token_embd.weight` (q5_k) — embedding
- `output.weight` (q4_k) — lm_head
- `attn_q_a.weight`, `attn_output.weight` (q5_k)
- dense-prefix FFN `ffn_gate`/`ffn_up` (q5_k), `ffn_down` (q6_k)

Left on the existing path (q8_0, handled separately): `attn_q_b`, `attn_kv_a_mqa`, `attn_k_b`, `attn_v_b`.

Also adds `QuantizedGGUFLinear.row_start` so it can stand in for the reference lm_head in the TP logits gather/argmax path.

## Results (real GLM-5.2 UD-Q2_K_XL, 4-layer smoke)

- Load time: **~88s → ~5.3s**
- Correctness: next-token argmax and top-5 **identical** to the fp32 reference path; `rel_max_diff = 2.8e-3`

## Testing

- `tests/test_glm_dsa_spec.py` (7 passed) — tiny-bundle raw-block + fp32 fallback
- `tests/test_glm_dsa_quant_cuda.py` — iq2_xs/iq3_xxs/q6_k GEMM parity
- Regression: 10 GLM/MiniMax CUDA tests pass; no new whole-GGUF `cudaHostRegister` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)