### PR TITLE
Load GLM-DSA q8_0 attention projections as raw GGUF blocks

### DIFF
--- a/src/components/gguf/quantized_ops.py
+++ b/src/components/gguf/quantized_ops.py
@@ -75,6 +75,54 @@ class QuantizedGGUFLinear:
         return y0.to(first.out_dtype), y1.to(second.out_dtype)
 
 
+class Q8_0GGUFLinear:
+    """CUDA linear over raw GGUF q8_0 matrix blocks.
+
+    q8_0 uses a dedicated kernel (``q8_0_gemm_forward``) rather than the
+    grid/type-id block-dot path, so it keeps its own thin wrapper.  Blocks are
+    ``[out_dim, blocks_per_row, 34]`` uint8; ``row_start`` is non-zero only for
+    row-sliced (TP-sharded) weights.
+    """
+
+    def __init__(
+        self,
+        blocks: torch.Tensor,
+        row_elems: int,
+        *,
+        source_name: str = "",
+        out_dtype: torch.dtype = torch.float16,
+        row_start: int = 0,
+    ):
+        if blocks.dim() != 3 or blocks.size(-1) != 34:
+            raise ValueError(f"q8_0 blocks must be [N, K_blocks, 34], got {tuple(blocks.shape)}")
+        self.blocks = blocks.contiguous()
+        self.row_elems = int(row_elems)
+        self.source_name = source_name
+        self.out_dtype = out_dtype
+        self._row_start = int(row_start)
+        self._cuda = load_cuda_kernel()
+        if self._cuda is None or not hasattr(self._cuda, "q8_0_gemm_forward"):
+            raise RuntimeError("q8_0 CUDA extension is required for Q8_0GGUFLinear")
+
+    @property
+    def in_dim(self) -> int:
+        return int(self.row_elems)
+
+    @property
+    def out_dim(self) -> int:
+        return int(self.blocks.size(0))
+
+    @property
+    def row_start(self) -> int:
+        return int(self._row_start)
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        if x.size(-1) != self.in_dim:
+            raise ValueError(f"{self.source_name}: expected input dim {self.in_dim}, got {x.size(-1)}")
+        y = self._cuda.q8_0_gemm_forward(x.contiguous(), self.blocks, int(self.row_elems))
+        return y.to(self.out_dtype)
+
+
 class QuantizedGGUFEmbedding:
     """CUDA selected-row embedding over raw GGUF quantized matrix blocks."""
 

--- a/src/models/glm_dsa/gguf_model.py
+++ b/src/models/glm_dsa/gguf_model.py
@@ -174,6 +174,27 @@ class GLMDSAGGUFModelLoader:
         quant = self._quant_tensor(name)
         return QuantizedGGUFEmbedding(quant, out_dtype=self.dtype)
 
+    def _quant_linear_q8_0(self, name: str):
+        """Build a raw-block CUDA linear over a 2D q8_0 GGUF tensor.
+
+        q8_0 uses its own ``q8_0_gemm_forward`` kernel, not the grid/type-id
+        block-dot path, so it reads raw 34-byte blocks and skips the dense
+        type-id map.
+        """
+        from src.components.gguf.quantized_ops import Q8_0GGUFLinear
+
+        tensor = self._tensor_ref(name)
+        reader = self._reader_for(tensor)
+        blocks = reader.read_q8_0_blocks(tensor.name)
+        row_elems = int(tensor.dimensions[0])
+        cuda_blocks = blocks.to(device=self.device, non_blocking=False).contiguous()
+        return Q8_0GGUFLinear(
+            cuda_blocks,
+            row_elems,
+            source_name=name,
+            out_dtype=self.dtype,
+        )
+
     def _glm_routed_type_names(self, prefix: str) -> tuple[str, str, str]:
         w1 = self._tensor_ref(f"{prefix}.ffn_gate_exps.weight").type_name
         w3 = self._tensor_ref(f"{prefix}.ffn_up_exps.weight").type_name
@@ -272,8 +293,8 @@ class GLMDSAGGUFModelLoader:
                 layer_id,
                 self._quant_linear(f"{prefix}.attn_q_a.weight"),
                 self._read_dense(f"{prefix}.attn_q_a_norm.weight"),
-                self._linear(f"{prefix}.attn_q_b.weight"),
-                self._linear(f"{prefix}.attn_kv_a_mqa.weight"),
+                self._quant_linear_q8_0(f"{prefix}.attn_q_b.weight"),
+                self._quant_linear_q8_0(f"{prefix}.attn_kv_a_mqa.weight"),
                 self._read_dense(f"{prefix}.attn_kv_a_norm.weight"),
                 self._read_q8_0_3d(
                     f"{prefix}.attn_k_b.weight",

--- a/tests/test_glm_dsa_quant_cuda.py
+++ b/tests/test_glm_dsa_quant_cuda.py
@@ -19,6 +19,7 @@ REAL_GLM_PATH = Path("/mnt/data3/GLM-5.2-GGUF/UD-Q2_K_XL")
 IQ2_XS_ROUTED = "blk.3.ffn_gate_exps.weight"   # type_id 5
 IQ3_XXS_ROUTED = "blk.3.ffn_down_exps.weight"  # type_id 6
 Q6_K_DENSE = "blk.0.ffn_down.weight"           # type_id 8
+Q8_0_ATTN = "blk.0.attn_q_b.weight"            # q8_0 attention projection
 
 
 def _cuda_gemm_available() -> bool:
@@ -85,3 +86,48 @@ def test_glm_quant_gemm_matches_reference(name: str, type_id: int, type_name: st
     rel_prefill = (yp - expected).abs().max() / scale
     assert float(rel_decode.item()) < 2.0e-2, f"{type_name} decode rel err {rel_decode.item()}"
     assert float(rel_prefill.item()) < 2.0e-2, f"{type_name} prefill rel err {rel_prefill.item()}"
+
+
+@pytest.mark.skipif(
+    not (REAL_GLM_PATH.exists() and _cuda_gemm_available()),
+    reason="real GLM GGUF or CUDA extension not available",
+)
+def test_glm_q8_0_gemm_matches_reference() -> None:
+    """q8_0 uses its own kernel (q8_0_gemm_forward), not the grid/type-id path."""
+    from src.kernels.ops import q8_0_weight_dequantize
+
+    bundle = read_gguf_bundle(REAL_GLM_PATH)
+    tensor = bundle.tensors_by_name[Q8_0_ATTN]
+    reader = GGUFTensorDataReader(tensor.shard_path)
+    rows = 16
+    try:
+        blocks = reader.read_q8_0_block_rows(tensor.name, 0, rows)
+        row_elems = int(tensor.dimensions[0])
+        ref = q8_0_weight_dequantize(blocks, row_elems=row_elems).float()
+    finally:
+        reader.close()
+
+    assert blocks.shape == (rows, row_elems // 32, 34)
+    assert ref.shape == (rows, row_elems)
+
+    mod = load_cuda_kernel()
+    blocks_cuda = blocks.cuda()
+    ref_cuda = ref.cuda()
+
+    x = torch.randn((5, row_elems), device="cuda", dtype=torch.float16)
+    expected = x.float() @ ref_cuda.t()
+    y = mod.q8_0_gemm_forward(x, blocks_cuda, row_elems).float()
+
+    x1 = torch.randn((1, row_elems), device="cuda", dtype=torch.float16)
+    expected1 = x1.float() @ ref_cuda.t()
+    y1 = mod.q8_0_gemm_forward(x1, blocks_cuda, row_elems).float()
+
+    assert bool(torch.isfinite(y).all().item())
+    assert bool(torch.isfinite(y1).all().item())
+
+    scale = expected.abs().max().clamp_min(1.0e-3)
+    rel_prefill = (y - expected).abs().max() / scale
+    scale1 = expected1.abs().max().clamp_min(1.0e-3)
+    rel_decode = (y1 - expected1).abs().max() / scale1
+    assert float(rel_prefill.item()) < 2.0e-2, f"q8_0 prefill rel err {rel_prefill.item()}"
+    assert float(rel_decode.item()) < 2.0e-2, f"q8_0 decode rel err {rel_decode.item()}"


### PR DESCRIPTION
## Summary
Switch GLM-DSA GGUF attention q8_0 projections (attn_q_b, attn_kv_a_mqa) from fp32 dequant to raw-block CUDA GEMM, eliminating the remaining fp32 weight-expansion load cost for non-MoE weights.

- New `Q8_0GGUFLinear` consumes raw `[N, K_blocks, 34]` uint8 blocks via the dedicated `q8_0_gemm_forward` kernel (no grid/type_id path).
- Wired `attn_q_b` / `attn_kv_a_mqa` (both q8_0) to the raw-block linear.
- Added q8_0 CUDA parity test covering prefill/decode.

## Validation (real GLM-5.2 UD-Q2_K_XL, 4-layer smoke, deepseek env)
- Load time: ~83s -> ~19s (4.5x).
- next-token argmax and top-5 identical to fp32 reference; rel_max_diff 3.1e-3.
- q8_0 CUDA parity: prefill rel 2.0e-3, decode rel 3.1e-3.
- Regression: 11 GLM + 3 MiniMax q4/q5 CUDA tests pass; no new whole-GGUF pinning.