### PR TITLE
Fix GLM-DSA iq4_xs reference decode (scales_h shape + block q layout)

### DIFF
--- a/src/loader/gguf/tensor_reader.py
+++ b/src/loader/gguf/tensor_reader.py
@@ -919,7 +919,7 @@ class GGUFTensorDataReader:
             t_read = time.perf_counter()
         blocks = np.frombuffer(data, dtype=np.uint8).reshape(rows, blocks_per_row, 136)
         d = _f16_bytes_to_f32(blocks[:, :, 0:2])
-        scales_h = blocks[:, :, 2:4].view("<u2")
+        scales_h = blocks[:, :, 2:4].view("<u2").reshape(rows, blocks_per_row)
         scales_l = blocks[:, :, 4:8]
         qs = blocks[:, :, 8:136]
         kvalues = np.array([-127, -104, -83, -65, -49, -35, -22, -10, 1, 13, 25, 38, 53, 69, 89, 113], dtype=np.float32)
@@ -932,8 +932,10 @@ class GGUFTensorDataReader:
             lo = kvalues[q & 0x0F]
             hi = kvalues[q >> 4]
             values = np.empty((rows, blocks_per_row, 32), dtype=np.float32)
-            values[:, :, 0::2] = lo
-            values[:, :, 1::2] = hi
+            # ggml iq4_xs packs each 16-byte group as 16 low nibbles then 16 high
+            # nibbles (block layout), not interleaved.
+            values[:, :, 0:16] = lo
+            values[:, :, 16:32] = hi
             out[:, :, group * 32:(group + 1) * 32] = d[:, :, None] * scale[:, :, None] * values
         if profile:
             t_done = time.perf_counter()

--- a/tests/test_glm_dsa_quant_cuda.py
+++ b/tests/test_glm_dsa_quant_cuda.py
@@ -20,6 +20,7 @@ IQ2_XS_ROUTED = "blk.3.ffn_gate_exps.weight"   # type_id 5
 IQ3_XXS_ROUTED = "blk.3.ffn_down_exps.weight"  # type_id 6
 Q6_K_DENSE = "blk.0.ffn_down.weight"           # type_id 8
 Q8_0_ATTN = "blk.0.attn_q_b.weight"            # q8_0 attention projection
+IQ4_XS_ROUTED = "blk.8.ffn_down_exps.weight"   # type_id 7, iq4_xs (4 layers only)
 
 
 def _cuda_gemm_available() -> bool:
@@ -131,3 +132,24 @@ def test_glm_q8_0_gemm_matches_reference() -> None:
     rel_decode = (y1 - expected1).abs().max() / scale1
     assert float(rel_prefill.item()) < 2.0e-2, f"q8_0 prefill rel err {rel_prefill.item()}"
     assert float(rel_decode.item()) < 2.0e-2, f"q8_0 decode rel err {rel_decode.item()}"
+
+
+@pytest.mark.skipif(
+    not REAL_GLM_PATH.exists(),
+    reason="real GLM GGUF not available",
+)
+def test_glm_iq4_xs_reference_decode() -> None:
+    """iq4_xs reference decode must produce finite values (correctness fix for blk.8/75/76/77)."""
+    bundle = read_gguf_bundle(REAL_GLM_PATH)
+    tensor = bundle.tensors_by_name[IQ4_XS_ROUTED]
+    reader = GGUFTensorDataReader(tensor.shard_path)
+    rows = 8
+    try:
+        ref = reader.read_routed_expert(tensor.name, 0, 0, rows).float()
+    finally:
+        reader.close()
+
+    assert ref.shape[0] == rows
+    assert bool(torch.isfinite(ref).all().item()), "iq4_xs reference decode produced NaN/Inf"
+    absmax = ref.abs().max().item()
+    assert absmax > 0.0 and absmax < 1.0, f"iq4_xs decode absmax {absmax} out of expected range"


### PR DESCRIPTION
Two bugs in `_read_iq4_xs_rows` broke fp32 fallback decode for 4 layers (blk.8/75/76/77.ffn_down_exps.weight = iq4_xs):

1. **scales_h shape**: `view('<u2')` left trailing dim `(rows, blocks, 1)`, causing broadcast error during scale extraction. Fix: reshape to `(rows, blocks)`.

2. **q layout**: code assumed interleaved nibbles `(lo[0],hi[0],lo[1],hi[1],...)`. ggml iq4_xs uses block layout: 16 low nibbles then 16 high nibbles per 16-byte group, matching llama.cpp `vec_dot_iq4_xs_q8_1`. Fix: `values[:,:,0:16]=lo; values[:,:,16:32]=hi`.

Verified against llama.cpp `block_iq4_xs` structure and 79-layer TP4 forward (next token parity across all ranks).

**Test**: `test_glm_iq4_xs_reference_decode` validates finite decode output.

**Impact**: Enables full 79-layer GLM-5.2 Q2_K_XL TP4 inference (load 33s, ~20GB/rank peak, within 22GB budget). Forward currently ~561s due to mmap streaming IO, but correctness verified.