### PR TITLE
Shard GLM-DSA lm_head across TP ranks by vocab rows

### DIFF
--- a/src/models/glm_dsa/gguf_model.py
+++ b/src/models/glm_dsa/gguf_model.py
@@ -42,6 +42,8 @@ class GLMDSAGGUFModelLoader:
         expert_start: int = 0,
         expert_count: int | None = None,
         use_raw_block_moe: bool = True,
+        world: int = 1,
+        rank: int = 0,
     ):
         self.bundle = read_gguf_bundle(bundle_or_path) if not isinstance(bundle_or_path, GGUFBundle) else bundle_or_path
         resolved = torch.device(device)
@@ -54,6 +56,8 @@ class GLMDSAGGUFModelLoader:
         self.args = GLMDSAArgs.from_bundle(self.bundle, n_layers=n_layers)
         self.allow_moe_layers = bool(allow_moe_layers)
         self.use_raw_block_moe = bool(use_raw_block_moe)
+        self.world = max(1, int(world))
+        self.rank = max(0, int(rank))
         self.expert_start = int(expert_start)
         available = max(0, int(self.args.n_routed_experts) - self.expert_start)
         self.expert_count = available if expert_count is None else int(expert_count)
@@ -174,6 +178,23 @@ class GLMDSAGGUFModelLoader:
         quant = self._quant_tensor(name)
         return QuantizedGGUFEmbedding(quant, out_dtype=self.dtype)
 
+    def _quant_lm_head(self, name: str):
+        """Build a raw-block CUDA lm_head, vocab-row-sharded across TP ranks.
+
+        When ``world > 1`` each rank loads only its ``[row_start, row_start +
+        row_count)`` slice of the vocab rows.  The transformer forward combines
+        the per-rank logit slices via ``distributed_argmax_local_logits`` (decode)
+        or ``gather_sharded_logits`` (return-logits), using ``lm_head.row_start``.
+        Embedding stays replicated.
+        """
+        if self.world <= 1:
+            return self._quant_linear(name)
+        from src.components.gguf.tp_logits import tp_vocab_row_range
+
+        total_rows = int(self._tensor_ref(name).dimensions[1])
+        row_start, row_count = tp_vocab_row_range(total_rows, self.world, self.rank)
+        return self._quant_linear(name, row_start=row_start, row_count=row_count)
+
     def _quant_linear_q8_0(self, name: str):
         """Build a raw-block CUDA linear over a 2D q8_0 GGUF tensor.
 
@@ -281,7 +302,7 @@ class GLMDSAGGUFModelLoader:
             )
 
         embedding = self._quant_embedding("token_embd.weight")
-        lm_head = self._quant_linear("output.weight")
+        lm_head = self._quant_lm_head("output.weight")
         final_norm = self._read_dense("output_norm.weight")
 
         layers: list[GLMDSABlock] = []
@@ -356,6 +377,8 @@ def load_glm_dsa_gguf_model(
     allow_moe_layers: bool = False,
     expert_start: int = 0,
     expert_count: int | None = None,
+    world: int = 1,
+    rank: int = 0,
 ) -> tuple[GLMDSATransformer, dict[str, Any]]:
     start = time.perf_counter()
     loader = GLMDSAGGUFModelLoader(
@@ -366,6 +389,8 @@ def load_glm_dsa_gguf_model(
         allow_moe_layers=allow_moe_layers,
         expert_start=expert_start,
         expert_count=expert_count,
+        world=world,
+        rank=rank,
     )
     try:
         model = loader.load()
@@ -385,5 +410,9 @@ def load_glm_dsa_gguf_model(
         "allow_moe_layers": bool(allow_moe_layers),
         "expert_start": int(loader.expert_start),
         "expert_count": int(loader.expert_count),
+        "world": int(loader.world),
+        "rank": int(loader.rank),
+        "lm_head_out_dim": int(model.lm_head.out_dim),
+        "lm_head_row_start": int(model.lm_head.row_start),
     }
     return model, info

--- a/src/models/glm_dsa/spec.py
+++ b/src/models/glm_dsa/spec.py
@@ -295,6 +295,8 @@ class GLMDSASpec:
             allow_moe_layers=allow_moe_layers,
             expert_start=expert_start,
             expert_count=expert_count,
+            world=int(world),
+            rank=int(rank),
         )
         load_seconds = time.perf_counter() - t_load
         eos = bundle.metadata.get("tokenizer.ggml.eos_token_id")

--- a/tests/test_glm_dsa_quant_cuda.py
+++ b/tests/test_glm_dsa_quant_cuda.py
@@ -153,3 +153,57 @@ def test_glm_iq4_xs_reference_decode() -> None:
     assert bool(torch.isfinite(ref).all().item()), "iq4_xs reference decode produced NaN/Inf"
     absmax = ref.abs().max().item()
     assert absmax > 0.0 and absmax < 1.0, f"iq4_xs decode absmax {absmax} out of expected range"
+
+
+@pytest.mark.skipif(
+    not (REAL_GLM_PATH.exists() and _cuda_gemm_available()),
+    reason="real GLM GGUF or CUDA extension not available",
+)
+def test_glm_lm_head_vocab_sharding() -> None:
+    """lm_head vocab sharding: each rank loads a disjoint vocab row slice that
+    tiles the full vocab, and every rank's local logits match the full lm_head's
+    corresponding slice."""
+    from src.models.glm_dsa.gguf_model import GLMDSAGGUFModelLoader
+
+    bundle = read_gguf_bundle(REAL_GLM_PATH)
+    world = 4
+    total_rows = int(bundle.tensors_by_name["output.weight"].dimensions[1])
+
+    # Full (unsharded) reference lm_head.
+    full_loader = GLMDSAGGUFModelLoader(bundle, world=1, rank=0)
+    try:
+        full_head = full_loader._quant_lm_head("output.weight")
+    finally:
+        full_loader.close()
+    assert full_head.row_start == 0
+    assert full_head.out_dim == total_rows
+
+    dim = int(full_head.in_dim)
+    x = torch.randn((3, dim), device="cuda", dtype=torch.float16)
+    full_logits = full_head(x).float()
+    assert full_logits.shape == (3, total_rows)
+
+    covered = 0
+    prev_end = 0
+    for rank in range(world):
+        loader = GLMDSAGGUFModelLoader(bundle, world=world, rank=rank)
+        try:
+            head = loader._quant_lm_head("output.weight")
+        finally:
+            loader.close()
+        start = head.row_start
+        count = head.out_dim
+        # Slices tile the vocab contiguously with no gaps/overlap.
+        assert start == prev_end, f"rank {rank} start {start} != prev_end {prev_end}"
+        prev_end = start + count
+        covered += count
+
+        local = head(x).float()
+        assert local.shape == (3, count)
+        ref_slice = full_logits[:, start:start + count]
+        scale = ref_slice.abs().max().clamp_min(1.0e-3)
+        rel = (local - ref_slice).abs().max() / scale
+        assert float(rel.item()) < 1.0e-3, f"rank {rank} logit slice rel err {rel.item()}"
+
+    assert prev_end == total_rows
+    assert covered == total_rows


### PR DESCRIPTION
Load `output.weight` as a per-rank vocab row-slice when `world > 1`, mirroring the minimax_m2 pattern. Each rank keeps only `vocab/world` rows of lm_head (154880 → 38720 at TP4), reducing resident lm_head memory ~4× per rank.

## Changes
- `GLMDSAGGUFModelLoader` gains `world`/`rank` params; new `_quant_lm_head` computes the vocab row range via `tp_vocab_row_range` and loads only that slice.
- `load_glm_dsa_gguf_model` + `build_token_runtime` thread `world`/`rank` through; `info` dict reports `lm_head_out_dim`/`lm_head_row_start`.
- Embedding stays replicated (vocab-parallel on lm_head only).

The downstream combine was already wired: `distributed_argmax_local_logits` (decode) and `gather_sharded_logits` (return-logits) use `lm_head.row_start`, and short-circuit correctly when unsharded.

## Verification
- New `test_glm_lm_head_vocab_sharding`: per-rank slices tile the full vocab; each rank's local logits match the full lm_head's slice (rel err < 1e-3).
- Real bundle TP4 vs TP1 parity: sharded next-token (9938) == full-replicate reference; local-combine argmax == full-gather argmax across all 4 ranks.
- Full GLM quant CUDA suite: 6 passed.