### PR TITLE
Add GLM-DSA iq4_xs raw-block CUDA kernel + q8_0 shared expert dispatch

### DIFF
--- a/src/components/moe/capability.py
+++ b/src/components/moe/capability.py
@@ -25,7 +25,7 @@ _CAPABILITIES = {
     "iq2_xs": QuantCapability("iq2_xs", True, True, False, False, "GGUF iq2_xs payload can be inventoried; CUDA runtime support is deferred"),
     "iq3_xxs": QuantCapability("iq3_xxs", True, True, False, False, "GGUF iq3_xxs payload can be inventoried; CUDA runtime support is deferred"),
     "iq1_m": QuantCapability("iq1_m", True, True, True, True, "routed expert raw blocks supported in existing DSV4 paths"),
-    "iq4_xs": QuantCapability("iq4_xs", True, True, False, False, "GGUF iq4_xs payload can be inventoried; CUDA runtime support is deferred"),
+    "iq4_xs": QuantCapability("iq4_xs", True, True, True, True, "raw iq4_xs CUDA block-dot GEMM supported (type_id 7)"),
     "q4_k": QuantCapability("q4_k", True, True, True, True, "raw q4_k CUDA GEMM and selected-row embedding supported"),
     "q5_k": QuantCapability("q5_k", True, True, True, True, "raw q5_k CUDA GEMM supported"),
     "q6_k": QuantCapability("q6_k", True, True, False, False, "GGUF q6_k payload can be inventoried; CUDA runtime support is deferred"),

--- a/src/csrc/cuda_kernel.cpp
+++ b/src/csrc/cuda_kernel.cpp
@@ -392,13 +392,15 @@ int64_t gguf_quant_block_bytes_for_type(int64_t type_id) {
     if (type_id == 4) return 176;   // q5_k
     if (type_id == 5) return 74;    // iq2_xs
     if (type_id == 6) return 98;    // iq3_xxs
+    if (type_id == 7) return 136;   // iq4_xs
     if (type_id == 8) return 210;   // q6_k
     TORCH_CHECK(false, "unsupported GGUF quant type_id: ", type_id);
 }
 
 bool gguf_quant_type_supported(int64_t type_id) {
     return type_id == 0 || type_id == 1 || type_id == 2 || type_id == 3 ||
-           type_id == 4 || type_id == 5 || type_id == 6 || type_id == 8;
+           type_id == 4 || type_id == 5 || type_id == 6 || type_id == 7 ||
+           type_id == 8;
 }
 
 void check_gguf_quant_grid(const torch::Tensor& grid, int64_t type_id, const char* name) {

--- a/src/csrc/cuda_kernel_impl.cu
+++ b/src/csrc/cuda_kernel_impl.cu
@@ -6131,6 +6131,10 @@ __global__ void gguf_quant_gemm_pair_kernel(
 
 constexpr int kIQ2XSSignedGridEntries = 512 * 128 * 8;
 
+// iq4_xs / iq4_nl non-linear codebook (int8). Matches llama.cpp kvalues_iq4nl.
+__device__ static const int8_t kIQ4NLValues[16] = {
+    -127, -104, -83, -65, -49, -35, -22, -10, 1, 13, 25, 38, 53, 69, 89, 113};
+
 __device__ __forceinline__ float iq2xs_block_dot_256(
     const float* __restrict__ x_shared,
     const uint8_t* __restrict__ block,
@@ -6244,6 +6248,40 @@ __device__ __forceinline__ float q6k_block_dot_256(
     return local;
 }
 
+__device__ __forceinline__ float iq4xs_block_dot_256(
+    const float* __restrict__ x_shared,
+    const uint8_t* __restrict__ block,
+    int lane) {
+    // block_iq4_xs (136 bytes): d(f16) | scales_h(u16) | scales_l[4] | qs[128].
+    // 8 groups of 32 elems.  Per-group 6-bit scale from scales_l/scales_h - 32.
+    // Each 16-byte group packs 16 low nibbles (elems 0..15) then 16 high
+    // nibbles (elems 16..31); nibble indexes the iq4_nl codebook.
+    const float d = gguf_block_scale_f16(block);
+    const uint16_t scales_h = static_cast<uint16_t>(block[2]) |
+        (static_cast<uint16_t>(block[3]) << 8);
+    const uint8_t* scales_l = block + 4;
+    const uint8_t* qs = block + 8;
+    const int byte_idx = lane & 15;      // 0..15 within the group
+    const int hi_half = lane >> 4;       // 0 => low nibble, 1 => high nibble
+    float local = 0.0f;
+    #pragma unroll
+    for (int group = 0; group < 8; ++group) {
+        const int ls = static_cast<int>(
+            ((scales_l[group >> 1] >> (4 * (group & 1))) & 0x0F) |
+            (((scales_h >> (2 * group)) & 0x03) << 4));
+        const float scale = d * static_cast<float>(ls - 32);
+        const uint8_t q = qs[group * 16 + byte_idx];
+        const int nib = hi_half ? (q >> 4) : (q & 0x0F);
+        const float val = static_cast<float>(kIQ4NLValues[nib]);
+        local += x_shared[group * 32 + lane] * scale * val;
+    }
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        local += __shfl_down_sync(0xffffffff, local, offset);
+    }
+    return local;
+}
+
 __device__ __forceinline__ float gguf_quant_block_dot_256(
     const float* __restrict__ x_shared,
     const uint8_t* __restrict__ block,
@@ -6291,6 +6329,9 @@ __device__ __forceinline__ float gguf_quant_block_dot_256(
         if (lane == 0) acc += blk;
     } else if (type_id == 6) {
         const float blk = iq3xxs_block_dot_256(x_shared, block, signed_grid, lane);
+        if (lane == 0) acc += blk;
+    } else if (type_id == 7) {
+        const float blk = iq4xs_block_dot_256(x_shared, block, lane);
         if (lane == 0) acc += blk;
     } else if (type_id == 8) {
         const float blk = q6k_block_dot_256(x_shared, block, lane);
@@ -6374,7 +6415,7 @@ __device__ __forceinline__ void gguf_quant_block_dot_256_rows4(
         q4k_block_dot_256_rows4(x_shared, block, lane, valid_rows, acc);
     } else if (type_id == 4) {
         q5k_block_dot_256_rows4(x_shared, block, lane, valid_rows, acc);
-    } else if (type_id == 5 || type_id == 6 || type_id == 8) {
+    } else if (type_id == 5 || type_id == 6 || type_id == 7 || type_id == 8) {
         if (valid_rows > 0) {
             float blk = gguf_quant_block_dot_256(x_shared, block, signed_grid, type_id, lane);
             if (lane == 0) acc[0] += blk;

--- a/src/loader/gguf/quant_types.py
+++ b/src/loader/gguf/quant_types.py
@@ -8,6 +8,7 @@ GGUF_DENSE_TYPE_IDS = {
     "q5_k": 4,
     "iq2_xs": 5,
     "iq3_xxs": 6,
+    "iq4_xs": 7,
     "q6_k": 8,
 }
 

--- a/src/models/glm_dsa/gguf_model.py
+++ b/src/models/glm_dsa/gguf_model.py
@@ -216,6 +216,18 @@ class GLMDSAGGUFModelLoader:
             out_dtype=self.dtype,
         )
 
+    def _quant_linear_auto(self, name: str):
+        """Build a raw-block CUDA linear, dispatching by GGUF dtype.
+
+        ``q8_0`` uses its dedicated ``q8_0_gemm_forward`` kernel; every other
+        supported dtype goes through the grid/type-id block-dot path.  GLM shared
+        experts are mostly q5_k/q6_k, but ``blk.8.ffn_down_shexp`` is q8_0, so the
+        raw-block MoE path must handle both.
+        """
+        if self._tensor_ref(name).type_name == "q8_0":
+            return self._quant_linear_q8_0(name)
+        return self._quant_linear(name)
+
     def _glm_routed_type_names(self, prefix: str) -> tuple[str, str, str]:
         w1 = self._tensor_ref(f"{prefix}.ffn_gate_exps.weight").type_name
         w3 = self._tensor_ref(f"{prefix}.ffn_up_exps.weight").type_name
@@ -266,9 +278,9 @@ class GLMDSAGGUFModelLoader:
                 layer_id,
                 self._read_dense(f"{prefix}.ffn_gate_inp.weight"),
                 self._read_dense(f"{prefix}.exp_probs_b.bias"),
-                self._quant_linear(f"{prefix}.ffn_gate_shexp.weight"),
-                self._quant_linear(f"{prefix}.ffn_up_shexp.weight"),
-                self._quant_linear(f"{prefix}.ffn_down_shexp.weight"),
+                self._quant_linear_auto(f"{prefix}.ffn_gate_shexp.weight"),
+                self._quant_linear_auto(f"{prefix}.ffn_up_shexp.weight"),
+                self._quant_linear_auto(f"{prefix}.ffn_down_shexp.weight"),
                 gguf_path=gate.shard_path,
                 w1_name=f"{prefix}.ffn_gate_exps.weight",
                 w3_name=f"{prefix}.ffn_up_exps.weight",

--- a/tests/test_glm_dsa_quant_cuda.py
+++ b/tests/test_glm_dsa_quant_cuda.py
@@ -47,6 +47,7 @@ def _empty_grid_cuda() -> torch.Tensor:
     [
         (IQ2_XS_ROUTED, 5, "iq2_xs", True),
         (IQ3_XXS_ROUTED, 6, "iq3_xxs", True),
+        (IQ4_XS_ROUTED, 7, "iq4_xs", True),
         (Q6_K_DENSE, 8, "q6_k", False),
     ],
 )


### PR DESCRIPTION
## Summary
- Add an iq4_xs (type_id 7) raw-block CUDA block-dot kernel so GLM-DSA's 4 iq4_xs layers (blk.8/75/76/77 `ffn_down_exps`) run through the raw-block MoE path instead of the fp32 reference fallback.
- Fix a latent q8_0 shared-expert bug surfaced by that switch: `blk.8.ffn_down_shexp.weight` is q8_0 (all other layers are q6_k). The raw-block MoE now dispatches shared-expert linears by dtype (`_quant_linear_auto`) so q8_0 uses its dedicated `q8_0_gemm_forward` kernel.

## Details
- CUDA: `iq4xs_block_dot_256` device fn matching llama.cpp `block_iq4_xs` (136B: d f16 | scales_h u16 | scales_l[4] | qs[128]; 8 groups of 32; 6-bit scale from scales_l/scales_h minus 32; iq4_nl 16-entry codebook; low nibbles = elems 0..15, high = 16..31). Added `type_id == 7` to the single-row and rows4 dispatch.
- cpp bindings: `gguf_quant_block_bytes_for_type` → 136; `gguf_quant_type_supported` → +7. No signed grid needed (like q6_k).
- Python: `GGUF_DENSE_TYPE_IDS["iq4_xs"] = 7`; capability flags flipped to CUDA/runtime supported.

## Verification
- `test_glm_quant_gemm_matches_reference[iq4_xs]`: GEMM decode+prefill vs reference dequant, rel err < 2e-2.
- Full GLM test suite: 7 passed.
- Real TP4 79-layer run: loads + forwards on 4×2080Ti, four ranks consistent (next=198), peak ~18 GB/rank (down from ~20 GB with the fp32 iq4_xs fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)