### PR TITLE
Ignore .scratch/ local probe scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,6 +252,7 @@ outputs/
 
 # Local runtime artifacts
 .tmp/
+.scratch/
 checkpoints/
 *.gguf
 gguf_hfd/


### PR DESCRIPTION
## Summary
- Add `.scratch/` to `.gitignore`, alongside the existing `.tmp/` local-artifact pattern.

`.scratch/` holds ad-hoc TP4 / lm_head verification probes and run logs used during GLM-5.2 GGUF development. These are local-only and should not be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)