### PR TITLE
Add optional GGUF page-cache prewarm for HDD-backed models

### DIFF
--- a/src/cli/generate_gguf.py
+++ b/src/cli/generate_gguf.py
@@ -25,6 +25,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--layers", type=int, default=0, help="debug: limit layer count; 0 means full model")
     parser.add_argument("--gpu-memory-gib", type=float, default=22.0)
     parser.add_argument("--dtype", type=str, choices=["float16", "bfloat16"], default="float16")
+    parser.add_argument(
+        "--prewarm",
+        action="store_true",
+        help="read GGUF shards into the OS page cache before load (helps on HDD)",
+    )
     return parser
 
 
@@ -47,6 +52,7 @@ def main(argv: list[str] | None = None) -> None:
         dtype=dtype,
         n_layers=None if int(args.layers) <= 0 else int(args.layers),
         gpu_memory_gib=float(args.gpu_memory_gib),
+        prewarm=bool(args.prewarm),
     )
 
 

--- a/src/loader/gguf/prewarm.py
+++ b/src/loader/gguf/prewarm.py
@@ -1,0 +1,116 @@
+"""Pull GGUF shard files into the OS page cache.
+
+GLM-5.2 (and other large GGUF bundles) live on a spinning disk here, and the
+MoE routed-expert hot path reads expert weights through an ``mmap`` view on
+every forward. The first forward is dominated by cold HDD reads (page faults
+that hit the platter); once the relevant pages are resident in the Linux page
+cache, subsequent forwards run from RAM and are ~60x faster.
+
+This module sequentially reads shard files so their pages become resident.
+It does not change the mmap semantics, does not pin host memory, and does not
+lock pages -- it only warms the cache. The page cache is shared system-wide,
+so under tensor parallelism a single rank prewarming benefits every rank.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.loader.gguf.bundle import GGUFBundle
+
+_DEFAULT_CHUNK_BYTES = 32 << 20  # 32 MiB sequential reads
+
+
+def _fadvise(fd: int) -> None:
+    """Hint the kernel to read ahead sequentially and prefetch the whole file.
+
+    ``posix_fadvise`` is POSIX-only; on platforms without it the sequential
+    reads below still make the pages resident, just without the readahead hint.
+    """
+    if not hasattr(os, "posix_fadvise"):
+        return
+    try:
+        os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_SEQUENTIAL)
+        os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_WILLNEED)
+    except OSError:
+        # Advisory only -- failure here does not affect correctness.
+        pass
+
+
+def prewarm_paths(
+    paths: Sequence[str],
+    *,
+    chunk_bytes: int = _DEFAULT_CHUNK_BYTES,
+    use_fadvise: bool = True,
+    log: bool = True,
+) -> dict[str, float]:
+    """Sequentially read files to pull them into the OS page cache.
+
+    Args:
+        paths: Files to warm (e.g. ``bundle.paths``).
+        chunk_bytes: Read size per ``os.read`` call.
+        use_fadvise: Issue ``POSIX_FADV_SEQUENTIAL``/``WILLNEED`` hints.
+        log: Print per-shard byte count, elapsed seconds, and bandwidth.
+
+    Returns:
+        Mapping of each path to the elapsed seconds spent reading it.
+
+    Raises:
+        FileNotFoundError: If a path does not exist.
+    """
+    if chunk_bytes <= 0:
+        raise ValueError(f"chunk_bytes must be positive, got {chunk_bytes}")
+
+    elapsed: dict[str, float] = {}
+    for path in paths:
+        fd = os.open(path, os.O_RDONLY)
+        try:
+            if use_fadvise:
+                _fadvise(fd)
+            t0 = time.perf_counter()
+            total = 0
+            while True:
+                chunk = os.read(fd, chunk_bytes)
+                if not chunk:
+                    break
+                total += len(chunk)
+            dt = time.perf_counter() - t0
+        finally:
+            os.close(fd)
+        elapsed[path] = dt
+        if log:
+            gib = total / 1024**3
+            bw = (total / 1024**2) / dt if dt > 0 else 0.0
+            name = os.path.basename(path)
+            print(
+                f"prewarm shard={name} bytes={gib:.2f}GB elapsed={dt:.1f}s bw={bw:.0f}MB/s",
+                flush=True,
+            )
+    return elapsed
+
+
+def prewarm_bundle(
+    bundle: "GGUFBundle",
+    *,
+    chunk_bytes: int = _DEFAULT_CHUNK_BYTES,
+    use_fadvise: bool = True,
+    log: bool = True,
+) -> dict[str, float]:
+    """Prewarm every shard file backing a :class:`GGUFBundle`.
+
+    A single sequential pass is intentional: on a spinning disk one stream
+    reaches full sequential bandwidth, whereas several concurrent streams
+    across ranks would thrash the head and lower aggregate throughput. Under
+    tensor parallelism, warm on one rank only (the page cache is shared
+    system-wide) and let the others wait at a barrier.
+    """
+    return prewarm_paths(
+        bundle.paths,
+        chunk_bytes=chunk_bytes,
+        use_fadvise=use_fadvise,
+        log=log,
+    )

--- a/src/runtime/generation.py
+++ b/src/runtime/generation.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import os
 import time
 from dataclasses import dataclass
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -34,7 +35,11 @@ def setup_dist() -> tuple[int, int, int, torch.device]:
         raise RuntimeError("GGUF raw-block runtime requires CUDA")
     torch.cuda.set_device(local_rank)
     if world > 1 and not dist.is_initialized():
-        dist.init_process_group("nccl")
+        # A long timeout so a slow one-time step on a single rank (e.g. reading
+        # a multi-hundred-GB GGUF into the page cache while the other ranks wait
+        # at the first barrier) does not trip the default 10-minute store
+        # timeout and tear down the NCCL communicator.
+        dist.init_process_group("nccl", timeout=timedelta(hours=2))
     return world, rank, local_rank, torch.device("cuda", local_rank)
 
 
@@ -169,6 +174,7 @@ def run_gguf_generation(
     dtype: torch.dtype = torch.float16,
     n_layers: int | None = None,
     gpu_memory_gib: float = 22.0,
+    prewarm: bool = False,
 ) -> tuple[list[int], dict[str, float]] | None:
     """Dispatch a GGUF checkpoint to its architecture spec and greedily decode.
 
@@ -206,6 +212,26 @@ def run_gguf_generation(
             f"dtype={str(dtype).removeprefix('torch.')}",
             flush=True,
         )
+
+    if prewarm:
+        # The page cache is shared system-wide, so warming on rank 0 benefits
+        # every rank. Other ranks wait at the barrier until warming completes.
+        # A single sequential reader is fastest on a spinning disk. Warming
+        # 236 GB at HDD bandwidth takes many minutes, so setup_dist raises the
+        # process-group timeout to keep the idle ranks from tripping it here.
+        if rank == 0:
+            from src.loader.gguf.prewarm import prewarm_bundle
+
+            t0 = time.perf_counter()
+            elapsed = prewarm_bundle(bundle)
+            total_bytes = sum(os.path.getsize(p) for p in bundle.paths)
+            print(
+                f"gguf_prewarm_done shards={len(elapsed)} "
+                f"total_bytes={total_bytes / 1024**3:.2f}GB "
+                f"elapsed={time.perf_counter() - t0:.1f}s",
+                flush=True,
+            )
+        sync()
 
     runtime = spec.build_token_runtime(
         bundle,

--- a/tests/test_gguf_prewarm.py
+++ b/tests/test_gguf_prewarm.py
@@ -1,0 +1,62 @@
+"""Tests for the GGUF page-cache prewarm utility."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from src.loader.gguf.prewarm import prewarm_paths
+
+REAL_GLM_PATH = Path("/mnt/data3/GLM-5.2-GGUF/UD-Q2_K_XL")
+
+
+def test_prewarm_paths_reads_file(tmp_path):
+    payload = os.urandom(3 << 20)  # 3 MiB
+    f = tmp_path / "shard.bin"
+    f.write_bytes(payload)
+
+    elapsed = prewarm_paths([str(f)], chunk_bytes=1 << 20, log=False)
+
+    assert str(f) in elapsed
+    assert elapsed[str(f)] >= 0.0
+    assert len(elapsed) == 1
+
+
+def test_prewarm_paths_multiple_files(tmp_path):
+    files = []
+    for i in range(3):
+        f = tmp_path / f"shard_{i}.bin"
+        f.write_bytes(os.urandom(1 << 20))
+        files.append(str(f))
+
+    elapsed = prewarm_paths(files, chunk_bytes=1 << 20, log=False)
+
+    assert set(elapsed.keys()) == set(files)
+    assert all(v >= 0.0 for v in elapsed.values())
+
+
+def test_prewarm_missing_file_raises(tmp_path):
+    missing = str(tmp_path / "does_not_exist.bin")
+    with pytest.raises(FileNotFoundError):
+        prewarm_paths([missing], log=False)
+
+
+def test_prewarm_rejects_nonpositive_chunk(tmp_path):
+    f = tmp_path / "shard.bin"
+    f.write_bytes(b"data")
+    with pytest.raises(ValueError):
+        prewarm_paths([str(f)], chunk_bytes=0, log=False)
+
+
+@pytest.mark.skipif(not REAL_GLM_PATH.exists(), reason="real GLM bundle not present")
+def test_prewarm_bundle_smoke():
+    from src.loader.gguf.bundle import read_gguf_bundle
+
+    bundle = read_gguf_bundle(REAL_GLM_PATH)
+    # Only warm the small header shard (00001, ~9 MB) to avoid reading 49 GB.
+    small = min(bundle.paths, key=os.path.getsize)
+    elapsed = prewarm_paths([small], log=False)
+    assert small in elapsed
+    assert elapsed[small] >= 0.0


### PR DESCRIPTION
## Summary
Adds an opt-in `--prewarm` step that reads GGUF shard files into the OS page cache before load, eliminating the cold-HDD-read bottleneck for large bundles on spinning disks.

## Motivation
Profiling GLM-5.2 (UD-Q2_K_XL, 236GB / 7 shards on a 14TB HDD) showed a single forward is dominated by cold page faults, not by compute or H2D:

| | stage_read | H2D | CUDA kernel |
|---|---|---|---|
| 20 layers, cold | 134s (89%) | 0.42s | <1s |
| 20 layers, warm (page cache) | 1.2s | 0.42s | ~1s |

~100x difference — the bottleneck is HDD physical IO, not the code path. Once the weight pages are resident in the shared page cache, forwards run from RAM.

## Changes
- **`src/loader/gguf/prewarm.py`** (new): `prewarm_paths` / `prewarm_bundle` sequentially read shards, with `POSIX_FADV_SEQUENTIAL`/`WILLNEED` hints where available.
- **`src/runtime/generation.py`**: `run_gguf_generation` gains an opt-in `prewarm` param. Rank 0 warms once (cache is system-wide); other ranks wait at a barrier. A single sequential reader is intentional — concurrent streams thrash a spinning-disk head.
- **`setup_dist`**: raise process-group init timeout to 2h, so idle ranks don't trip the default 10-min store timeout while rank 0 warms 236GB (~24 min).
- **`src/cli/generate_gguf.py`**: `--prewarm` flag.
- **`tests/test_gguf_prewarm.py`** (new): unit tests + real-bundle smoke.

Default is off — 236GB sequential read on HDD still takes minutes, so it's user-triggered. Does not touch the MoE/attention/CUDA hot path, mmap semantics, or introduce host pinning.

## Testing
- `pytest tests/test_gguf_prewarm.py` — 5 passed (incl. real-bundle smoke).
- Full TP4 e2e with `--prewarm`: warmed 236.44GB in 1425s, then `prefill_seconds=0.24` (vs ~579s cold), decode_tps=55.5, no NCCL timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)