### PR TITLE
Reconcile GLM-DSA capability flags and docstrings with working MoE runtime

### DIFF
--- a/src/components/moe/capability.py
+++ b/src/components/moe/capability.py
@@ -22,13 +22,13 @@ _CAPABILITIES = {
     "q2_k": QuantCapability("q2_k", True, True, True, True, "routed expert raw blocks supported in existing DSV4 paths"),
     "q3_k": QuantCapability("q3_k", True, True, False, False, "GGUF q3_k payload can be inventoried; CUDA runtime support is deferred"),
     "iq2_xxs": QuantCapability("iq2_xxs", True, True, True, True, "routed expert raw blocks supported by MiniMax/DSV4 GGUF CUDA paths"),
-    "iq2_xs": QuantCapability("iq2_xs", True, True, False, False, "GGUF iq2_xs payload can be inventoried; CUDA runtime support is deferred"),
-    "iq3_xxs": QuantCapability("iq3_xxs", True, True, False, False, "GGUF iq3_xxs payload can be inventoried; CUDA runtime support is deferred"),
+    "iq2_xs": QuantCapability("iq2_xs", True, True, True, True, "raw iq2_xs CUDA block-dot GEMM supported (type_id 5)"),
+    "iq3_xxs": QuantCapability("iq3_xxs", True, True, True, True, "raw iq3_xxs CUDA block-dot GEMM supported (type_id 6)"),
     "iq1_m": QuantCapability("iq1_m", True, True, True, True, "routed expert raw blocks supported in existing DSV4 paths"),
     "iq4_xs": QuantCapability("iq4_xs", True, True, True, True, "raw iq4_xs CUDA block-dot GEMM supported (type_id 7)"),
     "q4_k": QuantCapability("q4_k", True, True, True, True, "raw q4_k CUDA GEMM and selected-row embedding supported"),
     "q5_k": QuantCapability("q5_k", True, True, True, True, "raw q5_k CUDA GEMM supported"),
-    "q6_k": QuantCapability("q6_k", True, True, False, False, "GGUF q6_k payload can be inventoried; CUDA runtime support is deferred"),
+    "q6_k": QuantCapability("q6_k", True, True, True, True, "raw q6_k CUDA block-dot GEMM supported (type_id 8)"),
 }
 
 
@@ -42,8 +42,10 @@ def quant_capability(type_name: str) -> QuantCapability:
 def capability_status_for_role(role: str, type_name: str, *, architecture: str) -> tuple[str, str]:
     cap = quant_capability(type_name)
     if architecture == "glm-dsa":
+        if cap.runtime_supported:
+            return "supported", f"{cap.notes}; runs through the GLM-DSA GGUF runtime"
         if cap.header_supported and cap.payload_reader_supported:
-            return "deferred", f"{cap.notes}; optimized GLM-DSA runtime path is deferred"
+            return "deferred", f"{cap.notes}; GLM-DSA runtime path is deferred"
         return "unsupported", cap.notes
     if architecture == "minimax-m2":
         if role in {"routed_w1", "routed_w2", "routed_w3"} and type_name == "iq2_xxs":

--- a/src/models/glm_dsa/architecture.py
+++ b/src/models/glm_dsa/architecture.py
@@ -273,12 +273,12 @@ class GLMDSADenseMLP:
 
 
 class GLMDSAMoE:
-    """Reference GLM-DSA routed+shared MoE.
+    """Reference GLM-DSA routed+shared MoE (fp32 fallback path).
 
-    This is deliberately a correctness bring-up path: selected experts are
-    dequantized on CPU by the GGUF loader, moved to CUDA, and evaluated with
-    PyTorch matmuls.  It enables small-layer full-model smoke tests before the
-    optimized PocketMoE active-expert kernels are wired in.
+    Selected experts are dequantized on CPU by the GGUF loader, moved to CUDA,
+    and evaluated with PyTorch matmuls.  This is the fallback used when the routed
+    dtypes or block layout are not eligible for the raw-block CUDA kernels; the
+    optimized path is ``GLMDSARawBlockMoE``.
     """
 
     def __init__(
@@ -545,8 +545,9 @@ class GLMDSAMoEPlaceholder:
 
     def __call__(self, x: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError(
-            f"GLM-DSA MoE runtime is not implemented for layer {self.layer_id}; "
-            "use --n-layers within leading_dense_block_count for the first dense-prefix smoke"
+            f"GLM-DSA MoE layer {self.layer_id} was reached with MoE disabled; "
+            "MoE is implemented but this run opted out (allow_moe_layers=False). "
+            "Request n_layers beyond leading_dense_block_count to enable MoE layers."
         )
 
 

--- a/src/models/glm_dsa/gguf_model.py
+++ b/src/models/glm_dsa/gguf_model.py
@@ -23,12 +23,12 @@ from src.models.glm_dsa.architecture import (
 
 
 class GLMDSAGGUFModelLoader:
-    """Assemble a first-pass GLM-DSA reference runtime from a GGUF bundle.
+    """Assemble a GLM-DSA GGUF runtime from a GGUF bundle.
 
-    This loader intentionally uses dequantized reference tensors for correctness
-    bring-up. It is only meant for small-layer smoke tests at first; optimized
-    raw-block kernels and PocketMoE active-expert staging should replace the
-    fallback paths once the GLM-DSA math is validated.
+    Routed MoE experts run through the raw-block CUDA grouped kernel
+    (``GLMDSARawBlockMoE``) when the routed dtypes and block layout are eligible;
+    otherwise the loader falls back to the dequantized fp32 reference MoE
+    (``GLMDSAMoE``).  Dense/attention projections use raw quantized GGUF linears.
     """
 
     def __init__(
@@ -309,8 +309,9 @@ class GLMDSAGGUFModelLoader:
     def load(self) -> GLMDSATransformer:
         if self.args.n_layers > self.args.leading_dense_layers and not self.allow_moe_layers:
             raise NotImplementedError(
-                f"GLM-DSA MoE layers are not implemented in the first reference runtime; "
-                f"requested n_layers={self.args.n_layers}, leading_dense_layers={self.args.leading_dense_layers}"
+                f"GLM-DSA MoE layers are implemented but disabled for this load "
+                f"(allow_moe_layers=False); requested n_layers={self.args.n_layers} exceeds "
+                f"leading_dense_layers={self.args.leading_dense_layers}. Enable MoE to load these layers."
             )
 
         embedding = self._quant_embedding("token_embd.weight")

--- a/src/models/glm_dsa/spec.py
+++ b/src/models/glm_dsa/spec.py
@@ -231,7 +231,7 @@ class GLMDSASpec:
             seen.add(key)
             status, reason = capability_status_for_role(role, tensor.type_name, architecture=self.architecture)
             caps.append(CapabilityItem(f"{role}:{tensor.type_name}", status, reason))
-        caps.append(CapabilityItem("generation", "candidate", "GLM-DSA dense-prefix reference GGUF generation is implemented; MoE layers remain deferred"))
+        caps.append(CapabilityItem("generation", "candidate", "GLM-DSA GGUF generation is implemented for dense-prefix and MoE layers (routed experts run through the CUDA grouped MoE kernel)"))
 
         tensor_bytes = sum(int(t.nbytes or 0) for t in bundle.tensors)
         routed_bytes = sum(int(t.nbytes or 0) for t in bundle.tensors if role_by_name[t.name] in {"routed_w1", "routed_w2", "routed_w3"})
@@ -262,13 +262,13 @@ class GLMDSASpec:
         n_layers: int | None,
         gpu_memory_gib: float,
     ) -> "GGUFTokenRuntime":
-        """Build the first GLM-DSA GGUF token runtime.
+        """Build the GLM-DSA GGUF token runtime.
 
-        The current implementation is a correctness bring-up path: it dequantizes
-        tensors into reference PyTorch modules and only supports the dense-prefix
-        layers.  If ``n_layers`` is omitted, default to ``leading_dense_layers`` so
-        the generic generation CLI can smoke-test GLM attention/dense FFN without
-        accidentally entering the not-yet-implemented 76 MoE layers.
+        Supports the full model: the dense-prefix layers plus the routed+shared
+        MoE layers (routed experts run through the CUDA grouped MoE kernel, with
+        experts sharded across ranks).  If ``n_layers`` is omitted, default to
+        ``leading_dense_layers`` so the generic generation CLI runs only the dense
+        prefix unless more layers are explicitly requested.
         """
         from src.runtime.generation import GGUFTokenRuntime
         from src.models.glm_dsa.gguf_model import load_glm_dsa_gguf_model

--- a/tests/test_glm_dsa_spec.py
+++ b/tests/test_glm_dsa_spec.py
@@ -57,7 +57,7 @@ def test_glm_dsa_registry_detects_architecture(tmp_path: Path) -> None:
     assert detect_spec(bundle).architecture == "glm-dsa"
 
 
-def test_glm_dsa_capability_is_inventory_supported_but_generation_deferred(tmp_path: Path) -> None:
+def test_glm_dsa_capability_reports_routed_types_supported(tmp_path: Path) -> None:
     root = write_glm_dsa_bundle(tmp_path / "bundle", n_layers=4, leading_dense=1)
     bundle = read_gguf_bundle(root)
     report = GLMDSASpec().capability_report(bundle, gpu_count=4, gpu_memory_gib=22.0)
@@ -68,8 +68,8 @@ def test_glm_dsa_capability_is_inventory_supported_but_generation_deferred(tmp_p
     assert report.tensor_type_counts["iq2_xs"] == 6
     assert report.tensor_type_counts["iq3_xxs"] == 3
     assert report.tensor_type_counts["q6_k"] == 4
-    assert caps["routed_w1:iq2_xs"].status == "deferred"
-    assert caps["routed_w2:iq3_xxs"].status == "deferred"
+    assert caps["routed_w1:iq2_xs"].status == "supported"
+    assert caps["routed_w2:iq3_xxs"].status == "supported"
     assert caps["generation"].status == "candidate"
     assert placements["heterogeneous_routed_experts"].status == "candidate"
 


### PR DESCRIPTION
Follow-up text/metadata cleanup after the GLM-DSA GGUF MoE runtime landed. Several capability flags, docstrings, and error messages still described the routed/shared MoE paths as deferred or not-implemented, even though they now run through the raw-block CUDA grouped kernel.

## Changes
- capability.py: mark iq2_xs/iq3_xxs/q6_k as routed_raw_supported + runtime_supported (live CUDA block-dot GEMM kernels, type_id 5/6/8); add a glm-dsa 'supported' branch for runtime-backed dtypes.
- spec.py: generation capability item + build_token_runtime docstring now describe full-model support (dense-prefix + MoE, experts sharded across ranks).
- architecture.py / gguf_model.py: reframe GLMDSAMoE as the fp32 fallback path and clarify the MoE-disabled error messages (implemented but opted out via allow_moe_layers=False).
- test_glm_dsa_spec.py: assert routed types now report 'supported'.

## Not changed
Runtime logic. Path selection still keys off GGUF_DENSE_TYPE_IDS / _routed_dtypes_raw_supported, not these capability flags — these flags feed only the capability/inventory report.

## Testing
pytest -q tests/test_glm_dsa_spec.py tests/test_inspect_gguf_specs.py tests/test_minimax_m2_spec.py -> 18 passed, 1 skipped