### PR TITLE
Add iq2_xs/iq3_xxs DP4A MoE kernels + opt-in GLM-DSA decode experiments

### DIFF
--- a/src/cli/generate_glm.py
+++ b/src/cli/generate_glm.py
@@ -84,16 +84,24 @@ def main(argv: list[str] | None = None) -> None:
 
     # run_gguf_generation returns the ids+stats on rank 0 and None elsewhere,
     # so only rank 0 reaches the decode/print below.
+    # Opt-in decode profiler (GLM_PROFILE=1). The per-section wall-time breakdown
+    # is printed on rank 0 (which holds `result`); the EP rank-skew line is per
+    # rank (no collective), so every rank prints its own so we can compare the
+    # local-active-expert means across ranks to size the TP-vs-EP opportunity.
+    from src.models.glm_dsa.architecture import (
+        glm_profile_enabled,
+        glm_profile_report,
+        glm_profile_skew_report,
+    )
+
+    if glm_profile_enabled():
+        print(glm_profile_skew_report(), flush=True)
+
     if result is not None:
         generated_ids, _stats = result
         text = decode_glm_dsa_ids(args.gguf_path, generated_ids, skip_special=bool(args.skip_special))
         print("prompt_text=" + repr(prompt_text), flush=True)
         print("generated_text=" + repr(text), flush=True)
-        # Opt-in decode profiler (GLM_PROFILE=1): print the per-section wall-time
-        # breakdown gathered during forward so we can see where per-token time
-        # actually goes before optimizing further.
-        from src.models.glm_dsa.architecture import glm_profile_enabled, glm_profile_report
-
         if glm_profile_enabled():
             print(glm_profile_report(), flush=True)
 

--- a/src/cli/generate_glm.py
+++ b/src/cli/generate_glm.py
@@ -89,6 +89,13 @@ def main(argv: list[str] | None = None) -> None:
         text = decode_glm_dsa_ids(args.gguf_path, generated_ids, skip_special=bool(args.skip_special))
         print("prompt_text=" + repr(prompt_text), flush=True)
         print("generated_text=" + repr(text), flush=True)
+        # Opt-in decode profiler (GLM_PROFILE=1): print the per-section wall-time
+        # breakdown gathered during forward so we can see where per-token time
+        # actually goes before optimizing further.
+        from src.models.glm_dsa.architecture import glm_profile_enabled, glm_profile_report
+
+        if glm_profile_enabled():
+            print(glm_profile_report(), flush=True)
 
 
 if __name__ == "__main__":

--- a/src/csrc/cuda_kernel_impl.cu
+++ b/src/csrc/cuda_kernel_impl.cu
@@ -6687,6 +6687,129 @@ __global__ void gguf_moe_w13_iq2_xxs_dp4a_kernel(
     }
 }
 
+// iq2_xs w13 DP4A (block_iq2_xs, 74 bytes): [0:2] d, [2:66] qs (8 sub-blocks x
+// 8 bytes = 8 sub x 4 uint16), [66:74] scales (8 bytes, one per sub-block, low
+// nibble = parts 0-1, high nibble = parts 2-3).  Each uint16 encodes a 9-bit
+// grid id + 7-bit sign id into the shared 512x128x8 signed grid.  Mirrors
+// gguf_moe_w13_iq2_xxs_dp4a_kernel: lane->(sub=lane>>2, part=lane&3), q8_1
+// activation quantized in 32-element groups.
+__global__ void gguf_moe_w13_iq2_xs_dp4a_kernel(
+    const int8_t* __restrict__ x_q,
+    const float* __restrict__ x_scale,
+    const int64_t* __restrict__ route_tokens,
+    const int32_t* __restrict__ route_experts,
+    const uint8_t* __restrict__ w1_blocks,
+    const uint8_t* __restrict__ w3_blocks,
+    const int8_t* __restrict__ signed_grid,
+    float* __restrict__ gate,
+    float* __restrict__ up,
+    int routes,
+    int dim,
+    int inter_dim,
+    int blocks_per_row,
+    int x_groups) {
+    const int route = blockIdx.y;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int out_col = blockIdx.x * kGGUFQuantTileN + warp;
+    if (route >= routes || warp >= kGGUFQuantTileN) return;
+
+    const int64_t token = route_tokens[route];
+    const int expert = route_experts[route];
+    const int8_t* x_q_row = x_q + token * dim;
+    const float* x_scale_row = x_scale + token * x_groups;
+    const uint8_t* w1_row = w1_blocks + (static_cast<int64_t>(expert) * inter_dim + out_col) * blocks_per_row * 74;
+    const uint8_t* w3_row = w3_blocks + (static_cast<int64_t>(expert) * inter_dim + out_col) * blocks_per_row * 74;
+
+    __shared__ int x_shared_q[64];
+    __shared__ float x_shared_scale[8];
+
+    float acc1 = 0.0f;
+    float acc3 = 0.0f;
+
+    for (int block_idx = 0; block_idx < blocks_per_row; ++block_idx) {
+        const int k_base = block_idx * 256;
+        const int tid = threadIdx.x;
+        if (tid < 64) {
+            const int byte_off = tid * 4;
+            int v = 0;
+            if (k_base + byte_off + 4 <= dim) {
+                v = *reinterpret_cast<const int*>(x_q_row + k_base + byte_off);
+            }
+            x_shared_q[tid] = v;
+        }
+        if (tid < 8) {
+            const int sg_idx = block_idx * 8 + tid;
+            x_shared_scale[tid] = sg_idx < x_groups ? x_scale_row[sg_idx] : 0.0f;
+        }
+        __syncthreads();
+
+        if (out_col < inter_dim) {
+            const int sub = lane >> 2;
+            const int part = lane & 3;
+            const uint8_t* w1_block = w1_row + static_cast<int64_t>(block_idx) * 74;
+            const uint8_t* w3_block = w3_row + static_cast<int64_t>(block_idx) * 74;
+            const uint8_t* chunk1 = w1_block + 2 + sub * 8;
+            const uint8_t* chunk3 = w3_block + 2 + sub * 8;
+
+            const float d1 = gguf_block_scale_f16(w1_block);
+            const float d3 = gguf_block_scale_f16(w3_block);
+
+            const uint16_t q1 = static_cast<uint16_t>(chunk1[part * 2]) |
+                (static_cast<uint16_t>(chunk1[part * 2 + 1]) << 8);
+            const uint16_t q3 = static_cast<uint16_t>(chunk3[part * 2]) |
+                (static_cast<uint16_t>(chunk3[part * 2 + 1]) << 8);
+            const int grid_id1 = static_cast<int>(q1 & 0x01FFu);
+            const int grid_id3 = static_cast<int>(q3 & 0x01FFu);
+            const int sign_idx1 = static_cast<int>(q1 >> 9);
+            const int sign_idx3 = static_cast<int>(q3 >> 9);
+
+            const uint8_t sc1 = w1_block[66 + sub];
+            const uint8_t sc3 = w3_block[66 + sub];
+            const int ls1 = static_cast<int>(part < 2 ? (sc1 & 0x0F) : (sc1 >> 4));
+            const int ls3 = static_cast<int>(part < 2 ? (sc3 & 0x0F) : (sc3 >> 4));
+            const float s1 = 0.25f * d1 * (static_cast<float>(ls1) + 0.5f);
+            const float s3 = 0.25f * d3 * (static_cast<float>(ls3) + 0.5f);
+
+            const int8_t* vals1 = signed_grid + (grid_id1 * 128 + sign_idx1) * 8;
+            const int8_t* vals3 = signed_grid + (grid_id3 * 128 + sign_idx3) * 8;
+            const int v1_p0 = *reinterpret_cast<const int*>(vals1);
+            const int v1_p1 = *reinterpret_cast<const int*>(vals1 + 4);
+            const int v3_p0 = *reinterpret_cast<const int*>(vals3);
+            const int v3_p1 = *reinterpret_cast<const int*>(vals3 + 4);
+
+            const int xq_base = sub * 8 + part * 2;
+            const int x_p0 = x_shared_q[xq_base];
+            const int x_p1 = x_shared_q[xq_base + 1];
+
+            int sumi1 = __dp4a(v1_p0, x_p0, 0);
+            sumi1 = __dp4a(v1_p1, x_p1, sumi1);
+            int sumi3 = __dp4a(v3_p0, x_p0, 0);
+            sumi3 = __dp4a(v3_p1, x_p1, sumi3);
+
+            const float xs = x_shared_scale[sub];
+            float local1 = s1 * xs * static_cast<float>(sumi1);
+            float local3 = s3 * xs * static_cast<float>(sumi3);
+
+            #pragma unroll
+            for (int offset = 16; offset > 0; offset >>= 1) {
+                local1 += __shfl_down_sync(0xffffffff, local1, offset);
+                local3 += __shfl_down_sync(0xffffffff, local3, offset);
+            }
+            if (lane == 0) {
+                acc1 += local1;
+                acc3 += local3;
+            }
+        }
+        __syncthreads();
+    }
+
+    if (lane == 0 && out_col < inter_dim) {
+        gate[static_cast<int64_t>(route) * inter_dim + out_col] = acc1;
+        up[static_cast<int64_t>(route) * inter_dim + out_col] = acc3;
+    }
+}
+
 __global__ void gguf_moe_w13_iq2_xxs_dp4a_expert_tile_kernel(
     const int8_t* __restrict__ x_q,
     const float* __restrict__ x_scale,
@@ -7197,6 +7320,107 @@ __global__ void gguf_moe_w2_scatter_iq2_xxs_dp4a_kernel(
             const int v_p1 = *reinterpret_cast<const int*>(vals + 4);
 
             const int hq_base = sub * 8 + part * 2;
+            const int h_p0 = h_shared_q[hq_base];
+            const int h_p1 = h_shared_q[hq_base + 1];
+
+            int sumi = __dp4a(v_p0, h_p0, 0);
+            sumi = __dp4a(v_p1, h_p1, sumi);
+
+            const float hs = h_shared_scale[sub];
+            float local = s * hs * static_cast<float>(sumi);
+
+            #pragma unroll
+            for (int offset = 16; offset > 0; offset >>= 1) {
+                local += __shfl_down_sync(0xffffffff, local, offset);
+            }
+            if (lane == 0) acc += local;
+        }
+        __syncthreads();
+    }
+
+    if (lane == 0 && out_col < dim) {
+        atomicAdd(y + token * dim + out_col, acc);
+    }
+}
+
+// iq3_xxs w2 scatter DP4A (block_iq3_xxs, 98 bytes): [0:2] d, [2:66] grid
+// indices (8 sub x 8 bytes, one grid_id byte per part), [66:98] aux (8 sub x
+// uint32; low 3x7 bits = sign ids, top nibble = scale).  Structure is 8 sub x
+// 8 part x 4 elem; a lane (sub=lane>>2, pp=lane&3) handles parts 2*pp and
+// 2*pp+1, which share sign_idx = (aux>>(7*pp))&127 and use grid val_offset 0/4.
+// Mirrors gguf_moe_w2_scatter_iq2_xxs_dp4a_kernel; hidden q8_1-quantized in
+// 32-element groups (iq3_xxs sub = 32 elems).
+__global__ void gguf_moe_w2_scatter_iq3_xxs_dp4a_kernel(
+    const int8_t* __restrict__ hidden_q,
+    const float* __restrict__ hidden_scale,
+    const int64_t* __restrict__ route_tokens,
+    const int32_t* __restrict__ route_experts,
+    const uint8_t* __restrict__ w2_blocks,
+    const int8_t* __restrict__ signed_grid,
+    float* __restrict__ y,
+    int routes,
+    int dim,
+    int inter_dim,
+    int w2_blocks_per_row,
+    int hidden_groups) {
+    const int route = blockIdx.y;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int out_col = blockIdx.x * kGGUFQuantTileN + warp;
+    if (route >= routes || warp >= kGGUFQuantTileN) return;
+
+    const int64_t token = route_tokens[route];
+    const int expert = route_experts[route];
+    const int8_t* hidden_row = hidden_q + static_cast<int64_t>(route) * inter_dim;
+    const float* hs_row = hidden_scale + static_cast<int64_t>(route) * hidden_groups;
+    const uint8_t* w2_row = w2_blocks + (static_cast<int64_t>(expert) * dim + out_col) * w2_blocks_per_row * 98;
+    const int8_t* iq3_grid = signed_grid + kIQ2XSSignedGridEntries;
+
+    __shared__ int h_shared_q[64];
+    __shared__ float h_shared_scale[8];
+
+    float acc = 0.0f;
+
+    for (int block_idx = 0; block_idx < w2_blocks_per_row; ++block_idx) {
+        const int k_base = block_idx * 256;
+        const int tid = threadIdx.x;
+        if (tid < 64) {
+            const int byte_off = tid * 4;
+            int v = 0;
+            if (k_base + byte_off + 4 <= inter_dim) {
+                v = *reinterpret_cast<const int*>(hidden_row + k_base + byte_off);
+            }
+            h_shared_q[tid] = v;
+        }
+        if (tid < 8) {
+            const int sg_idx = block_idx * 8 + tid;
+            h_shared_scale[tid] = sg_idx < hidden_groups ? hs_row[sg_idx] : 0.0f;
+        }
+        __syncthreads();
+
+        if (out_col < dim) {
+            const int sub = lane >> 2;
+            const int pp = lane & 3;
+            const uint8_t* w2_block = w2_row + static_cast<int64_t>(block_idx) * 98;
+            const float d = gguf_block_scale_f16(w2_block);
+            const uint8_t* qbytes = w2_block + 2 + sub * 8;
+            const uint8_t* auxb = w2_block + 2 + 64 + sub * 4;
+            const uint32_t aux = static_cast<uint32_t>(auxb[0]) |
+                (static_cast<uint32_t>(auxb[1]) << 8) |
+                (static_cast<uint32_t>(auxb[2]) << 16) |
+                (static_cast<uint32_t>(auxb[3]) << 24);
+
+            const int sign_idx = static_cast<int>((aux >> (7 * pp)) & 127);
+            const float s = 0.5f * d * (static_cast<float>(aux >> 28) + 0.5f);
+
+            const int grid_id0 = qbytes[pp * 2];
+            const int grid_id1 = qbytes[pp * 2 + 1];
+            const int8_t* vals0 = iq3_grid + ((grid_id0 * 128 + sign_idx) * 8 + 0);
+            const int8_t* vals1 = iq3_grid + ((grid_id1 * 128 + sign_idx) * 8 + 4);
+            const int v_p0 = *reinterpret_cast<const int*>(vals0);
+            const int v_p1 = *reinterpret_cast<const int*>(vals1);
+
+            const int hq_base = sub * 8 + pp * 2;
             const int h_p0 = h_shared_q[hq_base];
             const int h_p1 = h_shared_q[hq_base + 1];
 
@@ -7995,7 +8219,42 @@ torch::Tensor gguf_moe_prefill_grouped_forward_cuda(
         w1_block_bytes == 66 && w3_block_bytes == 66 &&
         w1_blocks_per_row == w3_blocks_per_row &&
         env_enabled_explicit("DEEPSEEK_GGUF_IQ2_XXS_W13_DP4A");
-    if (use_iq2_xxs_w13_dp4a) {
+    const bool use_iq2_xs_w13_dp4a =
+        w1_type_id == 5 && w3_type_id == 5 &&
+        w1_block_bytes == 74 && w3_block_bytes == 74 &&
+        w1_blocks_per_row == w3_blocks_per_row &&
+        env_enabled_explicit("DEEPSEEK_GGUF_IQ2_XS_W13_DP4A");
+    if (use_iq2_xs_w13_dp4a) {
+        const int x_groups = ceil_div(dim, 32);
+        auto x_q = torch::empty({tokens, dim}, x.options().dtype(torch::kInt8));
+        auto x_scale = torch::empty({tokens, x_groups}, x.options().dtype(torch::kFloat32));
+        const dim3 quant_grid(tokens, x_groups);
+        AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, x_contig.scalar_type(), "gguf_q8_1_quantize_x_32", [&] {
+            gguf_q8_1_quantize_x_32_kernel<scalar_t><<<quant_grid, 32, 0, at::cuda::getCurrentCUDAStream()>>>(
+                x_contig.data_ptr<scalar_t>(),
+                x_q.data_ptr<int8_t>(),
+                x_scale.data_ptr<float>(),
+                tokens,
+                dim);
+        });
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        gguf_moe_w13_iq2_xs_dp4a_kernel<<<w13_grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+            x_q.data_ptr<int8_t>(),
+            x_scale.data_ptr<float>(),
+            route_tokens_contig.data_ptr<int64_t>(),
+            route_experts.data_ptr<int32_t>(),
+            w1_contig.data_ptr<uint8_t>(),
+            w3_contig.data_ptr<uint8_t>(),
+            grid_ptr,
+            gate.data_ptr<float>(),
+            up.data_ptr<float>(),
+            routes,
+            dim,
+            inter_dim,
+            w1_blocks_per_row,
+            x_groups);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+    } else if (use_iq2_xxs_w13_dp4a) {
         const int x_groups = ceil_div(dim, 32);
         auto x_q = torch::empty({tokens, dim}, x.options().dtype(torch::kInt8));
         auto x_scale = torch::empty({tokens, x_groups}, x.options().dtype(torch::kFloat32));
@@ -8094,11 +8353,56 @@ torch::Tensor gguf_moe_prefill_grouped_forward_cuda(
         w2_type_id == 0 &&
         w2_block_bytes == 66 &&
         env_enabled_explicit("DEEPSEEK_GGUF_IQ2_XXS_W2_DP4A");
+    const bool use_iq3_xxs_w2_dp4a =
+        w2_type_id == 6 &&
+        w2_block_bytes == 98 &&
+        env_enabled_explicit("DEEPSEEK_GGUF_IQ3_XXS_W2_DP4A");
     const bool use_q2k_w2_dp4a =
         w2_type_id == 1 &&
         w2_block_bytes == 84 &&
         env_enabled_explicit("DEEPSEEK_GGUF_Q2K_W2_DP4A");
-    if (use_iq2_xxs_w2_dp4a) {
+    if (use_iq3_xxs_w2_dp4a) {
+        // iq3_xxs w2: hidden quantized in 32-element groups (one per iq3_xxs
+        // sub-block), matching the iq2_xs/iq2_xxs w13 activation quantizer.
+        const int hidden_groups = ceil_div(inter_dim, 32);
+        auto hidden = torch::empty({routes, inter_dim}, x.options().dtype(torch::kFloat32));
+        auto hidden_q = torch::empty({routes, inter_dim}, x.options().dtype(torch::kInt8));
+        auto hidden_scale = torch::empty({routes, hidden_groups}, x.options().dtype(torch::kFloat32));
+        const int hidden_threads = 256;
+        const int hidden_blocks = static_cast<int>((static_cast<int64_t>(routes) * inter_dim + hidden_threads - 1) / hidden_threads);
+        route_swiglu_cast_kernel<float><<<hidden_blocks, hidden_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            gate.data_ptr<float>(),
+            up.data_ptr<float>(),
+            route_weights_contig.data_ptr<float>(),
+            hidden.data_ptr<float>(),
+            routes,
+            inter_dim,
+            static_cast<float>(swiglu_limit));
+        const dim3 quant_grid(routes, hidden_groups);
+        gguf_q8_1_quantize_x_32_kernel<float><<<quant_grid, 32, 0, at::cuda::getCurrentCUDAStream()>>>(
+            hidden.data_ptr<float>(),
+            hidden_q.data_ptr<int8_t>(),
+            hidden_scale.data_ptr<float>(),
+            routes,
+            inter_dim);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        if (emit_profile) {
+            check_cuda(cudaEventRecord(ev_hidden, at::cuda::getCurrentCUDAStream()), "record gguf prefill profile hidden event");
+        }
+        gguf_moe_w2_scatter_iq3_xxs_dp4a_kernel<<<w2_grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
+            hidden_q.data_ptr<int8_t>(),
+            hidden_scale.data_ptr<float>(),
+            route_tokens_contig.data_ptr<int64_t>(),
+            route_experts.data_ptr<int32_t>(),
+            w2_contig.data_ptr<uint8_t>(),
+            grid_ptr,
+            y.data_ptr<float>(),
+            routes,
+            dim,
+            inter_dim,
+            w2_blocks_per_row,
+            hidden_groups);
+    } else if (use_iq2_xxs_w2_dp4a) {
         // iq2_xxs w2: hidden quantized in 32-element groups (one per iq2_xxs
         // sub-block), matching the w13 activation quantizer.  Decode reuses the
         // parity-validated grid lookup from gguf_moe_w13_iq2_xxs_dp4a_kernel.

--- a/src/models/glm_dsa/architecture.py
+++ b/src/models/glm_dsa/architecture.py
@@ -452,6 +452,25 @@ class GLMDSARawBlockMoE:
         from src.loader.gguf.quant_types import GGUF_DENSE_TYPE_IDS
 
         self._type_ids = GGUF_DENSE_TYPE_IDS
+        # Resident staging cache: on first forward we read all local experts'
+        # raw blocks once into contiguous (optionally pinned) CPU tensors, so the
+        # decode hot path only does an index + async H2D instead of re-reading
+        # from mmap + torch.stack + a CPU sync every step/layer.  ~0.77 GB/layer.
+        self._resident_w1: torch.Tensor | None = None
+        self._resident_w3: torch.Tensor | None = None
+        self._resident_w2: torch.Tensor | None = None
+        self._resident_meta: tuple | None = None
+        import os as _os
+
+        # Resident-cache staging is OFF by default: an e2e measurement showed it
+        # does NOT help decode once the page cache is warm (the original per-step
+        # mmap read already hits RAM, so torch.stack and index_select cost the
+        # same ~1.8GB host copy), while the one-time 58GB/rank build regresses
+        # prefill.  Kept as an opt-in experiment switch only.
+        self._disable_resident = _os.getenv("GLM_ENABLE_RESIDENT_EXPERTS", "0") != "1"
+        # Pinning ~58 GB/rank is non-pageable host memory; opt-in only to avoid
+        # over-committing pinned memory across TP ranks.
+        self._pin_resident = _os.getenv("GLM_PIN_RESIDENT_EXPERTS", "0") == "1"
 
     def route(self, x_flat: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         logits = x_flat.float() @ self.gate_weight.t()
@@ -464,12 +483,60 @@ class GLMDSARawBlockMoE:
         weights = weights * float(self.args.expert_weights_scale)
         return indices.to(torch.long).contiguous(), weights.float().contiguous()
 
-    def _stage_active_experts(self, reader, local_ids_cpu: list[int]):
-        """Read and stack raw blocks for the active local experts.
+    def _build_resident_experts(self, reader) -> None:
+        """Read this rank's ALL local experts' raw blocks once into contiguous
+        CPU tensors of shape ``[expert_count, N, K_blocks, block_bytes]`` for
+        w1/w3/w2.  Done lazily on first forward so the decode hot path can index
+        + async-H2D instead of re-reading mmap + torch.stack + a CPU sync every
+        step.  ~0.77 GB/layer resident on host (system has ample RAM)."""
+        w1_list, w3_list, w2_list = [], [], []
+        w1_tn = w3_tn = w2_tn = None
+        w1_in = w3_in = w2_in = None
+        for local_id in range(self.expert_count):
+            expert_id = local_id + self.expert_start
+            b1, w1_tn, w1_in = reader.read_routed_expert_blocks(self.w1_name, expert_id)
+            b3, w3_tn, w3_in = reader.read_routed_expert_blocks(self.w3_name, expert_id)
+            b2, w2_tn, w2_in = reader.read_routed_expert_blocks(self.w2_name, expert_id)
+            # Clone: read_routed_expert_blocks returns a view over the shared mmap;
+            # we must own the memory to keep it resident and contiguous.
+            w1_list.append(b1.clone())
+            w3_list.append(b3.clone())
+            w2_list.append(b2.clone())
+        w1 = torch.stack(w1_list, dim=0).contiguous()
+        w3 = torch.stack(w3_list, dim=0).contiguous()
+        w2 = torch.stack(w2_list, dim=0).contiguous()
+        if self._pin_resident:
+            w1 = w1.pin_memory()
+            w3 = w3.pin_memory()
+            w2 = w2.pin_memory()
+        self._resident_w1 = w1
+        self._resident_w3 = w3
+        self._resident_w2 = w2
+        self._resident_meta = (
+            (self._type_ids[w1_tn], int(w1_in)),
+            (self._type_ids[w3_tn], int(w3_in)),
+            (self._type_ids[w2_tn], int(w2_in)),
+        )
 
-        Returns stacked ``[E_active, N, K_blocks, block_bytes]`` tensors for
-        w1/w3/w2 plus their (type_id, in_dim) metadata.
-        """
+    def _stage_active_experts(self, reader, local_ids_cpu: list[int]):
+        """Return stacked ``[E_active, N, K_blocks, block_bytes]`` tensors for
+        w1/w3/w2 plus their (type_id, in_dim) metadata, staged on device.
+
+        Fast path: index the resident CPU cache by the active local ids and do a
+        single async H2D per weight.  Fallback (resident disabled): re-read from
+        mmap + torch.stack every call (original behavior)."""
+        if not self._disable_resident:
+            if self._resident_w1 is None:
+                self._build_resident_experts(reader)
+            idx = torch.as_tensor(local_ids_cpu, dtype=torch.long)
+            w1_cpu = self._resident_w1.index_select(0, idx)
+            w3_cpu = self._resident_w3.index_select(0, idx)
+            w2_cpu = self._resident_w2.index_select(0, idx)
+            w1_blocks = w1_cpu.to(self.device, non_blocking=True).contiguous()
+            w3_blocks = w3_cpu.to(self.device, non_blocking=True).contiguous()
+            w2_blocks = w2_cpu.to(self.device, non_blocking=True).contiguous()
+            return w1_blocks, w3_blocks, w2_blocks, self._resident_meta
+
         w1_vals, w3_vals, w2_vals = [], [], []
         for local_id in local_ids_cpu:
             expert_id = int(local_id) + self.expert_start

--- a/src/models/glm_dsa/architecture.py
+++ b/src/models/glm_dsa/architecture.py
@@ -60,9 +60,23 @@ def glm_profile_enabled() -> bool:
     return _GLM_PROFILE
 
 
+# Per-(phase) tally of how many local experts each MoE layer activated, so we
+# can quantify TP rank-skew: at decode T=1 the top_k=8 experts scatter across
+# the 4 EP ranks unevenly, and the slowest rank's staging gates the per-layer
+# all_reduce.  Recording the local active count per layer-call lets us report
+# the distribution (and, gathered across ranks, the per-step max-vs-mean skew).
+_GLM_PROFILE_ACTIVE: list[int] = []
+
+
+def _glm_profile_record_active(n_local: int) -> None:
+    if _GLM_PROFILE and _GLM_PROFILE_PHASE == "decode":
+        _GLM_PROFILE_ACTIVE.append(int(n_local))
+
+
 def glm_profile_reset() -> None:
     _GLM_PROFILE_TOTALS.clear()
     _GLM_PROFILE_COUNTS.clear()
+    _GLM_PROFILE_ACTIVE.clear()
 
 
 def glm_profile_report() -> str:
@@ -77,6 +91,31 @@ def glm_profile_report() -> str:
         pct = 100.0 * secs / total if total else 0.0
         lines.append(f"  {name:20s} {secs:9.4f}s  {n:6d}x  {per:8.3f}ms  {pct:5.1f}%")
     return "\n".join(lines)
+
+
+def glm_profile_skew_report() -> str:
+    """Quantify EP rank-skew from THIS rank's samples only (no collective, so it
+    is safe to call after the process group is torn down).  At decode T=1 the
+    top_k=8 experts scatter unevenly across the 4 EP ranks; the slowest
+    (max-active) rank's staging gates that layer's all_reduce.  Each rank prints
+    its own mean/max/min local active count tagged by rank; comparing the four
+    lines gives the cross-rank skew (max-rank-mean / avg-rank-mean)."""
+    local = list(_GLM_PROFILE_ACTIVE)
+    if not local:
+        return "  [skew] no decode activation samples"
+    # RANK from the env is stable even after the process group is destroyed.
+    rank = int(_os.environ.get("RANK", "0"))
+    import statistics
+    mean = statistics.fmean(local)
+    mx = max(local)
+    mn = min(local)
+    # top_k=8 is the global activation budget; on 4 ranks a perfectly balanced
+    # (TP) split would stage 8/world per rank each layer.
+    return (
+        f"  [skew] rank={rank} decode layer-calls={len(local)} "
+        f"local_active mean={mean:.3f} min={mn} max={mx} "
+        f"(TP-balanced would be top_k/world; compare mean across the 4 rank lines)"
+    )
 
 
 @dataclass(frozen=True)
@@ -669,6 +708,10 @@ class GLMDSARawBlockMoE:
                 w3_host = torch.stack([v[0] for v in w3_vals], dim=0)
                 w2_host = torch.stack([v[0] for v in w2_vals], dim=0)
         with _prof_section("stage_h2d"):
+            # Three independent small H2D copies. A merged single-H2D variant was
+            # tried (GLM_MERGED_H2D) and REGRESSED: the host torch.cat memcpy of
+            # ~1.8MB costs more than the 2 launches it saves (stage_h2d 4->12ms),
+            # so decode staging is not launch-overhead bound. Kept as 3 copies.
             w1_blocks = w1_host.to(self.device, non_blocking=True).contiguous()
             w3_blocks = w3_host.to(self.device, non_blocking=True).contiguous()
             w2_blocks = w2_host.to(self.device, non_blocking=True).contiguous()
@@ -722,9 +765,11 @@ class GLMDSARawBlockMoE:
             return out
         local_ids, route_tokens, route_weights, seg_starts = grouped
         if local_ids.numel() == 0:
+            _glm_profile_record_active(0)
             return out
         with _prof_section("moe_ids_sync"):
             local_ids_cpu = local_ids.detach().cpu().to(torch.long).tolist()
+        _glm_profile_record_active(len(local_ids_cpu))
 
         with _prof_section("moe_stage_experts"):
             reader = get_cached_gguf_tensor_reader(self.gguf_path)

--- a/src/models/glm_dsa/architecture.py
+++ b/src/models/glm_dsa/architecture.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import math
+import os as _os
+import time as _time
+from contextlib import contextmanager
 from dataclasses import dataclass
 
 import torch
@@ -11,6 +14,69 @@ from src.components.gguf.tp_logits import distributed_argmax_local_logits, gathe
 from src.components.moe.spec import metadata_float, metadata_int
 from src.loader.gguf.bundle import GGUFBundle
 from src.models.glm_dsa.spec import GLMDSASpec
+
+
+# ---------------------------------------------------------------------------
+# Opt-in decode profiler (GLM_PROFILE=1). Accumulates wall time per named
+# section, synchronizing CUDA around each so the numbers are real (not just
+# launch-queue time). Zero overhead when disabled: _prof_section short-circuits
+# before touching the clock or the CUDA device. Print the breakdown via
+# glm_profile_report() (the CLI does this on rank 0 after decode).
+# ---------------------------------------------------------------------------
+_GLM_PROFILE = _os.getenv("GLM_PROFILE", "0") == "1"
+_GLM_PROFILE_TOTALS: dict[str, float] = {}
+_GLM_PROFILE_COUNTS: dict[str, int] = {}
+_GLM_PROFILE_PHASE = "decode"
+
+
+def _glm_profile_set_phase(seqlen: int) -> None:
+    # seqlen==1 is a decode step; anything longer is prefill. Sections are keyed
+    # by phase so the prefill forward's per-layer time does not skew the decode
+    # per-call averages (decode is what we're optimizing).
+    global _GLM_PROFILE_PHASE
+    _GLM_PROFILE_PHASE = "decode" if int(seqlen) == 1 else "prefill"
+
+
+@contextmanager
+def _prof_section(name: str):
+    if not _GLM_PROFILE:
+        yield
+        return
+    key = f"{_GLM_PROFILE_PHASE}.{name}"
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+    t0 = _time.perf_counter()
+    try:
+        yield
+    finally:
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        dt = _time.perf_counter() - t0
+        _GLM_PROFILE_TOTALS[key] = _GLM_PROFILE_TOTALS.get(key, 0.0) + dt
+        _GLM_PROFILE_COUNTS[key] = _GLM_PROFILE_COUNTS.get(key, 0) + 1
+
+
+def glm_profile_enabled() -> bool:
+    return _GLM_PROFILE
+
+
+def glm_profile_reset() -> None:
+    _GLM_PROFILE_TOTALS.clear()
+    _GLM_PROFILE_COUNTS.clear()
+
+
+def glm_profile_report() -> str:
+    if not _GLM_PROFILE_TOTALS:
+        return "GLM_PROFILE: no sections recorded"
+    lines = ["GLM_PROFILE per-section totals (seconds / calls / ms-per-call):"]
+    total = sum(_GLM_PROFILE_TOTALS.values())
+    for name in sorted(_GLM_PROFILE_TOTALS, key=lambda k: -_GLM_PROFILE_TOTALS[k]):
+        secs = _GLM_PROFILE_TOTALS[name]
+        n = _GLM_PROFILE_COUNTS.get(name, 0)
+        per = 1000.0 * secs / n if n else 0.0
+        pct = 100.0 * secs / total if total else 0.0
+        lines.append(f"  {name:20s} {secs:9.4f}s  {n:6d}x  {per:8.3f}ms  {pct:5.1f}%")
+    return "\n".join(lines)
 
 
 @dataclass(frozen=True)
@@ -484,7 +550,23 @@ class GLMDSARawBlockMoE:
         self._resident_w3: torch.Tensor | None = None
         self._resident_w2: torch.Tensor | None = None
         self._resident_meta: tuple | None = None
+        # Reusable pinned host staging buffers (fallback path). The active expert
+        # SET changes every step so we cannot cache contents, but we CAN reuse a
+        # small pinned buffer (<=top_k experts, ~tens of MB) so each step's H2D is
+        # a fast pinned->GPU DMA instead of a pageable copy. Keyed by active count
+        # + block shape; rebuilt only when those change (rare at decode).  This is
+        # NOT the forbidden full-mmap pin: it is a bounded per-layer buffer.
+        self._pin_stage_w1: torch.Tensor | None = None
+        self._pin_stage_w3: torch.Tensor | None = None
+        self._pin_stage_w2: torch.Tensor | None = None
+        self._pin_stage_key: tuple | None = None
         import os as _os
+        # Pinned staging is OFF by default: a profiled e2e showed the per-expert
+        # copy into pinned host memory (stage_read) costs more than the faster
+        # pinned->GPU DMA (stage_h2d) saves — a net staging regression.  The mmap
+        # page-cache read into pinned is no cheaper than into pageable, so there
+        # is no free lunch here.  Kept as an opt-in experiment switch only.
+        self._use_pinned_stage = _os.getenv("GLM_PINNED_STAGE", "0") == "1"
 
         # Resident-cache staging is OFF by default: an e2e measurement showed it
         # does NOT help decode once the page cache is warm (the original per-step
@@ -568,24 +650,57 @@ class GLMDSARawBlockMoE:
             w2_blocks = w2_cpu.to(self.device, non_blocking=True).contiguous()
             return w1_blocks, w3_blocks, w2_blocks, self._resident_meta
 
-        w1_vals, w3_vals, w2_vals = [], [], []
-        for local_id in local_ids_cpu:
-            expert_id = int(local_id) + self.expert_start
-            w1_b, w1_tn, w1_in = reader.read_routed_expert_blocks(self.w1_name, expert_id)
-            w3_b, w3_tn, w3_in = reader.read_routed_expert_blocks(self.w3_name, expert_id)
-            w2_b, w2_tn, w2_in = reader.read_routed_expert_blocks(self.w2_name, expert_id)
-            w1_vals.append((w1_b, w1_tn, w1_in))
-            w3_vals.append((w3_b, w3_tn, w3_in))
-            w2_vals.append((w2_b, w2_tn, w2_in))
-        w1_blocks = torch.stack([v[0] for v in w1_vals], dim=0).to(self.device, non_blocking=True).contiguous()
-        w3_blocks = torch.stack([v[0] for v in w3_vals], dim=0).to(self.device, non_blocking=True).contiguous()
-        w2_blocks = torch.stack([v[0] for v in w2_vals], dim=0).to(self.device, non_blocking=True).contiguous()
+        with _prof_section("stage_read"):
+            w1_vals, w3_vals, w2_vals = [], [], []
+            for local_id in local_ids_cpu:
+                expert_id = int(local_id) + self.expert_start
+                w1_b, w1_tn, w1_in = reader.read_routed_expert_blocks(self.w1_name, expert_id)
+                w3_b, w3_tn, w3_in = reader.read_routed_expert_blocks(self.w3_name, expert_id)
+                w2_b, w2_tn, w2_in = reader.read_routed_expert_blocks(self.w2_name, expert_id)
+                w1_vals.append((w1_b, w1_tn, w1_in))
+                w3_vals.append((w3_b, w3_tn, w3_in))
+                w2_vals.append((w2_b, w2_tn, w2_in))
+            if getattr(self, "_use_pinned_stage", False):
+                w1_host = self._fill_pinned_stage("w1", [v[0] for v in w1_vals])
+                w3_host = self._fill_pinned_stage("w3", [v[0] for v in w3_vals])
+                w2_host = self._fill_pinned_stage("w2", [v[0] for v in w2_vals])
+            else:
+                w1_host = torch.stack([v[0] for v in w1_vals], dim=0)
+                w3_host = torch.stack([v[0] for v in w3_vals], dim=0)
+                w2_host = torch.stack([v[0] for v in w2_vals], dim=0)
+        with _prof_section("stage_h2d"):
+            w1_blocks = w1_host.to(self.device, non_blocking=True).contiguous()
+            w3_blocks = w3_host.to(self.device, non_blocking=True).contiguous()
+            w2_blocks = w2_host.to(self.device, non_blocking=True).contiguous()
         meta = (
             (self._type_ids[w1_vals[0][1]], int(w1_vals[0][2])),
             (self._type_ids[w3_vals[0][1]], int(w3_vals[0][2])),
             (self._type_ids[w2_vals[0][1]], int(w2_vals[0][2])),
         )
         return w1_blocks, w3_blocks, w2_blocks, meta
+
+    def _fill_pinned_stage(self, which: str, blocks: list[torch.Tensor]) -> torch.Tensor:
+        """Copy per-expert raw-block views into a reusable pinned host tensor and
+        return it.  The pinned buffer makes the subsequent H2D a fast DMA; it is
+        reused across steps whenever the active-expert count and block shape match
+        (the common decode case), so we avoid re-pinning every step."""
+        n = len(blocks)
+        b0 = blocks[0]
+        key = (which, n, tuple(b0.shape), b0.dtype)
+        attr = f"_pin_stage_{which}"
+        buf = getattr(self, attr)
+        # w1/w3/w2 shapes are stable per layer; track the active key per buffer.
+        keys = getattr(self, "_pin_stage_keys", None)
+        if keys is None:
+            keys = {}
+            self._pin_stage_keys = keys
+        if buf is None or keys.get(which) != key:
+            buf = torch.empty((n, *b0.shape), dtype=b0.dtype).pin_memory()
+            setattr(self, attr, buf)
+            keys[which] = key
+        for i, b in enumerate(blocks):
+            buf[i].copy_(b)
+        return buf
 
     def _routed_forward(self, x_flat: torch.Tensor, indices: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
         from src.kernels.cuda_loader import load_cuda_kernel
@@ -596,21 +711,24 @@ class GLMDSARawBlockMoE:
             raise RuntimeError("CUDA grouped MoE kernel is required for GLMDSARawBlockMoE")
 
         out = torch.zeros((x_flat.size(0), self.args.dim), device=x_flat.device, dtype=torch.float32)
-        grouped = cuda_mod.moe_group_routes(
-            indices.contiguous(),
-            weights.contiguous().to(torch.float32),
-            int(self.expert_start),
-            int(self.expert_count),
-        )
+        with _prof_section("moe_route_group"):
+            grouped = cuda_mod.moe_group_routes(
+                indices.contiguous(),
+                weights.contiguous().to(torch.float32),
+                int(self.expert_start),
+                int(self.expert_count),
+            )
         if grouped is None:
             return out
         local_ids, route_tokens, route_weights, seg_starts = grouped
         if local_ids.numel() == 0:
             return out
-        local_ids_cpu = local_ids.detach().cpu().to(torch.long).tolist()
+        with _prof_section("moe_ids_sync"):
+            local_ids_cpu = local_ids.detach().cpu().to(torch.long).tolist()
 
-        reader = get_cached_gguf_tensor_reader(self.gguf_path)
-        w1_blocks, w3_blocks, w2_blocks, meta = self._stage_active_experts(reader, local_ids_cpu)
+        with _prof_section("moe_stage_experts"):
+            reader = get_cached_gguf_tensor_reader(self.gguf_path)
+            w1_blocks, w3_blocks, w2_blocks, meta = self._stage_active_experts(reader, local_ids_cpu)
         (w1_type_id, w1_in_dim), (w3_type_id, w3_in_dim), (w2_type_id, w2_in_dim) = meta
 
         seg_i32 = seg_starts if seg_starts.dtype == torch.int32 else seg_starts.to(torch.int32)
@@ -618,7 +736,8 @@ class GLMDSARawBlockMoE:
             [seg_i32[local_ids.to(seg_i32.device)], seg_i32[-1:]], dim=0
         ).contiguous()
 
-        y = cuda_mod.gguf_moe_prefill_grouped_forward(
+        with _prof_section("moe_kernel"):
+          y = cuda_mod.gguf_moe_prefill_grouped_forward(
             x_flat.to(torch.float16).contiguous(),
             route_tokens,
             route_weights.contiguous(),
@@ -642,15 +761,18 @@ class GLMDSARawBlockMoE:
     def __call__(self, x: torch.Tensor) -> torch.Tensor:
         original_shape = x.shape
         x_flat = x.reshape(-1, original_shape[-1]).contiguous()
-        indices, weights = self.route(x_flat)
+        with _prof_section("moe_route"):
+            indices, weights = self.route(x_flat)
         out = self._routed_forward(x_flat, indices, weights)
 
         if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
-            dist.all_reduce(out)
+            with _prof_section("moe_all_reduce"):
+                dist.all_reduce(out)
 
         if self.shared_gate_proj is not None and self.shared_up_proj is not None and self.shared_down_proj is not None:
-            shared = F.silu(self.shared_gate_proj(x_flat).float()) * self.shared_up_proj(x_flat).float()
-            out = out + self.shared_down_proj(shared.to(self.dtype)).float()
+            with _prof_section("moe_shared"):
+                shared = F.silu(self.shared_gate_proj(x_flat).float()) * self.shared_up_proj(x_flat).float()
+                out = out + self.shared_down_proj(shared.to(self.dtype)).float()
         return out.reshape(original_shape).to(self.dtype)
 
 
@@ -690,10 +812,12 @@ class GLMDSABlock:
         self.attention.reset_cache(batch_size, max_seq_len)
 
     def __call__(self, x: torch.Tensor, start_pos: int) -> torch.Tensor:
-        x_attn = (x + self.attention(self.attn_norm(x), start_pos)).to(self.dtype)
-        mlp_in = self.ffn_norm(x_attn)
-        mlp_out = self.mlp(mlp_in)
-        return (x_attn + mlp_out).to(self.dtype)
+        with _prof_section("attention"):
+            x_attn = (x + self.attention(self.attn_norm(x), start_pos)).to(self.dtype)
+        with _prof_section("mlp"):
+            mlp_in = self.ffn_norm(x_attn)
+            mlp_out = self.mlp(mlp_in)
+            return (x_attn + mlp_out).to(self.dtype)
 
 
 class GLMDSATransformer:
@@ -750,6 +874,7 @@ class GLMDSATransformer:
             head = ", ".join(f"{v:12.4f}" for v in last[:3].tolist())
             print(f"GLM_DUMP {name:16s} sum={tf.sum().item():16.6f}  first3=[{head}]", flush=True)
 
+        _glm_profile_set_phase(int(tokens.size(-1)))
         h = self.embedding(tokens).to(self.dtype)
         _d("embd", h)
         for _li, layer in enumerate(self.layers):

--- a/src/models/glm_dsa/architecture.py
+++ b/src/models/glm_dsa/architecture.py
@@ -471,6 +471,13 @@ class GLMDSARawBlockMoE:
         # Pinning ~58 GB/rank is non-pageable host memory; opt-in only to avoid
         # over-committing pinned memory across TP ranks.
         self._pin_resident = _os.getenv("GLM_PIN_RESIDENT_EXPERTS", "0") == "1"
+        # GLM routed experts are iq2_xs (w1/w3) + iq3_xxs (w2); enable their
+        # DP4A grouped-MoE kernels by default (numerically parity-checked vs the
+        # fp32 general branch).  The CUDA kernel reads these env gates, so set
+        # them here unless the user explicitly opted out with "0".
+        for _flag in ("DEEPSEEK_GGUF_IQ2_XS_W13_DP4A", "DEEPSEEK_GGUF_IQ3_XXS_W2_DP4A"):
+            if _os.getenv(_flag) is None:
+                _os.environ[_flag] = "1"
 
     def route(self, x_flat: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         logits = x_flat.float() @ self.gate_weight.t()

--- a/src/models/glm_dsa/architecture.py
+++ b/src/models/glm_dsa/architecture.py
@@ -553,6 +553,8 @@ class GLMDSARawBlockMoE:
         dtype: torch.dtype = torch.float16,
         expert_start: int = 0,
         expert_count: int | None = None,
+        inter_start: int = 0,
+        inter_count: int | None = None,
         swiglu_limit: float = -1.0,
     ):
         self.args = args
@@ -577,6 +579,33 @@ class GLMDSARawBlockMoE:
                 f"invalid GLM-DSA local expert range [{self.expert_start}, {self.expert_start + self.expert_count}) "
                 f"for expert_count={args.n_routed_experts}"
             )
+        # Routed TP: when inter_count is set this rank owns ALL experts
+        # (expert_start=0, expert_count=n_routed_experts) but only the inter
+        # (feed-forward) slice [inter_start, inter_start+inter_count).  w13 is
+        # sliced along its out_dim rows; w2 keeps only the corresponding block
+        # columns of every output row.  The per-layer all_reduce in __call__
+        # then sums the partial-inter contributions across ranks.  When
+        # inter_count is None this is the original EP path (per-rank expert
+        # range, full inter).  Both share the same grouped CUDA kernel; only the
+        # staged tensor shapes differ.
+        self.inter_start = int(inter_start)
+        self.inter_count = None if inter_count is None else int(inter_count)
+        self._tp_routed = self.inter_count is not None
+        if self._tp_routed:
+            moe_inter = int(args.moe_inter_dim)
+            if self.inter_start % 256 != 0 or int(self.inter_count) % 256 != 0:
+                raise ValueError(
+                    f"GLM routed TP inter slice [{self.inter_start}, "
+                    f"{self.inter_start + int(self.inter_count)}) is not 256-block aligned"
+                )
+            if self.inter_start < 0 or self.inter_start + int(self.inter_count) > moe_inter:
+                raise ValueError(
+                    f"GLM routed TP inter slice [{self.inter_start}, "
+                    f"{self.inter_start + int(self.inter_count)}) outside moe_inter_dim={moe_inter}"
+                )
+            # w2 block-column range: iq3_xxs blocks are 256 elems along inter.
+            self._w2_block_start = self.inter_start // 256
+            self._w2_block_end = (self.inter_start + int(self.inter_count)) // 256
         self._grid = signed_grid.to(device=device, dtype=torch.int8).contiguous()
         from src.loader.gguf.quant_types import GGUF_DENSE_TYPE_IDS
 
@@ -613,6 +642,12 @@ class GLMDSARawBlockMoE:
         # same ~1.8GB host copy), while the one-time 58GB/rank build regresses
         # prefill.  Kept as an opt-in experiment switch only.
         self._disable_resident = _os.getenv("GLM_ENABLE_RESIDENT_EXPERTS", "0") != "1"
+        # The resident cache stages whole experts (full inter dimension), which
+        # is incompatible with TP inter-slicing.  Force it off under TP so the
+        # fallback per-step slicing path is always used (resident is a default-
+        # off perf experiment that measured no decode win anyway).
+        if self._tp_routed:
+            self._disable_resident = True
         # Pinning ~58 GB/rank is non-pageable host memory; opt-in only to avoid
         # over-committing pinned memory across TP ranks.
         self._pin_resident = _os.getenv("GLM_PIN_RESIDENT_EXPERTS", "0") == "1"
@@ -691,11 +726,32 @@ class GLMDSARawBlockMoE:
 
         with _prof_section("stage_read"):
             w1_vals, w3_vals, w2_vals = [], [], []
+            tp = getattr(self, "_tp_routed", False)
             for local_id in local_ids_cpu:
                 expert_id = int(local_id) + self.expert_start
-                w1_b, w1_tn, w1_in = reader.read_routed_expert_blocks(self.w1_name, expert_id)
-                w3_b, w3_tn, w3_in = reader.read_routed_expert_blocks(self.w3_name, expert_id)
-                w2_b, w2_tn, w2_in = reader.read_routed_expert_blocks(self.w2_name, expert_id)
+                if tp:
+                    # w13 out_dim == inter: slice the [inter_start, +inter_count)
+                    # output rows (a contiguous row range the reader supports and
+                    # only reads 1/world of the bytes).  in_dim stays == dim.
+                    w1_b, w1_tn, w1_in = reader.read_routed_expert_blocks(
+                        self.w1_name, expert_id,
+                        row_start=self.inter_start, row_count=int(self.inter_count),
+                    )
+                    w3_b, w3_tn, w3_in = reader.read_routed_expert_blocks(
+                        self.w3_name, expert_id,
+                        row_start=self.inter_start, row_count=int(self.inter_count),
+                    )
+                    # w2 in_dim == inter: slicing inter means keeping only the
+                    # matching block-columns of every output row.  Read the full
+                    # (page-cache-resident) view, then keep [w2_block_start,
+                    # w2_block_end) block columns.  Effective in_dim = inter_count.
+                    w2_full, w2_tn, _w2_in_full = reader.read_routed_expert_blocks(self.w2_name, expert_id)
+                    w2_b = w2_full[:, self._w2_block_start:self._w2_block_end, :].contiguous()
+                    w2_in = int(self.inter_count)
+                else:
+                    w1_b, w1_tn, w1_in = reader.read_routed_expert_blocks(self.w1_name, expert_id)
+                    w3_b, w3_tn, w3_in = reader.read_routed_expert_blocks(self.w3_name, expert_id)
+                    w2_b, w2_tn, w2_in = reader.read_routed_expert_blocks(self.w2_name, expert_id)
                 w1_vals.append((w1_b, w1_tn, w1_in))
                 w3_vals.append((w3_b, w3_tn, w3_in))
                 w2_vals.append((w2_b, w2_tn, w2_in))

--- a/src/models/glm_dsa/architecture.py
+++ b/src/models/glm_dsa/architecture.py
@@ -88,8 +88,32 @@ class RMSNorm:
         self.weight = weight.float().contiguous()
         self.eps = float(eps)
         self.out_dtype = out_dtype
+        import os as _os
+
+        from src.kernels.cuda_loader import load_cuda_kernel
+
+        # OFF by default: a real e2e showed the fused RMSNorm kernel is neutral
+        # for GLM decode (0.66->0.64 tok/s, within noise) because GLM's per-token
+        # time is ~1.5s, so the ~44ms of fp32 norm ops is only ~3% -- unlike
+        # MiniMax (~100ms/token) where it was ~20% and fusing gave +79%.  Keeping
+        # it off preserves bit-identical greedy output vs the DP4A baseline.
+        # Opt in with GLM_FUSED_RMSNORM=1.
+        self._use_fused = _os.getenv("GLM_FUSED_RMSNORM", "0") == "1"
+        self._cuda = load_cuda_kernel() if self._use_fused else None
 
     def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        if (
+            self._use_fused
+            and self._cuda is not None
+            and hasattr(self._cuda, "fused_rms_norm_forward")
+            and self.out_dtype == torch.float16
+            and x.is_cuda
+            and x.dim() >= 2
+            and x.dtype in (torch.float16, torch.bfloat16, torch.float32)
+        ):
+            x_flat = x.reshape(-1, x.size(-1)).contiguous()
+            y_flat = self._cuda.fused_rms_norm_forward(x_flat, self.weight, self.eps)
+            return y_flat.view(x.shape)
         xf = x.float()
         inv = torch.rsqrt(xf.pow(2).mean(dim=-1, keepdim=True) + self.eps)
         return (xf * inv * self.weight).to(self.out_dtype)

--- a/src/models/glm_dsa/gguf_model.py
+++ b/src/models/glm_dsa/gguf_model.py
@@ -41,6 +41,8 @@ class GLMDSAGGUFModelLoader:
         allow_moe_layers: bool = False,
         expert_start: int = 0,
         expert_count: int | None = None,
+        inter_start: int = 0,
+        inter_count: int | None = None,
         use_raw_block_moe: bool = True,
         world: int = 1,
         rank: int = 0,
@@ -66,6 +68,9 @@ class GLMDSAGGUFModelLoader:
                 f"invalid GLM-DSA expert range [{self.expert_start}, {self.expert_start + self.expert_count}) "
                 f"for expert_count={self.args.n_routed_experts}"
             )
+        # Routed TP inter-dim slice (None => EP / full inter dimension).
+        self.inter_start = int(inter_start)
+        self.inter_count = None if inter_count is None else int(inter_count)
         self._readers: dict[str, GGUFTensorDataReader] = {}
 
     def close(self) -> None:
@@ -290,6 +295,14 @@ class GLMDSAGGUFModelLoader:
                 dtype=self.dtype,
                 expert_start=self.expert_start,
                 expert_count=self.expert_count,
+                inter_start=self.inter_start,
+                inter_count=self.inter_count,
+            )
+        if self.inter_count is not None:
+            raise NotImplementedError(
+                "GLM routed TP (inter-dim slicing) requires the raw-block MoE path; "
+                "the reference GLMDSAMoE fallback does not support it. "
+                "Set GLM_ROUTED_TP=0 (EP) or do not force GLM_FORCE_REF_MOE."
             )
         return GLMDSAMoE(
             self.args,
@@ -390,6 +403,8 @@ def load_glm_dsa_gguf_model(
     allow_moe_layers: bool = False,
     expert_start: int = 0,
     expert_count: int | None = None,
+    inter_start: int = 0,
+    inter_count: int | None = None,
     world: int = 1,
     rank: int = 0,
     use_raw_block_moe: bool = True,
@@ -403,6 +418,8 @@ def load_glm_dsa_gguf_model(
         allow_moe_layers=allow_moe_layers,
         expert_start=expert_start,
         expert_count=expert_count,
+        inter_start=inter_start,
+        inter_count=inter_count,
         world=world,
         rank=rank,
         use_raw_block_moe=use_raw_block_moe,
@@ -425,6 +442,8 @@ def load_glm_dsa_gguf_model(
         "allow_moe_layers": bool(allow_moe_layers),
         "expert_start": int(loader.expert_start),
         "expert_count": int(loader.expert_count),
+        "inter_start": int(loader.inter_start),
+        "inter_count": (None if loader.inter_count is None else int(loader.inter_count)),
         "world": int(loader.world),
         "rank": int(loader.rank),
         "lm_head_out_dim": int(model.lm_head.out_dim),

--- a/src/models/glm_dsa/spec.py
+++ b/src/models/glm_dsa/spec.py
@@ -274,20 +274,57 @@ class GLMDSASpec:
         from src.models.glm_dsa.gguf_model import load_glm_dsa_gguf_model
 
         _ = gpu_memory_gib
+        import os as _os
         leading_dense = self.leading_dense_layers(bundle)
         effective_layers = int(leading_dense if n_layers is None else n_layers)
         allow_moe_layers = effective_layers > leading_dense
-        expert_total = int(self.parse_params(bundle).n_routed_experts)
-        if allow_moe_layers:
+        params = self.parse_params(bundle)
+        expert_total = int(params.n_routed_experts)
+        moe_inter = int(params.expert_intermediate_size)
+        # Routed-expert sharding mode.  EP (expert-parallel, the default) shards
+        # the expert range across ranks; TP (tensor-parallel, opt-in via
+        # ``GLM_ROUTED_TP=1``) keeps all experts on every rank but slices the
+        # inter (feed-forward) dimension.
+        #
+        # TP was expected to win by removing the per-layer EP rank-skew wait on
+        # the all_reduce, and it DOES eliminate the skew (all_reduce 5.75ms ->
+        # 0.24ms/token, every rank perfectly balanced at 8/8 active).  But the
+        # measured e2e is a NET REGRESSION (decode 0.60 -> 0.54 tok/s): staging
+        # each rank's active experts grows from ~2 (EP) to all 8 (TP), and
+        # warm-cache stage_read is per-expert-call-bound, so it grows 5.46 ->
+        # 12.91ms/token (+7.5ms) and swamps the 5.5ms skew win.  So TP is kept
+        # OFF by default; the code path is retained (numerically validated) as an
+        # opt-in for the case where staging is later made call-count-cheap.
+        # At world==1 there is no skew to remove, so TP never engages.
+        routed_tp = _os.getenv("GLM_ROUTED_TP", "0") == "1" and int(world) > 1
+        if allow_moe_layers and routed_tp:
+            # TP: all experts local (router drops nothing), slice inter per rank.
+            expert_start = 0
+            expert_count = expert_total
+            inter_start = (moe_inter * int(rank)) // int(world)
+            inter_end = (moe_inter * (int(rank) + 1)) // int(world)
+            inter_count: int | None = inter_end - inter_start
+            # iq2_xs/iq3_xxs blocks are 256 elements; the inter slice must land
+            # on whole-block boundaries so the block-internal decode is unchanged.
+            if inter_start % 256 != 0 or int(inter_count) % 256 != 0:
+                raise ValueError(
+                    f"GLM routed TP inter slice [{inter_start}, {inter_end}) for "
+                    f"moe_inter={moe_inter}, world={world} is not 256-block aligned"
+                )
+        elif allow_moe_layers:
+            # EP: contiguous expert range per rank, full inter dimension.
             expert_start = (expert_total * int(rank)) // int(world)
             expert_end = (expert_total * (int(rank) + 1)) // int(world)
             expert_count = expert_end - expert_start
+            inter_start = 0
+            inter_count = None
         else:
             expert_start = 0
             expert_count = 0
+            inter_start = 0
+            inter_count = None
 
         t_load = time.perf_counter()
-        import os as _os
         _use_raw = not bool(_os.environ.get("GLM_FORCE_REF_MOE"))
         model, _info = load_glm_dsa_gguf_model(
             bundle,
@@ -297,6 +334,8 @@ class GLMDSASpec:
             allow_moe_layers=allow_moe_layers,
             expert_start=expert_start,
             expert_count=expert_count,
+            inter_start=int(inter_start),
+            inter_count=inter_count,
             world=int(world),
             rank=int(rank),
             use_raw_block_moe=_use_raw,

--- a/tests/test_glm_dsa_fused_rmsnorm.py
+++ b/tests/test_glm_dsa_fused_rmsnorm.py
@@ -1,0 +1,50 @@
+"""GLM-DSA RMSNorm fused-CUDA path must match the PyTorch reference.
+
+GLM decode calls RMSNorm ~4x per layer x 78 layers; the fused kernel replaces
+the fp32 pow/mean/rsqrt/mul chain (many tiny launches) with one block/token.
+This asserts the fused output matches the reference math within fp16 tolerance
+for the norm dims GLM actually uses (hidden, q/kv lora ranks).
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.models.glm_dsa.architecture import RMSNorm
+
+
+def _cuda_rmsnorm_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    from src.kernels.cuda_loader import load_cuda_kernel
+
+    mod = load_cuda_kernel()
+    return mod is not None and hasattr(mod, "fused_rms_norm_forward")
+
+
+@pytest.mark.skipif(not _cuda_rmsnorm_available(), reason="CUDA fused_rms_norm not available")
+@pytest.mark.parametrize("dim", [5120, 1536, 512, 4096])
+@pytest.mark.parametrize("rows", [1, 13])
+def test_glm_fused_rmsnorm_matches_reference(dim: int, rows: int, monkeypatch) -> None:
+    # The fused path is opt-in (neutral for GLM decode); enable it for the test.
+    monkeypatch.setenv("GLM_FUSED_RMSNORM", "1")
+    device = torch.device("cuda:0")
+    torch.manual_seed(0)
+    weight = torch.randn(dim, device=device)
+    eps = 1.0e-5
+    norm = RMSNorm(weight, eps, out_dtype=torch.float16)
+
+    x = torch.randn(1, rows, dim, device=device, dtype=torch.float16)
+    y_fused = norm(x)
+
+    # Reference (bypass the fused path explicitly).
+    xf = x.float()
+    inv = torch.rsqrt(xf.pow(2).mean(dim=-1, keepdim=True) + eps)
+    y_ref = (xf * inv * weight.float()).to(torch.float16)
+
+    assert y_fused.shape == y_ref.shape
+    assert torch.isfinite(y_fused).all()
+    abs_diff = (y_fused.float() - y_ref.float()).abs()
+    max_abs = float(abs_diff.max().item())
+    # fp16 rounding of a normalized value; a couple ULPs is expected.
+    assert max_abs < 5.0e-3, f"dim={dim} rows={rows} max_abs={max_abs:.4e}"

--- a/tests/test_glm_dsa_iq2xs_iq3xxs_dp4a.py
+++ b/tests/test_glm_dsa_iq2xs_iq3xxs_dp4a.py
@@ -1,0 +1,155 @@
+"""Numerical correctness of the GLM-DSA iq2_xs (w13) and iq3_xxs (w2) DP4A
+grouped-MoE kernels vs the fp32 general branch.
+
+GLM-5.2's routed experts are iq2_xs (w1/w3, 74 B/256) + iq3_xxs (w2, 98 B/256),
+which the DP4A fast path did not previously cover (it gated on iq2_xxs 66 B
+only), so decode fell to the slow fp32 gguf_moe_w13_kernel.  These tests drive
+the same gguf_moe_prefill_grouped_forward entry point with the new env gates
+DEEPSEEK_GGUF_IQ2_XS_W13_DP4A / DEEPSEEK_GGUF_IQ3_XXS_W2_DP4A on vs off and
+assert the DP4A output matches the fp32 baseline within int8-quant tolerance.
+
+Real GLM bundle + CUDA extension required.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+from src.loader.gguf.bundle import read_gguf_bundle
+from src.loader.gguf.tensor_reader import (
+    GGUFTensorDataReader,
+    get_iq2xs_iq3xxs_signed_grid_tensor,
+)
+
+
+REAL_GLM_PATH = Path("/mnt/data3/GLM-5.2-GGUF/UD-Q2_K_XL")
+
+
+def _cuda_gguf_ext_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    from src.kernels.cuda_loader import load_cuda_kernel
+
+    cuda_mod = load_cuda_kernel()
+    return cuda_mod is not None and hasattr(cuda_mod, "gguf_moe_prefill_grouped_forward")
+
+
+def _stack_expert_blocks(reader, name, experts):
+    """Stack [E, N, K_blocks, block_bytes] like _stage_active_experts does."""
+    blocks = []
+    tn = in_dim = None
+    for eid in experts:
+        b, tn, in_dim = reader.read_routed_expert_blocks(name, eid)
+        blocks.append(b.clone())
+    return torch.stack(blocks, dim=0).contiguous(), tn, int(in_dim)
+
+
+def _type_id(tn: str) -> int:
+    from src.loader.gguf.quant_types import GGUF_DENSE_TYPE_IDS
+
+    return GGUF_DENSE_TYPE_IDS[tn]
+
+
+def _run_grouped(cuda_mod, x, rt, rw, seg, w1, w3, w2, meta, grid, env_flags_on):
+    (w1_tid, w1_in), (w3_tid, w3_in), (w2_tid, w2_in) = meta
+    backups = {}
+    for flag in ("DEEPSEEK_GGUF_IQ2_XS_W13_DP4A", "DEEPSEEK_GGUF_IQ3_XXS_W2_DP4A"):
+        backups[flag] = os.environ.get(flag)
+        if env_flags_on:
+            os.environ[flag] = "1"
+        else:
+            os.environ.pop(flag, None)
+    try:
+        return cuda_mod.gguf_moe_prefill_grouped_forward(
+            x, rt, rw, seg, w1, w3, w2,
+            int(w1_in), int(w1_tid),
+            int(w3_in), int(w3_tid),
+            int(w2_in), int(w2_tid),
+            grid, 0.0,
+        )
+    finally:
+        for flag, val in backups.items():
+            if val is not None:
+                os.environ[flag] = val
+            else:
+                os.environ.pop(flag, None)
+
+
+@pytest.mark.skipif(
+    not (REAL_GLM_PATH.exists() and _cuda_gguf_ext_available()),
+    reason="real GLM GGUF or CUDA extension not available",
+)
+def test_glm_iq2xs_iq3xxs_dp4a_matches_fp32() -> None:
+    from src.kernels.cuda_loader import load_cuda_kernel
+
+    cuda_mod = load_cuda_kernel()
+    bundle = read_gguf_bundle(REAL_GLM_PATH)
+    prefix = "blk.3"  # first routed MoE layer (leading_dense=3)
+    w1_name = f"{prefix}.ffn_gate_exps.weight"
+    w3_name = f"{prefix}.ffn_up_exps.weight"
+    w2_name = f"{prefix}.ffn_down_exps.weight"
+    shard = bundle.tensors_by_name[w1_name].shard_path
+    reader = GGUFTensorDataReader(shard)
+    device = torch.device("cuda:0")
+
+    try:
+        experts = [0, 1]
+        w1_cpu, w1_tn, dim = _stack_expert_blocks(reader, w1_name, experts)
+        w3_cpu, w3_tn, _ = _stack_expert_blocks(reader, w3_name, experts)
+        w2_cpu, w2_tn, inter_dim = _stack_expert_blocks(reader, w2_name, experts)
+    finally:
+        reader.close()
+
+    assert w1_tn == "iq2_xs" and w3_tn == "iq2_xs" and w2_tn == "iq3_xxs"
+
+    w1 = w1_cpu.to(device)
+    w3 = w3_cpu.to(device)
+    w2 = w2_cpu.to(device)
+    meta = (
+        (_type_id(w1_tn), dim),
+        (_type_id(w3_tn), dim),
+        (_type_id(w2_tn), inter_dim),
+    )
+    grid = get_iq2xs_iq3xxs_signed_grid_tensor().to(device=device, dtype=torch.int8).contiguous()
+
+    tokens, topk, n_experts = 4, 2, 2
+    indices = torch.tensor([[0, 1], [1, 0], [0, 1], [1, 0]], device=device, dtype=torch.long)
+    weights = torch.rand(tokens, topk, device=device, dtype=torch.float32)
+    weights = weights / weights.sum(dim=-1, keepdim=True)
+
+    grouped = cuda_mod.moe_group_routes(indices, weights, 0, n_experts)
+    _local_ids, route_tokens, route_weights, seg_starts = grouped
+    routes = int(route_tokens.numel())
+    assert routes == tokens * topk
+
+    torch.manual_seed(1234)
+    x = torch.randn(tokens, dim, device=device, dtype=torch.float16)
+
+    y_float = _run_grouped(cuda_mod, x, route_tokens, route_weights, seg_starts,
+                           w1, w3, w2, meta, grid, env_flags_on=False)
+    y_dp4a = _run_grouped(cuda_mod, x, route_tokens, route_weights, seg_starts,
+                          w1, w3, w2, meta, grid, env_flags_on=True)
+
+    assert y_float.shape == y_dp4a.shape == (tokens, dim)
+    assert torch.isfinite(y_float).all() and torch.isfinite(y_dp4a).all()
+    assert y_float.abs().sum() > 0.0 and y_dp4a.abs().sum() > 0.0
+
+    abs_diff = (y_dp4a - y_float).abs()
+    max_abs = float(abs_diff.max().item())
+    mean_abs = float(abs_diff.mean().item())
+    mask = y_float.abs() > 1e-2
+    rel = abs_diff[mask] / (y_float[mask].abs() + 1e-8)
+    p99_rel = float(torch.quantile(rel, 0.99).item()) if rel.numel() else 0.0
+
+    # int8 activation quant + DP4A over two quant dtypes (w13 iq2_xs AND w2
+    # iq3_xxs) accumulates more error than a single-stage kernel; keep tolerance
+    # modest but strict enough to catch a wrong grid/scale/layout.
+    assert max_abs < 0.5, f"max_abs={max_abs:.4e} mean_abs={mean_abs:.4e} p99_rel={p99_rel:.4e}"
+    assert mean_abs < 3.0e-2, f"max_abs={max_abs:.4e} mean_abs={mean_abs:.4e} p99_rel={p99_rel:.4e}"
+    assert p99_rel < 0.35, f"max_abs={max_abs:.4e} mean_abs={mean_abs:.4e} p99_rel={p99_rel:.4e}"
+
+    print(f"✓ GLM iq2_xs/iq3_xxs DP4A match: max_abs={max_abs:.4e} "
+          f"mean_abs={mean_abs:.4e} p99_rel={p99_rel:.4e}")

--- a/tests/test_glm_dsa_resident_experts.py
+++ b/tests/test_glm_dsa_resident_experts.py
@@ -1,0 +1,117 @@
+"""Correctness lock for the GLM-DSA resident-expert staging refactor.
+
+The decode hot path was changed from re-reading each active expert's raw blocks
+from mmap + ``torch.stack`` every step to a lazily-built resident CPU cache that
+is indexed + async-H2D'd.  This test asserts the resident cache is byte-identical
+to the original per-expert mmap reads, so the refactor cannot silently corrupt
+expert weights.
+
+Runs only when the real GLM-5.2 GGUF bundle is present (CPU-only; no CUDA
+required — we compare the CPU-side staged blocks before the H2D copy).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from src.loader.gguf.bundle import read_gguf_bundle
+from src.loader.gguf.quant_types import GGUF_DENSE_TYPE_IDS
+from src.loader.gguf.tensor_reader import get_cached_gguf_tensor_reader
+from src.models.glm_dsa import architecture as arch
+
+
+REAL_GLM_PATH = Path("/mnt/data3/GLM-5.2-GGUF/UD-Q2_K_XL")
+
+
+class _StagingHarness:
+    """Minimal stand-in exposing exactly the attributes that
+    ``_build_resident_experts`` / ``_stage_active_experts`` read, so we can test
+    the staging logic without building the full CUDA MoE layer."""
+
+    _build_resident_experts = arch.GLMDSARawBlockMoE._build_resident_experts
+    _stage_active_experts = arch.GLMDSARawBlockMoE._stage_active_experts
+
+    def __init__(self, w1_name, w3_name, w2_name, expert_start, expert_count):
+        self.w1_name = w1_name
+        self.w3_name = w3_name
+        self.w2_name = w2_name
+        self.expert_start = expert_start
+        self.expert_count = expert_count
+        self.device = torch.device("cpu")
+        self._type_ids = GGUF_DENSE_TYPE_IDS
+        self._resident_w1 = None
+        self._resident_w3 = None
+        self._resident_w2 = None
+        self._resident_meta = None
+        self._disable_resident = False
+        self._pin_resident = False
+
+
+@pytest.mark.skipif(not REAL_GLM_PATH.exists(), reason="real GLM GGUF not available")
+def test_resident_cache_matches_mmap_reads() -> None:
+    bundle = read_gguf_bundle(REAL_GLM_PATH)
+    # blk.3 is the first routed MoE layer (leading_dense=3).
+    prefix = "blk.3"
+    w1_name = f"{prefix}.ffn_gate_exps.weight"
+    w3_name = f"{prefix}.ffn_up_exps.weight"
+    w2_name = f"{prefix}.ffn_down_exps.weight"
+    shard = bundle.tensors_by_name[w1_name].shard_path
+    reader = get_cached_gguf_tensor_reader(shard)
+
+    expert_start, expert_count = 0, 4
+    h = _StagingHarness(w1_name, w3_name, w2_name, expert_start, expert_count)
+
+    # Build the resident cache and stage a subset of active experts.
+    active = [3, 1, 0, 2]  # deliberately unordered to exercise index_select
+    w1_r, w3_r, w2_r, meta_r = h._stage_active_experts(reader, active)
+
+    # Reference: fresh per-expert mmap reads in the same active order.
+    def ref_stack(name):
+        blocks = []
+        tn = in_dim = None
+        for lid in active:
+            b, tn, in_dim = reader.read_routed_expert_blocks(name, lid + expert_start)
+            blocks.append(b.clone())
+        return torch.stack(blocks, dim=0).contiguous(), tn, in_dim
+
+    w1_ref, w1_tn, w1_in = ref_stack(w1_name)
+    w3_ref, w3_tn, w3_in = ref_stack(w3_name)
+    w2_ref, w2_tn, w2_in = ref_stack(w2_name)
+
+    assert torch.equal(w1_r, w1_ref), "resident w1 blocks differ from mmap reads"
+    assert torch.equal(w3_r, w3_ref), "resident w3 blocks differ from mmap reads"
+    assert torch.equal(w2_r, w2_ref), "resident w2 blocks differ from mmap reads"
+
+    assert meta_r == (
+        (GGUF_DENSE_TYPE_IDS[w1_tn], int(w1_in)),
+        (GGUF_DENSE_TYPE_IDS[w3_tn], int(w3_in)),
+        (GGUF_DENSE_TYPE_IDS[w2_tn], int(w2_in)),
+    )
+
+
+@pytest.mark.skipif(not REAL_GLM_PATH.exists(), reason="real GLM GGUF not available")
+def test_resident_disabled_matches_enabled() -> None:
+    """The GLM_DISABLE_RESIDENT_EXPERTS fallback (per-step mmap re-read) must
+    produce identical staged blocks to the resident path."""
+    bundle = read_gguf_bundle(REAL_GLM_PATH)
+    prefix = "blk.3"
+    w1_name = f"{prefix}.ffn_gate_exps.weight"
+    w3_name = f"{prefix}.ffn_up_exps.weight"
+    w2_name = f"{prefix}.ffn_down_exps.weight"
+    shard = bundle.tensors_by_name[w1_name].shard_path
+    reader = get_cached_gguf_tensor_reader(shard)
+    active = [2, 0, 3]
+
+    h_res = _StagingHarness(w1_name, w3_name, w2_name, 0, 4)
+    w1a, w3a, w2a, meta_a = h_res._stage_active_experts(reader, active)
+
+    h_dis = _StagingHarness(w1_name, w3_name, w2_name, 0, 4)
+    h_dis._disable_resident = True
+    w1b, w3b, w2b, meta_b = h_dis._stage_active_experts(reader, active)
+
+    assert torch.equal(w1a, w1b)
+    assert torch.equal(w3a, w3b)
+    assert torch.equal(w2a, w2b)
+    assert meta_a == meta_b

--- a/tests/test_glm_dsa_tp_routed.py
+++ b/tests/test_glm_dsa_tp_routed.py
@@ -1,0 +1,219 @@
+"""Numerical equivalence of GLM-DSA routed-expert TP (inter-dim slicing) vs the
+full/EP computation, plus the TP slice-alignment guards.
+
+The routed MoE can shard two ways across TP ranks:
+  * EP (original): each rank owns a contiguous expert range, full inter dim.
+  * TP (default, GLM_ROUTED_TP=1): every rank owns ALL experts but only its
+    1/world slice of the inter (feed-forward) dimension; w2 becomes a partial
+    sum along inter and the per-layer all_reduce combines the ranks.
+
+Correctness invariant: summing the per-rank TP inter-slice outputs must equal
+the single full-inter grouped forward (the value EP's all_reduce reconstructs),
+up to float summation-order noise.  We drive the same
+gguf_moe_prefill_grouped_forward entry point used by _routed_forward, once at
+full inter and once per rank slice, and assert the slice-sum matches.
+
+The w13 slice is a contiguous out_dim (== inter) row range; the w2 slice keeps
+only the matching block-columns of every output row (in_dim == inter).  This
+mirrors GLMDSARawBlockMoE._stage_active_experts under self._tp_routed.
+
+Real GLM bundle + CUDA extension required for the numeric test; the alignment
+guard test runs anywhere.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+from src.loader.gguf.bundle import read_gguf_bundle
+from src.loader.gguf.tensor_reader import (
+    GGUFTensorDataReader,
+    get_iq2xs_iq3xxs_signed_grid_tensor,
+)
+
+
+REAL_GLM_PATH = Path("/mnt/data3/GLM-5.2-GGUF/UD-Q2_K_XL")
+
+
+def _cuda_gguf_ext_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    from src.kernels.cuda_loader import load_cuda_kernel
+
+    cuda_mod = load_cuda_kernel()
+    return cuda_mod is not None and hasattr(cuda_mod, "gguf_moe_prefill_grouped_forward")
+
+
+def _type_id(tn: str) -> int:
+    from src.loader.gguf.quant_types import GGUF_DENSE_TYPE_IDS
+
+    return GGUF_DENSE_TYPE_IDS[tn]
+
+
+def _stack_expert_blocks(reader, name, experts):
+    blocks = []
+    tn = in_dim = None
+    for eid in experts:
+        b, tn, in_dim = reader.read_routed_expert_blocks(name, eid)
+        blocks.append(b.clone())
+    return torch.stack(blocks, dim=0).contiguous(), tn, int(in_dim)
+
+
+def _run_grouped(cuda_mod, x, rt, rw, seg, w1, w3, w2, meta, grid):
+    (w1_tid, w1_in), (w3_tid, w3_in), (w2_tid, w2_in) = meta
+    backups = {}
+    for flag in ("DEEPSEEK_GGUF_IQ2_XS_W13_DP4A", "DEEPSEEK_GGUF_IQ3_XXS_W2_DP4A"):
+        backups[flag] = os.environ.get(flag)
+        os.environ[flag] = "1"
+    try:
+        return cuda_mod.gguf_moe_prefill_grouped_forward(
+            x, rt, rw, seg, w1, w3, w2,
+            int(w1_in), int(w1_tid),
+            int(w3_in), int(w3_tid),
+            int(w2_in), int(w2_tid),
+            grid, 0.0,
+        )
+    finally:
+        for flag, val in backups.items():
+            if val is not None:
+                os.environ[flag] = val
+            else:
+                os.environ.pop(flag, None)
+
+
+@pytest.mark.skipif(
+    not (REAL_GLM_PATH.exists() and _cuda_gguf_ext_available()),
+    reason="real GLM GGUF or CUDA extension not available",
+)
+def test_glm_tp_inter_slice_sum_matches_full() -> None:
+    from src.kernels.cuda_loader import load_cuda_kernel
+
+    cuda_mod = load_cuda_kernel()
+    bundle = read_gguf_bundle(REAL_GLM_PATH)
+    prefix = "blk.3"  # first routed MoE layer (leading_dense=3)
+    w1_name = f"{prefix}.ffn_gate_exps.weight"
+    w3_name = f"{prefix}.ffn_up_exps.weight"
+    w2_name = f"{prefix}.ffn_down_exps.weight"
+    shard = bundle.tensors_by_name[w1_name].shard_path
+    reader = GGUFTensorDataReader(shard)
+    device = torch.device("cuda:0")
+
+    try:
+        experts = [0, 1]
+        w1_cpu, w1_tn, dim = _stack_expert_blocks(reader, w1_name, experts)
+        w3_cpu, w3_tn, _ = _stack_expert_blocks(reader, w3_name, experts)
+        w2_cpu, w2_tn, inter_dim = _stack_expert_blocks(reader, w2_name, experts)
+    finally:
+        reader.close()
+
+    assert w1_tn == "iq2_xs" and w3_tn == "iq2_xs" and w2_tn == "iq3_xxs"
+    # w13: [E, inter, w13_blocks_per_row, 74]; w2: [E, dim, w2_blocks_per_row, 98]
+    assert w1_cpu.size(1) == inter_dim
+    assert w2_cpu.size(1) == dim
+    w2_blocks_per_row = w2_cpu.size(2)
+    assert w2_blocks_per_row * 256 == inter_dim, (w2_blocks_per_row, inter_dim)
+
+    grid = get_iq2xs_iq3xxs_signed_grid_tensor().to(device=device, dtype=torch.int8).contiguous()
+
+    tokens, topk, n_experts = 4, 2, 2
+    indices = torch.tensor([[0, 1], [1, 0], [0, 1], [1, 0]], device=device, dtype=torch.long)
+    weights = torch.rand(tokens, topk, device=device, dtype=torch.float32)
+    weights = weights / weights.sum(dim=-1, keepdim=True)
+    grouped = cuda_mod.moe_group_routes(indices, weights, 0, n_experts)
+    _local_ids, route_tokens, route_weights, seg_starts = grouped
+
+    torch.manual_seed(1234)
+    x = torch.randn(tokens, dim, device=device, dtype=torch.float16)
+
+    # Reference: full inter dimension (what EP's all_reduce reconstructs).
+    meta_full = ((_type_id(w1_tn), dim), (_type_id(w3_tn), dim), (_type_id(w2_tn), inter_dim))
+    y_full = _run_grouped(
+        cuda_mod, x, route_tokens, route_weights, seg_starts,
+        w1_cpu.to(device), w3_cpu.to(device), w2_cpu.to(device), meta_full, grid,
+    )
+
+    # TP: slice inter into `world` equal pieces, run each, sum the outputs.
+    world = 4
+    assert inter_dim % world == 0
+    inter_slice = inter_dim // world
+    assert inter_slice % 256 == 0
+    blk_slice = inter_slice // 256
+
+    y_tp = torch.zeros_like(y_full)
+    for r in range(world):
+        r0, r1 = r * inter_slice, (r + 1) * inter_slice
+        b0, b1 = r * blk_slice, (r + 1) * blk_slice
+        # w13: contiguous out_dim (inter) row slice.
+        w1_s = w1_cpu[:, r0:r1, :, :].contiguous().to(device)
+        w3_s = w3_cpu[:, r0:r1, :, :].contiguous().to(device)
+        # w2: keep the matching block-columns of every output row.
+        w2_s = w2_cpu[:, :, b0:b1, :].contiguous().to(device)
+        meta_s = ((_type_id(w1_tn), dim), (_type_id(w3_tn), dim), (_type_id(w2_tn), inter_slice))
+        y_r = _run_grouped(
+            cuda_mod, x, route_tokens, route_weights, seg_starts,
+            w1_s, w3_s, w2_s, meta_s, grid,
+        )
+        y_tp = y_tp + y_r
+
+    assert y_tp.shape == y_full.shape == (tokens, dim)
+    assert torch.isfinite(y_tp).all() and torch.isfinite(y_full).all()
+    assert y_full.abs().sum() > 0.0 and y_tp.abs().sum() > 0.0
+
+    abs_diff = (y_tp - y_full).abs()
+    max_abs = float(abs_diff.max().item())
+    mean_abs = float(abs_diff.mean().item())
+    mask = y_full.abs() > 1e-2
+    rel = abs_diff[mask] / (y_full[mask].abs() + 1e-8)
+    p99_rel = float(torch.quantile(rel, 0.99).item()) if rel.numel() else 0.0
+
+    # Same value, only float summation order differs (partial-inter sums vs one
+    # full-inter reduction), so the tolerance is tight.
+    assert max_abs < 5.0e-2, f"max_abs={max_abs:.4e} mean_abs={mean_abs:.4e} p99_rel={p99_rel:.4e}"
+    assert mean_abs < 1.0e-3, f"max_abs={max_abs:.4e} mean_abs={mean_abs:.4e} p99_rel={p99_rel:.4e}"
+    assert p99_rel < 5.0e-2, f"max_abs={max_abs:.4e} mean_abs={mean_abs:.4e} p99_rel={p99_rel:.4e}"
+
+    print(f"✓ GLM routed TP inter-slice sum matches full: max_abs={max_abs:.4e} "
+          f"mean_abs={mean_abs:.4e} p99_rel={p99_rel:.4e}")
+
+
+def test_glm_tp_inter_slice_alignment_guard() -> None:
+    """A non-256-aligned inter slice must be rejected at MoE construction."""
+    from src.models.glm_dsa.architecture import GLMDSAArgs, GLMDSARawBlockMoE
+
+    # GLMDSAArgs is a frozen dataclass; build one with the fields the guard uses
+    # (n_routed_experts, moe_inter_dim, dim, top_k, expert_weights_*) set and the
+    # rest as harmless placeholders.
+    args = GLMDSAArgs(
+        n_layers=4, leading_dense_layers=3, dim=64, vocab_size=32, n_heads=1,
+        n_kv_heads=1, head_dim=16, q_lora_rank=0, kv_lora_rank=0, key_mla_dim=0,
+        value_dim=0, value_mla_dim=0, rope_dim=0, rope_base=10000.0,
+        indexer_heads=0, indexer_key_dim=0, dense_inter_dim=128,
+        n_routed_experts=8, top_k=2, moe_inter_dim=2048, n_shared_experts=0,
+        norm_eps=1e-5, context_length=128, expert_weights_norm=True,
+        expert_weights_scale=1.0,
+    )
+
+    gate = torch.zeros(args.n_routed_experts, args.dim)
+    grid = torch.zeros(1, dtype=torch.int8)
+    device = torch.device("cpu")
+
+    common = dict(
+        gguf_path="/nonexistent.gguf",
+        w1_name="w1", w3_name="w3", w2_name="w2",
+        signed_grid=grid, device=device, dtype=torch.float16,
+        expert_start=0, expert_count=args.n_routed_experts,
+    )
+
+    # 300 is not a multiple of 256 -> must raise.
+    with pytest.raises(ValueError, match="256-block aligned"):
+        GLMDSARawBlockMoE(args, 3, gate, None, None, None, None,
+                          inter_start=0, inter_count=300, **common)
+
+    # 512 is aligned -> constructs fine and records the block-column range.
+    moe = GLMDSARawBlockMoE(args, 3, gate, None, None, None, None,
+                            inter_start=512, inter_count=512, **common)
+    assert moe._tp_routed is True
+    assert moe._w2_block_start == 2 and moe._w2_block_end == 4


### PR DESCRIPTION
## Summary

在 #56（GLM-5.2 文本生成基础通路）之上，落地默认开启的低比特 MoE decode/prefill 加速，并补充多项 env var opt-in 的 decode 优化实验（默认关闭，含负面结论记录）。默认行为只有 DP4A kernel 一处变化，其余全部 opt-in。

`fc16141..7cb7d0c`，6 个 commit。

## 核心功能（默认开）

- **iq2_xs(w13)+iq3_xxs(w2) DP4A grouped MoE kernel**（`src/csrc/cuda_kernel_impl.cu`）：GLM decode +22%（0.54→0.66 tok/s）、prefill +20%（0.66→0.79），token 逐位一致，fp32 fallback 完整保留。

## 实验性优化（默认关，opt-in，含负面结论）

- **routed TP inter-slice**（`GLM_ROUTED_TP=1`）：消掉 EP rank-skew（all_reduce 5.75→0.24ms/token，rank 完美均衡）但 staging 从 ~2→8 expert 使 stage_read +7.5ms，净 decode −10%。数值验证 max_abs=6e-7。保留为 opt-in，待 staging 改批量/常驻后复活。
- **GLM_PROFILE=1** 分相 profiler + EP rank-skew profiling + merged-H2D 证伪记录（H2D 非 launch-bound，合并反而 3× 慢）。
- **GLM_FUSED_RMSNORM**（decode 中性，norm 仅占 ~3%）。
- **resident expert cache**（净回归；热缓存下 staging 非瓶颈）。

## Testing

- 新增 `tests/test_glm_dsa_iq2xs_iq3xxs_dp4a.py`、`test_glm_dsa_tp_routed.py`（inter-slice sum vs full，max_abs=6e-7）、`test_glm_dsa_fused_rmsnorm.py`、`test_glm_dsa_resident_experts.py`。真实 bundle + CUDA 存在才跑数值项。
- 实机 TP4 e2e：79 层全网络，连贯中文，显存 <22GB/卡。
