### PR TITLE
Keep chat markup out of the special-token strip; align DSV4 template

### DIFF
--- a/cpp_engine/include/tokenizer.hpp
+++ b/cpp_engine/include/tokenizer.hpp
@@ -21,14 +21,22 @@ public:
     std::string decode_tokens(const std::vector<int>& ids, bool skip_special_tokens = true) const;
     std::vector<int> encode_basic(const std::string& text, bool add_bos = true) const;
     size_t vocab_size() const { return id_to_token_.size(); }
+    // -1 when the exact token string is not in the vocabulary.
+    int token_id(const std::string& token) const;
     bool is_special_token(int id) const;
 
 private:
     std::vector<std::string> id_to_token_;
     std::unordered_map<std::string, int> token_to_id_;
     std::map<std::pair<std::string, std::string>, int> merge_rank_;
+    // Tokens hidden from decoded text when skip_special_tokens is set: BOS/EOS,
+    // padding, placeholders. Deliberately narrower than atomic_token_id_list_ —
+    // markup such as <think>, </think> and ｜DSML｜ must survive decoding because
+    // the chat-completion parser consumes it.
     std::vector<uint8_t> special_token_ids_;
-    std::vector<int> special_token_id_list_;
+    // Tokens that must be matched verbatim while encoding instead of being run
+    // through BPE. Every added token belongs here, special or not.
+    std::vector<int> atomic_token_id_list_;
 };
 
 }  // namespace dsv4

--- a/cpp_engine/src/openai_server.cpp
+++ b/cpp_engine/src/openai_server.cpp
@@ -326,22 +326,31 @@ struct OpenAIServer::Impl {
         generated.reserve(static_cast<size_t>(max_tokens));
         size_t sent_offset = 0;  // bytes of decode_tokens(generated) already sent
 
+        // In thinking mode the prompt ends with <think>, so the completion starts
+        // inside the reasoning block and switches to the answer at the first
+        // </think>. Splitting on the token id rather than the decoded text keeps
+        // each stream's UTF-8 decoding self-contained and cannot be fooled by a
+        // model that writes the literal characters.
+        const int think_end_id = engine.tokenizer().token_id("</think>");
+        bool in_reasoning = (thinking_mode == "thinking");
+
         res.set_header("Cache-Control", "no-cache");
         res.set_chunked_content_provider("text/event-stream",
-            [this, enc, max_tokens, sp, thinking_mode, id, created, model, eos_id,
-             generated, sent_offset]
+            [this, enc, max_tokens, sp, id, created, model, eos_id, think_end_id,
+             generated, sent_offset, in_reasoning]
             (size_t /*offset*/, httplib::DataSink& sink) mutable -> bool {
 
             engine.worker_command_reset();
             engine.reset_session();
 
-            auto send_chunk = [&](const std::string& delta, const char* finish_reason = nullptr) {
+            auto send_chunk = [&](const std::string& delta, const char* field,
+                                  const char* finish_reason = nullptr) {
                 std::ostringstream os;
                 os << "{\"id\":\"" << id << "\",\"object\":\"chat.completion.chunk\""
                    << ",\"created\":" << created << ",\"model\":\"" << model << "\""
                    << ",\"choices\":[{\"index\":0,\"delta\":{";
                 if (!delta.empty()) {
-                    os << "\"content\":\"" << json_escape(delta) << "\"";
+                    os << "\"" << field << "\":\"" << json_escape(delta) << "\"";
                 }
                 os << "}";
                 if (finish_reason != nullptr) {
@@ -369,10 +378,6 @@ struct OpenAIServer::Impl {
             bool hit_eos = (token == eos_id);
             int position = static_cast<int>(enc.token_ids.size());
             int decoded_count = 0;
-            if (!hit_eos) {
-                generated.push_back(token);
-                ++decoded_count;
-            }
 
             auto emit_delta = [&]() {
                 const std::string full = engine.tokenizer().decode_tokens(generated);
@@ -381,19 +386,36 @@ struct OpenAIServer::Impl {
                 auto [complete, leftover] = split_utf8_complete(candidate);
                 if (!complete.empty()) {
                     sent_offset += complete.size();
-                    send_chunk(complete);
+                    send_chunk(complete, in_reasoning ? "reasoning_content" : "content");
                 }
             };
 
-            emit_delta();
+            // Closing the reasoning block restarts the delta window: the marker
+            // itself belongs to neither stream, and dropping the tokens before it
+            // keeps decode_tokens() cheap on long generations.
+            auto accept = [&](int tok) {
+                if (in_reasoning && tok == think_end_id) {
+                    emit_delta();
+                    generated.clear();
+                    sent_offset = 0;
+                    in_reasoning = false;
+                    return;
+                }
+                generated.push_back(tok);
+                emit_delta();
+            };
+
+            if (!hit_eos) {
+                accept(token);
+                ++decoded_count;
+            }
 
             for (int step = 1; step < max_tokens && !hit_eos; ++step) {
                 engine.worker_command_decode(token, position + step - 1);
                 token = engine.decode_step(token, position + step - 1, sp);
                 if (token == eos_id) { hit_eos = true; break; }
-                generated.push_back(token);
+                accept(token);
                 ++decoded_count;
-                emit_delta();
             }
 
             // Flush any remaining tail bytes (e.g. an isolated partial sequence
@@ -404,12 +426,12 @@ struct OpenAIServer::Impl {
                 if (full.size() > sent_offset) {
                     std::string tail = full.substr(sent_offset);
                     sent_offset += tail.size();
-                    send_chunk(tail);
+                    send_chunk(tail, in_reasoning ? "reasoning_content" : "content");
                 }
             }
 
             // Final chunk with finish_reason.
-            send_chunk("", hit_eos ? "stop" : "length");
+            send_chunk("", "content", hit_eos ? "stop" : "length");
             const std::string done = "data: [DONE]\n\n";
             sink.write(done.data(), done.size());
             sink.done();

--- a/cpp_engine/src/tokenizer.cpp
+++ b/cpp_engine/src/tokenizer.cpp
@@ -191,20 +191,31 @@ Tokenizer::Tokenizer(const std::string& ckpt_dir) {
         }
     }
     if (const JsonValue* added = object_get(root, "added_tokens")) {
+        std::vector<uint8_t> seen;
         for (const JsonValue& item : added->array()) {
             const JsonObject& obj = item.object();
             const JsonValue* id = object_get(obj, "id");
             const JsonValue* content = object_get(obj, "content");
-            if (id != nullptr && content != nullptr) {
-                const uint64_t token_id = json_u64(*id);
-                set_token(id_to_token_, token_id, content->string());
-                token_to_id_[content->string()] = static_cast<int>(token_id);
-                if (token_id >= special_token_ids_.size()) special_token_ids_.resize(static_cast<size_t>(token_id) + 1, 0);
-                if (special_token_ids_[static_cast<size_t>(token_id)] == 0) {
-                    special_token_ids_[static_cast<size_t>(token_id)] = 1;
-                    special_token_id_list_.push_back(static_cast<int>(token_id));
-                }
+            if (id == nullptr || content == nullptr) continue;
+            const uint64_t token_id = json_u64(*id);
+            set_token(id_to_token_, token_id, content->string());
+            token_to_id_[content->string()] = static_cast<int>(token_id);
+
+            // Every added token is atomic for encoding purposes.
+            if (token_id >= seen.size()) seen.resize(static_cast<size_t>(token_id) + 1, 0);
+            if (seen[static_cast<size_t>(token_id)] == 0) {
+                seen[static_cast<size_t>(token_id)] = 1;
+                atomic_token_id_list_.push_back(static_cast<int>(token_id));
             }
+
+            // Only tokens HF itself marks special are stripped from decoded text.
+            // <think>, </think> and ｜DSML｜ carry "special": false precisely
+            // because downstream parsing needs them.
+            const JsonValue* special = object_get(obj, "special");
+            const bool is_special = special != nullptr && special->is_bool() && special->boolean();
+            if (!is_special) continue;
+            if (token_id >= special_token_ids_.size()) special_token_ids_.resize(static_cast<size_t>(token_id) + 1, 0);
+            special_token_ids_[static_cast<size_t>(token_id)] = 1;
         }
     }
 }
@@ -221,7 +232,7 @@ Tokenizer Tokenizer::from_gguf(const GGUFFile& gguf) {
         tok.token_to_id_[tokens[i]] = static_cast<int>(i);
         if (token_types[i] != 1) {
             tok.special_token_ids_[i] = 1;
-            tok.special_token_id_list_.push_back(static_cast<int>(i));
+            tok.atomic_token_id_list_.push_back(static_cast<int>(i));
         }
     }
     int rank = 0;
@@ -245,6 +256,11 @@ std::string Tokenizer::decode_piece(int id) const {
     return s;
 }
 
+int Tokenizer::token_id(const std::string& token) const {
+    const auto it = token_to_id_.find(token);
+    return it == token_to_id_.end() ? -1 : it->second;
+}
+
 bool Tokenizer::is_special_token(int id) const {
     return id >= 0 && static_cast<size_t>(id) < special_token_ids_.size() && special_token_ids_[static_cast<size_t>(id)] != 0;
 }
@@ -254,7 +270,7 @@ std::string Tokenizer::decode_tokens(const std::vector<int>& ids, bool skip_spec
     std::string out;
     for (int id : ids) {
         std::string piece = token(id);
-        if (skip_special_tokens && (is_special_token(id) || (piece.size() >= 2 && piece.front() == '<' && piece.back() == '>'))) continue;
+        if (skip_special_tokens && is_special_token(id)) continue;
         for (size_t i = 0; i < piece.size();) {
             bool matched = false;
             for (const auto& [encoded, byte] : decoder) {
@@ -307,10 +323,10 @@ std::vector<int> Tokenizer::encode_basic(const std::string& text, bool add_bos) 
         }
     };
 
-    auto longest_special_at = [&](size_t pos, int& token_id, size_t& len) -> bool {
+    auto longest_atomic_at = [&](size_t pos, int& token_id, size_t& len) -> bool {
         token_id = -1;
         len = 0;
-        for (int id : special_token_id_list_) {
+        for (int id : atomic_token_id_list_) {
             if (id < 0 || static_cast<size_t>(id) >= id_to_token_.size()) continue;
             const std::string& tok = id_to_token_[static_cast<size_t>(id)];
             if (tok.empty()) continue;
@@ -326,7 +342,7 @@ std::vector<int> Tokenizer::encode_basic(const std::string& text, bool add_bos) 
     for (size_t pos = 0; pos < text.size();) {
         int special_id = -1;
         size_t special_len = 0;
-        if (longest_special_at(pos, special_id, special_len)) {
+        if (longest_atomic_at(pos, special_id, special_len)) {
             if (!segment.empty()) {
                 append_bpe_segment(segment);
                 segment.clear();

--- a/cpp_engine/tests/test_tokenizer.cpp
+++ b/cpp_engine/tests/test_tokenizer.cpp
@@ -45,6 +45,38 @@ int main(int argc, char** argv) {
         require(bos.size() == 2 && bos[0] == 0 && bos[1] == 33310, "bad add_bos encode");
         require(tok.decode_tokens(tok.encode_basic("Hello world", true)) == "Hello world", "bad decode roundtrip");
         require(tok.decode_tokens({55262}) == "我们必须", "bad byte-level decode");
+
+        // Chat markup carries "special": false in tokenizer.json and must survive
+        // skip_special_tokens decoding — the completion parser splits reasoning
+        // from content on </think>, and tool calls on ｜DSML｜.
+        const int think_open = tok.token_id("<think>");
+        const int think_close = tok.token_id("</think>");
+        const int dsml = tok.token_id("｜DSML｜");
+        require(think_open == 128821 && think_close == 128822 && dsml == 128825,
+                "unexpected chat markup token ids");
+        for (int id : {think_open, think_close, dsml, tok.token_id("<｜User｜>"),
+                       tok.token_id("<｜Assistant｜>")}) {
+            require(!tok.is_special_token(id),
+                    "chat markup must not be flagged special: id " + std::to_string(id));
+        }
+        require(tok.decode_tokens({think_close}) == "</think>", "</think> was stripped");
+        require(tok.decode_tokens({dsml}) == "｜DSML｜", "｜DSML｜ was stripped");
+        require(tok.decode_tokens({19923, think_close, 2058}) == "Hello</think> world",
+                "bad markup-preserving decode");
+        // Markup is still atomic when encoding.
+        check_encode(tok, "</think>", {think_close});
+        check_encode(tok, "Hello</think>", {19923, think_close});
+
+        // BOS/EOS/padding stay hidden, and explicitly asking for them works.
+        for (int id : {0, 1, 2}) {
+            require(tok.is_special_token(id),
+                    "bos/eos/pad must be special: id " + std::to_string(id));
+        }
+        require(tok.decode_tokens({0, 19923, 1}) == "Hello", "bos/eos leaked into text");
+        require(tok.decode_tokens({0, 19923, 1}, false) ==
+                    "<｜begin▁of▁sentence｜>Hello<｜end▁of▁sentence｜>",
+                "bad decode with skip_special_tokens=false");
+
         std::cout << "[PASS] tokenizer vocab=" << tok.vocab_size()
                   << " token107590=" << tok.decode_piece(107590) << "\n";
         return 0;

--- a/src/encoding/dsv4.py
+++ b/src/encoding/dsv4.py
@@ -61,11 +61,30 @@ tool_output_template: str = (
     "<tool_result>{content}</tool_result>"
 )
 
-REASONING_EFFORT_MAX = (
-    "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
-    "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
-    "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
-)
+# Reasoning effort levels. In thinking mode, the prompt for the selected level is
+# prepended at the very beginning of the conversation. `low` is the default and
+# adds nothing.
+REASONING_EFFORT_PROMPTS: Dict[str, str] = {
+    "low": "",
+    "high": (
+        "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
+        "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
+        "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
+    ),
+    "max": (
+        "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\n"
+        "You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\n"
+        "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n"
+    ),
+}
+DEFAULT_REASONING_EFFORT = "low"
+
+# OpenAI clients send effort levels DeepSeek-V4 does not define. Map them onto the
+# nearest official level that is not stronger than what was asked for.
+REASONING_EFFORT_ALIASES: Dict[str, str] = {
+    "minimal": "low",
+    "medium": "low",
+}
 
 TOOLS_TEMPLATE = """## Tools
 
@@ -232,7 +251,8 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
         messages: Full list of messages in the conversation.
         thinking_mode: Either "chat" or "thinking".
         drop_thinking: Whether to drop reasoning content from earlier turns.
-        reasoning_effort: Optional reasoning effort level ("minimal", "low", "medium", "high", "max", or None).
+        reasoning_effort: Reasoning effort level. DeepSeek-V4 defines "low",
+            "high", and "max"; None, "minimal", and "medium" map to "low".
 
     Returns:
         Encoded string for this message.
@@ -257,10 +277,14 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
     if tool_calls:
         tool_calls = tool_calls_from_openai_format(tool_calls)
 
-    # Reasoning effort prefix (only at index 0 in thinking mode with max effort)
-    assert reasoning_effort in ['max', None, 'minimal', 'low', 'medium', 'high'], f"Invalid reasoning effort: {reasoning_effort}"
-    if index == 0 and thinking_mode == "thinking" and reasoning_effort == 'max':
-        prompt += REASONING_EFFORT_MAX
+    # Reasoning effort prefix (only at index 0 in thinking mode; "low" adds nothing)
+    effort = reasoning_effort or DEFAULT_REASONING_EFFORT
+    effort = REASONING_EFFORT_ALIASES.get(effort, effort)
+    assert effort in REASONING_EFFORT_PROMPTS, \
+        f"Invalid reasoning effort: {reasoning_effort}, expected one of " \
+        f"{list(REASONING_EFFORT_PROMPTS) + list(REASONING_EFFORT_ALIASES)}"
+    if index == 0 and thinking_mode == "thinking":
+        prompt += REASONING_EFFORT_PROMPTS[effort]
 
     if role == "system":
         prompt += system_msg_template.format(content=content or "")
@@ -526,8 +550,10 @@ def encode_messages(
         context: Optional preceding context messages (already encoded prefix).
         drop_thinking: If True, drop reasoning_content from earlier assistant turns
                       (only keep reasoning for messages after the last user message).
+        reasoning_effort: Reasoning effort level. DeepSeek-V4 defines "low",
+            "high", and "max"; None, "minimal", and "medium" map to "low".
+            Only takes effect in thinking mode.
         add_default_bos_token: Whether to prepend BOS token at conversation start.
-        reasoning_effort: Optional reasoning effort level ("minimal", "low", "medium", "high", "max", or None).
 
     Returns:
         The encoded prompt string.

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -1,6 +1,6 @@
 import json
 
-from src.encoding.dsv4 import REASONING_EFFORT_MAX, encode_messages
+from src.encoding.dsv4 import REASONING_EFFORT_PROMPTS, encode_messages
 from src.server.openai import (
     _completion_response,
     _make_payload,
@@ -130,10 +130,27 @@ def test_make_payload_accepts_top_level_reasoning_effort_max():
 
 def test_encode_messages_injects_prefix_only_for_reasoning_effort_max():
     messages = [{"role": "user", "content": "hello"}]
-    max_prompt = encode_messages(messages, thinking_mode="thinking", reasoning_effort="max")
-    high_prompt = encode_messages(messages, thinking_mode="thinking", reasoning_effort="high")
-    assert REASONING_EFFORT_MAX in max_prompt
-    assert REASONING_EFFORT_MAX not in high_prompt
+
+    def prompt(effort):
+        return encode_messages(messages, thinking_mode="thinking", reasoning_effort=effort)
+
+    assert REASONING_EFFORT_PROMPTS["max"] in prompt("max")
+    assert REASONING_EFFORT_PROMPTS["high"] in prompt("high")
+    assert REASONING_EFFORT_PROMPTS["max"] not in prompt("high")
+    # DeepSeek-V4 only defines low/high/max; None and OpenAI's extra levels all
+    # fall back to low, which prepends nothing at all.
+    for effort in (None, "low", "minimal", "medium"):
+        assert REASONING_EFFORT_PROMPTS["high"] not in prompt(effort)
+        assert REASONING_EFFORT_PROMPTS["max"] not in prompt(effort)
+    assert prompt(None) == prompt("low") == prompt("minimal") == prompt("medium")
+
+
+def test_encode_messages_ignores_reasoning_effort_in_chat_mode():
+    messages = [{"role": "user", "content": "hello"}]
+    for effort in (None, "low", "high", "max"):
+        chat_prompt = encode_messages(messages, thinking_mode="chat", reasoning_effort=effort)
+        assert REASONING_EFFORT_PROMPTS["high"] not in chat_prompt
+        assert REASONING_EFFORT_PROMPTS["max"] not in chat_prompt
 
 
 def test_make_payload_accepts_common_openai_params():


### PR DESCRIPTION
Two defects made the cpp_engine OpenAI server unusable in thinking mode on DeepSeek-V4-Flash-0731.

## Decode: chat markup was stripped

`Tokenizer` conflated two separate ideas under one "special" list — tokens matched verbatim while *encoding*, and tokens hidden while *decoding*. Every added token went into both, and `decode_tokens` additionally dropped anything shaped like `<...>`.

So `</think>` (128822) and `｜DSML｜` (128825) never reached the completion parser, and reasoning was indistinguishable from the answer. HF marks exactly the markup the parser needs with `"special": false` — of DSV4's 1283 added tokens, 1230 are special (BOS/EOS/pad/placeholders) and the 53 that aren't are precisely the chat markup. The two concepts are now separate lists (`special_token_ids_` / `atomic_token_id_list_`) and the `<...>` heuristic is gone.

The GGUF path keeps its own `token_type != 1` rule untouched: the C++ sidecar only parses DSV4, and MiniMax runs through the Python server.

Streaming then splits on the `</think>` token id rather than the decoded text — that keeps each stream's UTF-8 decoding self-contained and cannot be fooled by a model writing the characters literally. This also closes a gap where streaming never emitted `reasoning_content` at all.

Before: `content='We need answer number only. 17*23=391.391'`
After: `reasoning_content='We need answer number only. 17*23=391.'` / `content='391'`

## Encoding: template drift

`src/encoding/dsv4.py` had only `REASONING_EFFORT_MAX`, so `reasoning_effort="high"` silently rendered as `low`. Restoring all three levels from the checkpoint's own `encoding/encoding_dsv4.py` takes an 80-case comparison against that official encoder from **60/80 to 80/80 byte-identical**.

Aliases for OpenAI's `minimal`/`medium` are kept deliberately, mapping to `low`: the official encoder asserts on them, so copying it verbatim would turn those requests into 500s. `medium`→`low` rather than `high` because DSV4 describes `high` as "Absolute maximum".

## Verification

- `tests/test_openai_utils.py` — 19 passed
- `test_tokenizer` PASS on DeepSeek-V4-Flash-0731 (new assertions: `</think>`/`｜DSML｜` survive `skip_special_tokens`, BOS/EOS still stripped, both encode atomically)
- **DeepSeek's own 4 fixtures** from the checkpoint's `encoding/test_encoding_dsv4.py` pass against our encoder
- Server end-to-end at TP=4: streamed text byte-identical to non-streamed; A→B→A byte-identical for both an 11-token and a 3073-token B (no cross-request state leak)
- Chat-mode output byte-identical before and after

No numeric code is touched — the diff greps clean for `fp4|fp8|e8m0|dequant|matvec|matmul|__global__|cudaMemcpy`.

**Not verified:** `test_gguf_tokenizer` passed against MiniMax when the change was written, but the MiniMax GGUF is no longer on this machine, so it was not re-run on the rebased branch. The `｜DSML｜` round-trip is covered by the unit test only — across three prompting strategies the model never emitted a tool-call block, so that path was not exercised end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
