### PR TITLE
Small-batch FP4 MoE kernel for speculative verify (default off)

### DIFF
--- a/src/components/moe/gpu_prefill_backend.py
+++ b/src/components/moe/gpu_prefill_backend.py
@@ -140,6 +140,12 @@ class GPUPrefillMoEBackend:
         self.bucketed_gemm_enabled = os.getenv("DEEPSEEK_GPU_PREFILL_MOE_BUCKETED_GEMM", "0").lower() in {"1", "true", "yes"}
         self.fp4_direct_grouped_enabled = os.getenv("DEEPSEEK_GPU_PREFILL_MOE_FP4_DIRECT_GROUPED", "0").lower() in {"1", "true", "yes"}
         self.single_token_group_enabled = os.getenv("DEEPSEEK_GPU_MOE_SINGLE_TOKEN_GROUP", "1").lower() in {"1", "true", "yes"}
+        # Small-batch FP4 path for speculative verify. Without it a k+1 token
+        # verify batch drops out of the single-token FP4 kernel into the prefill
+        # grouped path, which launches over all n_local_experts and restages the
+        # layer as int8; measured at +619ms of MoE for one extra token.
+        self.multi_token_fp4_enabled = os.getenv("DEEPSEEK_GPU_MOE_MULTI_TOKEN_FP4", "0").lower() in {"1", "true", "yes"}
+        self.multi_token_fp4_max_tokens = max(0, int(os.getenv("DEEPSEEK_GPU_MOE_MULTI_TOKEN_FP4_MAX_TOKENS", "8")))
 
     @staticmethod
     def _device_index(device: torch.device) -> int:
@@ -565,6 +571,78 @@ class GPUPrefillMoEBackend:
         the layer-LRU staging in _stage_local_experts."""
         return 0
 
+    def _forward_multi_token_fp4(
+        self,
+        x: torch.Tensor,
+        indices: torch.Tensor,
+        weights: torch.Tensor,
+        swiglu_limit: float,
+    ) -> Optional[torch.Tensor]:
+        """Small-batch FP4 MoE over only the experts this batch routes to.
+
+        Returns None when the FP4 arena is unavailable, so the caller falls
+        through to the existing grouped path rather than changing behaviour on
+        int8-only layers.
+
+        The kernel wants routes compacted into (slot -> tokens) form: one slot
+        per distinct local expert, its tokens contiguous. That way the launch
+        scales with the experts the batch touched (~8 for a 6-token verify)
+        instead of with n_local_experts (64).
+        """
+        # The decode-active call site passes indices/weights straight from the
+        # gate without making them contiguous (unlike the prefill call site), so
+        # reshape(-1) is only row-major -- which is what pairs a route with its
+        # token below -- after this.
+        indices = indices.contiguous()
+        weights = weights.contiguous()
+        local_ids = indices.reshape(-1) - self.experts_start_idx
+        mask = (local_ids >= 0) & (local_ids < self.n_local_experts)
+        if not bool(mask.any().item()):
+            return torch.zeros((x.shape[0], self.dim), device=x.device, dtype=torch.float32)
+        tokens, topk = indices.shape
+        pair_tokens = torch.arange(tokens, device=indices.device).repeat_interleave(topk)[mask]
+        pair_experts = local_ids[mask]
+        pair_w = weights.reshape(-1)[mask].to(torch.float32)
+        # stable sort keeps a token's routes in top-k order within a slot, so the
+        # accumulation order matches the single-token kernel's.
+        order = torch.argsort(pair_experts, stable=True)
+        pair_experts = pair_experts[order]
+        pair_tokens = pair_tokens[order].to(torch.int32).contiguous()
+        pair_w = pair_w[order].contiguous()
+        slot_expert, counts = torch.unique_consecutive(pair_experts, return_counts=True)
+        slot_starts = torch.zeros(slot_expert.numel() + 1, dtype=torch.int32, device=x.device)
+        slot_starts[1:] = counts.cumsum(0).to(torch.int32)
+
+        staged_ids = slot_expert.to(torch.long)
+        if self._w1q is None or self._prepared_device != x.device or self._staged_arena_format != "fp4":
+            self._stage_local_experts(x.device, staged_ids)
+        elif len(self._staged_local_experts) < self.n_local_experts:
+            unstaged = [i for i in staged_ids.tolist() if int(i) not in self._staged_local_experts]
+            if unstaged:
+                self._stage_local_experts(
+                    x.device,
+                    torch.tensor(unstaged, device=x.device, dtype=torch.long),
+                )
+        if self._staged_arena_format != "fp4":
+            return None
+        self.wait_for_stage(x.device)
+        self._record_staged_weights_on_current_stream(x.device)
+        self._touch_cache(x.device)
+        return self._cuda_ext.moe_multi_token_fp4_forward(
+            x.contiguous(),
+            slot_expert.to(torch.int32).contiguous(),
+            slot_starts,
+            pair_tokens,
+            pair_w,
+            self._w1q,
+            self._w1s,
+            self._w2q,
+            self._w2s,
+            self._w3q,
+            self._w3s,
+            float(swiglu_limit),
+        )
+
     def forward(self, x: torch.Tensor, indices: torch.Tensor, weights: torch.Tensor, swiglu_limit: float) -> torch.Tensor:
         if not x.is_cuda:
             raise RuntimeError("GPU prefill MoE requires CUDA input")
@@ -662,6 +740,15 @@ class GPUPrefillMoEBackend:
                     flush=True,
                 )
             return y
+
+        if (
+            self.multi_token_fp4_enabled
+            and 1 < x.shape[0] <= self.multi_token_fp4_max_tokens
+            and hasattr(self._cuda_ext, "moe_multi_token_fp4_forward")
+        ):
+            y = self._forward_multi_token_fp4(x, indices, weights, swiglu_limit)
+            if y is not None:
+                return y
 
         if hasattr(self._cuda_ext, "moe_group_routes"):
             grouped = self._cuda_ext.moe_group_routes(

--- a/src/csrc/cuda_kernel.cpp
+++ b/src/csrc/cuda_kernel.cpp
@@ -141,6 +141,20 @@ torch::Tensor moe_single_token_fp4_forward_cuda(
     int64_t experts_start_idx,
     double swiglu_limit);
 
+torch::Tensor moe_multi_token_fp4_forward_cuda(
+    const torch::Tensor& x,
+    const torch::Tensor& slot_expert,
+    const torch::Tensor& slot_starts,
+    const torch::Tensor& slot_tokens,
+    const torch::Tensor& pair_weights,
+    const torch::Tensor& w1q,
+    const torch::Tensor& w1s,
+    const torch::Tensor& w2q,
+    const torch::Tensor& w2s,
+    const torch::Tensor& w3q,
+    const torch::Tensor& w3s,
+    double swiglu_limit);
+
 torch::Tensor moe_single_token_int8_forward_v2_cuda(
     const torch::Tensor& x,
     const torch::Tensor& route_to_slot,
@@ -1428,6 +1442,77 @@ torch::Tensor moe_single_token_fp4_forward(
         swiglu_limit);
 }
 
+torch::Tensor moe_multi_token_fp4_forward(
+    const torch::Tensor& x,
+    const torch::Tensor& slot_expert,
+    const torch::Tensor& slot_starts,
+    const torch::Tensor& slot_tokens,
+    const torch::Tensor& pair_weights,
+    const torch::Tensor& w1q,
+    const torch::Tensor& w1s,
+    const torch::Tensor& w2q,
+    const torch::Tensor& w2s,
+    const torch::Tensor& w3q,
+    const torch::Tensor& w3s,
+    double swiglu_limit) {
+    TORCH_CHECK(x.dim() == 2, "x must have shape [T, D]");
+    TORCH_CHECK(slot_expert.dim() == 1, "slot_expert must have shape [S]");
+    TORCH_CHECK(slot_starts.dim() == 1, "slot_starts must have shape [S + 1]");
+    TORCH_CHECK(slot_tokens.dim() == 1, "slot_tokens must have shape [P]");
+    TORCH_CHECK(pair_weights.dim() == 1, "pair_weights must have shape [P]");
+    TORCH_CHECK(slot_starts.size(0) == slot_expert.size(0) + 1, "slot_starts must be slot_expert length + 1");
+    TORCH_CHECK(slot_tokens.size(0) == pair_weights.size(0), "slot_tokens/pair_weights length mismatch");
+    TORCH_CHECK(w1q.dim() == 3 && w2q.dim() == 3 && w3q.dim() == 3, "fp4 weights must have shape [E, N, K/2]");
+    TORCH_CHECK(w1s.dim() == 3 && w2s.dim() == 3 && w3s.dim() == 3, "fp4 scales must have shape [E, N, K/32]");
+    TORCH_CHECK(w1q.size(0) == w2q.size(0) && w1q.size(0) == w3q.size(0), "expert count mismatch");
+    TORCH_CHECK(w1q.size(1) == w3q.size(1), "w1/w3 inter_dim mismatch");
+    const int64_t dim = x.size(1);
+    const int64_t inter_dim = w1q.size(1);
+    TORCH_CHECK(dim % 32 == 0, "dim must be divisible by 32 for fp4 path");
+    TORCH_CHECK(inter_dim % 32 == 0, "inter_dim must be divisible by 32 for fp4 path");
+    TORCH_CHECK(w1q.size(2) == dim / 2 && w3q.size(2) == dim / 2, "w1/w3 packed K must equal dim/2");
+    TORCH_CHECK(w1s.size(2) == dim / 32 && w3s.size(2) == dim / 32, "w1/w3 scale K must equal dim/32");
+    TORCH_CHECK(w2q.size(1) == dim, "w2 output dim must equal x.dim");
+    TORCH_CHECK(w2q.size(2) == inter_dim / 2, "w2 packed K must equal inter_dim/2");
+    TORCH_CHECK(w2s.size(2) == inter_dim / 32, "w2 scale K must equal inter_dim/32");
+    TORCH_CHECK(w1s.size(1) == w1q.size(1) && w3s.size(1) == w3q.size(1) && w2s.size(1) == w2q.size(1), "scale row count mismatch");
+    TORCH_CHECK(w1s.size(0) == w1q.size(0) && w3s.size(0) == w3q.size(0) && w2s.size(0) == w2q.size(0), "scale expert dim mismatch");
+    TORCH_CHECK(x.is_cuda() && slot_expert.is_cuda() && slot_starts.is_cuda() && slot_tokens.is_cuda() && pair_weights.is_cuda(),
+                "x and route tensors must be CUDA tensors");
+    TORCH_CHECK(w1q.is_cuda() && w1s.is_cuda() && w2q.is_cuda() && w2s.is_cuda() && w3q.is_cuda() && w3s.is_cuda(), "weight tensors must be CUDA tensors");
+    TORCH_CHECK(x.is_contiguous() && slot_expert.is_contiguous() && slot_starts.is_contiguous() && slot_tokens.is_contiguous() && pair_weights.is_contiguous(),
+                "x and route tensors must be contiguous");
+    TORCH_CHECK(w1q.is_contiguous() && w1s.is_contiguous() && w2q.is_contiguous() && w2s.is_contiguous() && w3q.is_contiguous() && w3s.is_contiguous(), "weight tensors must be contiguous");
+    TORCH_CHECK(
+        x.scalar_type() == torch::kFloat16 ||
+        x.scalar_type() == torch::kBFloat16 ||
+        x.scalar_type() == torch::kFloat32,
+        "x must be float16, bfloat16, or float32");
+    TORCH_CHECK(slot_expert.scalar_type() == torch::kInt32, "slot_expert must be int32");
+    TORCH_CHECK(slot_starts.scalar_type() == torch::kInt32, "slot_starts must be int32");
+    TORCH_CHECK(slot_tokens.scalar_type() == torch::kInt32, "slot_tokens must be int32");
+    TORCH_CHECK(pair_weights.scalar_type() == torch::kFloat32, "pair_weights must be float32");
+    check_tensor(w1q, "w1q", torch::kUInt8);
+    check_tensor(w2q, "w2q", torch::kUInt8);
+    check_tensor(w3q, "w3q", torch::kUInt8);
+    check_tensor(w1s, "w1s", torch::kUInt8);
+    check_tensor(w2s, "w2s", torch::kUInt8);
+    check_tensor(w3s, "w3s", torch::kUInt8);
+    return moe_multi_token_fp4_forward_cuda(
+        x,
+        slot_expert,
+        slot_starts,
+        slot_tokens,
+        pair_weights,
+        w1q,
+        w1s,
+        w2q,
+        w2s,
+        w3q,
+        w3s,
+        swiglu_limit);
+}
+
 torch::Tensor moe_single_token_int8_forward_v2(
     const torch::Tensor& x,
     const torch::Tensor& route_to_slot,
@@ -1934,6 +2019,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("moe_single_token_int8_forward", &moe_single_token_int8_forward, "single-token top-k MoE int8 forward (CUDA)");
     m.def("moe_single_token_int8_forward_v2", &moe_single_token_int8_forward_v2, "single-token top-k MoE int8 forward with compact buffer + slot map (CUDA)");
     m.def("moe_single_token_fp4_forward", &moe_single_token_fp4_forward, "single-token top-k MoE FP4 (e2m1fn_x2 + e8m0 block) forward (CUDA)");
+    m.def("moe_multi_token_fp4_forward", &moe_multi_token_fp4_forward, "small-batch top-k MoE FP4 forward, active experts only (CUDA)");
     m.def("moe_prefill_int8_grouped_forward", &moe_prefill_int8_grouped_forward, "prefill MoE grouped int8 forward (CUDA)");
     m.def("moe_prefill_int8_grouped_gemm_forward", &moe_prefill_int8_grouped_gemm_forward, "prefill MoE grouped-GEMM int8 forward (CUDA)");
     m.def("moe_prefill_fp4_grouped_gemm_forward", &moe_prefill_fp4_grouped_gemm_forward, "prefill MoE grouped-GEMM FP4 forward (CUDA)");

--- a/src/csrc/cuda_kernel_impl.cu
+++ b/src/csrc/cuda_kernel_impl.cu
@@ -2716,6 +2716,336 @@ torch::Tensor moe_single_token_fp4_forward_cuda(
     return y;
 }
 
+// ---------------------------------------------------------------------------
+// Small-batch (speculative-verify) FP4 MoE.
+//
+// The single-token path above is gated on exactly one token, so a k+1 token
+// verify batch falls into the prefill grouped path, which allocates and
+// launches over ALL n_local_experts (64) even when the batch touches ~8, pads
+// every expert to max_count rows, and uses wmma (measured slower than dp4a for
+// these 2-bit-ish layouts). Measured cost of that fallback: a 2-token decode
+// costs +619ms of MoE over a 1-token decode.
+//
+// Here the unit of work is a (route slot, token) pair drawn from a compacted
+// list of only the experts the batch actually hit. One block handles one
+// (slot, column) tile and walks the tokens routed to that slot, so each
+// weight pack is fetched once and reused across those tokens -- which is the
+// whole point, since these GEMMs are weight-bandwidth bound at small batch.
+//
+// The arithmetic is deliberately identical to the single-token kernels (same
+// dp4a over the same fp4_unpack_4codes_prmt / fp4_block_scale, same per-row
+// int8 activation scaling), so results match the one-token path bit for bit
+// when a batch is fed one token at a time. That matters: the existing
+// FP4_DIRECT_GROUPED kernel is fast at large batch but shifts logits by up to
+// 1.48, which would silently change which draft tokens get accepted.
+// ---------------------------------------------------------------------------
+
+// One block: (slot, column tile). Loops over the slot's tokens.
+__global__ void moe_multi_w1w3_fp4_kernel(
+    const int8_t* __restrict__ x_q,          // [tokens, dim] int8
+    const float* __restrict__ x_scale,       // [tokens]
+    const int32_t* __restrict__ slot_expert, // [slots] local expert id
+    const int32_t* __restrict__ slot_starts, // [slots + 1] into slot_tokens
+    const int32_t* __restrict__ slot_tokens, // [pairs] token row per slot entry
+    const uint8_t* __restrict__ w1q,
+    const uint8_t* __restrict__ w1s,
+    const uint8_t* __restrict__ w3q,
+    const uint8_t* __restrict__ w3s,
+    float* __restrict__ gate_f32,            // [pairs, inter_dim]
+    float* __restrict__ up_f32,              // [pairs, inter_dim]
+    int dim,
+    int inter_dim) {
+    const int slot = blockIdx.y;
+    const int col = blockIdx.x * blockDim.x + threadIdx.x;
+    const int start = slot_starts[slot];
+    const int end = slot_starts[slot + 1];
+    const int n_tok = end - start;
+    if (n_tok <= 0) return;
+    const int local = slot_expert[slot];
+    const int dim_packs = dim / 4;
+    const int blocks_k = dim / 32;
+
+    extern __shared__ int xs_shared[];
+    const uint8_t* w1_row_bytes = w1q + (static_cast<int64_t>(local) * inter_dim + col) * (dim / 2);
+    const uint8_t* w3_row_bytes = w3q + (static_cast<int64_t>(local) * inter_dim + col) * (dim / 2);
+    const uint8_t* w1_scale_row = w1s + (static_cast<int64_t>(local) * inter_dim + col) * blocks_k;
+    const uint8_t* w3_scale_row = w3s + (static_cast<int64_t>(local) * inter_dim + col) * blocks_k;
+    const uint16_t* w1_pack_base = reinterpret_cast<const uint16_t*>(w1_row_bytes);
+    const uint16_t* w3_pack_base = reinterpret_cast<const uint16_t*>(w3_row_bytes);
+
+    // Tokens are processed kMaxTokens at a time: the accumulators live in
+    // registers, so the tile width is what bounds register pressure. A slot
+    // with more tokens than that just takes another pass over the weights,
+    // which keeps the kernel correct for any batch size instead of silently
+    // dropping rows.
+    constexpr int kMaxTokens = 8;
+    for (int base_t = 0; base_t < n_tok; base_t += kMaxTokens) {
+        const int tile = min(kMaxTokens, n_tok - base_t);
+        // Stage this tile's activations once; the K loop below rereads them
+        // for every weight pack.
+        __syncthreads();
+        for (int idx = threadIdx.x; idx < tile * dim_packs; idx += blockDim.x) {
+            const int r = idx / dim_packs;
+            const int pack = idx - r * dim_packs;
+            const int token = slot_tokens[start + base_t + r];
+            xs_shared[idx] = reinterpret_cast<const int*>(
+                x_q + static_cast<int64_t>(token) * dim)[pack];
+        }
+        __syncthreads();
+        if (col >= inter_dim) continue;
+
+        float gate_acc[kMaxTokens];
+        float up_acc[kMaxTokens];
+        #pragma unroll
+        for (int t = 0; t < kMaxTokens; ++t) { gate_acc[t] = 0.0f; up_acc[t] = 0.0f; }
+
+        for (int kb = 0; kb < blocks_k; ++kb) {
+            const uint16_t* w1_pack = w1_pack_base + kb * 8;
+            const uint16_t* w3_pack = w3_pack_base + kb * 8;
+            int gate_blk[kMaxTokens];
+            int up_blk[kMaxTokens];
+            #pragma unroll
+            for (int t = 0; t < kMaxTokens; ++t) { gate_blk[t] = 0; up_blk[t] = 0; }
+            #pragma unroll
+            for (int ip = 0; ip < 8; ++ip) {
+                const int w1_p = fp4_unpack_4codes_prmt(static_cast<uint32_t>(w1_pack[ip]));
+                const int w3_p = fp4_unpack_4codes_prmt(static_cast<uint32_t>(w3_pack[ip]));
+                for (int t = 0; t < tile; ++t) {
+                    const int x_p = xs_shared[t * dim_packs + kb * 8 + ip];
+                    gate_blk[t] = __dp4a(x_p, w1_p, gate_blk[t]);
+                    up_blk[t] = __dp4a(x_p, w3_p, up_blk[t]);
+                }
+            }
+            const float w1_s = fp4_block_scale(w1_scale_row[kb]);
+            const float w3_s = fp4_block_scale(w3_scale_row[kb]);
+            for (int t = 0; t < tile; ++t) {
+                gate_acc[t] += static_cast<float>(gate_blk[t]) * w1_s;
+                up_acc[t] += static_cast<float>(up_blk[t]) * w3_s;
+            }
+        }
+        for (int t = 0; t < tile; ++t) {
+            const int pair = start + base_t + t;
+            const float xs = x_scale[slot_tokens[pair]];
+            gate_f32[static_cast<int64_t>(pair) * inter_dim + col] = gate_acc[t] * xs;
+            up_f32[static_cast<int64_t>(pair) * inter_dim + col] = up_acc[t] * xs;
+        }
+    }
+}
+
+// One block per (slot, token) pair, matching the single-token swiglu kernel.
+__global__ void moe_multi_swiglu_quant_fp4_kernel(
+    const float* __restrict__ gate_f32,
+    const float* __restrict__ up_f32,
+    const float* __restrict__ pair_weights, // [pairs] routing weight
+    int8_t* __restrict__ hidden_q,
+    float* __restrict__ hidden_scale,
+    int pairs,
+    int inter_dim,
+    float swiglu_limit) {
+    const int pair = blockIdx.x;
+    const int tid = threadIdx.x;
+    if (pair >= pairs) return;
+    __shared__ float sdata[kQuantThreads];
+    const float route_weight = pair_weights[pair];
+    const int64_t base = static_cast<int64_t>(pair) * inter_dim;
+    float local_max = 0.0f;
+    for (int col = tid; col < inter_dim; col += blockDim.x) {
+        float gate = gate_f32[base + col];
+        float up = up_f32[base + col];
+        if (swiglu_limit > 0.0f) {
+            up = fminf(fmaxf(up, -swiglu_limit), swiglu_limit);
+            gate = fminf(gate, swiglu_limit);
+        }
+        const float silu = gate / (1.0f + expf(-gate));
+        local_max = fmaxf(local_max, fabsf(silu * up * route_weight));
+    }
+    sdata[tid] = local_max;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) sdata[tid] = fmaxf(sdata[tid], sdata[tid + stride]);
+        __syncthreads();
+    }
+    const float scale = fmaxf(sdata[0], 1.0e-6f) / 127.0f;
+    if (tid == 0) hidden_scale[pair] = scale;
+    __syncthreads();
+    const float inv_scale = 1.0f / scale;
+    for (int col = tid; col < inter_dim; col += blockDim.x) {
+        float gate = gate_f32[base + col];
+        float up = up_f32[base + col];
+        if (swiglu_limit > 0.0f) {
+            up = fminf(fmaxf(up, -swiglu_limit), swiglu_limit);
+            gate = fminf(gate, swiglu_limit);
+        }
+        const float silu = gate / (1.0f + expf(-gate));
+        int q = __float2int_rn(silu * up * route_weight * inv_scale);
+        q = max(-127, min(127, q));
+        hidden_q[base + col] = static_cast<int8_t>(q);
+    }
+}
+
+// Mirrors moe_multi_w1w3: one block per (slot, column tile), looping tokens.
+__global__ void moe_multi_w2_accum_fp4_kernel(
+    const int8_t* __restrict__ hidden_q,     // [pairs, inter_dim]
+    const float* __restrict__ hidden_scale,  // [pairs]
+    const int32_t* __restrict__ slot_expert,
+    const int32_t* __restrict__ slot_starts,
+    const int32_t* __restrict__ slot_tokens,
+    const uint8_t* __restrict__ w2q,
+    const uint8_t* __restrict__ w2s,
+    float* __restrict__ y,                   // [tokens, dim]
+    int dim,
+    int inter_dim) {
+    const int slot = blockIdx.y;
+    const int col = blockIdx.x * blockDim.x + threadIdx.x;
+    const int start = slot_starts[slot];
+    const int end = slot_starts[slot + 1];
+    const int n_tok = end - start;
+    if (n_tok <= 0) return;
+    const int local = slot_expert[slot];
+    const int packs = inter_dim / 4;
+    const int blocks_k = inter_dim / 32;
+
+    extern __shared__ int hs_shared[];
+    const uint8_t* w2_row_bytes = w2q + (static_cast<int64_t>(local) * dim + col) * (inter_dim / 2);
+    const uint8_t* w2_scale_row = w2s + (static_cast<int64_t>(local) * dim + col) * blocks_k;
+    const uint16_t* w2_pack_base = reinterpret_cast<const uint16_t*>(w2_row_bytes);
+
+    constexpr int kMaxTokens = 8;
+    for (int base_t = 0; base_t < n_tok; base_t += kMaxTokens) {
+        const int tile = min(kMaxTokens, n_tok - base_t);
+        __syncthreads();
+        for (int idx = threadIdx.x; idx < tile * packs; idx += blockDim.x) {
+            const int r = idx / packs;
+            const int pack = idx - r * packs;
+            hs_shared[idx] = reinterpret_cast<const int*>(
+                hidden_q + static_cast<int64_t>(start + base_t + r) * inter_dim)[pack];
+        }
+        __syncthreads();
+        if (col >= dim) continue;
+
+        float acc[kMaxTokens];
+        #pragma unroll
+        for (int t = 0; t < kMaxTokens; ++t) acc[t] = 0.0f;
+
+        for (int kb = 0; kb < blocks_k; ++kb) {
+            const uint16_t* w2_pack = w2_pack_base + kb * 8;
+            int blk[kMaxTokens];
+            #pragma unroll
+            for (int t = 0; t < kMaxTokens; ++t) blk[t] = 0;
+            #pragma unroll
+            for (int ip = 0; ip < 8; ++ip) {
+                const int w_p = fp4_unpack_4codes_prmt(static_cast<uint32_t>(w2_pack[ip]));
+                for (int t = 0; t < tile; ++t) {
+                    blk[t] = __dp4a(hs_shared[t * packs + kb * 8 + ip], w_p, blk[t]);
+                }
+            }
+            const float w2_s = fp4_block_scale(w2_scale_row[kb]);
+            for (int t = 0; t < tile; ++t) acc[t] += static_cast<float>(blk[t]) * w2_s;
+        }
+        // Different slots can hold the same token (top-k routing), so a token's
+        // partial sums must be combined atomically, exactly as the single-token
+        // kernel accumulates over its routes.
+        for (int t = 0; t < tile; ++t) {
+            const int pair = start + base_t + t;
+            const int token = slot_tokens[pair];
+            atomicAdd(y + static_cast<int64_t>(token) * dim + col, acc[t] * hidden_scale[pair]);
+        }
+    }
+}
+
+torch::Tensor moe_multi_token_fp4_forward_cuda(
+    const torch::Tensor& x,             // [T, dim]
+    const torch::Tensor& slot_expert,   // [S] int32 local expert ids
+    const torch::Tensor& slot_starts,   // [S+1] int32
+    const torch::Tensor& slot_tokens,   // [P] int32 token row per pair
+    const torch::Tensor& pair_weights,  // [P] float32 routing weight
+    const torch::Tensor& w1q,
+    const torch::Tensor& w1s,
+    const torch::Tensor& w2q,
+    const torch::Tensor& w2s,
+    const torch::Tensor& w3q,
+    const torch::Tensor& w3s,
+    double swiglu_limit) {
+    c10::cuda::CUDAGuard device_guard(x.device());
+    const int tokens = static_cast<int>(x.size(0));
+    const int dim = static_cast<int>(x.size(1));
+    const int inter_dim = static_cast<int>(w1q.size(1));
+    const int slots = static_cast<int>(slot_expert.size(0));
+    const int pairs = static_cast<int>(slot_tokens.size(0));
+    auto y = torch::zeros({tokens, dim}, x.options().dtype(torch::kFloat32));
+    if (slots == 0 || pairs == 0) {
+        return y;
+    }
+
+    auto x_contig = x.contiguous();
+    auto x_q = torch::empty({tokens, dim}, x.options().dtype(torch::kInt8));
+    auto x_scale = torch::empty({tokens}, x.options().dtype(torch::kFloat32));
+    auto gate_f32 = torch::empty({pairs, inter_dim}, x.options().dtype(torch::kFloat32));
+    auto up_f32 = torch::empty({pairs, inter_dim}, x.options().dtype(torch::kFloat32));
+    auto hidden_q = torch::empty({pairs, inter_dim}, x.options().dtype(torch::kInt8));
+    auto hidden_scale = torch::empty({pairs}, x.options().dtype(torch::kFloat32));
+
+    // Per-row int8 quantization, same as the single-token path (one row per
+    // block there, `tokens` rows here).
+    AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, x_contig.scalar_type(), "moe_multi_quantize_x_fp4", [&] {
+        quantize_rows_kernel<scalar_t><<<tokens, kQuantThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            x_contig.data_ptr<scalar_t>(),
+            x_q.data_ptr<int8_t>(),
+            x_scale.data_ptr<float>(),
+            tokens,
+            1,
+            dim);
+    });
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    constexpr int kMultiMaxTokens = 8;
+    const dim3 gemm_block(kGemmThreads);
+    const dim3 w1w3_grid(ceil_div(inter_dim, kGemmThreads), slots);
+    const size_t x_shared_bytes = static_cast<size_t>(kMultiMaxTokens) * (dim / 4) * sizeof(int);
+    moe_multi_w1w3_fp4_kernel<<<w1w3_grid, gemm_block, x_shared_bytes, at::cuda::getCurrentCUDAStream()>>>(
+        x_q.data_ptr<int8_t>(),
+        x_scale.data_ptr<float>(),
+        slot_expert.data_ptr<int32_t>(),
+        slot_starts.data_ptr<int32_t>(),
+        slot_tokens.data_ptr<int32_t>(),
+        w1q.data_ptr<uint8_t>(),
+        w1s.data_ptr<uint8_t>(),
+        w3q.data_ptr<uint8_t>(),
+        w3s.data_ptr<uint8_t>(),
+        gate_f32.data_ptr<float>(),
+        up_f32.data_ptr<float>(),
+        dim,
+        inter_dim);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    moe_multi_swiglu_quant_fp4_kernel<<<pairs, kQuantThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
+        gate_f32.data_ptr<float>(),
+        up_f32.data_ptr<float>(),
+        pair_weights.data_ptr<float>(),
+        hidden_q.data_ptr<int8_t>(),
+        hidden_scale.data_ptr<float>(),
+        pairs,
+        inter_dim,
+        static_cast<float>(swiglu_limit));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    const dim3 w2_grid(ceil_div(dim, kGemmThreads), slots);
+    const size_t h_shared_bytes = static_cast<size_t>(kMultiMaxTokens) * (inter_dim / 4) * sizeof(int);
+    moe_multi_w2_accum_fp4_kernel<<<w2_grid, gemm_block, h_shared_bytes, at::cuda::getCurrentCUDAStream()>>>(
+        hidden_q.data_ptr<int8_t>(),
+        hidden_scale.data_ptr<float>(),
+        slot_expert.data_ptr<int32_t>(),
+        slot_starts.data_ptr<int32_t>(),
+        slot_tokens.data_ptr<int32_t>(),
+        w2q.data_ptr<uint8_t>(),
+        w2s.data_ptr<uint8_t>(),
+        y.data_ptr<float>(),
+        dim,
+        inter_dim);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return y;
+}
+
 constexpr int kFp4GroupedCols = 128;
 constexpr int kFp4GroupedRows = 4;
 

--- a/tests/test_moe_multi_token_fp4.py
+++ b/tests/test_moe_multi_token_fp4.py
@@ -1,0 +1,380 @@
+"""Small-batch FP4 MoE kernel: agreement with the single-token kernel.
+
+The point of moe_multi_token_fp4_forward is to serve a speculative-verify batch
+(k+1 tokens) without falling into the prefill grouped path. It is only useful if
+it agrees with the one-token kernel that decode already uses: a batch kernel
+that shifts logits changes which draft tokens get accepted, which is how the
+existing FP4_DIRECT_GROUPED path fails (max logit diff up to 1.48 on the real
+model).
+
+So the reference here is moe_single_token_fp4_forward applied one token at a
+time. Both kernels use the same dp4a math over the same fp4 unpack and the same
+per-row int8 activation scale, so they should agree to within float32 summation
+order.
+
+Bit-exactness is the wrong bar: both kernels accumulate a token's top-k
+contributions with atomicAdd, so neither is deterministic. Measured on this box,
+the reference kernel disagrees with ITSELF by up to ~9e-7 relative across
+repeated runs of the same inputs. The tolerance below is set from that floor, and
+`test_reference_is_not_bit_exact` pins the reasoning in place so a future reader
+does not tighten it to zero and get a phantom failure.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+cuda_kernel = pytest.importorskip("cuda_kernel")
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+DIM = 256
+INTER_DIM = 128
+N_EXPERTS = 8
+TOPK = 3
+SWIGLU_LIMIT = 7.0
+# Fallback tolerance for the shapes where the reference's own spread is measured
+# to be tiny. Tests that can measure the floor prefer the measured value: the
+# spread grows with how many routes are summed per token (~9e-7 relative at
+# topk=3, ~8e-4 at topk=8), so no single constant fits every shape.
+RTOL = 1e-4
+
+
+def _random_fp4_weights(n_experts: int, rows: int, k: int, device, seed: int):
+    """Random packed FP4 blocks: two 4-bit codes per byte, one e8m0 scale/32."""
+    gen = torch.Generator(device=device).manual_seed(seed)
+    q = torch.randint(0, 256, (n_experts, rows, k // 2), dtype=torch.uint8,
+                      device=device, generator=gen)
+    # Keep exponents in a narrow band so the reference and the kernel are
+    # compared on values that neither overflow nor collapse to zero.
+    s = torch.randint(120, 136, (n_experts, rows, k // 32), dtype=torch.uint8,
+                      device=device, generator=gen)
+    return q.contiguous(), s.contiguous()
+
+
+def _build_routes(indices: torch.Tensor, weights: torch.Tensor, n_local: int):
+    """Compact [T, topk] routing into the kernel's slot/pair layout.
+
+    Only experts the batch actually touches get a slot, which is what keeps the
+    launch proportional to the batch instead of to n_local_experts.
+    """
+    tokens, topk = indices.shape
+    flat_e = indices.reshape(-1)
+    flat_t = torch.arange(tokens, device=indices.device).repeat_interleave(topk)
+    flat_w = weights.reshape(-1).to(torch.float32)
+    keep = (flat_e >= 0) & (flat_e < n_local)
+    flat_e, flat_t, flat_w = flat_e[keep], flat_t[keep], flat_w[keep]
+    order = torch.argsort(flat_e, stable=True)
+    flat_e, flat_t, flat_w = flat_e[order], flat_t[order], flat_w[order]
+    slot_expert, counts = torch.unique_consecutive(flat_e, return_counts=True)
+    slot_starts = torch.zeros(slot_expert.numel() + 1, dtype=torch.int32,
+                              device=indices.device)
+    slot_starts[1:] = counts.cumsum(0).to(torch.int32)
+    return (slot_expert.to(torch.int32).contiguous(),
+            slot_starts.contiguous(),
+            flat_t.to(torch.int32).contiguous(),
+            flat_w.contiguous())
+
+
+def _reference_per_token(x, indices, weights, w, swiglu_limit):
+    """Run the production single-token kernel once per row."""
+    outs = []
+    for t in range(x.size(0)):
+        outs.append(cuda_kernel.moe_single_token_fp4_forward(
+            x[t:t + 1].contiguous(),
+            indices[t].contiguous().to(torch.int64),
+            weights[t].contiguous().to(torch.float32),
+            *w, 0, swiglu_limit,
+        ))
+    return torch.cat(outs, dim=0)
+
+
+def _rel_spread(runs) -> float:
+    return max(float(((runs[0] - r).abs() / runs[0].abs().clamp_min(1e-9)).max())
+               for r in runs[1:])
+
+
+def _assert_within_reference_noise(got, want, ref_runs, label: str):
+    """Compare against the reference's own nondeterminism, not a fixed epsilon.
+
+    atomicAdd makes both kernels order-dependent, and the spread grows with the
+    number of routes summed per token. Demanding better agreement than the
+    reference has with itself would be testing the GPU scheduler.
+    """
+    floor = max(_rel_spread(ref_runs), RTOL)
+    diff = (got - want).abs()
+    rel = float((diff / want.abs().clamp_min(1e-9)).max())
+    assert rel <= floor * 4.0, (
+        f"{label}: cross-kernel max_rel={rel:.3e} exceeds 4x the reference's own "
+        f"run-to-run spread ({floor:.3e}); the batching changed the arithmetic")
+
+
+def _run_pair(tokens: int, seed: int, topk: int = TOPK):
+    device = torch.device("cuda")
+    gen = torch.Generator(device=device).manual_seed(seed)
+    x = torch.randn(tokens, DIM, dtype=torch.bfloat16, device=device, generator=gen)
+    w1q, w1s = _random_fp4_weights(N_EXPERTS, INTER_DIM, DIM, device, seed + 1)
+    w3q, w3s = _random_fp4_weights(N_EXPERTS, INTER_DIM, DIM, device, seed + 2)
+    w2q, w2s = _random_fp4_weights(N_EXPERTS, DIM, INTER_DIM, device, seed + 3)
+    w = (w1q, w1s, w2q, w2s, w3q, w3s)
+
+    indices = torch.stack([
+        torch.randperm(N_EXPERTS, device=device, generator=gen)[:topk]
+        for _ in range(tokens)
+    ]).to(torch.int64)
+    weights = torch.rand(tokens, topk, dtype=torch.float32, device=device, generator=gen) + 0.1
+
+    slot_expert, slot_starts, slot_tokens, pair_weights = _build_routes(
+        indices, weights, N_EXPERTS)
+    got = cuda_kernel.moe_multi_token_fp4_forward(
+        x, slot_expert, slot_starts, slot_tokens, pair_weights, *w, SWIGLU_LIMIT)
+    # Several reference runs: the first is the value to match, the spread across
+    # them is the noise floor that match is judged against.
+    ref_runs = [_reference_per_token(x, indices, weights, w, SWIGLU_LIMIT)
+                for _ in range(4)]
+    return got, ref_runs[0], ref_runs
+
+
+@pytest.mark.parametrize("tokens", [1, 2, 3, 6])
+def test_matches_single_token_kernel(tokens):
+    """A verify batch must produce what the same tokens produce one at a time."""
+    got, want, ref_runs = _run_pair(tokens, seed=1000 + tokens)
+    assert got.shape == want.shape == (tokens, DIM)
+    _assert_within_reference_noise(got, want, ref_runs, f"tokens={tokens}")
+
+
+def test_reference_is_not_bit_exact():
+    """Guards the tolerance above: the reference kernel is itself nondeterministic.
+
+    Both kernels atomicAdd a token's top-k contributions, so summation order
+    varies between launches. If this ever starts passing at rtol=0, the
+    tolerance in the other tests can be tightened -- until then, demanding
+    bit-exactness would be testing the GPU scheduler, not the kernel.
+    """
+    device = torch.device("cuda")
+    gen = torch.Generator(device=device).manual_seed(4242)
+    x = torch.randn(2, DIM, dtype=torch.bfloat16, device=device, generator=gen)
+    w1q, w1s = _random_fp4_weights(N_EXPERTS, INTER_DIM, DIM, device, 11)
+    w3q, w3s = _random_fp4_weights(N_EXPERTS, INTER_DIM, DIM, device, 12)
+    w2q, w2s = _random_fp4_weights(N_EXPERTS, DIM, INTER_DIM, device, 13)
+    w = (w1q, w1s, w2q, w2s, w3q, w3s)
+    indices = torch.stack([
+        torch.randperm(N_EXPERTS, device=device, generator=gen)[:TOPK] for _ in range(2)
+    ]).to(torch.int64)
+    weights = torch.rand(2, TOPK, dtype=torch.float32, device=device, generator=gen) + 0.1
+    runs = [_reference_per_token(x, indices, weights, w, SWIGLU_LIMIT) for _ in range(5)]
+    spread = max(float((runs[0] - r).abs().max()) for r in runs[1:])
+    rel = max(float(((runs[0] - r).abs() / runs[0].abs().clamp_min(1e-9)).max())
+              for r in runs[1:])
+    # Whatever the spread is, it must stay well inside the tolerance the
+    # cross-kernel tests use, or those tests are not measuring the kernel.
+    assert rel < RTOL, f"reference spread {rel:.2e} exceeds test tolerance {RTOL:.0e}"
+    print(f"reference self-disagreement: max_abs={spread:.3g} max_rel={rel:.2e}")
+
+
+def test_tokens_above_register_tile():
+    """More tokens per expert than the register tile takes a second pass."""
+    # topk == N_EXPERTS puts every token on every expert, so with 10 tokens each
+    # slot holds 10 -- past the kernel's 8-wide tile. It also sums 8 routes per
+    # token, which is where the atomicAdd noise floor is widest (~8e-4).
+    got, want, ref_runs = _run_pair(10, seed=77, topk=N_EXPERTS)
+    _assert_within_reference_noise(got, want, ref_runs, "tokens=10 topk=8")
+
+
+def test_rows_for_non_local_experts_are_zero():
+    """Experts outside this rank's range contribute nothing.
+
+    Under TP each rank holds a slice of the experts and drops routes outside it.
+    The caller filters those out, so an empty route list must yield zeros rather
+    than reading out of bounds.
+    """
+    device = torch.device("cuda")
+    x = torch.randn(3, DIM, dtype=torch.bfloat16, device=device)
+    w1q, w1s = _random_fp4_weights(N_EXPERTS, INTER_DIM, DIM, device, 5)
+    w3q, w3s = _random_fp4_weights(N_EXPERTS, INTER_DIM, DIM, device, 6)
+    w2q, w2s = _random_fp4_weights(N_EXPERTS, DIM, INTER_DIM, device, 7)
+    empty_i32 = torch.empty(0, dtype=torch.int32, device=device)
+    y = cuda_kernel.moe_multi_token_fp4_forward(
+        x,
+        empty_i32,
+        torch.zeros(1, dtype=torch.int32, device=device),
+        empty_i32,
+        torch.empty(0, dtype=torch.float32, device=device),
+        w1q, w1s, w2q, w2s, w3q, w3s, SWIGLU_LIMIT,
+    )
+    assert torch.count_nonzero(y) == 0
+
+
+class _FakeCPUBackend:
+    """Minimal stand-in for the CPU MoE backend's staging interface.
+
+    _forward_multi_token_fp4 only needs the FP4 arena and a layer index; the
+    real backend brings a pinned host arena and a CPU expert pool that are
+    irrelevant to the route bookkeeping under test here.
+    """
+
+    def __init__(self, arena):
+        self._arena = arena
+        self.layer_idx = 0
+        self._swiglu_limit = SWIGLU_LIMIT
+
+    def get_fp4_arena(self):
+        return self._arena
+
+    def _apply_topk_limit(self, ids, w):
+        return ids, w
+
+
+def _backend_with_arena(device, n_local, seed):
+    """A GPUPrefillMoEBackend wired to host-pinned FP4 weights."""
+    from src.components.moe.gpu_prefill_backend import GPUPrefillMoEBackend
+
+    w1q, w1s = _random_fp4_weights(n_local, INTER_DIM, DIM, device, seed + 1)
+    w3q, w3s = _random_fp4_weights(n_local, INTER_DIM, DIM, device, seed + 2)
+    w2q, w2s = _random_fp4_weights(n_local, DIM, INTER_DIM, device, seed + 3)
+    gpu_w = (w1q, w1s, w2q, w2s, w3q, w3s)
+    arena = tuple(t.to("cpu") for t in gpu_w)
+    backend = GPUPrefillMoEBackend(
+        _FakeCPUBackend(arena), dim=DIM, num_experts=n_local,
+        experts_start_idx=0, experts_end_idx=n_local,
+    )
+    backend.multi_token_fp4_enabled = True
+    return backend, gpu_w
+
+
+def test_backend_route_layout_handles_non_contiguous_indices():
+    """The decode-active call site does not make indices contiguous.
+
+    runtime.py's _should_use_gpu_decode_active_moe branch hands the gate's
+    indices/weights straight to forward(), unlike the prefill branch which calls
+    .contiguous() first. A transposed view reshapes in expert-major order, so
+    pairing route i with token i // topk silently mismatches routes to tokens --
+    which showed up on the real model as logits differing by up to 3.65 with
+    only 50-67% argmax agreement, while the unit tests (building their own
+    contiguous routes) passed.
+    """
+    device = torch.device("cuda")
+    n_local, tokens, topk = N_EXPERTS, 3, TOPK
+    backend, gpu_w = _backend_with_arena(device, n_local, seed=900)
+    gen = torch.Generator(device=device).manual_seed(901)
+    x = torch.randn(tokens, DIM, dtype=torch.bfloat16, device=device, generator=gen)
+
+    # Build routing whose natural layout is [topk, tokens], then transpose: same
+    # values as a contiguous [tokens, topk] tensor, different memory order.
+    idx_t = torch.stack([
+        torch.randperm(n_local, device=device, generator=gen)[:tokens] for _ in range(topk)
+    ]).to(torch.int64)                       # [topk, tokens]
+    w_t = torch.rand(topk, tokens, dtype=torch.float32, device=device, generator=gen) + 0.1
+    indices_nc, weights_nc = idx_t.t(), w_t.t()   # [tokens, topk] views
+    assert not indices_nc.is_contiguous()
+
+    got = backend._forward_multi_token_fp4(
+        x, indices_nc, weights_nc, SWIGLU_LIMIT)
+    assert got is not None, "FP4 arena was available; the path should have run"
+    want = _reference_per_token(
+        x, indices_nc.contiguous(), weights_nc.contiguous(), gpu_w, SWIGLU_LIMIT)
+    ref_runs = [_reference_per_token(
+        x, indices_nc.contiguous(), weights_nc.contiguous(), gpu_w, SWIGLU_LIMIT)
+        for _ in range(4)]
+    _assert_within_reference_noise(got, want, ref_runs, "non-contiguous indices")
+
+
+def test_backend_route_layout_matches_reference_contiguous():
+    """Same check with a contiguous batch, so the two cases can be compared."""
+    device = torch.device("cuda")
+    n_local, tokens, topk = N_EXPERTS, 6, TOPK
+    backend, gpu_w = _backend_with_arena(device, n_local, seed=910)
+    gen = torch.Generator(device=device).manual_seed(911)
+    x = torch.randn(tokens, DIM, dtype=torch.bfloat16, device=device, generator=gen)
+    indices = torch.stack([
+        torch.randperm(n_local, device=device, generator=gen)[:topk] for _ in range(tokens)
+    ]).to(torch.int64)
+    weights = torch.rand(tokens, topk, dtype=torch.float32, device=device, generator=gen) + 0.1
+
+    got = backend._forward_multi_token_fp4(x, indices, weights, SWIGLU_LIMIT)
+    assert got is not None
+    ref_runs = [_reference_per_token(x, indices, weights, gpu_w, SWIGLU_LIMIT)
+                for _ in range(4)]
+    _assert_within_reference_noise(got, ref_runs[0], ref_runs, "contiguous indices")
+
+
+# Production shapes: the TP4 rank slice of DSV4-Flash (dim 4096, moe_inter_dim
+# 2048, n_activated_experts 6, 256/4 = 64 local experts). The small shapes above
+# exercise the code paths; this one pins the tolerance at the arithmetic width
+# the model actually runs, where more routes per token widen the atomicAdd floor.
+REAL_DIM, REAL_INTER, REAL_NLOC, REAL_TOPK = 4096, 2048, 64, 6
+
+
+@pytest.mark.parametrize("tokens", [2, 3, 6])
+def test_agreement_at_production_shapes(tokens):
+    """Agreement measured on the layer output, not on logits.
+
+    The real-model probes compared logits after 43 layers and lm_head, where a
+    per-layer relative error is amplified and mixed with attention's own
+    batch-vs-sequential differences -- so a 0.29 logit delta there could not be
+    attributed. Comparing the MoE layer output directly makes the number the
+    kernel's own, and it lands at the reference's atomicAdd noise floor.
+    """
+    device = torch.device("cuda")
+    seed = 4000 + tokens
+    gen = torch.Generator(device=device).manual_seed(seed)
+    x = torch.randn(tokens, REAL_DIM, dtype=torch.bfloat16, device=device, generator=gen)
+    w1q, w1s = _random_fp4_weights(REAL_NLOC, REAL_INTER, REAL_DIM, device, seed + 1)
+    w3q, w3s = _random_fp4_weights(REAL_NLOC, REAL_INTER, REAL_DIM, device, seed + 2)
+    w2q, w2s = _random_fp4_weights(REAL_NLOC, REAL_DIM, REAL_INTER, device, seed + 3)
+    w = (w1q, w1s, w2q, w2s, w3q, w3s)
+    indices = torch.stack([
+        torch.randperm(REAL_NLOC, device=device, generator=gen)[:REAL_TOPK]
+        for _ in range(tokens)
+    ]).to(torch.int64)
+    weights = torch.rand(tokens, REAL_TOPK, dtype=torch.float32, device=device,
+                         generator=gen) + 0.1
+
+    routes = _build_routes(indices, weights, REAL_NLOC)
+    got = cuda_kernel.moe_multi_token_fp4_forward(x, *routes, *w, SWIGLU_LIMIT)
+    ref_runs = [_reference_per_token(x, indices, weights, w, SWIGLU_LIMIT)
+                for _ in range(4)]
+    assert got.shape == (tokens, REAL_DIM)
+    # Our own spread counts too: at topk=6 both kernels sum 6 atomicAdd
+    # contributions per output element, and either arm can be the noisier one.
+    ours = [cuda_kernel.moe_multi_token_fp4_forward(x, *routes, *w, SWIGLU_LIMIT)
+            for _ in range(3)]
+    floor = max(_rel_spread(ref_runs), _rel_spread([got] + ours), RTOL)
+    rel = float(((got - ref_runs[0]).abs()
+                 / ref_runs[0].abs().clamp_min(1e-9)).max())
+    assert rel <= floor * 8.0, (
+        f"tokens={tokens} at production shapes: max_rel={rel:.3e} exceeds 8x the "
+        f"measured noise floor ({floor:.3e})")
+
+
+def test_one_token_per_slot_is_the_single_token_computation():
+    """Disjoint routing per token means every slot holds one token.
+
+    With one token per slot the multi-token kernel does not enter its tile loop
+    and performs the same arithmetic as the single-token kernel, so agreement
+    here isolates the slot bookkeeping from the multi-token accumulation. Swept
+    over many routings because the real-model bs=2 probe disagreed on 1 of 3
+    draws, which a single seed would have missed.
+    """
+    device = torch.device("cuda")
+    n_experts, tokens, topk = 16, 2, 3
+    worst, worst_seed = 0.0, None
+    for seed in range(24):
+        gen = torch.Generator(device=device).manual_seed(seed)
+        x = torch.randn(tokens, DIM, dtype=torch.bfloat16, device=device, generator=gen)
+        w1q, w1s = _random_fp4_weights(n_experts, INTER_DIM, DIM, device, seed + 1)
+        w3q, w3s = _random_fp4_weights(n_experts, INTER_DIM, DIM, device, seed + 2)
+        w2q, w2s = _random_fp4_weights(n_experts, DIM, INTER_DIM, device, seed + 3)
+        w = (w1q, w1s, w2q, w2s, w3q, w3s)
+        perm = torch.randperm(n_experts, device=device, generator=gen)
+        indices = torch.stack([perm[:topk], perm[topk:2 * topk]]).to(torch.int64)
+        weights = torch.rand(tokens, topk, dtype=torch.float32, device=device,
+                             generator=gen) + 0.1
+        routes = _build_routes(indices, weights, n_experts)
+        got = cuda_kernel.moe_multi_token_fp4_forward(x, *routes, *w, SWIGLU_LIMIT)
+        ref = _reference_per_token(x, indices, weights, w, SWIGLU_LIMIT)
+        rel = float(((got - ref).abs() / ref.abs().clamp_min(1e-9)).max())
+        if rel > worst:
+            worst, worst_seed = rel, seed
+    assert worst < 1e-3, (
+        f"one token per slot should match the single-token kernel to the atomicAdd "
+        f"floor; worst max_rel={worst:.3e} at seed={worst_seed}")


### PR DESCRIPTION
## What

A `k+1` token verify batch drops out of the single-token FP4 kernel (gated on `x.shape[0] == 1`) into the prefill grouped path, which launches over all 64 `n_local_experts` and restages the layer as int8. Measured on DSV4-Flash TP4: **+619ms of MoE for one extra token**, which made DSpark speculative decoding a net loss — k=5 needed a 99.7% accept rate to break even against 281ms/token sequential decode.

`moe_multi_token_fp4_forward` compacts routes into (slot -> tokens) form, one slot per distinct local expert, so the launch scales with the experts the batch actually touched (~8 for a 6-token verify) instead of with `n_local_experts`. It consumes the same FP4 blocks and per-row int8 activation scale as the single-token kernel, so decode and verify agree on the arithmetic.

## Performance

Real-model A/B, TP4 on 4x2080Ti, `config_fp4_active`, both arms in one process:

| bs | grouped path | new kernel | speedup |
|---|---|---|---|
| 2 | 944ms | 432ms | 2.19x |
| 3 | 1149ms | 494ms | 2.33x |
| 6 | 1699ms | 817ms | 2.08x |

k=5 spec break-even accept rate: **99.7% -> 37.6%**, below the measured 61.3%.

## End-to-end DSpark, per prompt class

Verify cost is nearly fixed (798-917ms across classes) while the payoff scales with accept rate, so the aggregate mean is misleading — reporting per class:

| class | accept | ms/token | speedup |
|---|---|---|---|
| repeat | 100% | 160ms | **1.73x** |
| code | 82% | 200ms | **1.37x** |
| prose | 40% | 375ms | 0.82x |
| math | 18% | 588ms | 0.57x |

Every class was a net loss before this kernel (0.17x-0.59x). Two classes are still net losses: DSpark needs gating on draft confidence to be worth enabling generally, which is a scheduler change and not in scope here.

Counter-intuitive detail worth knowing: low-accept classes have the *more* expensive verify (math 917ms vs repeat 798ms). Scattered draft tokens hit more experts, so more H2D — losses compound rather than scale linearly.

## Numerics

The reference is **sequential bs=1 decode**, not the other batch path. An earlier comparison of the two batch arms against each other produced a wrong conclusion; comparing two approximations cannot establish which is correct.

- **argmax agrees 100%** with row-by-row single-token MoE on every batch size and trial. This is what decides which draft tokens get accepted.
- At production shapes (dim 4096, inter 2048, topk 6, 64 local experts) the layer-output disagreement sits at the reference kernel's own atomicAdd noise floor: worst cross 3.06e-03 against 1.4e-03 self-spread. Both kernels accumulate a token's top-k contributions with float32 `atomicAdd`, so neither is deterministic and bit-exactness is the wrong bar.
- Fixed a real defect found along the way: the decode-active call site does not call `.contiguous()` (unlike the prefill site), so route-to-token pairing was silently wrong — argmax agreement was 50-67% before the fix. `test_backend_route_layout_handles_non_contiguous_indices` reproduces it.
- **Pre-existing, not introduced here:** batch decode does not reproduce sequential decode (top1 87-96%, logit deltas up to 5.8). The grouped path shows the same thing (90.7%) and toggling the prefuse gate does not explain it, so it lives in attention's batch path. No MoE kernel closes this, and it means measured accept rates already include this loss.

## Safety

Off by default (`DEEPSEEK_GPU_MOE_MULTI_TOKEN_FP4=0`). `_forward_multi_token_fp4` returns `None` when the FP4 arena is unavailable, so int8-only layers fall through to the existing grouped path unchanged.

## Testing

- 13 unit tests, all passing. Tolerances are keyed to the measured per-shape noise floor; `test_reference_is_not_bit_exact` pins the reasoning so a future reader does not tighten it to zero and get a phantom failure.
- FP4 default-path smoke (flag unset), short and long prompt, serial: short prompt decode 1.939 tok/s; long prompt (1001 tokens) prefill 139.3 tok/s, decode 1.940 tok/s. Both produce coherent output; decode rate matches across both, so the default path is unaffected.