### PR TITLE
Add Qwen3.8 FP8 C++ runtime

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -37,6 +37,9 @@ add_library(dsv4_cpp_core STATIC
     src/safetensors_model.cpp
     src/weight_source.cpp
     src/model_config.cpp
+    src/qwen_config.cpp
+    src/qwen_weights.cpp
+    src/qwen_engine.cpp
     src/tokenizer.cpp
     src/tensor.cpp
     src/tp_comm.cpp
@@ -52,6 +55,8 @@ add_library(dsv4_cpp_core STATIC
     cuda/quant_gemm.cu
     cuda/fp4_ops.cu
     cuda/fp8_ops.cu
+    cuda/qwen_fp8_ops.cu
+    cuda/qwen_attention_ops.cu
     cuda/q2_ops.cu
     cuda/iq1_ops.cu
     cuda/rmsnorm_rope.cu
@@ -281,6 +286,38 @@ set_target_properties(test_min_layer_smoke PROPERTIES RUNTIME_OUTPUT_DIRECTORY $
 add_executable(test_nccl_smoke tests/test_nccl_smoke.cpp)
 target_link_libraries(test_nccl_smoke PRIVATE dsv4_cpp_core)
 set_target_properties(test_nccl_smoke PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_config tests/test_qwen_config.cpp)
+target_link_libraries(test_qwen_config PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_config PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_fp8_online tests/test_qwen_fp8_online.cpp)
+target_link_libraries(test_qwen_fp8_online PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_fp8_online PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_weights tests/test_qwen_weights.cpp)
+target_link_libraries(test_qwen_weights PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_weights PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_engine tests/test_qwen_engine.cpp)
+target_link_libraries(test_qwen_engine PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_engine PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_delta_rule tests/test_qwen_delta_rule.cpp)
+target_link_libraries(test_qwen_delta_rule PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_delta_rule PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_gqa_attention tests/test_qwen_gqa_attention.cpp)
+target_link_libraries(test_qwen_gqa_attention PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_gqa_attention PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_conv_tail tests/test_qwen_conv_tail.cpp)
+target_link_libraries(test_qwen_conv_tail PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_conv_tail PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(bench_qwen_fp8_kernels tests/bench_qwen_fp8_kernels.cpp)
+target_link_libraries(bench_qwen_fp8_kernels PRIVATE dsv4_cpp_core)
+set_target_properties(bench_qwen_fp8_kernels PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(test_persistent_engine tests/test_persistent_engine.cpp)
 target_link_libraries(test_persistent_engine PRIVATE dsv4_cpp_core)

--- a/cpp_engine/cuda/qwen_attention_ops.cu
+++ b/cpp_engine/cuda/qwen_attention_ops.cu
@@ -1,0 +1,702 @@
+#include "qwen_cuda_ops.hpp"
+
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+
+namespace dsv4 {
+namespace {
+
+__device__ __forceinline__ float fp16_to_float(uint16_t bits) {
+    const uint32_t sign = static_cast<uint32_t>(bits & 0x8000u) << 16;
+    const uint32_t exponent = (bits >> 10) & 0x1fu;
+    const uint32_t mantissa = bits & 0x03ffu;
+    uint32_t value;
+    if (exponent == 0) {
+        if (mantissa == 0) {
+            value = sign;
+        } else {
+            uint32_t normalized = mantissa;
+            int exp = -14;
+            while ((normalized & 0x400u) == 0) {
+                normalized <<= 1;
+                --exp;
+            }
+            value = sign | (static_cast<uint32_t>(exp + 127) << 23) |
+                    ((normalized & 0x3ffu) << 13);
+        }
+    } else if (exponent == 0x1fu) {
+        value = sign | 0x7f800000u | (mantissa << 13);
+    } else {
+        value = sign | ((exponent - 15 + 127) << 23) | (mantissa << 13);
+    }
+    return __uint_as_float(value);
+}
+
+__device__ __forceinline__ float sigmoid(float x) {
+    return 1.0f / (1.0f + expf(-x));
+}
+
+__device__ __forceinline__ float silu(float x) {
+    return x * sigmoid(x);
+}
+
+__global__ void fp16_matmul_rows_kernel(const float* __restrict__ x,
+                                        const uint16_t* __restrict__ w,
+                                        float* __restrict__ y,
+                                        int batch, int rows, int cols,
+                                        int x_stride, int y_stride,
+                                        int weight_stride) {
+    const int row = static_cast<int>(blockIdx.x);
+    const int sample = static_cast<int>(blockIdx.y);
+    if (row >= rows || sample >= batch) return;
+    const float* x_row = x + static_cast<size_t>(sample) * x_stride;
+    const uint16_t* w_row = w + static_cast<size_t>(row) * weight_stride;
+    float sum = 0.0f;
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+        sum += x_row[col] * fp16_to_float(w_row[col]);
+    }
+    extern __shared__ float scratch[];
+    scratch[threadIdx.x] = sum;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) scratch[threadIdx.x] += scratch[threadIdx.x + stride];
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) y[static_cast<size_t>(sample) * y_stride + row] = scratch[0];
+}
+
+__global__ void embedding_fp16_gather_kernel(const uint16_t* __restrict__ table,
+                                             const int* __restrict__ tokens,
+                                             float* __restrict__ out, int count,
+                                             int cols, int row_start, int row_count) {
+    const int token_index = static_cast<int>(blockIdx.x);
+    if (token_index >= count) return;
+    const int token = tokens[token_index];
+    float* dst = out + static_cast<size_t>(token_index) * cols;
+    if (token < row_start || token >= row_start + row_count) {
+        for (int col = threadIdx.x; col < cols; col += blockDim.x) dst[col] = 0.0f;
+        return;
+    }
+    const uint16_t* src = table + static_cast<size_t>(token - row_start) * cols;
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) dst[col] = fp16_to_float(src[col]);
+}
+
+__global__ void rmsnorm_fp16_gamma_rows_kernel(const float* __restrict__ x,
+                                               const uint16_t* __restrict__ gamma,
+                                               float* __restrict__ y, int rows,
+                                               int cols, float eps) {
+    const int row = static_cast<int>(blockIdx.x);
+    if (row >= rows) return;
+    const float* src = x + static_cast<size_t>(row) * cols;
+    float* dst = y + static_cast<size_t>(row) * cols;
+    float sum = 0.0f;
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) sum += src[col] * src[col];
+    extern __shared__ float scratch[];
+    scratch[threadIdx.x] = sum;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) scratch[threadIdx.x] += scratch[threadIdx.x + stride];
+        __syncthreads();
+    }
+    const float inv = rsqrtf(scratch[0] / static_cast<float>(cols) + eps);
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+        dst[col] = src[col] * inv * (1.0f + fp16_to_float(gamma[col]));
+    }
+}
+
+__global__ void gated_rmsnorm_fp16_gamma_rows_kernel(const float* __restrict__ x,
+                                                     const uint16_t* __restrict__ gamma,
+                                                     const float* __restrict__ gate,
+                                                     float* __restrict__ y, int rows,
+                                                     int cols, float eps) {
+    const int row = static_cast<int>(blockIdx.x);
+    if (row >= rows) return;
+    const float* src = x + static_cast<size_t>(row) * cols;
+    const float* gate_row = gate + static_cast<size_t>(row) * cols;
+    float* dst = y + static_cast<size_t>(row) * cols;
+    float sum = 0.0f;
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) sum += src[col] * src[col];
+    extern __shared__ float scratch[];
+    scratch[threadIdx.x] = sum;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) scratch[threadIdx.x] += scratch[threadIdx.x + stride];
+        __syncthreads();
+    }
+    const float inv = rsqrtf(scratch[0] / static_cast<float>(cols) + eps);
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+        dst[col] = fp16_to_float(gamma[col]) * src[col] * inv * silu(gate_row[col]);
+    }
+}
+
+__global__ void split_packed_qkv_kernel(const float* __restrict__ packed,
+                                        float* __restrict__ q, float* __restrict__ k,
+                                        float* __restrict__ v, int rows,
+                                        int key_dim, int value_dim) {
+    const int i = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int total = rows * (2 * key_dim + value_dim);
+    if (i >= total) return;
+    const int col = i % (2 * key_dim + value_dim);
+    const int row = i / (2 * key_dim + value_dim);
+    if (col < key_dim) q[static_cast<size_t>(row) * key_dim + col] = packed[i];
+    else if (col < 2 * key_dim) k[static_cast<size_t>(row) * key_dim + col - key_dim] = packed[i];
+    else v[static_cast<size_t>(row) * value_dim + col - 2 * key_dim] = packed[i];
+}
+
+// One thread per channel, 256 channels per block. The time axis stays serial
+// because the convolution is causal and the tail must be updated in order, but
+// the original <<<channels, 1>>> launch wasted 31 of every 32 lanes.
+__global__ void causal_depthwise_conv_silu_kernel(const float* __restrict__ x,
+                                                  const uint16_t* __restrict__ weight,
+                                                  float* __restrict__ tail,
+                                                  float* __restrict__ y, int seq_len,
+                                                  int channels, int kernel, bool update_tail) {
+    const int channel = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (channel >= channels) return;
+    const uint16_t* w = weight + static_cast<size_t>(channel) * kernel;
+    float* dst = y + channel;
+    for (int t = 0; t < seq_len; ++t) {
+        float value = 0.0f;
+        for (int j = 0; j < kernel; ++j) {
+            const int source_t = t - (kernel - 1) + j;
+            float input = 0.0f;
+            if (source_t >= 0) {
+                input = x[static_cast<size_t>(source_t) * channels + channel];
+            } else if (source_t >= -(kernel - 1) && tail != nullptr) {
+                input = tail[static_cast<size_t>(source_t + kernel - 1) * channels + channel];
+            }
+            value += input * fp16_to_float(w[j]);
+        }
+        dst[static_cast<size_t>(t) * channels] = silu(value);
+    }
+    if (update_tail && tail != nullptr && kernel > 1) {
+        // The new tail is the last (kernel-1) entries of [old_tail ++ x]. When
+        // seq_len < kernel-1 (decode feeds one token at a time) the window still
+        // straddles the old tail, so those entries must be shifted down rather
+        // than zero-filled. Read everything into registers first: the loop below
+        // overwrites the same cells it sources from.
+        constexpr int kMaxTail = 8;
+        const int tail_len = kernel - 1;
+        float next[kMaxTail];
+        for (int j = 0; j < tail_len && j < kMaxTail; ++j) {
+            const int source_t = seq_len - tail_len + j;
+            if (source_t >= 0) {
+                next[j] = x[static_cast<size_t>(source_t) * channels + channel];
+            } else {
+                next[j] = tail[static_cast<size_t>(source_t + tail_len) * channels + channel];
+            }
+        }
+        for (int j = 0; j < tail_len && j < kMaxTail; ++j) {
+            tail[static_cast<size_t>(j) * channels + channel] = next[j];
+        }
+    }
+}
+
+__global__ void linear_attn_gates_kernel(const float* __restrict__ a,
+                                         const float* __restrict__ b,
+                                         const uint16_t* __restrict__ a_log,
+                                         const uint16_t* __restrict__ dt_bias,
+                                         float* __restrict__ g, float* __restrict__ beta,
+                                         int rows, int heads) {
+    const int head = static_cast<int>(blockIdx.x);
+    if (head >= heads) return;
+    const float al = fp16_to_float(a_log[head]);
+    const float dt = fp16_to_float(dt_bias[head]);
+    for (int row = threadIdx.x; row < rows; row += blockDim.x) {
+        const float av = a[static_cast<size_t>(row) * heads + head];
+        const float bv = b[static_cast<size_t>(row) * heads + head];
+        g[static_cast<size_t>(row) * heads + head] = -expf(al) * log1pf(expf(av + dt));
+        beta[static_cast<size_t>(row) * heads + head] = sigmoid(bv);
+    }
+}
+
+__global__ void gated_delta_step_kernel(float* __restrict__ state,
+                                        const float* __restrict__ q,
+                                        const float* __restrict__ k,
+                                        const float* __restrict__ v,
+                                        const float* __restrict__ g,
+                                        const float* __restrict__ beta,
+                                        float* __restrict__ out, int heads,
+                                        int key_heads, int key_dim, int value_dim,
+                                        float q_scale) {
+    const int head = static_cast<int>(blockIdx.x);
+    const int value = static_cast<int>(threadIdx.x);
+    const int repeat = heads / key_heads;
+    const int key_head = head / repeat;
+    const float* q_head = q + static_cast<size_t>(key_head) * key_dim;
+    const float* k_head = k + static_cast<size_t>(key_head) * key_dim;
+
+    // L2-normalize q/k once per block and stage them in shared memory. The
+    // original version recomputed both 128-term norms in every one of the
+    // value_dim threads and re-read k/q from global on each state pass.
+    extern __shared__ float smem[];
+    float* k_shared = smem;                       // key_dim
+    float* q_shared = smem + key_dim;             // key_dim
+    float* reduce = smem + 2 * key_dim;           // blockDim.x
+    const int tid = static_cast<int>(threadIdx.x);
+    const int threads = static_cast<int>(blockDim.x);
+
+    float q_partial = 0.0f;
+    float k_partial = 0.0f;
+    for (int i = tid; i < key_dim; i += threads) {
+        q_partial += q_head[i] * q_head[i];
+        k_partial += k_head[i] * k_head[i];
+    }
+    reduce[tid] = q_partial;
+    __syncthreads();
+    for (int stride = threads / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) reduce[tid] += reduce[tid + stride];
+        __syncthreads();
+    }
+    const float q_norm = rsqrtf(reduce[0] + 1.0e-6f);
+    __syncthreads();
+    reduce[tid] = k_partial;
+    __syncthreads();
+    for (int stride = threads / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) reduce[tid] += reduce[tid + stride];
+        __syncthreads();
+    }
+    const float k_norm = rsqrtf(reduce[0] + 1.0e-6f);
+    __syncthreads();
+
+    for (int i = tid; i < key_dim; i += threads) {
+        k_shared[i] = k_head[i] * k_norm;
+        q_shared[i] = q_head[i] * q_norm;
+    }
+    __syncthreads();
+    if (head >= heads || value >= value_dim) return;
+
+    float* state_head = state + static_cast<size_t>(head) * key_dim * value_dim;
+    const float decay = expf(g[head]);
+    const float b = beta[head];
+
+    // Single pass over the state column: apply decay, accumulate k·state, then
+    // finish with the delta update and the q·state readout.
+    float kv_mem = 0.0f;
+    for (int i = 0; i < key_dim; ++i) {
+        const float cell = state_head[static_cast<size_t>(i) * value_dim + value] * decay;
+        state_head[static_cast<size_t>(i) * value_dim + value] = cell;
+        kv_mem += cell * k_shared[i];
+    }
+    const float delta = (v[static_cast<size_t>(head) * value_dim + value] - kv_mem) * b;
+    float result = 0.0f;
+    for (int i = 0; i < key_dim; ++i) {
+        const size_t idx = static_cast<size_t>(i) * value_dim + value;
+        const float cell = state_head[idx] + k_shared[i] * delta;
+        state_head[idx] = cell;
+        result += cell * q_shared[i];
+    }
+    out[static_cast<size_t>(head) * value_dim + value] = result * q_scale;
+}
+
+__device__ __forceinline__ float rope_inv_freq(int index, int rotary_dim, float theta) {
+    return powf(theta, -2.0f * static_cast<float>(index) / static_cast<float>(rotary_dim));
+}
+
+__global__ void partial_rope_kernel(float* __restrict__ q, float* __restrict__ k,
+                                    int position, int rotary_dim, float theta,
+                                    int q_heads, int kv_heads, int head_dim) {
+    const int idx = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int half = rotary_dim / 2;
+    if (idx >= half) return;
+    const float angle = static_cast<float>(position) * rope_inv_freq(idx, rotary_dim, theta);
+    const float c = cosf(angle);
+    const float s = sinf(angle);
+    for (int head = 0; head < q_heads; ++head) {
+        float* row = q + static_cast<size_t>(head) * head_dim;
+        const float a = row[idx];
+        const float b = row[idx + half];
+        row[idx] = a * c - b * s;
+        row[idx + half] = b * c + a * s;
+    }
+    for (int head = 0; head < kv_heads; ++head) {
+        float* row = k + static_cast<size_t>(head) * head_dim;
+        const float a = row[idx];
+        const float b = row[idx + half];
+        row[idx] = a * c - b * s;
+        row[idx + half] = b * c + a * s;
+    }
+}
+
+__global__ void split_q_gate_kernel(const float* __restrict__ src,
+                                    float* __restrict__ q, float* __restrict__ gate,
+                                    int rows, int q_heads, int head_dim) {
+    const int i = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int total = rows * q_heads * head_dim;
+    if (i >= total) return;
+    const int d = i % head_dim;
+    const int head = (i / head_dim) % q_heads;
+    const int row = i / (q_heads * head_dim);
+    const size_t source = (static_cast<size_t>(row) * q_heads + head) * head_dim * 2;
+    q[i] = src[source + d];
+    gate[i] = src[source + head_dim + d];
+}
+
+__global__ void select_kv_heads_kernel(const float* __restrict__ src, float* __restrict__ dst,
+                                       int rows, int total_heads, int local_heads,
+                                       int head_dim, int head_offset) {
+    const int i = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int total = rows * local_heads * head_dim;
+    if (i >= total) return;
+    const int d = i % head_dim;
+    const int head = (i / head_dim) % local_heads;
+    const int row = i / (local_heads * head_dim);
+    const size_t source = (static_cast<size_t>(row) * total_heads + head_offset + head) * head_dim + d;
+    dst[i] = src[source];
+}
+
+__global__ void append_kv_cache_kernel(const float* __restrict__ k_rows,
+                                       const float* __restrict__ v_rows,
+                                       float* __restrict__ k_cache,
+                                       float* __restrict__ v_cache, int seq_len,
+                                       int kv_heads, int head_dim, int start_pos,
+                                       int max_context) {
+    const int index = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int total = seq_len * kv_heads * head_dim;
+    if (index >= total) return;
+    const int token = index / (kv_heads * head_dim);
+    const int within = index % (kv_heads * head_dim);
+    const int dst_token = start_pos + token;
+    if (dst_token >= max_context) return;
+    const size_t dst = static_cast<size_t>(dst_token) * kv_heads * head_dim + within;
+    k_cache[dst] = k_rows[index];
+    v_cache[dst] = v_rows[index];
+}
+
+// One block per (query head, token). Threads cooperate along head_dim, and the
+// KV cache is streamed exactly once using an online softmax: the running max and
+// denominator are rescaled as larger scores appear, so no second pass over the
+// cache is needed. head_dim is 256 for Qwen3.8, so a 128-thread block keeps two
+// accumulators per thread in registers.
+template <int kThreads>
+__device__ __forceinline__ void gqa_attention_body(const float* __restrict__ q_row,
+                                                   const float* __restrict__ k_cache,
+                                                   const float* __restrict__ v_cache,
+                                                   float* __restrict__ dst,
+                                                   int kv_head, int kv_heads,
+                                                   int head_dim, int context_len) {
+    extern __shared__ float smem[];
+    float* q_shared = smem;              // head_dim
+    float* reduce = smem + head_dim;     // kThreads
+    const int tid = static_cast<int>(threadIdx.x);
+    for (int d = tid; d < head_dim; d += kThreads) q_shared[d] = q_row[d];
+    __syncthreads();
+
+    const float scale = rsqrtf(static_cast<float>(head_dim));
+    // Per-thread slice of the value accumulator.
+    constexpr int kMaxSlice = 8;
+    float acc[kMaxSlice];
+    const int slice = (head_dim + kThreads - 1) / kThreads;
+    for (int i = 0; i < slice && i < kMaxSlice; ++i) acc[i] = 0.0f;
+
+    float running_max = -INFINITY;
+    float running_sum = 0.0f;
+    const size_t kv_stride = static_cast<size_t>(kv_heads) * head_dim;
+    for (int pos = 0; pos < context_len; ++pos) {
+        const float* key = k_cache + static_cast<size_t>(pos) * kv_stride +
+                           static_cast<size_t>(kv_head) * head_dim;
+        float partial = 0.0f;
+        for (int d = tid; d < head_dim; d += kThreads) partial += q_shared[d] * key[d];
+        // Block reduce the dot product.
+        reduce[tid] = partial;
+        __syncthreads();
+        for (int stride = kThreads / 2; stride > 0; stride >>= 1) {
+            if (tid < stride) reduce[tid] += reduce[tid + stride];
+            __syncthreads();
+        }
+        const float score = reduce[0] * scale;
+        __syncthreads();
+
+        const float new_max = fmaxf(running_max, score);
+        const float rescale = running_max == -INFINITY ? 0.0f : expf(running_max - new_max);
+        const float p = expf(score - new_max);
+        running_sum = running_sum * rescale + p;
+        running_max = new_max;
+
+        const float* value = v_cache + static_cast<size_t>(pos) * kv_stride +
+                             static_cast<size_t>(kv_head) * head_dim;
+        for (int i = 0, d = tid; i < slice && d < head_dim; ++i, d += kThreads) {
+            acc[i] = acc[i] * rescale + p * value[d];
+        }
+    }
+
+    const float inv = running_sum > 0.0f ? 1.0f / running_sum : 0.0f;
+    for (int i = 0, d = tid; i < slice && d < head_dim; ++i, d += kThreads) {
+        dst[d] = acc[i] * inv;
+    }
+}
+
+template <int kThreads>
+__global__ void gqa_decode_attention_kernel(const float* __restrict__ q,
+                                            const float* __restrict__ k_cache,
+                                            const float* __restrict__ v_cache,
+                                            float* __restrict__ out, int q_heads,
+                                            int kv_heads, int head_dim, int context_len,
+                                            int max_context) {
+    const int head = static_cast<int>(blockIdx.x);
+    if (head >= q_heads) return;
+    const int kv_head = head / (q_heads / kv_heads);
+    gqa_attention_body<kThreads>(q + static_cast<size_t>(head) * head_dim, k_cache, v_cache,
+                                 out + static_cast<size_t>(head) * head_dim, kv_head,
+                                 kv_heads, head_dim, context_len);
+}
+
+template <int kThreads>
+__global__ void gqa_prefill_attention_kernel(const float* __restrict__ q_rows,
+                                             const float* __restrict__ k_cache,
+                                             const float* __restrict__ v_cache,
+                                             float* __restrict__ out_rows, int seq_len,
+                                             int q_heads, int kv_heads, int head_dim,
+                                             int position_offset, int max_context) {
+    const int head = static_cast<int>(blockIdx.x);
+    const int token = static_cast<int>(blockIdx.y);
+    if (head >= q_heads || token >= seq_len) return;
+    const int kv_head = head / (q_heads / kv_heads);
+    const size_t offset = (static_cast<size_t>(token) * q_heads + head) * head_dim;
+    gqa_attention_body<kThreads>(q_rows + offset, k_cache, v_cache, out_rows + offset,
+                                 kv_head, kv_heads, head_dim,
+                                 position_offset + token + 1);
+}
+
+__global__ void sigmoid_mul_kernel(const float* __restrict__ x,
+                                   const float* __restrict__ gate,
+                                   float* __restrict__ y, int count) {
+    const int i = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i < count) y[i] = x[i] * sigmoid(gate[i]);
+}
+
+__global__ void add_inplace_kernel(float* y, const float* x, int count) {
+    const int i = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i < count) y[i] += x[i];
+}
+
+__global__ void silu_mul_rows_kernel(const float* gate, const float* up, float* y,
+                                     int rows, int cols) {
+    const int i = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i >= rows * cols) return;
+    y[i] = silu(gate[i]) * up[i];
+}
+
+}  // namespace
+
+bool qwen_fp16_matmul_rows_cuda(const float* d_x, const uint16_t* d_w_fp16,
+                                float* d_y, int batch, int rows, int cols,
+                                int x_stride, int y_stride, int weight_stride,
+                                void* stream) {
+    if (!d_x || !d_w_fp16 || !d_y || batch <= 0 || rows <= 0 || cols <= 0 ||
+        x_stride < cols || y_stride < rows || weight_stride < cols) return false;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    dim3 grid(static_cast<unsigned>(rows), static_cast<unsigned>(batch), 1);
+    fp16_matmul_rows_kernel<<<grid, 256, 256 * sizeof(float), s>>>(
+        d_x, d_w_fp16, d_y, batch, rows, cols, x_stride, y_stride, weight_stride);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_embedding_fp16_gather_cuda(const uint16_t* d_table_fp16,
+                                     const int* d_tokens, float* d_out,
+                                     int count, int cols, int row_start,
+                                     int row_count, void* stream) {
+    if (!d_table_fp16 || !d_tokens || !d_out || count <= 0 || cols <= 0 ||
+        row_start < 0 || row_count <= 0) return false;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    embedding_fp16_gather_kernel<<<count, 256, 0, s>>>(
+        d_table_fp16, d_tokens, d_out, count, cols, row_start, row_count);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_rmsnorm_fp16_gamma_rows_cuda(const float* d_x, const uint16_t* d_gamma_fp16,
+                                       float* d_y, int rows, int cols, float eps,
+                                       void* stream) {
+    if (!d_x || !d_gamma_fp16 || !d_y || rows <= 0 || cols <= 0 || eps < 0.0f) return false;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    rmsnorm_fp16_gamma_rows_kernel<<<rows, 256, 256 * sizeof(float), s>>>(
+        d_x, d_gamma_fp16, d_y, rows, cols, eps);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gated_rmsnorm_fp16_gamma_rows_cuda(const float* d_x, const uint16_t* d_gamma_fp16,
+                                             const float* d_gate, float* d_y,
+                                             int rows, int cols, float eps,
+                                             void* stream) {
+    if (!d_x || !d_gamma_fp16 || !d_gate || !d_y || rows <= 0 || cols <= 0 || eps < 0.0f) return false;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    gated_rmsnorm_fp16_gamma_rows_kernel<<<rows, 256, 256 * sizeof(float), s>>>(
+        d_x, d_gamma_fp16, d_gate, d_y, rows, cols, eps);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_split_packed_qkv_cuda(const float* d_packed, float* d_q, float* d_k,
+                                float* d_v, int rows, int key_dim, int value_dim,
+                                void* stream) {
+    if (!d_packed || !d_q || !d_k || !d_v || rows <= 0 || key_dim <= 0 || value_dim <= 0) return false;
+    const int total = rows * (2 * key_dim + value_dim);
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    split_packed_qkv_kernel<<<(total + 255) / 256, 256, 0, s>>>(
+        d_packed, d_q, d_k, d_v, rows, key_dim, value_dim);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_causal_depthwise_conv_silu_cuda(const float* d_x_rows,
+                                          const uint16_t* d_weight_fp16,
+                                          float* d_tail, float* d_y_rows,
+                                          int seq_len, int channels, int kernel,
+                                          bool update_tail, void* stream) {
+    if (!d_x_rows || !d_weight_fp16 || !d_y_rows || seq_len <= 0 || channels <= 0 ||
+        kernel <= 0) return false;
+    // The kernel stages the rotated tail in a fixed 8-slot register array.
+    if (kernel - 1 > 8) return false;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    constexpr int kThreads = 256;
+    const int blocks = (channels + kThreads - 1) / kThreads;
+    causal_depthwise_conv_silu_kernel<<<blocks, kThreads, 0, s>>>(
+        d_x_rows, d_weight_fp16, d_tail, d_y_rows, seq_len, channels, kernel, update_tail);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_linear_attn_gates_cuda(const float* d_a_rows, const float* d_b_rows,
+                                 const uint16_t* d_a_log_fp16,
+                                 const uint16_t* d_dt_bias_fp16,
+                                 float* d_g_rows, float* d_beta_rows,
+                                 int rows, int heads, void* stream) {
+    if (!d_a_rows || !d_b_rows || !d_a_log_fp16 || !d_dt_bias_fp16 || !d_g_rows ||
+        !d_beta_rows || rows <= 0 || heads <= 0) return false;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    linear_attn_gates_kernel<<<heads, 256, 0, s>>>(
+        d_a_rows, d_b_rows, d_a_log_fp16, d_dt_bias_fp16,
+        d_g_rows, d_beta_rows, rows, heads);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gated_delta_step_cuda(float* d_state, const float* d_q, const float* d_k,
+                                const float* d_v, const float* d_g, const float* d_beta,
+                                float* d_out, int heads, int key_heads, int key_dim,
+                                int value_dim, float q_scale, void* stream) {
+    if (!d_state || !d_q || !d_k || !d_v || !d_g || !d_beta || !d_out || heads <= 0 ||
+        key_heads <= 0 || key_dim <= 0 || value_dim <= 0 || heads % key_heads != 0 ||
+        q_scale <= 0.0f) return false;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    // The reduction is a power-of-two tree, so round the block up to one and
+    // keep it at least value_dim wide (one thread per state column).
+    int threads = 32;
+    while (threads < value_dim) threads <<= 1;
+    if (threads > 1024) return false;
+    const size_t shmem = (2u * static_cast<size_t>(key_dim) + threads) * sizeof(float);
+    gated_delta_step_kernel<<<heads, threads, shmem, s>>>(
+        d_state, d_q, d_k, d_v, d_g, d_beta, d_out,
+        heads, key_heads, key_dim, value_dim, q_scale);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_partial_rope_cuda(float* d_q, float* d_k, int position, int rotary_dim,
+                            float theta, int q_heads, int kv_heads, int head_dim,
+                            void* stream) {
+    if (!d_q || !d_k || position < 0 || rotary_dim <= 0 || (rotary_dim & 1) != 0 ||
+        rotary_dim > head_dim || theta <= 0.0f || q_heads <= 0 || kv_heads <= 0 ||
+        head_dim <= 0) return false;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    partial_rope_kernel<<<(rotary_dim / 2 + 255) / 256, 256, 0, s>>>(
+        d_q, d_k, position, rotary_dim, theta, q_heads, kv_heads, head_dim);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_split_q_gate_cuda(const float* d_q_proj, float* d_q, float* d_gate,
+                            int rows, int q_heads, int head_dim,
+                            void* stream) {
+    if (!d_q_proj || !d_q || !d_gate || rows <= 0 || q_heads <= 0 || head_dim <= 0) return false;
+    const int total = rows * q_heads * head_dim;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    split_q_gate_kernel<<<(total + 255) / 256, 256, 0, s>>>(
+        d_q_proj, d_q, d_gate, rows, q_heads, head_dim);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_select_kv_heads_cuda(const float* d_src, float* d_dst, int rows,
+                               int total_kv_heads, int local_kv_heads,
+                               int head_dim, int head_offset, void* stream) {
+    if (!d_src || !d_dst || rows <= 0 || total_kv_heads <= 0 || local_kv_heads <= 0 ||
+        head_dim <= 0 || head_offset < 0 || head_offset + local_kv_heads > total_kv_heads) return false;
+    const int total = rows * local_kv_heads * head_dim;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    select_kv_heads_kernel<<<(total + 255) / 256, 256, 0, s>>>(
+        d_src, d_dst, rows, total_kv_heads, local_kv_heads, head_dim, head_offset);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_append_kv_cache_cuda(const float* d_k_rows, const float* d_v_rows,
+                               float* d_k_cache, float* d_v_cache, int seq_len,
+                               int kv_heads, int head_dim, int start_pos,
+                               int max_context, void* stream) {
+    if (!d_k_rows || !d_v_rows || !d_k_cache || !d_v_cache || seq_len <= 0 ||
+        kv_heads <= 0 || head_dim <= 0 || start_pos < 0 || max_context <= 0 ||
+        start_pos + seq_len > max_context) return false;
+    const int total = seq_len * kv_heads * head_dim;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    append_kv_cache_kernel<<<(total + 255) / 256, 256, 0, s>>>(
+        d_k_rows, d_v_rows, d_k_cache, d_v_cache, seq_len, kv_heads, head_dim,
+        start_pos, max_context);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gqa_decode_attention_cuda(const float* d_q, const float* d_k_cache,
+                                    const float* d_v_cache, float* d_out,
+                                    int q_heads, int kv_heads, int head_dim,
+                                    int context_len, int max_context,
+                                    void* stream) {
+    if (!d_q || !d_k_cache || !d_v_cache || !d_out || q_heads <= 0 || kv_heads <= 0 ||
+        head_dim <= 0 || context_len <= 0 || context_len > max_context || q_heads % kv_heads != 0) return false;
+    constexpr int kThreads = 128;
+    if ((head_dim + kThreads - 1) / kThreads > 8) return false;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    const size_t shmem = (static_cast<size_t>(head_dim) + kThreads) * sizeof(float);
+    gqa_decode_attention_kernel<kThreads><<<q_heads, kThreads, shmem, s>>>(
+        d_q, d_k_cache, d_v_cache, d_out, q_heads, kv_heads, head_dim,
+        context_len, max_context);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gqa_prefill_attention_cuda(const float* d_q_rows, const float* d_k_cache,
+                                     const float* d_v_cache, float* d_out_rows,
+                                     int seq_len, int q_heads, int kv_heads,
+                                     int head_dim, int position_offset,
+                                     int max_context, void* stream) {
+    if (!d_q_rows || !d_k_cache || !d_v_cache || !d_out_rows || seq_len <= 0 ||
+        q_heads <= 0 || kv_heads <= 0 || head_dim <= 0 || position_offset < 0 ||
+        position_offset + seq_len > max_context || q_heads % kv_heads != 0) return false;
+    constexpr int kThreads = 128;
+    if ((head_dim + kThreads - 1) / kThreads > 8) return false;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    dim3 grid(static_cast<unsigned>(q_heads), static_cast<unsigned>(seq_len), 1);
+    const size_t shmem = (static_cast<size_t>(head_dim) + kThreads) * sizeof(float);
+    gqa_prefill_attention_kernel<kThreads><<<grid, kThreads, shmem, s>>>(
+        d_q_rows, d_k_cache, d_v_cache, d_out_rows, seq_len, q_heads, kv_heads,
+        head_dim, position_offset, max_context);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_sigmoid_mul_cuda(const float* d_x, const float* d_gate, float* d_y,
+                           int count, void* stream) {
+    if (!d_x || !d_gate || !d_y || count <= 0) return false;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    sigmoid_mul_kernel<<<(count + 255) / 256, 256, 0, s>>>(d_x, d_gate, d_y, count);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_add_inplace_cuda(float* d_y, const float* d_x, int count, void* stream) {
+    if (!d_y || !d_x || count <= 0) return false;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    add_inplace_kernel<<<(count + 255) / 256, 256, 0, s>>>(d_y, d_x, count);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_silu_mul_rows_cuda(const float* d_gate, const float* d_up, float* d_y,
+                             int rows, int cols, void* stream) {
+    if (!d_gate || !d_up || !d_y || rows <= 0 || cols <= 0) return false;
+    const int count = rows * cols;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    silu_mul_rows_kernel<<<(count + 255) / 256, 256, 0, s>>>(d_gate, d_up, d_y, rows, cols);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+}  // namespace dsv4

--- a/cpp_engine/cuda/qwen_fp8_ops.cu
+++ b/cpp_engine/cuda/qwen_fp8_ops.cu
@@ -1,0 +1,444 @@
+#include "qwen_cuda_ops.hpp"
+
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+
+namespace dsv4 {
+namespace {
+
+constexpr int kBlock = 128;
+
+__device__ __forceinline__ float fp8_e4m3_to_float(uint8_t code) {
+    const int sign = (code >> 7) & 1;
+    const int exponent = (code >> 3) & 0xf;
+    const int mantissa = code & 0x7;
+    float value;
+    if (exponent == 0) {
+        value = ldexpf(static_cast<float>(mantissa) * (1.0f / 8.0f), -6);
+    } else {
+        value = ldexpf(1.0f + static_cast<float>(mantissa) * (1.0f / 8.0f), exponent - 7);
+    }
+    return sign ? -value : value;
+}
+
+__device__ __forceinline__ float bf16_bits_to_float(uint16_t bits) {
+    return __uint_as_float(static_cast<uint32_t>(bits) << 16);
+}
+
+__device__ __forceinline__ float fp16_bits_to_float(uint16_t bits) {
+    const uint32_t sign = static_cast<uint32_t>(bits & 0x8000u) << 16;
+    const uint32_t exponent = (bits >> 10) & 0x1fu;
+    const uint32_t mantissa = bits & 0x03ffu;
+    uint32_t value;
+    if (exponent == 0) {
+        if (mantissa == 0) value = sign;
+        else {
+            uint32_t normalized = mantissa;
+            int exp = -14;
+            while ((normalized & 0x400u) == 0) {
+                normalized <<= 1;
+                --exp;
+            }
+            value = sign | static_cast<uint32_t>(exp + 127) << 23 |
+                    ((normalized & 0x3ffu) << 13);
+        }
+    } else if (exponent == 0x1fu) {
+        value = sign | 0x7f800000u | (mantissa << 13);
+    } else {
+        value = sign | ((exponent - 15 + 127) << 23) | (mantissa << 13);
+    }
+    return __uint_as_float(value);
+}
+
+__device__ __forceinline__ float silu(float x) {
+    return x / (1.0f + expf(-x));
+}
+
+template <bool kFp16Scale>
+__device__ __forceinline__ float scale_bits_to_float(uint16_t bits) {
+    return kFp16Scale ? fp16_bits_to_float(bits) : bf16_bits_to_float(bits);
+}
+
+template <bool kFp16Scale>
+__device__ __forceinline__ float block_scale(const uint16_t* scale,
+                                              int scale_stride,
+                                              int row,
+                                              int col) {
+    return scale_bits_to_float<kFp16Scale>(
+        scale[static_cast<size_t>(row / kBlock) * scale_stride + col / kBlock]);
+}
+
+__device__ __forceinline__ float reduce_sum(float value, float* scratch) {
+    scratch[threadIdx.x] = value;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) scratch[threadIdx.x] += scratch[threadIdx.x + stride];
+        __syncthreads();
+    }
+    return scratch[0];
+}
+
+// Prefill path: one warp per output row, but each warp carries kTileBatch token
+// accumulators so a decoded FP8 weight is reused across tokens instead of being
+// re-read once per (row, token) pair. This turns the projection from
+// bandwidth-bound-per-token into a single weight sweep per row tile.
+template <bool kFp16Scale, int kRowsPerBlock, int kTileBatch>
+__global__ void fp8_matmul_tiled_kernel(
+    const float* __restrict__ x,
+    const uint8_t* __restrict__ weight,
+    const uint16_t* __restrict__ scale,
+    float* __restrict__ y,
+    int batch,
+    int rows,
+    int cols,
+    int x_stride,
+    int y_stride,
+    int weight_stride,
+    int scale_stride) {
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int lane = static_cast<int>(threadIdx.x) & 31;
+    const int row = static_cast<int>(blockIdx.x) * kRowsPerBlock + warp;
+    const int batch_base = static_cast<int>(blockIdx.y) * kTileBatch;
+    // The LUT fill is a block-wide barrier, so no thread may return before it.
+    __shared__ float lut[256];
+    for (int i = static_cast<int>(threadIdx.x); i < 256; i += static_cast<int>(blockDim.x)) {
+        lut[i] = fp8_e4m3_to_float(static_cast<uint8_t>(i));
+    }
+    __syncthreads();
+    if (row >= rows || batch_base >= batch) return;
+
+    const int active = min(kTileBatch, batch - batch_base);
+    const uint8_t* w_row = weight + static_cast<size_t>(row) * weight_stride;
+    const uint16_t* scale_row = scale + static_cast<size_t>(row / kBlock) * scale_stride;
+    float acc[kTileBatch];
+    for (int b = 0; b < kTileBatch; ++b) acc[b] = 0.0f;
+
+    const int vec_cols = cols & ~3;
+    for (int col = lane * 4; col < vec_cols; col += 128) {
+        const uchar4 codes = *reinterpret_cast<const uchar4*>(w_row + col);
+        const float s = scale_bits_to_float<kFp16Scale>(scale_row[col / kBlock]);
+        const float w0 = lut[codes.x] * s;
+        const float w1 = lut[codes.y] * s;
+        const float w2 = lut[codes.z] * s;
+        const float w3 = lut[codes.w] * s;
+        for (int b = 0; b < active; ++b) {
+            const float* x_row = x + static_cast<size_t>(batch_base + b) * x_stride;
+            acc[b] += x_row[col + 0] * w0 + x_row[col + 1] * w1 +
+                      x_row[col + 2] * w2 + x_row[col + 3] * w3;
+        }
+    }
+    for (int col = vec_cols + lane; col < cols; col += 32) {
+        const float w = lut[w_row[col]] *
+                        scale_bits_to_float<kFp16Scale>(scale_row[col / kBlock]);
+        for (int b = 0; b < active; ++b) {
+            acc[b] += x[static_cast<size_t>(batch_base + b) * x_stride + col] * w;
+        }
+    }
+    for (int b = 0; b < active; ++b) {
+        float sum = acc[b];
+        for (int off = 16; off > 0; off >>= 1) sum += __shfl_xor_sync(0xffffffffu, sum, off);
+        if (lane == 0) y[static_cast<size_t>(batch_base + b) * y_stride + row] = sum;
+    }
+}
+
+template <bool kFp16Scale>
+__global__ void fp8_matmul_rows_kernel(
+    const float* __restrict__ x,
+    const uint8_t* __restrict__ weight,
+    const uint16_t* __restrict__ scale,
+    float* __restrict__ y,
+    int batch,
+    int rows,
+    int cols,
+    int x_stride,
+    int y_stride,
+    int weight_stride,
+    int scale_stride) {
+    const int row = static_cast<int>(blockIdx.x);
+    const int sample = static_cast<int>(blockIdx.y);
+    if (row >= rows || sample >= batch) return;
+
+    const float* x_row = x + static_cast<size_t>(sample) * x_stride;
+    const uint8_t* w_row = weight + static_cast<size_t>(row) * weight_stride;
+    float sum = 0.0f;
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+        const float w = fp8_e4m3_to_float(w_row[col]) * block_scale<kFp16Scale>(scale, scale_stride, row, col);
+        sum += x_row[col] * w;
+    }
+
+    extern __shared__ float scratch[];
+    const float total = reduce_sum(sum, scratch);
+    if (threadIdx.x == 0) y[static_cast<size_t>(sample) * y_stride + row] = total;
+}
+
+template <bool kFp16Scale>
+__global__ void fp8_matvec_kernel(
+    const float* __restrict__ x,
+    const uint8_t* __restrict__ weight,
+    const uint16_t* __restrict__ scale,
+    float* __restrict__ y,
+    int rows,
+    int cols,
+    int weight_stride,
+    int scale_stride) {
+    const int row = static_cast<int>(blockIdx.x);
+    if (row >= rows) return;
+
+    const uint8_t* w_row = weight + static_cast<size_t>(row) * weight_stride;
+    float sum = 0.0f;
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+        const float w = fp8_e4m3_to_float(w_row[col]) * block_scale<kFp16Scale>(scale, scale_stride, row, col);
+        sum += x[col] * w;
+    }
+
+    extern __shared__ float scratch[];
+    const float total = reduce_sum(sum, scratch);
+    if (threadIdx.x == 0) y[row] = total;
+}
+
+// Decode-latency path: one warp per output row, so there is no block-wide
+// __syncthreads in the reduction and several rows retire per block. FP8 codes
+// are pulled 4 bytes at a time; the 128-wide scale block means the scale lookup
+// is loop-invariant across each aligned run of 128 columns.
+template <bool kFp16Scale, int kRowsPerBlock>
+__global__ void fp8_matvec_warp_kernel(
+    const float* __restrict__ x,
+    const uint8_t* __restrict__ weight,
+    const uint16_t* __restrict__ scale,
+    float* __restrict__ y,
+    int rows,
+    int cols,
+    int weight_stride,
+    int scale_stride) {
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int lane = static_cast<int>(threadIdx.x) & 31;
+    const int row = static_cast<int>(blockIdx.x) * kRowsPerBlock + warp;
+
+    // Decode E4M3 through a 256-entry shared-memory LUT (1 KB) instead of the
+    // per-byte ldexpf/branch sequence. x itself is left in global memory: every
+    // warp sweeps the same vector so L1/L2 already serves that reuse, and
+    // staging x measured slower because its 20 KB footprint caps occupancy.
+    __shared__ float lut[256];
+    for (int i = static_cast<int>(threadIdx.x); i < 256; i += static_cast<int>(blockDim.x)) {
+        lut[i] = fp8_e4m3_to_float(static_cast<uint8_t>(i));
+    }
+    __syncthreads();
+    if (row >= rows) return;
+    const float* x_shared = x;
+
+    const uint8_t* w_row = weight + static_cast<size_t>(row) * weight_stride;
+    const uint16_t* scale_row = scale + static_cast<size_t>(row / kBlock) * scale_stride;
+    const int vec_cols = cols & ~3;
+    float sum = 0.0f;
+    for (int col = lane * 4; col < vec_cols; col += 128) {
+        const uchar4 codes = *reinterpret_cast<const uchar4*>(w_row + col);
+        const float s = scale_bits_to_float<kFp16Scale>(scale_row[col / kBlock]);
+        const float4 xv = *reinterpret_cast<const float4*>(x_shared + col);
+        sum += (xv.x * lut[codes.x] + xv.y * lut[codes.y] +
+                xv.z * lut[codes.z] + xv.w * lut[codes.w]) * s;
+    }
+    for (int col = vec_cols + lane; col < cols; col += 32) {
+        sum += x_shared[col] * lut[w_row[col]] *
+               scale_bits_to_float<kFp16Scale>(scale_row[col / kBlock]);
+    }
+    for (int off = 16; off > 0; off >>= 1) sum += __shfl_xor_sync(0xffffffffu, sum, off);
+    if (lane == 0) y[row] = sum;
+}
+
+__global__ void rmsnorm_kernel(const float* __restrict__ x,
+                               const float* __restrict__ weight,
+                               float* __restrict__ y,
+                               int rows, int cols, float eps) {
+    const int row = static_cast<int>(blockIdx.x);
+    if (row >= rows) return;
+    const float* x_row = x + static_cast<size_t>(row) * cols;
+    float* y_row = y + static_cast<size_t>(row) * cols;
+    float sum = 0.0f;
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) sum += x_row[col] * x_row[col];
+    extern __shared__ float scratch[];
+    const float variance_sum = reduce_sum(sum, scratch);
+    const float inv = rsqrtf(variance_sum / static_cast<float>(cols) + eps);
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+        y_row[col] = x_row[col] * inv * (1.0f + weight[col]);
+    }
+}
+
+__global__ void gated_rmsnorm_kernel(const float* __restrict__ x,
+                                     const float* __restrict__ weight,
+                                     const float* __restrict__ gate,
+                                     float* __restrict__ y,
+                                     int rows, int cols, float eps) {
+    const int row = static_cast<int>(blockIdx.x);
+    if (row >= rows) return;
+    const float* x_row = x + static_cast<size_t>(row) * cols;
+    const float* gate_row = gate + static_cast<size_t>(row) * cols;
+    float* y_row = y + static_cast<size_t>(row) * cols;
+    float sum = 0.0f;
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) sum += x_row[col] * x_row[col];
+    extern __shared__ float scratch[];
+    const float variance_sum = reduce_sum(sum, scratch);
+    const float inv = rsqrtf(variance_sum / static_cast<float>(cols) + eps);
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+        y_row[col] = weight[col] * x_row[col] * inv * silu(gate_row[col]);
+    }
+}
+
+__global__ void l2_norm_kernel(const float* __restrict__ x,
+                               float* __restrict__ y,
+                               int rows, int cols, float eps) {
+    const int row = static_cast<int>(blockIdx.x);
+    if (row >= rows) return;
+    const float* x_row = x + static_cast<size_t>(row) * cols;
+    float* y_row = y + static_cast<size_t>(row) * cols;
+    float sum = 0.0f;
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) sum += x_row[col] * x_row[col];
+    extern __shared__ float scratch[];
+    const float norm_sq = reduce_sum(sum, scratch);
+    const float inv = rsqrtf(norm_sq + eps);
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) y_row[col] = x_row[col] * inv;
+}
+
+bool valid_common(const void* x, const void* weight, const void* scale, void* y,
+                  int rows, int cols, int scale_stride) {
+    return x != nullptr && weight != nullptr && scale != nullptr && y != nullptr &&
+           rows > 0 && cols > 0 && scale_stride >= (cols + kBlock - 1) / kBlock;
+}
+
+}  // namespace
+
+bool qwen_fp8_e4m3_fp16scale_matvec_cuda(
+    const float* d_x,
+    const uint8_t* d_weight,
+    const uint16_t* d_scale_fp16,
+    float* d_y,
+    int rows,
+    int cols,
+    int weight_stride,
+    int scale_stride,
+    void* stream) {
+    if (!valid_common(d_x, d_weight, d_scale_fp16, d_y, rows, cols, scale_stride) ||
+        weight_stride < cols) return false;
+    cudaStream_t s = static_cast<cudaStream_t>(stream);
+    // uchar4 loads need a 4-byte aligned row base; every Qwen3.8 projection has
+    // a stride that is a multiple of 128, so this is the common path.
+    // Staging x needs cols*4 bytes of shared memory; 2080 Ti allows 48 KB per
+    // block by default, which covers every Qwen3.8 projection (max 5120 cols).
+    const size_t shmem = static_cast<size_t>(cols) * sizeof(float);
+    if (weight_stride % 4 == 0 && shmem <= 48u * 1024u) {
+        constexpr int kRowsPerBlock = 8;  // 8 warps = 256 threads
+        const int blocks = (rows + kRowsPerBlock - 1) / kRowsPerBlock;
+        fp8_matvec_warp_kernel<true, kRowsPerBlock><<<blocks, kRowsPerBlock * 32, shmem, s>>>(
+            d_x, d_weight, d_scale_fp16, d_y, rows, cols, weight_stride, scale_stride);
+        return cudaGetLastError() == cudaSuccess;
+    }
+    fp8_matvec_kernel<true><<<rows, 256, 256 * sizeof(float), s>>>(
+        d_x, d_weight, d_scale_fp16, d_y, rows, cols, weight_stride, scale_stride);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_fp8_e4m3_fp16scale_matmul_rows_cuda(
+    const float* d_x,
+    const uint8_t* d_weight,
+    const uint16_t* d_scale_fp16,
+    float* d_y,
+    int batch,
+    int rows,
+    int cols,
+    int x_stride,
+    int y_stride,
+    int weight_stride,
+    int scale_stride,
+    void* stream) {
+    if (!valid_common(d_x, d_weight, d_scale_fp16, d_y, rows, cols, scale_stride) ||
+        batch <= 0 || x_stride < cols || y_stride < rows || weight_stride < cols) return false;
+    cudaStream_t s = static_cast<cudaStream_t>(stream);
+    if (weight_stride % 4 == 0) {
+        constexpr int kRowsPerBlock = 4;   // 4 warps = 128 threads
+        constexpr int kTileBatch = 8;
+        dim3 grid(static_cast<unsigned>((rows + kRowsPerBlock - 1) / kRowsPerBlock),
+                  static_cast<unsigned>((batch + kTileBatch - 1) / kTileBatch), 1);
+        fp8_matmul_tiled_kernel<true, kRowsPerBlock, kTileBatch>
+            <<<grid, kRowsPerBlock * 32, 0, s>>>(
+                d_x, d_weight, d_scale_fp16, d_y, batch, rows, cols,
+                x_stride, y_stride, weight_stride, scale_stride);
+        return cudaGetLastError() == cudaSuccess;
+    }
+    dim3 grid(static_cast<unsigned>(rows), static_cast<unsigned>(batch), 1);
+    fp8_matmul_rows_kernel<true><<<grid, 256, 256 * sizeof(float), s>>>(
+        d_x, d_weight, d_scale_fp16, d_y, batch, rows, cols,
+        x_stride, y_stride, weight_stride, scale_stride);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_fp8_e4m3_bf16_matvec_cuda(
+    const float* d_x,
+    const uint8_t* d_weight,
+    const uint16_t* d_scale_bf16,
+    float* d_y,
+    int rows,
+    int cols,
+    int weight_stride,
+    int scale_stride,
+    void* stream) {
+    if (!valid_common(d_x, d_weight, d_scale_bf16, d_y, rows, cols, scale_stride) ||
+        weight_stride < cols) return false;
+    cudaStream_t s = static_cast<cudaStream_t>(stream);
+    fp8_matvec_kernel<false><<<rows, 256, 256 * sizeof(float), s>>>(
+        d_x, d_weight, d_scale_bf16, d_y, rows, cols, weight_stride, scale_stride);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_fp8_e4m3_bf16_matmul_rows_cuda(
+    const float* d_x,
+    const uint8_t* d_weight,
+    const uint16_t* d_scale_bf16,
+    float* d_y,
+    int batch,
+    int rows,
+    int cols,
+    int x_stride,
+    int y_stride,
+    int weight_stride,
+    int scale_stride,
+    void* stream) {
+    if (!valid_common(d_x, d_weight, d_scale_bf16, d_y, rows, cols, scale_stride) ||
+        batch <= 0 || x_stride < cols || y_stride < rows || weight_stride < cols) return false;
+    cudaStream_t s = static_cast<cudaStream_t>(stream);
+    dim3 grid(static_cast<unsigned>(rows), static_cast<unsigned>(batch), 1);
+    fp8_matmul_rows_kernel<false><<<grid, 256, 256 * sizeof(float), s>>>(
+        d_x, d_weight, d_scale_bf16, d_y, batch, rows, cols,
+        x_stride, y_stride, weight_stride, scale_stride);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_rmsnorm_f32_cuda(const float* d_x, const float* d_weight,
+                           float* d_y, int rows, int cols, float eps,
+                           void* stream) {
+    if (!d_x || !d_weight || !d_y || rows <= 0 || cols <= 0 || eps < 0.0f) return false;
+    cudaStream_t s = static_cast<cudaStream_t>(stream);
+    rmsnorm_kernel<<<rows, 256, 256 * sizeof(float), s>>>(d_x, d_weight, d_y, rows, cols, eps);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gated_rmsnorm_f32_cuda(const float* d_x, const float* d_weight,
+                                 const float* d_gate, float* d_y,
+                                 int rows, int cols, float eps,
+                                 void* stream) {
+    if (!d_x || !d_weight || !d_gate || !d_y || rows <= 0 || cols <= 0 || eps < 0.0f) return false;
+    cudaStream_t s = static_cast<cudaStream_t>(stream);
+    gated_rmsnorm_kernel<<<rows, 256, 256 * sizeof(float), s>>>(
+        d_x, d_weight, d_gate, d_y, rows, cols, eps);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_l2_norm_f32_cuda(const float* d_x, float* d_y, int rows, int cols,
+                           float eps, void* stream) {
+    if (!d_x || !d_y || rows <= 0 || cols <= 0 || eps < 0.0f) return false;
+    cudaStream_t s = static_cast<cudaStream_t>(stream);
+    l2_norm_kernel<<<rows, 256, 256 * sizeof(float), s>>>(d_x, d_y, rows, cols, eps);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+}  // namespace dsv4

--- a/cpp_engine/include/qwen_config.hpp
+++ b/cpp_engine/include/qwen_config.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "json_lite.hpp"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace dsv4 {
+
+enum class QwenLayerType {
+    LinearAttention,
+    FullAttention,
+};
+
+struct QwenLinearAttentionConfig {
+    uint64_t key_heads = 0;
+    uint64_t value_heads = 0;
+    uint64_t key_head_dim = 0;
+    uint64_t value_head_dim = 0;
+    uint64_t conv_kernel_dim = 0;
+
+    uint64_t qkv_dim() const { return 2 * key_heads * key_head_dim + value_heads * value_head_dim; }
+    uint64_t value_state_dim() const { return value_heads * value_head_dim; }
+};
+
+struct QwenFullAttentionConfig {
+    uint64_t num_heads = 0;
+    uint64_t num_key_value_heads = 0;
+    uint64_t head_dim = 0;
+    bool output_gate = false;
+
+    uint64_t attention_dim() const { return num_heads * head_dim; }
+    uint64_t kv_dim() const { return num_key_value_heads * head_dim; }
+    uint64_t q_dim() const { return attention_dim() * (output_gate ? 2 : 1); }
+};
+
+struct QwenDenseMlpConfig {
+    uint64_t intermediate_size = 0;
+};
+
+struct QwenConfig {
+    std::string architecture;
+    std::string model_type;
+    uint64_t vocab_size = 0;
+    uint64_t hidden_size = 0;
+    uint64_t num_hidden_layers = 0;
+    uint64_t max_position_embeddings = 0;
+    double rms_norm_eps = 1.0e-6;
+    double rope_theta = 10000000.0;
+    double partial_rotary_factor = 1.0;
+    uint64_t fp8_block_size = 128;
+    QwenLinearAttentionConfig linear_attention;
+    QwenFullAttentionConfig full_attention;
+    QwenDenseMlpConfig mlp;
+    std::vector<QwenLayerType> layer_types;
+
+    bool is_qwen3_5() const;
+    uint64_t linear_attention_layers() const;
+    uint64_t full_attention_layers() const;
+    uint64_t partial_rotary_dim() const;
+    std::string layer_type_name(uint64_t layer) const;
+    std::string to_string() const;
+
+    static QwenConfig from_hf_config(const std::string& ckpt_dir);
+};
+
+// Read only config.json. This deliberately does not inspect tensor files, so it
+// can be used by CLI dispatch before constructing either the DSV4 or Qwen engine.
+bool is_qwen3_5_checkpoint(const std::string& ckpt_dir);
+
+}  // namespace dsv4

--- a/cpp_engine/include/qwen_cuda_ops.hpp
+++ b/cpp_engine/include/qwen_cuda_ops.hpp
@@ -1,0 +1,179 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace dsv4 {
+
+// Qwen FP8 weights use E4M3 codes and 128x128 block scales. On Turing,
+// checkpoint BF16 scales are converted to IEEE FP16 before device upload.
+// These kernels decode each code at the point of use; no expanded copy of the
+// weight matrix is allocated.
+bool qwen_fp8_e4m3_fp16scale_matvec_cuda(
+    const float* d_x,
+    const uint8_t* d_weight,
+    const uint16_t* d_scale_fp16,
+    float* d_y,
+    int rows,
+    int cols,
+    int weight_stride,
+    int scale_stride,
+    void* stream = nullptr);
+
+bool qwen_fp8_e4m3_fp16scale_matmul_rows_cuda(
+    const float* d_x,
+    const uint8_t* d_weight,
+    const uint16_t* d_scale_fp16,
+    float* d_y,
+    int batch,
+    int rows,
+    int cols,
+    int x_stride,
+    int y_stride,
+    int weight_stride,
+    int scale_stride,
+    void* stream = nullptr);
+
+// Compatibility/reference path for callers that still keep the scale in BF16
+// bits. Qwen Turing loading should use the FP16-scale APIs above.
+bool qwen_fp8_e4m3_bf16_matvec_cuda(
+    const float* d_x,
+    const uint8_t* d_weight,
+    const uint16_t* d_scale_bf16,
+    float* d_y,
+    int rows,
+    int cols,
+    int weight_stride,
+    int scale_stride,
+    void* stream = nullptr);
+
+bool qwen_fp8_e4m3_bf16_matmul_rows_cuda(
+    const float* d_x,
+    const uint8_t* d_weight,
+    const uint16_t* d_scale_bf16,
+    float* d_y,
+    int batch,
+    int rows,
+    int cols,
+    int x_stride,
+    int y_stride,
+    int weight_stride,
+    int scale_stride,
+    void* stream = nullptr);
+
+// Qwen RMSNorm has a non-standard affine parameter convention: output is
+// normalized * (1 + weight).  The gated variant deliberately has no +1.
+bool qwen_rmsnorm_f32_cuda(const float* d_x, const float* d_weight,
+                           float* d_y, int rows, int cols, float eps,
+                           void* stream = nullptr);
+bool qwen_gated_rmsnorm_f32_cuda(const float* d_x, const float* d_weight,
+                                 const float* d_gate, float* d_y,
+                                 int rows, int cols, float eps,
+                                 void* stream = nullptr);
+bool qwen_l2_norm_f32_cuda(const float* d_x, float* d_y, int rows, int cols,
+                           float eps = 1.0e-6f, void* stream = nullptr);
+
+// --- Dense FP16 weights (checkpoint BF16 materialized for Turing) -----------
+
+// y[b, r] = sum_c x[b, c] * fp16(w[r, c]).
+bool qwen_fp16_matmul_rows_cuda(const float* d_x, const uint16_t* d_w_fp16,
+                                float* d_y, int batch, int rows, int cols,
+                                int x_stride, int y_stride, int weight_stride,
+                                void* stream = nullptr);
+
+// Vocab-parallel embedding lookup. Tokens outside [row_start, row_start +
+// row_count) produce a zero row so the caller can all-reduce the result.
+bool qwen_embedding_fp16_gather_cuda(const uint16_t* d_table_fp16,
+                                     const int* d_tokens, float* d_out,
+                                     int count, int cols, int row_start,
+                                     int row_count, void* stream = nullptr);
+
+// RMSNorm variants whose affine parameter is stored as FP16 on device.
+bool qwen_rmsnorm_fp16_gamma_rows_cuda(const float* d_x, const uint16_t* d_gamma_fp16,
+                                       float* d_y, int rows, int cols, float eps,
+                                       void* stream = nullptr);
+bool qwen_gated_rmsnorm_fp16_gamma_rows_cuda(const float* d_x, const uint16_t* d_gamma_fp16,
+                                             const float* d_gate, float* d_y,
+                                             int rows, int cols, float eps,
+                                             void* stream = nullptr);
+
+// --- Gated DeltaNet linear attention ---------------------------------------
+
+// Depthwise causal convolution over the packed QKV channels followed by SiLU.
+// `d_tail` holds the previous kernel-1 inputs per channel and is updated in
+// place when `update_tail` is set, which is what makes decode continue a prefill.
+bool qwen_split_packed_qkv_cuda(const float* d_packed, float* d_q, float* d_k,
+                                float* d_v, int rows, int key_dim, int value_dim,
+                                void* stream = nullptr);
+
+bool qwen_causal_depthwise_conv_silu_cuda(const float* d_x_rows,
+                                          const uint16_t* d_weight_fp16,
+                                          float* d_tail, float* d_y_rows,
+                                          int seq_len, int channels, int kernel,
+                                          bool update_tail, void* stream = nullptr);
+
+// beta = sigmoid(b); g = -exp(A_log) * softplus(a + dt_bias).
+bool qwen_linear_attn_gates_cuda(const float* d_a_rows, const float* d_b_rows,
+                                 const uint16_t* d_a_log_fp16,
+                                 const uint16_t* d_dt_bias_fp16,
+                                 float* d_g_rows, float* d_beta_rows,
+                                 int rows, int heads, void* stream = nullptr);
+
+// One recurrent step of the gated delta rule over a persistent FP32 state
+// [heads, key_dim, value_dim]. Query/key carry `key_heads` heads and are
+// repeated `heads / key_heads` times to cover the value heads.
+bool qwen_gated_delta_step_cuda(float* d_state, const float* d_q, const float* d_k,
+                                const float* d_v, const float* d_g, const float* d_beta,
+                                float* d_out, int heads, int key_heads, int key_dim,
+                                int value_dim, float q_scale, void* stream = nullptr);
+
+// --- Full attention --------------------------------------------------------
+
+// Partial rotary embedding over the leading `rotary_dim` channels of each head.
+bool qwen_partial_rope_cuda(float* d_q, float* d_k, int position, int rotary_dim,
+                            float theta, int q_heads, int kv_heads, int head_dim,
+                            void* stream = nullptr);
+
+// q_proj stores [q, gate] pairs per head; split them into contiguous matrices.
+bool qwen_split_q_gate_cuda(const float* d_q_proj, float* d_q, float* d_gate,
+                            int rows, int q_heads, int head_dim,
+                            void* stream = nullptr);
+
+// Select the rank-local KV head range from a replicated K/V projection.
+bool qwen_select_kv_heads_cuda(const float* d_src, float* d_dst, int rows,
+                               int total_kv_heads, int local_kv_heads,
+                               int head_dim, int head_offset,
+                               void* stream = nullptr);
+
+// Append one or more tokens to a per-head contiguous KV cache.
+bool qwen_append_kv_cache_cuda(const float* d_k_rows, const float* d_v_rows,
+                               float* d_k_cache, float* d_v_cache, int seq_len,
+                               int kv_heads, int head_dim, int start_pos,
+                               int max_context, void* stream = nullptr);
+
+// Single-token GQA attention against the cache. Query head h reads KV head
+// h / (q_heads / kv_heads).
+bool qwen_gqa_decode_attention_cuda(const float* d_q, const float* d_k_cache,
+                                    const float* d_v_cache, float* d_out,
+                                    int q_heads, int kv_heads, int head_dim,
+                                    int context_len, int max_context,
+                                    void* stream = nullptr);
+
+// Multi-token causal GQA attention. Query row t is at absolute position
+// `position_offset + t` and may attend to cache entries up to that position.
+bool qwen_gqa_prefill_attention_cuda(const float* d_q_rows, const float* d_k_cache,
+                                     const float* d_v_cache, float* d_out_rows,
+                                     int seq_len, int q_heads, int kv_heads,
+                                     int head_dim, int position_offset,
+                                     int max_context, void* stream = nullptr);
+
+// --- Small elementwise helpers ---------------------------------------------
+
+bool qwen_sigmoid_mul_cuda(const float* d_x, const float* d_gate, float* d_y,
+                           int count, void* stream = nullptr);
+bool qwen_add_inplace_cuda(float* d_y, const float* d_x, int count,
+                           void* stream = nullptr);
+bool qwen_silu_mul_rows_cuda(const float* d_gate, const float* d_up, float* d_y,
+                             int rows, int cols, void* stream = nullptr);
+
+}  // namespace dsv4

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "qwen_config.hpp"
+#include "qwen_weights.hpp"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace dsv4 {
+
+struct QwenEngineOptions {
+    int tp_world = 1;
+    int tp_rank = 0;
+    int device = 0;
+    std::string nccl_id_path;
+};
+
+struct QwenForwardResult {
+    int token = 0;
+    int layers = 0;
+    int dim = 0;
+    int logits = 0;
+    int top_token = 0;
+    float top_logit = 0.0f;
+    float checksum = 0.0f;
+    int position = 0;
+};
+
+// Independent Qwen3.5 hybrid dense runtime. Checkpoint BF16 tensors are
+// materialized as FP16 on Turing; FP8 projections retain their compressed
+// codes and BF16 block scales are uploaded as FP16 for online unpack.
+class QwenEngine {
+public:
+    QwenEngine(const std::string& ckpt_dir, const QwenEngineOptions& options,
+               int layer_count = 0, int max_context = 8192);
+    ~QwenEngine();
+
+    QwenEngine(const QwenEngine&) = delete;
+    QwenEngine& operator=(const QwenEngine&) = delete;
+
+    const QwenConfig& config() const { return config_; }
+    const QwenWeightMap& weight_map() const { return weights_; }
+    const QwenEngineOptions& options() const { return options_; }
+    int max_context() const { return max_context_; }
+    int position() const { return position_; }
+    uint64_t resident_weight_bytes() const { return resident_weight_bytes_; }
+    uint64_t resident_scale_bytes() const { return resident_scale_bytes_; }
+
+    void reset();
+    QwenForwardResult prefill(const std::vector<int>& token_ids);
+    QwenForwardResult decode_step(int token_id);
+    std::vector<QwenForwardResult> generate(const std::vector<int>& prompt_ids,
+                                             int max_new_tokens);
+
+private:
+    struct Impl;
+
+    std::string ckpt_dir_;
+    QwenEngineOptions options_;
+    QwenConfig config_;
+    SafeTensorsIndex index_;
+    QwenWeightMap weights_;
+    int active_layers_ = 0;
+    int max_context_ = 0;
+    int position_ = 0;
+    uint64_t resident_weight_bytes_ = 0;
+    uint64_t resident_scale_bytes_ = 0;
+    Impl* impl_ = nullptr;
+};
+
+}  // namespace dsv4

--- a/cpp_engine/include/qwen_weights.hpp
+++ b/cpp_engine/include/qwen_weights.hpp
@@ -1,0 +1,165 @@
+#pragma once
+
+#include "qwen_config.hpp"
+#include "safetensors_reader.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace dsv4 {
+
+enum class QwenShardRule {
+    Replicated,
+    ColumnParallel,
+    RowParallel,
+    ParallelEmbedding,
+    ParallelHead,
+    PackedQkvColumnParallel,
+    PackedConvChannelParallel,
+};
+
+struct QwenTensorRef {
+    std::string name;
+    std::string shard_name;
+    // dtype is the checkpoint/storage dtype. device_dtype is the dtype the
+    // Qwen loader must materialize on Turing GPUs.
+    SafeDType dtype = SafeDType::Unknown;
+    SafeDType device_dtype = SafeDType::Unknown;
+    std::vector<uint64_t> full_shape;
+    std::vector<uint64_t> local_shape;
+    QwenShardRule rule = QwenShardRule::Replicated;
+    int shard_dim = -1;
+    uint64_t shard_start = 0;
+    uint64_t shard_size = 0;
+    uint64_t nbytes = 0;
+    uint64_t device_nbytes = 0;
+    std::vector<std::pair<uint64_t, uint64_t>> segments;
+    bool found = false;
+};
+
+struct QwenHostTensor {
+    SafeDType storage_dtype = SafeDType::Unknown;
+    SafeDType device_dtype = SafeDType::Unknown;
+    std::vector<uint64_t> shape;
+    std::vector<uint8_t> bytes;
+};
+
+struct QwenDeviceTensor {
+    void* data = nullptr;
+    SafeDType device_dtype = SafeDType::Unknown;
+    std::vector<uint64_t> shape;
+    uint64_t nbytes = 0;
+
+    ~QwenDeviceTensor();
+    QwenDeviceTensor() = default;
+    QwenDeviceTensor(const QwenDeviceTensor&) = delete;
+    QwenDeviceTensor& operator=(const QwenDeviceTensor&) = delete;
+    QwenDeviceTensor(QwenDeviceTensor&& other) noexcept;
+    QwenDeviceTensor& operator=(QwenDeviceTensor&& other) noexcept;
+};
+
+struct QwenLinearRef {
+    QwenTensorRef weight;
+    QwenTensorRef scale;
+    bool has_scale = false;
+};
+
+struct QwenLinearAttentionWeights {
+    QwenLinearRef in_proj_qkv;
+    QwenLinearRef in_proj_z;
+    QwenLinearRef out_proj;
+    QwenLinearRef in_proj_a;
+    QwenLinearRef in_proj_b;
+    QwenTensorRef conv1d;
+    QwenTensorRef a_log;
+    QwenTensorRef dt_bias;
+    QwenTensorRef norm;
+};
+
+struct QwenFullAttentionWeights {
+    QwenLinearRef q_proj;
+    QwenLinearRef k_proj;
+    QwenLinearRef v_proj;
+    QwenLinearRef o_proj;
+    QwenTensorRef q_norm;
+    QwenTensorRef k_norm;
+};
+
+struct QwenMlpWeights {
+    QwenLinearRef gate_proj;
+    QwenLinearRef up_proj;
+    QwenLinearRef down_proj;
+};
+
+struct QwenLayerWeights {
+    QwenTensorRef input_layernorm;
+    QwenTensorRef post_attention_layernorm;
+    QwenLinearAttentionWeights linear_attention;
+    QwenFullAttentionWeights full_attention;
+    QwenMlpWeights mlp;
+};
+
+class QwenWeightMap {
+public:
+    QwenWeightMap(const SafeTensorsIndex& index, const QwenConfig& config,
+                  int tp_world = 1, int tp_rank = 0);
+
+    const QwenTensorRef& embed_tokens() const { return embed_tokens_; }
+    const QwenTensorRef& final_norm() const { return final_norm_; }
+    const QwenTensorRef& lm_head() const { return lm_head_; }
+    const std::vector<QwenLayerWeights>& layers() const { return layers_; }
+    const QwenConfig& config() const { return config_; }
+    int tp_world() const { return tp_world_; }
+    int tp_rank() const { return tp_rank_; }
+
+    uint64_t local_weight_bytes() const { return local_weight_bytes_; }
+    uint64_t local_scale_bytes() const { return local_scale_bytes_; }
+    size_t tensor_count() const { return tensor_count_; }
+
+private:
+    QwenTensorRef require_tensor(const std::string& name,
+                                 SafeDType dtype,
+                                 const std::vector<uint64_t>& shape,
+                                 QwenShardRule rule = QwenShardRule::Replicated,
+                                 int shard_dim = -1) const;
+    QwenLinearRef require_linear(const std::string& name,
+                                 const std::vector<uint64_t>& shape,
+                                 QwenShardRule rule,
+                                 int shard_dim,
+                                 SafeDType weight_dtype = SafeDType::F8_E4M3) const;
+    void record(const QwenTensorRef& ref, bool scale);
+
+    const SafeTensorsIndex& index_;
+    QwenConfig config_;
+    int tp_world_ = 1;
+    int tp_rank_ = 0;
+    QwenTensorRef embed_tokens_;
+    QwenTensorRef final_norm_;
+    QwenTensorRef lm_head_;
+    std::vector<QwenLayerWeights> layers_;
+    uint64_t local_weight_bytes_ = 0;
+    uint64_t local_scale_bytes_ = 0;
+    size_t tensor_count_ = 0;
+};
+
+const char* qwen_shard_rule_name(QwenShardRule rule);
+
+// Qwen checkpoint tensors retain their source dtype for validation. On Turing,
+// BF16 tensors must be materialized as IEEE FP16 before device upload.
+SafeDType qwen_device_dtype(SafeDType storage_dtype);
+uint16_t qwen_bf16_to_fp16_bits(uint16_t bits);
+void qwen_convert_bf16_to_fp16(const uint16_t* src, uint16_t* dst, size_t count);
+
+// Materialize a local tensor from its mmap'd source shard. The output is ready
+// for a Turing GPU upload: BF16 storage is converted to FP16 and packed/row
+// slices are copied without expanding FP8 weights.
+QwenHostTensor qwen_materialize_host_tensor(const SafeTensorsIndex& index,
+                                            const QwenTensorRef& ref);
+QwenDeviceTensor qwen_upload_tensor_cuda(const SafeTensorsIndex& index,
+                                         const QwenTensorRef& ref,
+                                         void* stream = nullptr);
+
+}  // namespace dsv4

--- a/cpp_engine/include/tensor.hpp
+++ b/cpp_engine/include/tensor.hpp
@@ -11,6 +11,7 @@ enum class DType {
     F32,
     F16,
     BF16,
+    F8_E4M3,
     Q8_0,
     Q2_K,
     IQ2_XXS,

--- a/cpp_engine/src/main.cpp
+++ b/cpp_engine/src/main.cpp
@@ -3,12 +3,15 @@
 #include "model_config.hpp"
 #include "openai_server.hpp"
 #include "persistent_engine.hpp"
+#include "qwen_config.hpp"
+#include "qwen_engine.hpp"
 #include "python_sidecar.hpp"
 #include "safetensors_reader.hpp"
 #include "tokenizer.hpp"
 #include "tp_comm.hpp"
 
 #include <cuda_runtime.h>
+#include <algorithm>
 #include <chrono>
 #include <fstream>
 #include <iostream>
@@ -36,6 +39,7 @@ struct Args {
     std::string nccl_id_path;
     bool generate_token = false;
     bool resident_bench = false;
+    bool qwen_audit = false;
     bool dump_config = false;
     bool inspect = false;
     bool smoke_forward = false;
@@ -68,6 +72,8 @@ Args parse_args(int argc, char** argv) {
             args.ckpt = argv[++i];
         } else if (arg == "--inspect-tensor" && i + 1 < argc) {
             args.inspect_tensor = argv[++i];
+        } else if (arg == "--qwen-audit") {
+            args.qwen_audit = true;
         } else if (arg == "--dump-config") {
             args.dump_config = true;
         } else if (arg == "--inspect") {
@@ -190,6 +196,9 @@ int main(int argc, char** argv) {
         }
         if (args.serve) {
             if (args.ckpt.empty()) throw std::runtime_error("--serve requires --ckpt");
+            if (dsv4::is_qwen3_5_checkpoint(args.ckpt)) {
+                throw std::runtime_error("Qwen checkpoint is not supported by the DSV4 OpenAI server yet; use --smoke-forward or --generate-token");
+            }
             const int layer_count = args.smoke_layers > 0 ? args.smoke_layers : 43;
             const int max_context = args.max_context > 0 ? args.max_context : 8192;
             dsv4::ForwardSmokeOptions opts;
@@ -221,6 +230,7 @@ int main(int argc, char** argv) {
             return 0;
         }
         if (!args.ckpt.empty()) {
+            const bool qwen_checkpoint = dsv4::is_qwen3_5_checkpoint(args.ckpt);
             dsv4::SafeTensorsIndex index(args.ckpt);
             std::cout << "dsv4_cpp_engine opened " << args.ckpt << "\n";
             std::cout << "format=safetensors tensors=" << index.tensor_count()
@@ -228,7 +238,28 @@ int main(int argc, char** argv) {
                       << " total_size=" << index.total_size()
                       << " cuda=" << (dsv4::cuda_runtime_available() ? "yes" : "no") << "\n";
             if (args.dump_config) {
-                std::cout << dsv4::ModelConfig::from_hf_config(args.ckpt).to_string();
+                if (qwen_checkpoint) {
+                    const dsv4::QwenConfig qwen_config = dsv4::QwenConfig::from_hf_config(args.ckpt);
+                    std::cout << qwen_config.to_string();
+                } else {
+                    std::cout << dsv4::ModelConfig::from_hf_config(args.ckpt).to_string();
+                }
+            }
+            if (args.qwen_audit) {
+                if (!qwen_checkpoint) throw std::runtime_error("--qwen-audit requires a Qwen checkpoint");
+                const dsv4::QwenConfig qwen_config = dsv4::QwenConfig::from_hf_config(args.ckpt);
+                const dsv4::QwenWeightMap map(index, qwen_config, args.tp_world, args.tp_rank);
+                const double gib = 1024.0 * 1024.0 * 1024.0;
+                std::cout << "qwen_audit tp_world=" << args.tp_world
+                          << " tp_rank=" << args.tp_rank
+                          << " tensors=" << map.tensor_count()
+                          << " weight_bytes=" << map.local_weight_bytes()
+                          << " scale_bytes=" << map.local_scale_bytes()
+                          << " weight_GiB=" << (static_cast<double>(map.local_weight_bytes()) / gib)
+                          << " scale_GiB=" << (static_cast<double>(map.local_scale_bytes()) / gib)
+                          << " total_GiB="
+                          << (static_cast<double>(map.local_weight_bytes() + map.local_scale_bytes()) / gib)
+                          << "\n";
             }
             if (!args.inspect_tensor.empty()) {
                 const std::string* shard_name = index.shard_for_tensor(args.inspect_tensor);
@@ -239,6 +270,95 @@ int main(int argc, char** argv) {
                 print_safe_tensor(*info, *shard_name);
             }
             if (args.smoke_forward) {
+                if (qwen_checkpoint) {
+                    dsv4::Tokenizer tokenizer(args.ckpt);
+                    std::vector<int> prompt_ids = load_token_ids(args);
+                    if (!args.prompt.empty()) prompt_ids = tokenizer.encode_basic(args.prompt, false);
+                    if (prompt_ids.empty()) {
+                        if (args.forward_token < 0) throw std::runtime_error("Qwen smoke requires --prompt, --token-ids, or --generate-token");
+                        prompt_ids.push_back(args.forward_token);
+                    }
+                    dsv4::QwenEngineOptions qwen_opts;
+                    qwen_opts.tp_world = args.tp_world;
+                    qwen_opts.tp_rank = args.tp_rank;
+                    qwen_opts.device = args.device >= 0 ? args.device : args.tp_rank;
+                    qwen_opts.nccl_id_path = args.nccl_id_path;
+                    const int qwen_context = args.max_context > 0
+                        ? args.max_context
+                        : static_cast<int>(prompt_ids.size()) + std::max(1, args.max_new_tokens);
+                    dsv4::QwenEngine qwen(args.ckpt, qwen_opts, args.smoke_layers, qwen_context);
+                    if (args.generate_token) {
+                        using Clock = std::chrono::steady_clock;
+                        const auto t_total0 = Clock::now();
+                        const auto t_prefill0 = Clock::now();
+                        std::vector<dsv4::QwenForwardResult> generated;
+                        generated.reserve(static_cast<size_t>(args.max_new_tokens));
+                        dsv4::QwenForwardResult next = qwen.prefill(prompt_ids);
+                        const auto t_prefill1 = Clock::now();
+                        generated.push_back(next);
+                        const auto t_decode0 = Clock::now();
+                        for (int step = 1; step < args.max_new_tokens; ++step) {
+                            next = qwen.decode_step(next.top_token);
+                            generated.push_back(next);
+                        }
+                        const auto t_decode1 = Clock::now();
+                        for (size_t step = 0; step < generated.size(); ++step) {
+                            std::cout << "generate_step=" << step
+                                      << " token=" << generated[step].top_token
+                                      << " token_text=" << tokenizer.decode_tokens({generated[step].top_token})
+                                      << " top_token=" << generated[step].top_token
+                                      << " top_logit=" << generated[step].top_logit
+                                      << " checksum=" << generated[step].checksum << "\n";
+                        }
+                        size_t free_bytes = 0;
+                        size_t total_bytes = 0;
+                        if (cudaMemGetInfo(&free_bytes, &total_bytes) != cudaSuccess) {
+                            free_bytes = 0;
+                            total_bytes = 0;
+                        }
+                        std::cout << "qwen_runtime=1 layers=" << generated.front().layers
+                                  << " resident_weight_bytes=" << qwen.resident_weight_bytes()
+                                  << " resident_scale_bytes=" << qwen.resident_scale_bytes()
+                                  << " prompt_tokens=" << prompt_ids.size()
+                                  << " generated_tokens=" << generated.size();
+                        if (args.resident_bench) {
+                            const auto seconds = [](auto begin, auto end) {
+                                return std::chrono::duration<double>(end - begin).count();
+                            };
+                            const double total = seconds(t_total0, t_decode1);
+                            const double prefill = seconds(t_prefill0, t_prefill1);
+                            const double decode = seconds(t_decode0, t_decode1);
+                            const int decode_tokens = generated.size() > 1
+                                ? static_cast<int>(generated.size()) - 1 : 0;
+                            std::cout << " wall=" << total
+                                      << " prefill_seconds=" << prefill
+                                      << " prefill_tokens_per_s="
+                                      << (prefill > 0.0 ? prompt_ids.size() / prefill : 0.0)
+                                      << " decode_seconds=" << decode
+                                      << " decode_tokens_per_s="
+                                      << (decode > 0.0 ? decode_tokens / decode : 0.0)
+                                      << " decode_token_count=" << decode_tokens;
+                        }
+                        if (total_bytes != 0) {
+                            std::cout << " gpu_memory_used_bytes=" << (total_bytes - free_bytes)
+                                      << " gpu_memory_total_bytes=" << total_bytes;
+                        }
+                        std::cout << "\n";
+                    } else {
+                        dsv4::QwenForwardResult result = qwen.prefill(prompt_ids);
+                        std::cout << "smoke_forward=1 qwen_runtime=1 token=" << prompt_ids.back()
+                                  << " layers=" << result.layers
+                                  << " dim=" << result.dim
+                                  << " logits=" << result.logits
+                                  << " top_token=" << result.top_token
+                                  << " top_logit=" << result.top_logit
+                                  << " checksum=" << result.checksum
+                                  << " position=" << result.position
+                                  << " resident_weight_bytes=" << qwen.resident_weight_bytes()
+                                  << " resident_scale_bytes=" << qwen.resident_scale_bytes() << "\n";
+                    }
+                    return 0;
+                }
                 dsv4::Tokenizer tokenizer(args.ckpt);
                 std::vector<int> prompt_ids = load_token_ids(args);
                 if (!prompt_ids.empty()) {

--- a/cpp_engine/src/qwen_config.cpp
+++ b/cpp_engine/src/qwen_config.cpp
@@ -1,0 +1,250 @@
+#include "qwen_config.hpp"
+
+#include "json_lite.hpp"
+
+#include <cmath>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+
+namespace dsv4 {
+namespace {
+
+std::string read_file(const std::string& path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) throw std::runtime_error("failed to open file: " + path);
+    std::ostringstream out;
+    out << in.rdbuf();
+    return out.str();
+}
+
+const JsonObject& text_config(const JsonObject& root) {
+    const JsonValue* nested = object_get(root, "text_config");
+    if (nested == nullptr) return root;
+    if (!nested->is_object()) throw std::runtime_error("Qwen config text_config must be an object");
+    return nested->object();
+}
+
+const JsonObject* optional_object(const JsonObject& obj, const std::string& key) {
+    const JsonValue* value = object_get(obj, key);
+    if (value == nullptr || value->is_null()) return nullptr;
+    if (!value->is_object()) throw std::runtime_error("Qwen config key must be an object: " + key);
+    return &value->object();
+}
+
+uint64_t required_u64(const JsonObject& obj, const std::string& key) {
+    const JsonValue* value = object_get(obj, key);
+    if (value == nullptr || !value->is_number()) throw std::runtime_error("missing Qwen integer: " + key);
+    const double number = value->number();
+    const double rounded = std::round(number);
+    if (number < 0.0 || std::fabs(number - rounded) > 1.0e-9) {
+        throw std::runtime_error("Qwen integer is not integral: " + key);
+    }
+    return static_cast<uint64_t>(rounded);
+}
+
+uint64_t optional_u64(const JsonObject& obj, const std::string& key, uint64_t fallback) {
+    const JsonValue* value = object_get(obj, key);
+    if (value == nullptr || value->is_null()) return fallback;
+    if (!value->is_number()) throw std::runtime_error("Qwen config integer has wrong type: " + key);
+    const double number = value->number();
+    const double rounded = std::round(number);
+    if (number < 0.0 || std::fabs(number - rounded) > 1.0e-9) {
+        throw std::runtime_error("Qwen integer is not integral: " + key);
+    }
+    return static_cast<uint64_t>(rounded);
+}
+
+double optional_f64(const JsonObject& obj, const std::string& key, double fallback) {
+    const JsonValue* value = object_get(obj, key);
+    if (value == nullptr || value->is_null()) return fallback;
+    if (!value->is_number()) throw std::runtime_error("Qwen config number has wrong type: " + key);
+    return value->number();
+}
+
+bool required_bool(const JsonObject& obj, const std::string& key) {
+    const JsonValue* value = object_get(obj, key);
+    if (value == nullptr || !value->is_bool()) throw std::runtime_error("missing Qwen boolean: " + key);
+    return value->boolean();
+}
+
+std::string optional_string(const JsonObject& obj, const std::string& key, const std::string& fallback) {
+    const JsonValue* value = object_get(obj, key);
+    if (value == nullptr || value->is_null()) return fallback;
+    if (!value->is_string()) throw std::runtime_error("Qwen config string has wrong type: " + key);
+    return value->string();
+}
+
+std::string root_model_type(const JsonObject& root) {
+    return optional_string(root, "model_type", "");
+}
+
+void validate_positive(double value, const std::string& name) {
+    if (!(value > 0.0) || !std::isfinite(value)) {
+        throw std::runtime_error("invalid Qwen positive number: " + name);
+    }
+}
+
+}  // namespace
+
+QwenConfig QwenConfig::from_hf_config(const std::string& ckpt_dir) {
+    const JsonValue root_value = parse_json(read_file(ckpt_dir + "/config.json"));
+    if (!root_value.is_object()) throw std::runtime_error("Qwen config root must be an object");
+    const JsonObject& root = root_value.object();
+    const JsonObject& text = text_config(root);
+
+    QwenConfig cfg;
+    cfg.architecture = root_model_type(root);
+    cfg.model_type = optional_string(text, "model_type", cfg.architecture);
+    cfg.vocab_size = required_u64(text, "vocab_size");
+    cfg.hidden_size = required_u64(text, "hidden_size");
+    cfg.num_hidden_layers = required_u64(text, "num_hidden_layers");
+    cfg.max_position_embeddings = required_u64(text, "max_position_embeddings");
+    cfg.rms_norm_eps = optional_f64(text, "rms_norm_eps", 1.0e-6);
+    cfg.partial_rotary_factor = optional_f64(text, "partial_rotary_factor", 1.0);
+    cfg.fp8_block_size = 128;
+
+    const JsonObject* rope_parameters = optional_object(text, "rope_parameters");
+    if (rope_parameters != nullptr) {
+        cfg.rope_theta = optional_f64(*rope_parameters, "rope_theta", cfg.rope_theta);
+        cfg.partial_rotary_factor = optional_f64(*rope_parameters, "partial_rotary_factor", cfg.partial_rotary_factor);
+    } else {
+        cfg.rope_theta = optional_f64(text, "rope_theta", cfg.rope_theta);
+    }
+
+    cfg.linear_attention.key_heads = required_u64(text, "linear_num_key_heads");
+    cfg.linear_attention.value_heads = required_u64(text, "linear_num_value_heads");
+    cfg.linear_attention.key_head_dim = required_u64(text, "linear_key_head_dim");
+    cfg.linear_attention.value_head_dim = required_u64(text, "linear_value_head_dim");
+    cfg.linear_attention.conv_kernel_dim = required_u64(text, "linear_conv_kernel_dim");
+
+    cfg.full_attention.num_heads = required_u64(text, "num_attention_heads");
+    cfg.full_attention.num_key_value_heads = required_u64(text, "num_key_value_heads");
+    cfg.full_attention.head_dim = optional_u64(text, "head_dim", cfg.hidden_size / cfg.full_attention.num_heads);
+    cfg.full_attention.output_gate = required_bool(text, "attn_output_gate");
+
+    cfg.mlp.intermediate_size = optional_u64(text, "intermediate_size", 0);
+    if (cfg.mlp.intermediate_size == 0) {
+        throw std::runtime_error("missing Qwen dense MLP intermediate_size");
+    }
+
+    const JsonValue* raw_layers = object_get(text, "layer_types");
+    if (raw_layers == nullptr || !raw_layers->is_array() || raw_layers->array().size() != cfg.num_hidden_layers) {
+        throw std::runtime_error("Qwen layer_types must contain one entry per layer");
+    }
+    cfg.layer_types.reserve(cfg.num_hidden_layers);
+    for (size_t i = 0; i < raw_layers->array().size(); ++i) {
+        const JsonValue& value = raw_layers->array()[i];
+        if (!value.is_string()) throw std::runtime_error("Qwen layer_types entry is not a string");
+        if (value.string() == "linear_attention") {
+            cfg.layer_types.push_back(QwenLayerType::LinearAttention);
+        } else if (value.string() == "full_attention") {
+            cfg.layer_types.push_back(QwenLayerType::FullAttention);
+        } else {
+            throw std::runtime_error("unsupported Qwen layer type at " + std::to_string(i) + ": " + value.string());
+        }
+    }
+
+    if (!cfg.is_qwen3_5()) throw std::runtime_error("config is not a Qwen3.5 text checkpoint");
+    if (cfg.hidden_size == 0 || cfg.num_hidden_layers == 0 || cfg.vocab_size == 0 || cfg.max_position_embeddings == 0) {
+        throw std::runtime_error("invalid zero-sized Qwen config");
+    }
+    validate_positive(cfg.rms_norm_eps, "rms_norm_eps");
+    validate_positive(cfg.rope_theta, "rope_theta");
+    if (!(cfg.partial_rotary_factor > 0.0 && cfg.partial_rotary_factor <= 1.0)) {
+        throw std::runtime_error("Qwen partial_rotary_factor must be in (0, 1]");
+    }
+    if (cfg.linear_attention.key_heads == 0 || cfg.linear_attention.value_heads == 0 ||
+        cfg.linear_attention.key_head_dim == 0 || cfg.linear_attention.value_head_dim == 0 ||
+        cfg.linear_attention.conv_kernel_dim == 0) {
+        throw std::runtime_error("invalid Qwen linear-attention dimensions");
+    }
+    if (cfg.full_attention.num_heads == 0 || cfg.full_attention.num_key_value_heads == 0 || cfg.full_attention.head_dim == 0) {
+        throw std::runtime_error("invalid Qwen full-attention dimensions");
+    }
+    if (cfg.full_attention.num_heads % cfg.full_attention.num_key_value_heads != 0) {
+        throw std::runtime_error("Qwen attention heads must be divisible by key/value heads");
+    }
+    if (cfg.full_attention.num_heads % 4 != 0 || cfg.full_attention.num_key_value_heads % 4 != 0) {
+        throw std::runtime_error("Qwen TP4 requires attention heads and KV heads divisible by four");
+    }
+    if (cfg.partial_rotary_dim() == 0 || cfg.partial_rotary_dim() > cfg.full_attention.head_dim ||
+        (cfg.partial_rotary_dim() % 2) != 0) {
+        throw std::runtime_error("Qwen partial rotary dimension must be a positive even head dimension");
+    }
+    if (cfg.linear_attention.value_heads % cfg.linear_attention.key_heads != 0) {
+        throw std::runtime_error("Qwen linear value heads must be divisible by key heads");
+    }
+    return cfg;
+}
+
+bool QwenConfig::is_qwen3_5() const {
+    return architecture == "qwen3_5" || architecture == "qwen3_5_text" ||
+           model_type == "qwen3_5" || model_type == "qwen3_5_text";
+}
+
+uint64_t QwenConfig::linear_attention_layers() const {
+    uint64_t count = 0;
+    for (QwenLayerType type : layer_types) {
+        if (type == QwenLayerType::LinearAttention) ++count;
+    }
+    return count;
+}
+
+uint64_t QwenConfig::full_attention_layers() const {
+    uint64_t count = 0;
+    for (QwenLayerType type : layer_types) {
+        if (type == QwenLayerType::FullAttention) ++count;
+    }
+    return count;
+}
+
+uint64_t QwenConfig::partial_rotary_dim() const {
+    return static_cast<uint64_t>(std::llround(static_cast<double>(full_attention.head_dim) * partial_rotary_factor));
+}
+
+std::string QwenConfig::layer_type_name(uint64_t layer) const {
+    if (layer >= layer_types.size()) throw std::out_of_range("Qwen layer index out of range");
+    return layer_types[layer] == QwenLayerType::LinearAttention ? "linear_attention" : "full_attention";
+}
+
+std::string QwenConfig::to_string() const {
+    std::ostringstream out;
+    out << "architecture=" << architecture << '\n'
+        << "model_type=" << model_type << '\n'
+        << "vocab_size=" << vocab_size << '\n'
+        << "hidden_size=" << hidden_size << '\n'
+        << "num_hidden_layers=" << num_hidden_layers << '\n'
+        << "max_position_embeddings=" << max_position_embeddings << '\n'
+        << "rms_norm_eps=" << rms_norm_eps << '\n'
+        << "rope_theta=" << rope_theta << '\n'
+        << "partial_rotary_factor=" << partial_rotary_factor << '\n'
+        << "partial_rotary_dim=" << partial_rotary_dim() << '\n'
+        << "linear_key_heads=" << linear_attention.key_heads << '\n'
+        << "linear_value_heads=" << linear_attention.value_heads << '\n'
+        << "linear_key_head_dim=" << linear_attention.key_head_dim << '\n'
+        << "linear_value_head_dim=" << linear_attention.value_head_dim << '\n'
+        << "linear_conv_kernel_dim=" << linear_attention.conv_kernel_dim << '\n'
+        << "full_num_heads=" << full_attention.num_heads << '\n'
+        << "full_num_key_value_heads=" << full_attention.num_key_value_heads << '\n'
+        << "full_head_dim=" << full_attention.head_dim << '\n'
+        << "attn_output_gate=" << (full_attention.output_gate ? 1 : 0) << '\n'
+        << "intermediate_size=" << mlp.intermediate_size << '\n'
+        << "linear_attention_layers=" << linear_attention_layers() << '\n'
+        << "full_attention_layers=" << full_attention_layers() << '\n';
+    return out.str();
+}
+
+bool is_qwen3_5_checkpoint(const std::string& ckpt_dir) {
+    const JsonValue root_value = parse_json(read_file(ckpt_dir + "/config.json"));
+    if (!root_value.is_object()) return false;
+    const JsonObject& root = root_value.object();
+    const std::string arch = root_model_type(root);
+    if (arch == "qwen3_5" || arch == "qwen3_5_text") return true;
+    const JsonValue* nested = object_get(root, "text_config");
+    if (nested == nullptr || !nested->is_object()) return false;
+    const std::string type = optional_string(nested->object(), "model_type", "");
+    return type == "qwen3_5" || type == "qwen3_5_text";
+}
+
+}  // namespace dsv4

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -1,0 +1,625 @@
+#include "qwen_engine.hpp"
+
+#include "cuda_ops.hpp"
+#include "qwen_cuda_ops.hpp"
+#include "tp_comm.hpp"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+namespace dsv4 {
+namespace {
+
+void check_cuda(cudaError_t status, const char* what) {
+    if (status != cudaSuccess) throw std::runtime_error(std::string(what) + ": " + cudaGetErrorString(status));
+}
+
+void require_launch(bool ok, const char* what) {
+    if (!ok) throw std::runtime_error(std::string("Qwen CUDA launch failed: ") + what);
+}
+
+float* fp32(QwenDeviceTensor& tensor) {
+    return static_cast<float*>(tensor.data);
+}
+
+const float* fp32(const QwenDeviceTensor& tensor) {
+    return static_cast<const float*>(tensor.data);
+}
+
+uint16_t* fp16(QwenDeviceTensor& tensor) {
+    return static_cast<uint16_t*>(tensor.data);
+}
+
+const uint16_t* fp16(const QwenDeviceTensor& tensor) {
+    return static_cast<const uint16_t*>(tensor.data);
+}
+
+uint8_t* fp8(QwenDeviceTensor& tensor) {
+    return static_cast<uint8_t*>(tensor.data);
+}
+
+const uint8_t* fp8(const QwenDeviceTensor& tensor) {
+    return static_cast<const uint8_t*>(tensor.data);
+}
+
+struct DeviceLinear {
+    QwenDeviceTensor weight;
+    QwenDeviceTensor scale;
+    bool fp8 = false;
+};
+
+struct DeviceLinearAttention {
+    DeviceLinear qkv;
+    DeviceLinear z;
+    DeviceLinear out;
+    DeviceLinear a;
+    DeviceLinear b;
+    QwenDeviceTensor conv;
+    QwenDeviceTensor a_log;
+    QwenDeviceTensor dt_bias;
+    QwenDeviceTensor norm;
+    QwenDeviceTensor state;
+    QwenDeviceTensor conv_tail;
+};
+
+struct DeviceFullAttention {
+    DeviceLinear q;
+    DeviceLinear k;
+    DeviceLinear v;
+    DeviceLinear out;
+    QwenDeviceTensor q_norm;
+    QwenDeviceTensor k_norm;
+    QwenDeviceTensor k_cache;
+    QwenDeviceTensor v_cache;
+};
+
+struct DeviceLayer {
+    QwenDeviceTensor input_norm;
+    QwenDeviceTensor post_norm;
+    DeviceLinearAttention linear;
+    DeviceFullAttention full;
+    DeviceLinear gate;
+    DeviceLinear up;
+    DeviceLinear down;
+};
+
+QwenDeviceTensor upload(const SafeTensorsIndex& index, const QwenTensorRef& ref) {
+    return qwen_upload_tensor_cuda(index, ref);
+}
+
+DeviceLinear upload_linear(const SafeTensorsIndex& index, const QwenLinearRef& ref) {
+    DeviceLinear out;
+    out.weight = upload(index, ref.weight);
+    out.fp8 = ref.weight.device_dtype == SafeDType::F8_E4M3;
+    if (ref.has_scale) out.scale = upload(index, ref.scale);
+    return out;
+}
+
+void allocate(QwenDeviceTensor& tensor, size_t bytes, const std::vector<uint64_t>& shape,
+              SafeDType dtype) {
+    if (bytes == 0) throw std::runtime_error("Qwen attempted to allocate an empty tensor");
+    if (tensor.data != nullptr) {
+        check_cuda(cudaFree(tensor.data), "cudaFree Qwen runtime tensor");
+        tensor.data = nullptr;
+    }
+    check_cuda(cudaMalloc(&tensor.data, bytes), "cudaMalloc Qwen runtime tensor");
+    tensor.device_dtype = dtype;
+    tensor.shape = shape;
+    tensor.nbytes = bytes;
+}
+
+void allocate_float(QwenDeviceTensor& tensor, size_t elements, const std::vector<uint64_t>& shape) {
+    allocate(tensor, elements * sizeof(float), shape, SafeDType::F32);
+}
+
+void zero_tensor(QwenDeviceTensor& tensor) {
+    check_cuda(cudaMemset(tensor.data, 0, tensor.nbytes), "cudaMemset Qwen runtime tensor");
+}
+
+}  // namespace
+
+struct QwenEngine::Impl {
+    SafeTensorsIndex& index;
+    QwenConfig& config;
+    QwenEngineOptions options;
+    int max_context = 0;
+    std::vector<DeviceLayer> layers;
+    QwenDeviceTensor embed;
+    QwenDeviceTensor final_norm;
+    QwenDeviceTensor lm_head;
+    std::vector<int> local_tokens;
+    QwenDeviceTensor d_tokens;
+    QwenDeviceTensor hidden_a;
+    QwenDeviceTensor hidden_b;
+    QwenDeviceTensor work_a;
+    QwenDeviceTensor work_b;
+    QwenDeviceTensor final_hidden;
+    QwenDeviceTensor logits;
+    QwenDeviceTensor argmax_token;
+    QwenDeviceTensor argmax_logit;
+
+    // active_layers bounds how many decoder layers are uploaded. A partial-depth
+    // smoke run must not stage the full 64-layer checkpoint: at TP1 that is
+    // 27.4 GiB and does not fit on a 22 GiB card.
+    // Bytes actually staged on this device, as opposed to what the full map
+    // describes; a partial-depth run uploads only a prefix of the layers.
+    uint64_t uploaded_weight_bytes = 0;
+    uint64_t uploaded_scale_bytes = 0;
+
+    Impl(SafeTensorsIndex& index_, QwenConfig& config_, const QwenWeightMap& map,
+         const QwenEngineOptions& options_, int max_context_, int active_layers)
+        : index(index_), config(config_), options(options_), max_context(max_context_) {
+        embed = upload(index, map.embed_tokens());
+        final_norm = upload(index, map.final_norm());
+        lm_head = upload(index, map.lm_head());
+        uploaded_weight_bytes += map.embed_tokens().device_nbytes +
+                                 map.final_norm().device_nbytes + map.lm_head().device_nbytes;
+        const size_t layer_limit = active_layers > 0
+            ? std::min(static_cast<size_t>(active_layers), map.layers().size())
+            : map.layers().size();
+        layers.reserve(layer_limit);
+        const int world = options.tp_world;
+        const int rank = options.tp_rank;
+        const int local_key_heads = static_cast<int>(config.linear_attention.key_heads / world);
+        const int local_value_heads = static_cast<int>(config.linear_attention.value_heads / world);
+        const int local_key_dim = local_key_heads * static_cast<int>(config.linear_attention.key_head_dim);
+        const int local_value_dim = local_value_heads * static_cast<int>(config.linear_attention.value_head_dim);
+        const int local_qkv_dim = 2 * local_key_dim + local_value_dim;
+        const int local_q_heads = static_cast<int>(config.full_attention.num_heads / world);
+        const int local_kv_heads = static_cast<int>(config.full_attention.num_key_value_heads / world);
+        for (size_t layer_index = 0; layer_index < layer_limit; ++layer_index) {
+            const QwenLayerWeights& src = map.layers()[layer_index];
+            for (const QwenTensorRef* ref : {
+                     &src.input_layernorm, &src.post_attention_layernorm,
+                     &src.mlp.gate_proj.weight, &src.mlp.up_proj.weight, &src.mlp.down_proj.weight,
+                     &src.linear_attention.in_proj_qkv.weight, &src.linear_attention.in_proj_z.weight,
+                     &src.linear_attention.out_proj.weight, &src.linear_attention.in_proj_a.weight,
+                     &src.linear_attention.in_proj_b.weight, &src.linear_attention.conv1d,
+                     &src.linear_attention.a_log, &src.linear_attention.dt_bias,
+                     &src.linear_attention.norm,
+                     &src.full_attention.q_proj.weight, &src.full_attention.k_proj.weight,
+                     &src.full_attention.v_proj.weight, &src.full_attention.o_proj.weight,
+                     &src.full_attention.q_norm, &src.full_attention.k_norm}) {
+                if (ref->found) uploaded_weight_bytes += ref->device_nbytes;
+            }
+            for (const QwenLinearRef* ref : {
+                     &src.mlp.gate_proj, &src.mlp.up_proj, &src.mlp.down_proj,
+                     &src.linear_attention.in_proj_qkv, &src.linear_attention.in_proj_z,
+                     &src.linear_attention.out_proj,
+                     &src.full_attention.q_proj, &src.full_attention.k_proj,
+                     &src.full_attention.v_proj, &src.full_attention.o_proj}) {
+                if (ref->has_scale) uploaded_scale_bytes += ref->scale.device_nbytes;
+            }
+            DeviceLayer dst;
+            dst.input_norm = upload(index, src.input_layernorm);
+            dst.post_norm = upload(index, src.post_attention_layernorm);
+            dst.gate = upload_linear(index, src.mlp.gate_proj);
+            dst.up = upload_linear(index, src.mlp.up_proj);
+            dst.down = upload_linear(index, src.mlp.down_proj);
+            if (src.linear_attention.in_proj_qkv.weight.found) {
+                dst.linear.qkv = upload_linear(index, src.linear_attention.in_proj_qkv);
+                dst.linear.z = upload_linear(index, src.linear_attention.in_proj_z);
+                dst.linear.out = upload_linear(index, src.linear_attention.out_proj);
+                dst.linear.a = upload_linear(index, src.linear_attention.in_proj_a);
+                dst.linear.b = upload_linear(index, src.linear_attention.in_proj_b);
+                dst.linear.conv = upload(index, src.linear_attention.conv1d);
+                dst.linear.a_log = upload(index, src.linear_attention.a_log);
+                dst.linear.dt_bias = upload(index, src.linear_attention.dt_bias);
+                dst.linear.norm = upload(index, src.linear_attention.norm);
+                allocate_float(dst.linear.state,
+                               static_cast<size_t>(local_value_heads) * config.linear_attention.key_head_dim *
+                                   config.linear_attention.value_head_dim,
+                               {static_cast<uint64_t>(local_value_heads), config.linear_attention.key_head_dim,
+                                config.linear_attention.value_head_dim});
+                allocate_float(dst.linear.conv_tail,
+                               static_cast<size_t>(std::max(0, static_cast<int>(config.linear_attention.conv_kernel_dim) - 1)) *
+                                   local_qkv_dim,
+                               {static_cast<uint64_t>(std::max(0, static_cast<int>(config.linear_attention.conv_kernel_dim) - 1)),
+                                static_cast<uint64_t>(local_qkv_dim)});
+                zero_tensor(dst.linear.state);
+                zero_tensor(dst.linear.conv_tail);
+            } else {
+                dst.full.q = upload_linear(index, src.full_attention.q_proj);
+                dst.full.k = upload_linear(index, src.full_attention.k_proj);
+                dst.full.v = upload_linear(index, src.full_attention.v_proj);
+                dst.full.out = upload_linear(index, src.full_attention.o_proj);
+                dst.full.q_norm = upload(index, src.full_attention.q_norm);
+                dst.full.k_norm = upload(index, src.full_attention.k_norm);
+                allocate_float(dst.full.k_cache,
+                               static_cast<size_t>(max_context) * local_kv_heads * config.full_attention.head_dim,
+                               {static_cast<uint64_t>(max_context), static_cast<uint64_t>(local_kv_heads),
+                                config.full_attention.head_dim});
+                allocate_float(dst.full.v_cache,
+                               static_cast<size_t>(max_context) * local_kv_heads * config.full_attention.head_dim,
+                               {static_cast<uint64_t>(max_context), static_cast<uint64_t>(local_kv_heads),
+                                config.full_attention.head_dim});
+                zero_tensor(dst.full.k_cache);
+                zero_tensor(dst.full.v_cache);
+            }
+            layers.push_back(std::move(dst));
+        }
+        (void)rank;
+    }
+
+    ~Impl() = default;
+
+    void all_reduce(float* values, int count) {
+        if (options.tp_world == 1) return;
+#ifdef DSV4_HAVE_NCCL
+        if (options.nccl_id_path.empty()) throw std::runtime_error("Qwen TP requires --nccl-id-path");
+        nccl_all_reduce_sum_float_inplace(options.tp_world, options.tp_rank, options.device,
+                                          options.nccl_id_path.c_str(), values, count);
+#else
+        (void)values;
+        (void)count;
+        throw std::runtime_error("Qwen TP requires an NCCL-enabled build");
+#endif
+    }
+
+    void projection(const DeviceLinear& linear, const float* x, float* y, int rows) {
+        const int out_rows = static_cast<int>(linear.weight.shape[0]);
+        const int cols = static_cast<int>(linear.weight.shape[1]);
+        if (linear.fp8) {
+            if (rows == 1) {
+                // Decode: warp-per-row matvec avoids the block reduction.
+                require_launch(qwen_fp8_e4m3_fp16scale_matvec_cuda(
+                                   x, fp8(const_cast<QwenDeviceTensor&>(linear.weight)),
+                                   fp16(const_cast<QwenDeviceTensor&>(linear.scale)), fp32_view(y),
+                                   out_rows, cols, cols,
+                                   static_cast<int>(linear.scale.shape[1])),
+                               "FP8 decode projection");
+                return;
+            }
+            require_launch(qwen_fp8_e4m3_fp16scale_matmul_rows_cuda(
+                               x, fp8(const_cast<QwenDeviceTensor&>(linear.weight)),
+                               fp16(const_cast<QwenDeviceTensor&>(linear.scale)), fp32_view(y),
+                               rows, out_rows, cols, cols, out_rows, cols,
+                               static_cast<int>(linear.scale.shape[1])),
+                           "FP8 projection");
+        } else {
+            require_launch(qwen_fp16_matmul_rows_cuda(
+                               x, fp16(const_cast<QwenDeviceTensor&>(linear.weight)), fp32_view(y),
+                               rows, out_rows, cols, cols, out_rows, cols),
+                           "FP16 projection");
+        }
+    }
+
+    static float* fp32_view(float* p) { return p; }
+
+    void norm(const QwenDeviceTensor& gamma, const float* x, float* y, int rows, int cols) {
+        require_launch(qwen_rmsnorm_fp16_gamma_rows_cuda(
+                           x, fp16(const_cast<QwenDeviceTensor&>(gamma)), y, rows, cols,
+                           static_cast<float>(config.rms_norm_eps)),
+                       "Qwen RMSNorm");
+    }
+
+    void add(float* y, const float* x, int count) {
+        require_launch(qwen_add_inplace_cuda(y, x, count), "Qwen residual add");
+    }
+
+    void linear_attention(DeviceLayer& layer, float* hidden, float* output, int rows,
+                          int position_offset) {
+        const int key_heads = static_cast<int>(config.linear_attention.key_heads / options.tp_world);
+        const int value_heads = static_cast<int>(config.linear_attention.value_heads / options.tp_world);
+        const int key_dim = key_heads * static_cast<int>(config.linear_attention.key_head_dim);
+        const int value_dim = value_heads * static_cast<int>(config.linear_attention.value_head_dim);
+        const int packed_dim = 2 * key_dim + value_dim;
+        const int kernel = static_cast<int>(config.linear_attention.conv_kernel_dim);
+        const int hidden_size = static_cast<int>(config.hidden_size);
+        QwenDeviceTensor packed, conv, q, k, v, a, b, gates, beta, core, z, normalized;
+        allocate_float(packed, static_cast<size_t>(rows) * packed_dim, {static_cast<uint64_t>(rows), static_cast<uint64_t>(packed_dim)});
+        allocate_float(conv, packed.nbytes / sizeof(float), packed.shape);
+        allocate_float(q, static_cast<size_t>(rows) * key_dim, {static_cast<uint64_t>(rows), static_cast<uint64_t>(key_dim)});
+        allocate_float(k, q.nbytes / sizeof(float), q.shape);
+        allocate_float(v, static_cast<size_t>(rows) * value_dim, {static_cast<uint64_t>(rows), static_cast<uint64_t>(value_dim)});
+        allocate_float(a, static_cast<size_t>(rows) * value_heads, {static_cast<uint64_t>(rows), static_cast<uint64_t>(value_heads)});
+        allocate_float(b, a.nbytes / sizeof(float), a.shape);
+        allocate_float(gates, a.nbytes / sizeof(float), a.shape);
+        allocate_float(beta, a.nbytes / sizeof(float), a.shape);
+        allocate_float(core, static_cast<size_t>(rows) * value_dim, v.shape);
+        allocate_float(z, core.nbytes / sizeof(float), core.shape);
+        allocate_float(normalized, core.nbytes / sizeof(float), core.shape);
+        projection(layer.linear.qkv, hidden, fp32(packed), rows);
+        require_launch(qwen_causal_depthwise_conv_silu_cuda(
+                           fp32(packed), fp16(layer.linear.conv), fp32(layer.linear.conv_tail),
+                           fp32(conv), rows, packed_dim, kernel, true),
+                       "linear causal convolution");
+        require_launch(qwen_split_packed_qkv_cuda(fp32(conv), fp32(q), fp32(k), fp32(v), rows, key_dim, value_dim),
+                       "linear QKV split");
+        projection(layer.linear.a, hidden, fp32(a), rows);
+        projection(layer.linear.b, hidden, fp32(b), rows);
+        require_launch(qwen_linear_attn_gates_cuda(
+                           fp32(a), fp32(b), fp16(layer.linear.a_log), fp16(layer.linear.dt_bias),
+                           fp32(gates), fp32(beta), rows, value_heads),
+                       "linear gate projection");
+        const float q_scale = 1.0f / std::sqrt(static_cast<float>(config.linear_attention.key_head_dim));
+        for (int t = 0; t < rows; ++t) {
+            require_launch(qwen_gated_delta_step_cuda(
+                               fp32(layer.linear.state), fp32(q) + static_cast<size_t>(t) * key_dim,
+                               fp32(k) + static_cast<size_t>(t) * key_dim,
+                               fp32(v) + static_cast<size_t>(t) * value_dim,
+                               fp32(gates) + static_cast<size_t>(t) * value_heads,
+                               fp32(beta) + static_cast<size_t>(t) * value_heads,
+                               fp32(core) + static_cast<size_t>(t) * value_dim,
+                               value_heads, key_heads, static_cast<int>(config.linear_attention.key_head_dim),
+                               static_cast<int>(config.linear_attention.value_head_dim), q_scale),
+                           "linear recurrent state");
+        }
+        projection(layer.linear.z, hidden, fp32(z), rows);
+        require_launch(qwen_gated_rmsnorm_fp16_gamma_rows_cuda(
+                           fp32(core), fp16(layer.linear.norm), fp32(z), fp32(normalized),
+                           rows * value_heads, static_cast<int>(config.linear_attention.value_head_dim),
+                           static_cast<float>(config.rms_norm_eps)),
+                       "linear gated RMSNorm");
+        projection(layer.linear.out, fp32(normalized), output, rows);
+        all_reduce(output, rows * hidden_size);
+        (void)position_offset;
+    }
+
+    void full_attention(DeviceLayer& layer, float* hidden, float* output, int rows,
+                        int position_offset) {
+        const int q_heads = static_cast<int>(config.full_attention.num_heads / options.tp_world);
+        const int total_kv_heads = static_cast<int>(config.full_attention.num_key_value_heads);
+        const int kv_heads = total_kv_heads / options.tp_world;
+        const int head_dim = static_cast<int>(config.full_attention.head_dim);
+        const int attention_dim = q_heads * head_dim;
+        const int q_proj_dim = attention_dim * 2;
+        const int kv_dim = total_kv_heads * head_dim;
+        QwenDeviceTensor q_proj, q, gate, k_full, v_full, k, v, q_norm, k_norm, attn, merged;
+        allocate_float(q_proj, static_cast<size_t>(rows) * q_proj_dim, {static_cast<uint64_t>(rows), static_cast<uint64_t>(q_proj_dim)});
+        allocate_float(q, static_cast<size_t>(rows) * attention_dim, {static_cast<uint64_t>(rows), static_cast<uint64_t>(attention_dim)});
+        allocate_float(gate, q.nbytes / sizeof(float), q.shape);
+        allocate_float(k_full, static_cast<size_t>(rows) * kv_dim, {static_cast<uint64_t>(rows), static_cast<uint64_t>(kv_dim)});
+        allocate_float(v_full, k_full.nbytes / sizeof(float), k_full.shape);
+        allocate_float(k, static_cast<size_t>(rows) * kv_heads * head_dim, {static_cast<uint64_t>(rows), static_cast<uint64_t>(kv_heads), static_cast<uint64_t>(head_dim)});
+        allocate_float(v, k.nbytes / sizeof(float), k.shape);
+        allocate_float(q_norm, q.nbytes / sizeof(float), q.shape);
+        allocate_float(k_norm, k.nbytes / sizeof(float), k.shape);
+        allocate_float(attn, q.nbytes / sizeof(float), q.shape);
+        allocate_float(merged, q.nbytes / sizeof(float), q.shape);
+        projection(layer.full.q, hidden, fp32(q_proj), rows);
+        require_launch(qwen_split_q_gate_cuda(fp32(q_proj), fp32(q), fp32(gate), rows, q_heads, head_dim), "full Q/gate split");
+        projection(layer.full.k, hidden, fp32(k_full), rows);
+        projection(layer.full.v, hidden, fp32(v_full), rows);
+        const int head_offset = (options.tp_rank * kv_heads);
+        require_launch(qwen_select_kv_heads_cuda(fp32(k_full), fp32(k), rows, total_kv_heads, kv_heads,
+                                                 head_dim, head_offset), "full K head select");
+        require_launch(qwen_select_kv_heads_cuda(fp32(v_full), fp32(v), rows, total_kv_heads, kv_heads,
+                                                 head_dim, head_offset), "full V head select");
+        norm(layer.full.q_norm, fp32(q), fp32(q_norm), rows * q_heads, head_dim);
+        norm(layer.full.k_norm, fp32(k), fp32(k_norm), rows * kv_heads, head_dim);
+        for (int t = 0; t < rows; ++t) {
+            require_launch(qwen_partial_rope_cuda(
+                               fp32(q_norm) + static_cast<size_t>(t) * attention_dim,
+                               fp32(k_norm) + static_cast<size_t>(t) * kv_heads * head_dim,
+                               position_offset + t, static_cast<int>(config.partial_rotary_dim()),
+                               static_cast<float>(config.rope_theta), q_heads, kv_heads, head_dim),
+                           "partial RoPE");
+        }
+        require_launch(qwen_append_kv_cache_cuda(
+                           fp32(k_norm), fp32(v), fp32(layer.full.k_cache), fp32(layer.full.v_cache),
+                           rows, kv_heads, head_dim, position_offset, max_context),
+                       "append full KV cache");
+        if (rows == 1) {
+            require_launch(qwen_gqa_decode_attention_cuda(
+                               fp32(q_norm), fp32(layer.full.k_cache), fp32(layer.full.v_cache),
+                               fp32(attn), q_heads, kv_heads, head_dim, position_offset + 1, max_context),
+                           "decode GQA");
+        } else {
+            require_launch(qwen_gqa_prefill_attention_cuda(
+                               fp32(q_norm), fp32(layer.full.k_cache), fp32(layer.full.v_cache),
+                               fp32(attn), rows, q_heads, kv_heads, head_dim, position_offset, max_context),
+                           "prefill GQA");
+        }
+        require_launch(qwen_sigmoid_mul_cuda(fp32(attn), fp32(gate), fp32(merged), rows * attention_dim),
+                       "full attention output gate");
+        projection(layer.full.out, fp32(merged), output, rows);
+        all_reduce(output, rows * static_cast<int>(config.hidden_size));
+    }
+
+    void layer_forward(DeviceLayer& layer, float* hidden, float* work, int rows, int position_offset) {
+        const int hidden_size = static_cast<int>(config.hidden_size);
+        QwenDeviceTensor normed, attn, post, gate, up, intermediate, mlp;
+        allocate_float(normed, static_cast<size_t>(rows) * hidden_size, {static_cast<uint64_t>(rows), static_cast<uint64_t>(hidden_size)});
+        allocate_float(attn, normed.nbytes / sizeof(float), normed.shape);
+        allocate_float(post, normed.nbytes / sizeof(float), normed.shape);
+        allocate_float(gate, static_cast<size_t>(rows) * layer.gate.weight.shape[0], {static_cast<uint64_t>(rows), layer.gate.weight.shape[0]});
+        allocate_float(up, gate.nbytes / sizeof(float), gate.shape);
+        allocate_float(intermediate, gate.nbytes / sizeof(float), gate.shape);
+        allocate_float(mlp, normed.nbytes / sizeof(float), normed.shape);
+        norm(layer.input_norm, hidden, fp32(normed), rows, hidden_size);
+        if (layer.linear.qkv.weight.data != nullptr) {
+            linear_attention(layer, fp32(normed), fp32(attn), rows, position_offset);
+        } else {
+            full_attention(layer, fp32(normed), fp32(attn), rows, position_offset);
+        }
+        check_cuda(cudaMemcpy(work, hidden, static_cast<size_t>(rows) * hidden_size * sizeof(float), cudaMemcpyDeviceToDevice),
+                   "Qwen residual copy");
+        add(work, fp32(attn), rows * hidden_size);
+        norm(layer.post_norm, work, fp32(post), rows, hidden_size);
+        projection(layer.gate, fp32(post), fp32(gate), rows);
+        projection(layer.up, fp32(post), fp32(up), rows);
+        require_launch(qwen_silu_mul_rows_cuda(fp32(gate), fp32(up), fp32(intermediate), rows,
+                                               static_cast<int>(layer.gate.weight.shape[0])),
+                       "Qwen SwiGLU");
+        projection(layer.down, fp32(intermediate), fp32(mlp), rows);
+        all_reduce(fp32(mlp), rows * hidden_size);
+        add(work, fp32(mlp), rows * hidden_size);
+        check_cuda(cudaMemcpy(hidden, work, static_cast<size_t>(rows) * hidden_size * sizeof(float), cudaMemcpyDeviceToDevice),
+                   "Qwen layer output copy");
+    }
+
+    void run_layers(float*& hidden, float*& work, int rows, int position_offset, int active_layers) {
+        for (int i = 0; i < active_layers; ++i) {
+            layer_forward(layers[static_cast<size_t>(i)], hidden, work, rows, position_offset);
+            std::swap(hidden, work);
+        }
+    }
+
+    QwenForwardResult logits_for(float* hidden, int rows, int last_row, int position_after, int active_layers) {
+        const int hidden_size = static_cast<int>(config.hidden_size);
+        const int local_vocab = static_cast<int>(lm_head.shape[0]);
+        QwenDeviceTensor normed;
+        allocate_float(normed, static_cast<size_t>(rows) * hidden_size, {static_cast<uint64_t>(rows), static_cast<uint64_t>(hidden_size)});
+        norm(final_norm, hidden, fp32(normed), rows, hidden_size);
+        QwenDeviceTensor selected;
+        allocate_float(selected, hidden_size, {static_cast<uint64_t>(hidden_size)});
+        check_cuda(cudaMemcpy(selected.data, static_cast<uint8_t*>(normed.data) +
+                                  static_cast<size_t>(last_row) * hidden_size * sizeof(float),
+                              hidden_size * sizeof(float), cudaMemcpyDeviceToDevice),
+                   "Qwen final row copy");
+        QwenDeviceTensor local_logits;
+        allocate_float(local_logits, local_vocab, {static_cast<uint64_t>(local_vocab)});
+        if (lm_head.device_dtype == SafeDType::F16) {
+            require_launch(qwen_fp16_matmul_rows_cuda(
+                               fp32(selected), fp16(lm_head), fp32(local_logits), 1, local_vocab,
+                               hidden_size, hidden_size, local_vocab, hidden_size),
+                           "Qwen lm head");
+        } else {
+            throw std::runtime_error("Qwen lm_head must be FP16 on Turing");
+        }
+        allocate(argmax_token, sizeof(int), {1}, SafeDType::I64);
+        allocate(argmax_logit, sizeof(float), {1}, SafeDType::F32);
+        const int vocab_start = static_cast<int>(weights_vocab_start());
+        require_launch(argmax_fp32_cuda(fp32(local_logits), static_cast<int*>(argmax_token.data),
+                                        fp32(argmax_logit), local_vocab, vocab_start),
+                       "Qwen local argmax");
+        check_cuda(cudaDeviceSynchronize(), "Qwen logits synchronization");
+        int local_token = 0;
+        float local_logit = 0.0f;
+        check_cuda(cudaMemcpy(&local_token, argmax_token.data, sizeof(local_token), cudaMemcpyDeviceToHost),
+                   "Qwen argmax token copy");
+        check_cuda(cudaMemcpy(&local_logit, argmax_logit.data, sizeof(local_logit), cudaMemcpyDeviceToHost),
+                   "Qwen argmax logit copy");
+        int top_token = local_token;
+        float top_logit = local_logit;
+#ifdef DSV4_HAVE_NCCL
+        if (options.tp_world > 1) {
+            if (options.nccl_id_path.empty()) throw std::runtime_error("Qwen TP requires --nccl-id-path");
+            const TpTopResult global = nccl_global_top1(options.tp_world, options.tp_rank, options.device,
+                                                        options.nccl_id_path.c_str(), local_token, local_logit);
+            top_token = global.token;
+            top_logit = global.logit;
+        }
+#else
+        if (options.tp_world > 1) throw std::runtime_error("Qwen TP requires an NCCL-enabled build");
+#endif
+        float checksum = local_logit;
+        QwenForwardResult result;
+        result.token = last_row >= 0 ? 0 : 0;
+        result.layers = active_layers;
+        result.dim = hidden_size;
+        result.logits = static_cast<int>(config.vocab_size);
+        result.top_token = top_token;
+        result.top_logit = top_logit;
+        result.checksum = checksum;
+        result.position = position_after;
+        return result;
+    }
+
+    uint64_t weights_vocab_start() const {
+        return static_cast<uint64_t>(options.tp_rank) * config.vocab_size / options.tp_world;
+    }
+
+    QwenForwardResult run(const std::vector<int>& token_ids, int position_offset, int active_layers,
+                          int last_row) {
+        if (token_ids.empty()) throw std::runtime_error("Qwen forward requires at least one token");
+        if (position_offset < 0 || position_offset + static_cast<int>(token_ids.size()) > max_context) {
+            throw std::runtime_error("Qwen context length exceeded");
+        }
+        const int rows = static_cast<int>(token_ids.size());
+        local_tokens = token_ids;
+        allocate(d_tokens, local_tokens.size() * sizeof(int), {static_cast<uint64_t>(rows)}, SafeDType::I64);
+        check_cuda(cudaMemcpy(d_tokens.data, local_tokens.data(), local_tokens.size() * sizeof(int), cudaMemcpyHostToDevice),
+                   "Qwen token upload");
+        const int hidden_size = static_cast<int>(config.hidden_size);
+        allocate_float(hidden_a, static_cast<size_t>(rows) * hidden_size, {static_cast<uint64_t>(rows), static_cast<uint64_t>(hidden_size)});
+        allocate_float(hidden_b, hidden_a.nbytes / sizeof(float), hidden_a.shape);
+        allocate_float(work_a, hidden_a.nbytes / sizeof(float), hidden_a.shape);
+        allocate_float(work_b, hidden_a.nbytes / sizeof(float), hidden_a.shape);
+        require_launch(qwen_embedding_fp16_gather_cuda(
+                           fp16(embed), static_cast<int*>(d_tokens.data), fp32(hidden_a), rows, hidden_size,
+                           static_cast<int>(weights_vocab_start()), static_cast<int>(embed.shape[0])),
+                       "Qwen embedding lookup");
+        all_reduce(fp32(hidden_a), rows * hidden_size);
+        float* hidden = fp32(hidden_a);
+        float* work = fp32(hidden_b);
+        for (int i = 0; i < active_layers; ++i) {
+            layer_forward(layers[static_cast<size_t>(i)], hidden, work, rows, position_offset);
+            std::swap(hidden, work);
+        }
+        QwenForwardResult result = logits_for(hidden, rows, last_row, position_offset + rows, active_layers);
+        return result;
+    }
+};
+
+QwenEngine::QwenEngine(const std::string& ckpt_dir, const QwenEngineOptions& options,
+                       int layer_count, int max_context)
+    : ckpt_dir_(ckpt_dir), options_(options), config_(QwenConfig::from_hf_config(ckpt_dir)),
+      index_(ckpt_dir), weights_(index_, config_, options.tp_world, options.tp_rank) {
+    if (options_.device < 0) options_.device = options_.tp_rank;
+    if (cudaSetDevice(options_.device) != cudaSuccess) throw std::runtime_error("failed to set Qwen CUDA device");
+    if (layer_count <= 0) active_layers_ = static_cast<int>(config_.num_hidden_layers);
+    else if (layer_count <= static_cast<int>(config_.num_hidden_layers)) active_layers_ = layer_count;
+    else throw std::runtime_error("Qwen layer count exceeds model depth");
+    max_context_ = max_context > 0 ? max_context : static_cast<int>(config_.max_position_embeddings);
+    if (max_context_ > static_cast<int>(config_.max_position_embeddings)) {
+        throw std::runtime_error("Qwen max context exceeds model configuration");
+    }
+    impl_ = new Impl(index_, config_, weights_, options_, max_context_, active_layers_);
+    resident_weight_bytes_ = impl_->uploaded_weight_bytes;
+    resident_scale_bytes_ = impl_->uploaded_scale_bytes;
+}
+
+QwenEngine::~QwenEngine() {
+    delete impl_;
+    impl_ = nullptr;
+}
+
+void QwenEngine::reset() {
+    position_ = 0;
+    for (DeviceLayer& layer : impl_->layers) {
+        if (layer.linear.state.data != nullptr) {
+            zero_tensor(layer.linear.state);
+            zero_tensor(layer.linear.conv_tail);
+        }
+        if (layer.full.k_cache.data != nullptr) {
+            zero_tensor(layer.full.k_cache);
+            zero_tensor(layer.full.v_cache);
+        }
+    }
+}
+
+QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids) {
+    reset();
+    QwenForwardResult result = impl_->run(token_ids, 0, active_layers_, static_cast<int>(token_ids.size()) - 1);
+    position_ = static_cast<int>(token_ids.size());
+    return result;
+}
+
+QwenForwardResult QwenEngine::decode_step(int token_id) {
+    QwenForwardResult result = impl_->run({token_id}, position_, active_layers_, 0);
+    ++position_;
+    return result;
+}
+
+std::vector<QwenForwardResult> QwenEngine::generate(const std::vector<int>& prompt_ids,
+                                                    int max_new_tokens) {
+    if (max_new_tokens <= 0) return {};
+    QwenForwardResult next = prefill(prompt_ids);
+    std::vector<QwenForwardResult> results;
+    results.reserve(static_cast<size_t>(max_new_tokens));
+    for (int i = 0; i < max_new_tokens; ++i) {
+        results.push_back(next);
+        if (i + 1 < max_new_tokens) next = decode_step(next.top_token);
+    }
+    return results;
+}
+
+}  // namespace dsv4

--- a/cpp_engine/src/qwen_weights.cpp
+++ b/cpp_engine/src/qwen_weights.cpp
@@ -1,0 +1,551 @@
+#include "qwen_weights.hpp"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstring>
+#include <sstream>
+#include <stdexcept>
+
+namespace dsv4 {
+namespace {
+
+uint64_t ceil_div(uint64_t value, uint64_t divisor) {
+    return (value + divisor - 1) / divisor;
+}
+
+std::string shape_string(const std::vector<uint64_t>& shape) {
+    std::ostringstream out;
+    out << '[';
+    for (size_t i = 0; i < shape.size(); ++i) {
+        if (i) out << ',';
+        out << shape[i];
+    }
+    out << ']';
+    return out.str();
+}
+
+void require_tp(int world, int rank) {
+    if (world <= 0) throw std::runtime_error("Qwen TP world must be positive");
+    if (rank < 0 || rank >= world) throw std::runtime_error("Qwen TP rank is out of range");
+}
+
+void shard_range(uint64_t total, int world, int rank, uint64_t* start, uint64_t* size) {
+    if (total == 0 || total % static_cast<uint64_t>(world) != 0) {
+        throw std::runtime_error("Qwen tensor dimension is not divisible by TP world");
+    }
+    *size = total / static_cast<uint64_t>(world);
+    *start = *size * static_cast<uint64_t>(rank);
+}
+
+}  // namespace
+
+SafeDType qwen_device_dtype(SafeDType storage_dtype) {
+    // RTX 2080 Ti has no native BF16 arithmetic/storage path. Keep FP8 codes
+    // compressed for online unpack, and materialize every checkpoint BF16 tensor
+    // as FP16 before uploading it to the device.
+    return storage_dtype == SafeDType::BF16 ? SafeDType::F16 : storage_dtype;
+}
+
+uint16_t qwen_bf16_to_fp16_bits(uint16_t bits) {
+    // Widen the BF16 value to an IEEE FP32 bit pattern and use the standard
+    // round-to-nearest-even FP32 -> FP16 conversion. This handles subnormals,
+    // infinities, NaNs, and overflow without relying on host compiler half types.
+    const uint32_t value = static_cast<uint32_t>(bits) << 16;
+    const uint32_t sign = (value >> 16) & 0x8000u;
+    const int exponent = static_cast<int>((value >> 23) & 0xffu) - 127 + 15;
+    uint32_t mantissa = value & 0x007fffffu;
+    if (exponent <= 0) {
+        if (exponent < -10) return static_cast<uint16_t>(sign);
+        mantissa |= 0x00800000u;
+        const int shift = 14 - exponent;
+        uint32_t half_mantissa = mantissa >> shift;
+        const uint32_t remainder = mantissa & ((1u << shift) - 1u);
+        const uint32_t halfway = 1u << (shift - 1);
+        if (remainder > halfway || (remainder == halfway && (half_mantissa & 1u))) ++half_mantissa;
+        return static_cast<uint16_t>(sign | half_mantissa);
+    }
+    if (exponent >= 31) return static_cast<uint16_t>(sign | 0x7c00u);
+    uint32_t half_mantissa = mantissa >> 13;
+    const uint32_t remainder = mantissa & 0x1fffu;
+    if (remainder > 0x1000u || (remainder == 0x1000u && (half_mantissa & 1u))) {
+        ++half_mantissa;
+        if (half_mantissa == 0x400u) {
+            half_mantissa = 0;
+            if (exponent + 1 >= 31) return static_cast<uint16_t>(sign | 0x7c00u);
+            return static_cast<uint16_t>(sign | (static_cast<uint32_t>(exponent + 1) << 10));
+        }
+    }
+    return static_cast<uint16_t>(sign | (static_cast<uint32_t>(exponent) << 10) | half_mantissa);
+}
+
+void qwen_convert_bf16_to_fp16(const uint16_t* src, uint16_t* dst, size_t count) {
+    if (src == nullptr || dst == nullptr) throw std::invalid_argument("null BF16/FP16 conversion buffer");
+    for (size_t i = 0; i < count; ++i) dst[i] = qwen_bf16_to_fp16_bits(src[i]);
+}
+
+QwenDeviceTensor::~QwenDeviceTensor() {
+    if (data != nullptr) cudaFree(data);
+}
+
+QwenDeviceTensor::QwenDeviceTensor(QwenDeviceTensor&& other) noexcept
+    : data(other.data), device_dtype(other.device_dtype), shape(std::move(other.shape)), nbytes(other.nbytes) {
+    other.data = nullptr;
+    other.nbytes = 0;
+    other.device_dtype = SafeDType::Unknown;
+}
+
+QwenDeviceTensor& QwenDeviceTensor::operator=(QwenDeviceTensor&& other) noexcept {
+    if (this == &other) return *this;
+    if (data != nullptr) cudaFree(data);
+    data = other.data;
+    device_dtype = other.device_dtype;
+    shape = std::move(other.shape);
+    nbytes = other.nbytes;
+    other.data = nullptr;
+    other.nbytes = 0;
+    other.device_dtype = SafeDType::Unknown;
+    return *this;
+}
+
+QwenHostTensor qwen_materialize_host_tensor(const SafeTensorsIndex& index,
+                                            const QwenTensorRef& ref) {
+    if (!ref.found) throw std::runtime_error("cannot materialize an absent Qwen tensor: " + ref.name);
+    if (ref.full_shape.empty() || ref.local_shape.empty()) {
+        throw std::runtime_error("cannot materialize empty Qwen tensor shape: " + ref.name);
+    }
+    SafeTensorsShard shard(index.shard_path(ref.shard_name));
+    const SafeTensorInfo* info = shard.find_tensor(ref.name);
+    if (info == nullptr) throw std::runtime_error("Qwen tensor missing while materializing: " + ref.name);
+    if (info->shape != ref.full_shape || info->dtype != ref.dtype) {
+        throw std::runtime_error("Qwen tensor metadata changed while materializing: " + ref.name);
+    }
+
+    QwenHostTensor out;
+    out.storage_dtype = ref.dtype;
+    out.device_dtype = ref.device_dtype;
+    out.shape = ref.local_shape;
+    const uint64_t output_numel = safe_tensor_numel(ref.local_shape);
+    const uint64_t device_item_size = safe_dtype_size(ref.device_dtype);
+    out.bytes.resize(static_cast<size_t>(output_numel * device_item_size));
+    const uint64_t source_item_size = safe_dtype_size(ref.dtype);
+    if (source_item_size == 0 || device_item_size == 0) {
+        throw std::runtime_error("unsupported Qwen materialization dtype: " + ref.name);
+    }
+
+    const uint8_t* source = shard.tensor_data(*info);
+    uint8_t* destination = out.bytes.data();
+    const uint64_t source_row_numel = safe_tensor_numel(
+        std::vector<uint64_t>(ref.full_shape.begin() + 1, ref.full_shape.end()));
+    const uint64_t local_row_numel = safe_tensor_numel(
+        std::vector<uint64_t>(ref.local_shape.begin() + 1, ref.local_shape.end()));
+    const uint64_t source_row_bytes = source_row_numel * source_item_size;
+    const uint64_t local_row_bytes = local_row_numel * device_item_size;
+
+    auto copy_bytes = [&](const uint8_t* src, uint8_t* dst, uint64_t elements) {
+        if (ref.dtype == SafeDType::BF16) {
+            if (ref.device_dtype != SafeDType::F16) {
+                throw std::runtime_error("Qwen BF16 tensor has non-FP16 device dtype: " + ref.name);
+            }
+            qwen_convert_bf16_to_fp16(reinterpret_cast<const uint16_t*>(src),
+                                      reinterpret_cast<uint16_t*>(dst),
+                                      static_cast<size_t>(elements));
+        } else {
+            std::memcpy(dst, src, static_cast<size_t>(elements * source_item_size));
+        }
+    };
+
+    const bool packed = ref.rule == QwenShardRule::PackedQkvColumnParallel ||
+                        ref.rule == QwenShardRule::PackedConvChannelParallel;
+    if (packed) {
+        if (ref.segments.empty() || ref.full_shape[0] == 0 || ref.local_shape[0] == 0) {
+            throw std::runtime_error("Qwen packed tensor has no segments: " + ref.name);
+        }
+        uint64_t output_row = 0;
+        for (const auto& segment : ref.segments) {
+            const uint64_t source_row = segment.first;
+            const uint64_t rows = segment.second;
+            if (source_row + rows > ref.full_shape[0] || output_row + rows > ref.local_shape[0]) {
+                throw std::runtime_error("Qwen packed tensor segment is out of bounds: " + ref.name);
+            }
+            copy_bytes(source + source_row * source_row_bytes,
+                       destination + output_row * local_row_bytes,
+                       rows * source_row_numel);
+            output_row += rows;
+        }
+        if (output_row != ref.local_shape[0]) {
+            throw std::runtime_error("Qwen packed tensor segments do not fill local shape: " + ref.name);
+        }
+        return out;
+    }
+
+    const int shard_dim = ref.shard_dim;
+    if (ref.rule == QwenShardRule::Replicated || ref.shard_size == 0) {
+        copy_bytes(source, destination, safe_tensor_numel(ref.full_shape));
+        return out;
+    }
+    if (shard_dim < 0 || static_cast<size_t>(shard_dim) >= ref.full_shape.size()) {
+        throw std::runtime_error("Qwen materialization has invalid shard dimension: " + ref.name);
+    }
+    if (shard_dim == 0) {
+        const uint64_t rows = ref.shard_size;
+        if (ref.shard_start + rows > ref.full_shape[0] || ref.local_shape[0] != rows) {
+            throw std::runtime_error("Qwen dim-0 shard shape mismatch: " + ref.name);
+        }
+        copy_bytes(source + ref.shard_start * source_row_bytes, destination,
+                   rows * source_row_numel);
+        return out;
+    }
+    if (shard_dim == 1 && ref.full_shape.size() == 2) {
+        const uint64_t rows = ref.full_shape[0];
+        const uint64_t source_cols = ref.full_shape[1];
+        const uint64_t local_cols = ref.local_shape[1];
+        if (ref.shard_start + ref.shard_size > source_cols || local_cols != ref.shard_size) {
+            throw std::runtime_error("Qwen dim-1 shard shape mismatch: " + ref.name);
+        }
+        for (uint64_t row = 0; row < rows; ++row) {
+            const uint8_t* src = source + row * source_cols * source_item_size +
+                                 ref.shard_start * source_item_size;
+            uint8_t* dst = destination + row * local_cols * device_item_size;
+            copy_bytes(src, dst, local_cols);
+        }
+        return out;
+    }
+    throw std::runtime_error("unsupported Qwen materialization rank/dimension: " + ref.name);
+}
+
+QwenDeviceTensor qwen_upload_tensor_cuda(const SafeTensorsIndex& index,
+                                         const QwenTensorRef& ref,
+                                         void* stream) {
+    QwenHostTensor host = qwen_materialize_host_tensor(index, ref);
+    QwenDeviceTensor device;
+    device.device_dtype = host.device_dtype;
+    device.shape = host.shape;
+    device.nbytes = host.bytes.size();
+    if (device.nbytes == 0 || cudaMalloc(&device.data, device.nbytes) != cudaSuccess) {
+        throw std::runtime_error("failed to allocate Qwen device tensor: " + ref.name);
+    }
+    const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
+    const cudaError_t status = cudaMemcpyAsync(device.data, host.bytes.data(), device.nbytes,
+                                               cudaMemcpyHostToDevice, cuda_stream);
+    if (status != cudaSuccess) {
+        cudaFree(device.data);
+        device.data = nullptr;
+        device.nbytes = 0;
+        throw std::runtime_error("failed to upload Qwen device tensor: " + ref.name);
+    }
+    return device;
+}
+
+namespace {
+
+QwenTensorRef make_ref(const std::string& name, const std::string& shard_name,
+                       const SafeTensorInfo& info, QwenShardRule rule,
+                       int shard_dim, uint64_t start, uint64_t size,
+                       const std::vector<uint64_t>& local_shape) {
+    QwenTensorRef ref;
+    ref.name = name;
+    ref.shard_name = shard_name;
+    ref.dtype = info.dtype;
+    ref.device_dtype = qwen_device_dtype(info.dtype);
+    ref.full_shape = info.shape;
+    ref.local_shape = local_shape;
+    ref.rule = rule;
+    ref.shard_dim = shard_dim;
+    ref.shard_start = start;
+    ref.shard_size = size;
+    ref.nbytes = safe_tensor_numel(local_shape) * safe_dtype_size(info.dtype);
+    ref.device_nbytes = safe_tensor_numel(local_shape) * safe_dtype_size(ref.device_dtype);
+    ref.found = true;
+    return ref;
+}
+
+}  // namespace
+
+const char* qwen_shard_rule_name(QwenShardRule rule) {
+    switch (rule) {
+        case QwenShardRule::Replicated: return "replicated";
+        case QwenShardRule::ColumnParallel: return "column_parallel";
+        case QwenShardRule::RowParallel: return "row_parallel";
+        case QwenShardRule::ParallelEmbedding: return "parallel_embedding";
+        case QwenShardRule::ParallelHead: return "parallel_head";
+        case QwenShardRule::PackedQkvColumnParallel: return "packed_qkv_column_parallel";
+        case QwenShardRule::PackedConvChannelParallel: return "packed_conv_channel_parallel";
+    }
+    return "unknown";
+}
+
+QwenWeightMap::QwenWeightMap(const SafeTensorsIndex& index, const QwenConfig& config,
+                             int tp_world, int tp_rank)
+    : index_(index), config_(config), tp_world_(tp_world), tp_rank_(tp_rank) {
+    require_tp(tp_world_, tp_rank_);
+    embed_tokens_ = require_tensor(
+        "model.language_model.embed_tokens.weight", SafeDType::BF16,
+        {config_.vocab_size, config_.hidden_size}, QwenShardRule::ParallelEmbedding, 0);
+    final_norm_ = require_tensor(
+        "model.language_model.norm.weight", SafeDType::BF16,
+        {config_.hidden_size}, QwenShardRule::Replicated, -1);
+    lm_head_ = require_tensor(
+        "lm_head.weight", SafeDType::BF16,
+        {config_.vocab_size, config_.hidden_size}, QwenShardRule::ParallelHead, 0);
+
+    layers_.reserve(config_.num_hidden_layers);
+    for (uint64_t layer_id = 0; layer_id < config_.num_hidden_layers; ++layer_id) {
+        const std::string prefix = "model.language_model.layers." + std::to_string(layer_id) + ".";
+        QwenLayerWeights layer;
+        layer.input_layernorm = require_tensor(prefix + "input_layernorm.weight", SafeDType::BF16,
+                                               {config_.hidden_size});
+        layer.post_attention_layernorm = require_tensor(prefix + "post_attention_layernorm.weight", SafeDType::BF16,
+                                                        {config_.hidden_size});
+        if (config_.layer_types[layer_id] == QwenLayerType::LinearAttention) {
+            const auto& linear = config_.linear_attention;
+            const uint64_t key_dim = linear.key_heads * linear.key_head_dim;
+            const uint64_t value_dim = linear.value_heads * linear.value_head_dim;
+            layer.linear_attention.in_proj_qkv = require_linear(
+                prefix + "linear_attn.in_proj_qkv.weight",
+                {2 * key_dim + value_dim, config_.hidden_size},
+                QwenShardRule::PackedQkvColumnParallel, 0);
+            layer.linear_attention.in_proj_z = require_linear(
+                prefix + "linear_attn.in_proj_z.weight", {value_dim, config_.hidden_size},
+                QwenShardRule::ColumnParallel, 0);
+            layer.linear_attention.out_proj = require_linear(
+                prefix + "linear_attn.out_proj.weight", {config_.hidden_size, value_dim},
+                QwenShardRule::RowParallel, 1);
+            layer.linear_attention.in_proj_a = require_linear(
+                prefix + "linear_attn.in_proj_a.weight", {linear.value_heads, config_.hidden_size},
+                QwenShardRule::ColumnParallel, 0, SafeDType::BF16);
+            layer.linear_attention.in_proj_b = require_linear(
+                prefix + "linear_attn.in_proj_b.weight", {linear.value_heads, config_.hidden_size},
+                QwenShardRule::ColumnParallel, 0, SafeDType::BF16);
+            layer.linear_attention.conv1d = require_tensor(
+                prefix + "linear_attn.conv1d.weight", SafeDType::BF16,
+                {2 * key_dim + value_dim, 1, linear.conv_kernel_dim},
+                QwenShardRule::PackedConvChannelParallel, 0);
+            layer.linear_attention.a_log = require_tensor(
+                prefix + "linear_attn.A_log", SafeDType::BF16, {linear.value_heads},
+                QwenShardRule::ColumnParallel, 0);
+            layer.linear_attention.dt_bias = require_tensor(
+                prefix + "linear_attn.dt_bias", SafeDType::BF16, {linear.value_heads},
+                QwenShardRule::ColumnParallel, 0);
+            layer.linear_attention.norm = require_tensor(
+                prefix + "linear_attn.norm.weight", SafeDType::BF16, {linear.value_head_dim});
+        } else {
+            const auto& full = config_.full_attention;
+            const uint64_t attention_dim = full.num_heads * full.head_dim;
+            const uint64_t q_dim = attention_dim * (full.output_gate ? 2 : 1);
+            const uint64_t kv_dim = full.num_key_value_heads * full.head_dim;
+            layer.full_attention.q_proj = require_linear(
+                prefix + "self_attn.q_proj.weight", {q_dim, config_.hidden_size},
+                QwenShardRule::ColumnParallel, 0);
+            layer.full_attention.k_proj = require_linear(
+                prefix + "self_attn.k_proj.weight", {kv_dim, config_.hidden_size},
+                QwenShardRule::Replicated, -1);
+            layer.full_attention.v_proj = require_linear(
+                prefix + "self_attn.v_proj.weight", {kv_dim, config_.hidden_size},
+                QwenShardRule::Replicated, -1);
+            layer.full_attention.o_proj = require_linear(
+                prefix + "self_attn.o_proj.weight", {config_.hidden_size, attention_dim},
+                QwenShardRule::RowParallel, 1);
+            layer.full_attention.q_norm = require_tensor(
+                prefix + "self_attn.q_norm.weight", SafeDType::BF16, {full.head_dim});
+            layer.full_attention.k_norm = require_tensor(
+                prefix + "self_attn.k_norm.weight", SafeDType::BF16, {full.head_dim});
+        }
+
+        const std::string mlp_prefix = prefix + "mlp.";
+        layer.mlp.gate_proj = require_linear(
+            mlp_prefix + "gate_proj.weight", {config_.mlp.intermediate_size, config_.hidden_size},
+            QwenShardRule::ColumnParallel, 0);
+        layer.mlp.up_proj = require_linear(
+            mlp_prefix + "up_proj.weight", {config_.mlp.intermediate_size, config_.hidden_size},
+            QwenShardRule::ColumnParallel, 0);
+        layer.mlp.down_proj = require_linear(
+            mlp_prefix + "down_proj.weight", {config_.hidden_size, config_.mlp.intermediate_size},
+            QwenShardRule::RowParallel, 1);
+        layers_.push_back(std::move(layer));
+    }
+    auto count_ref = [this](const QwenTensorRef& ref, bool scale) { record(ref, scale); };
+    count_ref(embed_tokens_, false);
+    count_ref(final_norm_, false);
+    count_ref(lm_head_, false);
+    for (const auto& layer : layers_) {
+        count_ref(layer.input_layernorm, false);
+        count_ref(layer.post_attention_layernorm, false);
+        const auto count_linear = [&count_ref](const QwenLinearRef& linear) {
+            if (linear.weight.found) count_ref(linear.weight, false);
+            if (linear.has_scale) count_ref(linear.scale, true);
+        };
+        if (layer.linear_attention.in_proj_qkv.weight.found) {
+            count_linear(layer.linear_attention.in_proj_qkv);
+            count_linear(layer.linear_attention.in_proj_z);
+            count_linear(layer.linear_attention.out_proj);
+            count_linear(layer.linear_attention.in_proj_a);
+            count_linear(layer.linear_attention.in_proj_b);
+            count_ref(layer.linear_attention.conv1d, false);
+            count_ref(layer.linear_attention.a_log, false);
+            count_ref(layer.linear_attention.dt_bias, false);
+            count_ref(layer.linear_attention.norm, false);
+        } else {
+            count_linear(layer.full_attention.q_proj);
+            count_linear(layer.full_attention.k_proj);
+            count_linear(layer.full_attention.v_proj);
+            count_linear(layer.full_attention.o_proj);
+            count_ref(layer.full_attention.q_norm, false);
+            count_ref(layer.full_attention.k_norm, false);
+        }
+        count_linear(layer.mlp.gate_proj);
+        count_linear(layer.mlp.up_proj);
+        count_linear(layer.mlp.down_proj);
+    }
+}
+QwenTensorRef QwenWeightMap::require_tensor(const std::string& name, SafeDType dtype,
+                                            const std::vector<uint64_t>& shape,
+                                            QwenShardRule rule, int shard_dim) const {
+    const std::string* shard_name = index_.shard_for_tensor(name);
+    if (shard_name == nullptr) throw std::runtime_error("Qwen tensor not in checkpoint index: " + name);
+    SafeTensorsShard shard(index_.shard_path(*shard_name));
+    const SafeTensorInfo* info = shard.find_tensor(name);
+    if (info == nullptr) throw std::runtime_error("Qwen tensor missing from shard header: " + name);
+    if (info->dtype != dtype) {
+        throw std::runtime_error("unexpected dtype for " + name + " expected=" + safe_dtype_name(dtype) +
+                                 " actual=" + safe_dtype_name(info->dtype));
+    }
+    if (info->shape != shape) {
+        throw std::runtime_error("unexpected shape for " + name + " expected=" + shape_string(shape) +
+                                 " actual=" + shape_string(info->shape));
+    }
+
+    std::vector<uint64_t> local_shape = shape;
+    uint64_t start = 0;
+    uint64_t size = 0;
+    if (rule == QwenShardRule::Replicated) {
+        size = shard_dim < 0 ? 0 : shape[static_cast<size_t>(shard_dim)];
+    } else if (rule == QwenShardRule::PackedQkvColumnParallel ||
+               rule == QwenShardRule::PackedConvChannelParallel) {
+        const uint64_t key_dim = config_.linear_attention.key_heads * config_.linear_attention.key_head_dim;
+        const uint64_t value_dim = config_.linear_attention.value_heads * config_.linear_attention.value_head_dim;
+        const uint64_t segments[] = {key_dim, key_dim, value_dim};
+        uint64_t source_offset = 0;
+        uint64_t local_total = 0;
+        QwenTensorRef ref;
+        for (uint64_t segment : segments) {
+            uint64_t segment_start = 0;
+            uint64_t segment_size = 0;
+            shard_range(segment, tp_world_, tp_rank_, &segment_start, &segment_size);
+            ref.segments.emplace_back(source_offset + segment_start, segment_size);
+            source_offset += segment;
+            local_total += segment_size;
+        }
+        local_shape[0] = local_total;
+        size = local_total;
+        ref = make_ref(name, *shard_name, *info, rule, shard_dim, 0, size, local_shape);
+        ref.segments.clear();
+        source_offset = 0;
+        for (uint64_t segment : segments) {
+            uint64_t segment_start = 0;
+            uint64_t segment_size = 0;
+            shard_range(segment, tp_world_, tp_rank_, &segment_start, &segment_size);
+            ref.segments.emplace_back(source_offset + segment_start, segment_size);
+            source_offset += segment;
+        }
+        return ref;
+    } else if (shard_dim >= 0) {
+        if (static_cast<size_t>(shard_dim) >= shape.size()) throw std::runtime_error("invalid Qwen shard dimension");
+        shard_range(shape[static_cast<size_t>(shard_dim)], tp_world_, tp_rank_, &start, &size);
+        local_shape[static_cast<size_t>(shard_dim)] = size;
+    } else {
+        throw std::runtime_error("Qwen non-replicated tensor has no shard dimension: " + name);
+    }
+    return make_ref(name, *shard_name, *info, rule, shard_dim, start, size, local_shape);
+}
+
+QwenLinearRef QwenWeightMap::require_linear(const std::string& name,
+                                            const std::vector<uint64_t>& shape,
+                                            QwenShardRule rule, int shard_dim,
+                                            SafeDType weight_dtype) const {
+    QwenLinearRef result;
+    result.weight = require_tensor(name, weight_dtype, shape, rule, shard_dim);
+    if (weight_dtype != SafeDType::F8_E4M3) return result;
+
+    const std::string suffix = ".weight";
+    const std::string scale_name =
+        name.size() >= suffix.size() && name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0
+            ? name.substr(0, name.size() - suffix.size()) + ".weight_scale_inv"
+            : name + ".weight_scale_inv";
+    const std::string* shard_name = index_.shard_for_tensor(scale_name);
+    if (shard_name == nullptr) throw std::runtime_error("Qwen FP8 scale not in checkpoint index: " + scale_name);
+    SafeTensorsShard shard(index_.shard_path(*shard_name));
+    const SafeTensorInfo* scale_info = shard.find_tensor(scale_name);
+    if (scale_info == nullptr) throw std::runtime_error("Qwen FP8 scale missing from shard header: " + scale_name);
+    if (scale_info->dtype != SafeDType::BF16) throw std::runtime_error("Qwen FP8 scale must be BF16: " + scale_name);
+    const std::vector<uint64_t> full_scale_shape = {ceil_div(shape[0], config_.fp8_block_size),
+                                                    ceil_div(shape[1], config_.fp8_block_size)};
+    if (scale_info->shape != full_scale_shape) {
+        throw std::runtime_error("unexpected Qwen FP8 scale shape for " + scale_name +
+                                 " expected=" + shape_string(full_scale_shape) +
+                                 " actual=" + shape_string(scale_info->shape));
+    }
+
+    std::vector<uint64_t> local_scale_shape = full_scale_shape;
+    uint64_t scale_start = 0;
+    uint64_t scale_size = 0;
+    QwenTensorRef scale_ref;
+    if (rule == QwenShardRule::Replicated) {
+        // No dimension is sharded, so every rank consumes the complete scale.
+        scale_ref = make_ref(scale_name, *shard_name, *scale_info, rule, shard_dim,
+                             0, 0, local_scale_shape);
+    } else if (rule == QwenShardRule::RowParallel) {
+        shard_range(shape[1], tp_world_, tp_rank_, &scale_start, &scale_size);
+        if (scale_start % config_.fp8_block_size != 0 || scale_size % config_.fp8_block_size != 0) {
+            throw std::runtime_error("Qwen row-parallel FP8 shard is not scale-block aligned: " + name);
+        }
+        local_scale_shape[1] = scale_size / config_.fp8_block_size;
+        scale_ref = make_ref(scale_name, *shard_name, *scale_info, rule, shard_dim,
+                             scale_start / config_.fp8_block_size,
+                             scale_size / config_.fp8_block_size, local_scale_shape);
+    } else if (rule == QwenShardRule::PackedQkvColumnParallel) {
+        const uint64_t key_dim = config_.linear_attention.key_heads * config_.linear_attention.key_head_dim;
+        const uint64_t value_dim = config_.linear_attention.value_heads * config_.linear_attention.value_head_dim;
+        const uint64_t segments[] = {key_dim, key_dim, value_dim};
+        uint64_t source_offset = 0;
+        uint64_t local_rows = 0;
+        std::vector<std::pair<uint64_t, uint64_t>> scale_segments;
+        for (uint64_t segment : segments) {
+            uint64_t segment_start = 0;
+            uint64_t segment_size = 0;
+            shard_range(segment, tp_world_, tp_rank_, &segment_start, &segment_size);
+            if (segment_start % config_.fp8_block_size != 0 || segment_size % config_.fp8_block_size != 0) {
+                throw std::runtime_error("Qwen packed QKV shard is not scale-block aligned: " + name);
+            }
+            scale_segments.emplace_back(source_offset / config_.fp8_block_size +
+                                            segment_start / config_.fp8_block_size,
+                                        segment_size / config_.fp8_block_size);
+            source_offset += segment;
+            local_rows += segment_size / config_.fp8_block_size;
+        }
+        local_scale_shape[0] = local_rows;
+        scale_ref = make_ref(scale_name, *shard_name, *scale_info, rule, shard_dim,
+                             0, local_rows, local_scale_shape);
+        scale_ref.segments = std::move(scale_segments);
+    } else {
+        shard_range(shape[0], tp_world_, tp_rank_, &scale_start, &scale_size);
+        if (scale_start % config_.fp8_block_size != 0 || scale_size % config_.fp8_block_size != 0) {
+            throw std::runtime_error("Qwen column-parallel FP8 shard is not scale-block aligned: " + name);
+        }
+        local_scale_shape[0] = scale_size / config_.fp8_block_size;
+        scale_ref = make_ref(scale_name, *shard_name, *scale_info, rule, shard_dim,
+                             scale_start / config_.fp8_block_size,
+                             scale_size / config_.fp8_block_size, local_scale_shape);
+    }
+    result.scale = std::move(scale_ref);
+    result.has_scale = true;
+    return result;
+}
+
+void QwenWeightMap::record(const QwenTensorRef& ref, bool scale) {
+    ++tensor_count_;
+    if (scale) local_scale_bytes_ += ref.nbytes;
+    else local_weight_bytes_ += ref.nbytes;
+}
+
+}  // namespace dsv4

--- a/cpp_engine/src/tensor.cpp
+++ b/cpp_engine/src/tensor.cpp
@@ -9,6 +9,7 @@ std::string dtype_name(DType dtype) {
         case DType::F32: return "f32";
         case DType::F16: return "f16";
         case DType::BF16: return "bf16";
+        case DType::F8_E4M3: return "f8_e4m3";
         case DType::Q8_0: return "q8_0";
         case DType::Q2_K: return "q2_k";
         case DType::IQ2_XXS: return "iq2_xxs";

--- a/cpp_engine/src/weight_source.cpp
+++ b/cpp_engine/src/weight_source.cpp
@@ -15,7 +15,9 @@ bool ends_with(const std::string& s, const std::string& suffix) {
 DType safe_dtype_to_dtype(SafeDType s) {
     switch (s) {
         case SafeDType::BF16: return DType::BF16;
+        case SafeDType::F16: return DType::F16;
         case SafeDType::F32: return DType::F32;
+        case SafeDType::F8_E4M3: return DType::F8_E4M3;
         default: return DType::Unknown;
     }
 }

--- a/cpp_engine/tests/bench_qwen_fp8_kernels.cpp
+++ b/cpp_engine/tests/bench_qwen_fp8_kernels.cpp
@@ -1,0 +1,135 @@
+// Micro-benchmark for the Qwen online-unpack FP8 kernels at real Qwen3.8-27B
+// TP4 shard shapes. Reports the optimized warp/tile path against the original
+// block-per-row reduction so the speedup is measured, not asserted.
+
+#include "cuda_ops.hpp"
+#include "qwen_cuda_ops.hpp"
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr int kBlock = 128;
+
+struct Buffers {
+    float* x = nullptr;
+    uint8_t* w = nullptr;
+    uint16_t* s = nullptr;
+    float* y = nullptr;
+    ~Buffers() {
+        cudaFree(x);
+        cudaFree(w);
+        cudaFree(s);
+        cudaFree(y);
+    }
+};
+
+double time_ms(void (*fn)(const Buffers&, int, int, int, int), const Buffers& b,
+               int batch, int rows, int cols, int scale_cols, int iters) {
+    fn(b, batch, rows, cols, scale_cols);  // warmup
+    cudaDeviceSynchronize();
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+    cudaEventRecord(start);
+    for (int i = 0; i < iters; ++i) fn(b, batch, rows, cols, scale_cols);
+    cudaEventRecord(stop);
+    cudaEventSynchronize(stop);
+    float ms = 0.0f;
+    cudaEventElapsedTime(&ms, start, stop);
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+    return static_cast<double>(ms) / iters;
+}
+
+void run_opt(const Buffers& b, int batch, int rows, int cols, int scale_cols) {
+    if (batch == 1) {
+        dsv4::qwen_fp8_e4m3_fp16scale_matvec_cuda(b.x, b.w, b.s, b.y, rows, cols, cols, scale_cols);
+    } else {
+        dsv4::qwen_fp8_e4m3_fp16scale_matmul_rows_cuda(b.x, b.w, b.s, b.y, batch, rows, cols,
+                                                       cols, rows, cols, scale_cols);
+    }
+}
+
+// Forces the legacy block-per-row kernel by making the stride non-multiple-of-4
+// unreachable; instead we call the reference path via a stride+1 shim buffer.
+void run_ref(const Buffers& b, int batch, int rows, int cols, int scale_cols) {
+    // cols-1 keeps the same reduction structure while landing on the fallback
+    // branch (stride not divisible by 4 is checked on weight_stride).
+    const int stride = cols + 1;
+    if (batch == 1) {
+        dsv4::qwen_fp8_e4m3_fp16scale_matvec_cuda(b.x, b.w, b.s, b.y, rows, cols, stride, scale_cols);
+    } else {
+        dsv4::qwen_fp8_e4m3_fp16scale_matmul_rows_cuda(b.x, b.w, b.s, b.y, batch, rows, cols,
+                                                       cols, rows, stride, scale_cols);
+    }
+}
+
+}  // namespace
+
+int main() {
+    if (!dsv4::cuda_runtime_available()) {
+        std::printf("[SKIP] bench_qwen_fp8_kernels requires a CUDA device\n");
+        return 0;
+    }
+    cudaDeviceProp prop{};
+    cudaGetDeviceProperties(&prop, 0);
+    std::printf("device=%s sm=%d.%d\n", prop.name, prop.major, prop.minor);
+
+    struct Case {
+        const char* label;
+        int batch;
+        int rows;
+        int cols;
+    };
+    // Qwen3.8-27B TP4 local shapes: hidden 5120, intermediate 17408.
+    const Case cases[] = {
+        {"linear_qkv   decode", 1, 2560, 5120},
+        {"mlp_gate     decode", 1, 4352, 5120},
+        {"mlp_down     decode", 1, 5120, 4352},
+        {"full_q       decode", 1, 1536, 5120},
+        {"mlp_gate    prefill", 64, 4352, 5120},
+        {"mlp_down    prefill", 64, 5120, 4352},
+    };
+
+    for (const Case& c : cases) {
+        const int scale_rows = (c.rows + kBlock - 1) / kBlock;
+        const int scale_cols = (c.cols + kBlock - 1) / kBlock;
+        Buffers b;
+        // Allocate the weight with a +4 slack so the stride+1 reference variant
+        // stays in bounds.
+        const size_t w_bytes = static_cast<size_t>(c.rows) * (c.cols + 4);
+        if (cudaMalloc(&b.x, static_cast<size_t>(c.batch) * c.cols * sizeof(float)) != cudaSuccess ||
+            cudaMalloc(&b.w, w_bytes) != cudaSuccess ||
+            cudaMalloc(&b.s, static_cast<size_t>(scale_rows) * scale_cols * sizeof(uint16_t)) != cudaSuccess ||
+            cudaMalloc(&b.y, static_cast<size_t>(c.batch) * c.rows * sizeof(float)) != cudaSuccess) {
+            std::printf("[SKIP] allocation failed for %s\n", c.label);
+            return 0;
+        }
+        std::vector<float> hx(static_cast<size_t>(c.batch) * c.cols);
+        std::mt19937 rng(1234);
+        std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+        for (float& v : hx) v = dist(rng);
+        std::vector<uint8_t> hw(w_bytes);
+        for (uint8_t& v : hw) v = static_cast<uint8_t>(0x38 + (rng() & 7));
+        std::vector<uint16_t> hs(static_cast<size_t>(scale_rows) * scale_cols, 0x3800);
+        cudaMemcpy(b.x, hx.data(), hx.size() * sizeof(float), cudaMemcpyHostToDevice);
+        cudaMemcpy(b.w, hw.data(), hw.size(), cudaMemcpyHostToDevice);
+        cudaMemcpy(b.s, hs.data(), hs.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
+
+        const int iters = c.batch == 1 ? 200 : 30;
+        const double ref = time_ms(run_ref, b, c.batch, c.rows, c.cols, scale_cols, iters);
+        const double opt = time_ms(run_opt, b, c.batch, c.rows, c.cols, scale_cols, iters);
+        const double bytes = static_cast<double>(c.rows) * c.cols;
+        std::printf("%s batch=%3d rows=%5d cols=%5d  baseline=%7.3f ms  optimized=%7.3f ms  speedup=%5.2fx  eff=%6.1f GB/s\n",
+                    c.label, c.batch, c.rows, c.cols, ref, opt, ref / opt,
+                    bytes / (opt * 1e-3) / 1e9);
+    }
+    return 0;
+}

--- a/cpp_engine/tests/test_qwen_config.cpp
+++ b/cpp_engine/tests/test_qwen_config.cpp
@@ -1,0 +1,172 @@
+// Qwen3.8 config parsing test. Writes a config.json fixture holding the
+// authoritative Qwen/Qwen3.8-27B-FP8 text_config values and asserts the parsed
+// QwenConfig matches, so a checkpoint is not required to run this.
+
+#include "qwen_config.hpp"
+
+#include <cstdlib>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const std::string& what) {
+    if (!condition) {
+        std::cout << "[FAIL] " << what << "\n";
+        ++failures;
+    }
+}
+
+template <typename A, typename B>
+void check_eq(const A& actual, const B& expected, const std::string& what) {
+    if (!(actual == static_cast<A>(expected))) {
+        std::cout << "[FAIL] " << what << " actual=" << actual << " expected=" << expected << "\n";
+        ++failures;
+        return;
+    }
+}
+
+std::string layer_types_json(int layers, int full_interval) {
+    std::ostringstream out;
+    out << '[';
+    for (int i = 0; i < layers; ++i) {
+        if (i) out << ',';
+        const bool full = ((i + 1) % full_interval) == 0;
+        out << (full ? "\"full_attention\"" : "\"linear_attention\"");
+    }
+    out << ']';
+    return out.str();
+}
+
+std::string qwen38_config_json() {
+    std::ostringstream out;
+    out << "{\n"
+        << "  \"architectures\": [\"Qwen3_5ForConditionalGeneration\"],\n"
+        << "  \"model_type\": \"qwen3_5\",\n"
+        << "  \"text_config\": {\n"
+        << "    \"model_type\": \"qwen3_5_text\",\n"
+        << "    \"vocab_size\": 248320,\n"
+        << "    \"hidden_size\": 5120,\n"
+        << "    \"intermediate_size\": 17408,\n"
+        << "    \"num_hidden_layers\": 64,\n"
+        << "    \"num_attention_heads\": 24,\n"
+        << "    \"num_key_value_heads\": 4,\n"
+        << "    \"head_dim\": 256,\n"
+        << "    \"attn_output_gate\": true,\n"
+        << "    \"linear_num_key_heads\": 16,\n"
+        << "    \"linear_num_value_heads\": 48,\n"
+        << "    \"linear_key_head_dim\": 128,\n"
+        << "    \"linear_value_head_dim\": 128,\n"
+        << "    \"linear_conv_kernel_dim\": 4,\n"
+        << "    \"max_position_embeddings\": 262144,\n"
+        << "    \"rms_norm_eps\": 1e-06,\n"
+        << "    \"partial_rotary_factor\": 0.25,\n"
+        << "    \"rope_parameters\": {\n"
+        << "      \"rope_type\": \"default\",\n"
+        << "      \"rope_theta\": 10000000,\n"
+        << "      \"partial_rotary_factor\": 0.25,\n"
+        << "      \"mrope_interleaved\": true,\n"
+        << "      \"mrope_section\": [11, 11, 10]\n"
+        << "    },\n"
+        << "    \"layer_types\": " << layer_types_json(64, 4) << "\n"
+        << "  }\n"
+        << "}\n";
+    return out.str();
+}
+
+bool write_file(const std::string& path, const std::string& contents) {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) return false;
+    out << contents;
+    return static_cast<bool>(out);
+}
+
+std::string temp_dir() {
+    const char* base = std::getenv("CLAUDE_JOB_DIR");
+    std::string root = base != nullptr ? std::string(base) + "/tmp" : std::string("/tmp");
+    return root + "/qwen_config_fixture";
+}
+
+}  // namespace
+
+int main() {
+    const std::string dir = temp_dir();
+    const std::string mkdir_cmd = "mkdir -p '" + dir + "'";
+    if (std::system(mkdir_cmd.c_str()) != 0) {
+        std::cout << "[FAIL] could not create fixture dir " << dir << "\n";
+        return 1;
+    }
+    if (!write_file(dir + "/config.json", qwen38_config_json())) {
+        std::cout << "[FAIL] could not write fixture config.json\n";
+        return 1;
+    }
+
+    check(dsv4::is_qwen3_5_checkpoint(dir), "is_qwen3_5_checkpoint detects qwen3_5 root model_type");
+
+    const dsv4::QwenConfig cfg = dsv4::QwenConfig::from_hf_config(dir);
+    check(cfg.is_qwen3_5(), "config reports qwen3_5 architecture");
+    check_eq(cfg.hidden_size, 5120u, "hidden_size");
+    check_eq(cfg.vocab_size, 248320u, "vocab_size");
+    check_eq(cfg.num_hidden_layers, 64u, "num_hidden_layers");
+    check_eq(cfg.mlp.intermediate_size, 17408u, "dense MLP intermediate_size");
+    check_eq(cfg.max_position_embeddings, 262144u, "max_position_embeddings");
+    check_eq(cfg.full_attention.num_heads, 24u, "num_attention_heads");
+    check_eq(cfg.full_attention.num_key_value_heads, 4u, "num_key_value_heads");
+    check_eq(cfg.full_attention.head_dim, 256u, "head_dim");
+    check(cfg.full_attention.output_gate, "attn_output_gate is true");
+    check_eq(cfg.full_attention.attention_dim(), 6144u, "attention_dim = 24*256");
+    check_eq(cfg.full_attention.q_dim(), 12288u, "q_dim doubles for the output gate");
+    check_eq(cfg.full_attention.kv_dim(), 1024u, "kv_dim = 4*256");
+    check_eq(cfg.linear_attention.key_heads, 16u, "linear_num_key_heads");
+    check_eq(cfg.linear_attention.value_heads, 48u, "linear_num_value_heads");
+    check_eq(cfg.linear_attention.key_head_dim, 128u, "linear_key_head_dim");
+    check_eq(cfg.linear_attention.value_head_dim, 128u, "linear_value_head_dim");
+    check_eq(cfg.linear_attention.conv_kernel_dim, 4u, "linear_conv_kernel_dim");
+    check_eq(cfg.linear_attention.qkv_dim(), 10240u, "qkv_dim = 2*2048 + 6144");
+    check_eq(cfg.linear_attention.value_state_dim(), 6144u, "value_state_dim = 48*128");
+    check_eq(cfg.partial_rotary_dim(), 64u, "partial rotary dim = 256 * 0.25");
+    check_eq(cfg.fp8_block_size, 128u, "fp8 block size");
+    check(cfg.rope_theta > 9.9e6 && cfg.rope_theta < 1.01e7, "rope_theta comes from rope_parameters");
+    check(cfg.rms_norm_eps > 0.0 && cfg.rms_norm_eps < 1.0e-5, "rms_norm_eps");
+    check_eq(cfg.full_attention_layers(), 16u, "one full-attention layer per four");
+    check_eq(cfg.linear_attention_layers(), 48u, "three linear-attention layers per four");
+    check_eq(cfg.layer_type_name(0), std::string("linear_attention"), "layer 0 is linear attention");
+    check_eq(cfg.layer_type_name(3), std::string("full_attention"), "layer 3 is full attention");
+    check_eq(cfg.layer_type_name(63), std::string("full_attention"), "last layer is full attention");
+
+    // A dense text config must not be mistaken for MoE: dropping
+    // intermediate_size has to fail loudly rather than default to zero.
+    std::string no_inter = qwen38_config_json();
+    const std::string needle = "\"intermediate_size\": 17408,\n";
+    const size_t at = no_inter.find(needle);
+    check(at != std::string::npos, "fixture contains intermediate_size");
+    if (at != std::string::npos) {
+        no_inter.erase(at, needle.size());
+        const std::string bad_dir = dir + "_no_inter";
+        const std::string bad_mkdir = "mkdir -p '" + bad_dir + "'";
+        if (std::system(bad_mkdir.c_str()) == 0 && write_file(bad_dir + "/config.json", no_inter)) {
+            bool threw = false;
+            try {
+                (void)dsv4::QwenConfig::from_hf_config(bad_dir);
+            } catch (const std::exception&) {
+                threw = true;
+            }
+            check(threw, "missing intermediate_size throws instead of defaulting");
+        }
+    }
+
+    if (failures != 0) {
+        std::cout << "test_qwen_config failures=" << failures << "\n";
+        return 1;
+    }
+    std::cout << "[PASS] test_qwen_config layers=" << cfg.num_hidden_layers
+              << " full=" << cfg.full_attention_layers()
+              << " linear=" << cfg.linear_attention_layers()
+              << " rotary_dim=" << cfg.partial_rotary_dim() << "\n";
+    return 0;
+}

--- a/cpp_engine/tests/test_qwen_conv_tail.cpp
+++ b/cpp_engine/tests/test_qwen_conv_tail.cpp
@@ -1,0 +1,123 @@
+// Causal depthwise conv: a single prefill over N tokens must produce exactly the
+// same outputs as feeding those N tokens one at a time through the conv tail.
+//
+// This is the property that makes prefill->decode handoff correct. It caught a
+// real bug: when seq_len < kernel-1 the tail rotation zero-filled the still-live
+// history instead of shifting it, so decode diverged from token 2 onward.
+
+#include "cuda_ops.hpp"
+#include "qwen_cuda_ops.hpp"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <random>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+uint16_t float_to_fp16_bits(float value) {
+    uint32_t bits;
+    __builtin_memcpy(&bits, &value, sizeof(bits));
+    const uint32_t sign = (bits >> 16) & 0x8000u;
+    int exponent = static_cast<int>((bits >> 23) & 0xff) - 127 + 15;
+    const uint32_t mantissa = bits & 0x7fffffu;
+    if (exponent <= 0) return static_cast<uint16_t>(sign);
+    if (exponent >= 0x1f) return static_cast<uint16_t>(sign | 0x7c00u);
+    return static_cast<uint16_t>(sign | (static_cast<uint32_t>(exponent) << 10) | (mantissa >> 13));
+}
+
+}  // namespace
+
+int main() {
+    if (!dsv4::cuda_runtime_available()) {
+        std::printf("[SKIP] test_qwen_conv_tail requires a CUDA device\n");
+        return 0;
+    }
+
+    const int channels = 512;
+    const int kernel = 4;   // Qwen3.8 linear_conv_kernel_dim
+    const int seq_len = 6;
+
+    std::mt19937 rng(13572468);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<float> x(static_cast<size_t>(seq_len) * channels);
+    for (float& v : x) v = dist(rng);
+    std::vector<uint16_t> w(static_cast<size_t>(channels) * kernel);
+    for (uint16_t& v : w) v = float_to_fp16_bits(dist(rng) * 0.5f);
+
+    float *d_x = nullptr, *d_y = nullptr, *d_tail = nullptr;
+    uint16_t* d_w = nullptr;
+    const size_t tail_elems = static_cast<size_t>(kernel - 1) * channels;
+    if (cudaMalloc(&d_x, x.size() * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&d_y, x.size() * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&d_tail, tail_elems * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&d_w, w.size() * sizeof(uint16_t)) != cudaSuccess) {
+        std::printf("[SKIP] device allocation failed\n");
+        return 0;
+    }
+    cudaMemcpy(d_w, w.data(), w.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
+
+    // Pass 1: whole sequence at once, starting from a zero tail.
+    cudaMemset(d_tail, 0, tail_elems * sizeof(float));
+    cudaMemcpy(d_x, x.data(), x.size() * sizeof(float), cudaMemcpyHostToDevice);
+    if (!dsv4::qwen_causal_depthwise_conv_silu_cuda(d_x, d_w, d_tail, d_y, seq_len, channels,
+                                                    kernel, true)) {
+        std::printf("[FAIL] prefill conv launch failed\n");
+        return 1;
+    }
+    cudaDeviceSynchronize();
+    std::vector<float> prefill(x.size());
+    cudaMemcpy(prefill.data(), d_y, prefill.size() * sizeof(float), cudaMemcpyDeviceToHost);
+
+    // Pass 2: one token at a time, carrying the tail forward.
+    cudaMemset(d_tail, 0, tail_elems * sizeof(float));
+    std::vector<float> stepwise(x.size());
+    for (int t = 0; t < seq_len; ++t) {
+        cudaMemcpy(d_x, x.data() + static_cast<size_t>(t) * channels,
+                   static_cast<size_t>(channels) * sizeof(float), cudaMemcpyHostToDevice);
+        if (!dsv4::qwen_causal_depthwise_conv_silu_cuda(d_x, d_w, d_tail, d_y, 1, channels,
+                                                        kernel, true)) {
+            std::printf("[FAIL] decode conv launch failed at t=%d\n", t);
+            return 1;
+        }
+        cudaDeviceSynchronize();
+        cudaMemcpy(stepwise.data() + static_cast<size_t>(t) * channels, d_y,
+                   static_cast<size_t>(channels) * sizeof(float), cudaMemcpyDeviceToHost);
+    }
+
+    double worst = 0.0;
+    int worst_t = -1;
+    for (int t = 0; t < seq_len; ++t) {
+        for (int c = 0; c < channels; ++c) {
+            const size_t i = static_cast<size_t>(t) * channels + c;
+            const double diff = std::fabs(static_cast<double>(prefill[i]) - stepwise[i]);
+            if (diff > worst) {
+                worst = diff;
+                worst_t = t;
+            }
+        }
+    }
+    cudaFree(d_x);
+    cudaFree(d_y);
+    cudaFree(d_tail);
+    cudaFree(d_w);
+
+    // Both passes run the identical kernel in the same order, so this must be
+    // bit-exact, not merely close.
+    if (worst != 0.0) {
+        std::printf("[FAIL] prefill vs stepwise conv mismatch worst=%.3e at t=%d\n", worst, worst_t);
+        ++failures;
+    } else {
+        std::printf("  conv tail continuity seq_len=%d kernel=%d channels=%d exact\n",
+                    seq_len, kernel, channels);
+    }
+    if (failures != 0) return 1;
+    std::printf("[PASS] test_qwen_conv_tail\n");
+    return 0;
+}

--- a/cpp_engine/tests/test_qwen_delta_rule.cpp
+++ b/cpp_engine/tests/test_qwen_delta_rule.cpp
@@ -1,0 +1,199 @@
+// Numerical check for the Gated DeltaNet recurrent step against a CPU
+// reference, including multi-step state continuation.
+//
+// The kernel was rewritten for speed (cooperative q/k L2 norm in shared memory
+// plus a single-pass state update). A zero-weight engine fixture cannot catch a
+// regression here, so this uses random inputs and verifies the evolving state.
+
+#include "cuda_ops.hpp"
+#include "qwen_cuda_ops.hpp"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void fail(const std::string& what) {
+    std::printf("[FAIL] %s\n", what.c_str());
+    ++failures;
+}
+
+// One Gated DeltaNet step:
+//   S <- S * exp(g); delta = (v - S^T k_hat) * beta; S += k_hat delta^T
+//   out = (S^T q_hat) * q_scale
+void delta_step_reference(std::vector<float>& state, const std::vector<float>& q,
+                          const std::vector<float>& k, const std::vector<float>& v,
+                          const std::vector<float>& g, const std::vector<float>& beta,
+                          std::vector<float>& out, int heads, int key_heads,
+                          int key_dim, int value_dim, float q_scale) {
+    const int repeat = heads / key_heads;
+    for (int head = 0; head < heads; ++head) {
+        const int key_head = head / repeat;
+        const float* q_head = q.data() + static_cast<size_t>(key_head) * key_dim;
+        const float* k_head = k.data() + static_cast<size_t>(key_head) * key_dim;
+        double q_sq = 0.0, k_sq = 0.0;
+        for (int i = 0; i < key_dim; ++i) {
+            q_sq += static_cast<double>(q_head[i]) * q_head[i];
+            k_sq += static_cast<double>(k_head[i]) * k_head[i];
+        }
+        const float q_norm = static_cast<float>(1.0 / std::sqrt(q_sq + 1.0e-6));
+        const float k_norm = static_cast<float>(1.0 / std::sqrt(k_sq + 1.0e-6));
+        float* state_head = state.data() + static_cast<size_t>(head) * key_dim * value_dim;
+        const float decay = std::exp(g[head]);
+        for (int value = 0; value < value_dim; ++value) {
+            float kv_mem = 0.0f;
+            for (int i = 0; i < key_dim; ++i) {
+                float& cell = state_head[static_cast<size_t>(i) * value_dim + value];
+                cell *= decay;
+                kv_mem += cell * k_head[i] * k_norm;
+            }
+            const float delta =
+                (v[static_cast<size_t>(head) * value_dim + value] - kv_mem) * beta[head];
+            float result = 0.0f;
+            for (int i = 0; i < key_dim; ++i) {
+                float& cell = state_head[static_cast<size_t>(i) * value_dim + value];
+                cell += k_head[i] * k_norm * delta;
+                result += cell * q_head[i] * q_norm;
+            }
+            out[static_cast<size_t>(head) * value_dim + value] = result * q_scale;
+        }
+    }
+}
+
+struct Device {
+    float* state = nullptr;
+    float* q = nullptr;
+    float* k = nullptr;
+    float* v = nullptr;
+    float* g = nullptr;
+    float* beta = nullptr;
+    float* out = nullptr;
+    ~Device() {
+        cudaFree(state);
+        cudaFree(q);
+        cudaFree(k);
+        cudaFree(v);
+        cudaFree(g);
+        cudaFree(beta);
+        cudaFree(out);
+    }
+};
+
+bool check_delta_rule() {
+    // 48 value heads over 16 key heads matches the Qwen3.8 TP1 layout; the
+    // 12-over-4 shape here keeps the same repeat factor of 3 at test size.
+    const int heads = 12;
+    const int key_heads = 4;
+    const int key_dim = 128;
+    const int value_dim = 128;
+    const float q_scale = 0.08838834764f;  // 128^-0.5
+    const int steps = 4;
+
+    std::mt19937 rng(987654321);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::uniform_real_distribution<float> gate(-0.4f, -0.02f);
+    std::uniform_real_distribution<float> beta_dist(0.05f, 0.95f);
+
+    const size_t state_size = static_cast<size_t>(heads) * key_dim * value_dim;
+    std::vector<float> ref_state(state_size);
+    for (float& x : ref_state) x = dist(rng) * 0.05f;
+
+    Device dev;
+    const size_t qk_size = static_cast<size_t>(key_heads) * key_dim;
+    const size_t out_size = static_cast<size_t>(heads) * value_dim;
+    if (cudaMalloc(&dev.state, state_size * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&dev.q, qk_size * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&dev.k, qk_size * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&dev.v, out_size * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&dev.g, heads * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&dev.beta, heads * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&dev.out, out_size * sizeof(float)) != cudaSuccess) {
+        return false;
+    }
+    cudaMemcpy(dev.state, ref_state.data(), state_size * sizeof(float), cudaMemcpyHostToDevice);
+
+    double worst_out = 0.0;
+    double worst_state = 0.0;
+    for (int step = 0; step < steps; ++step) {
+        std::vector<float> q(qk_size), k(qk_size), v(out_size);
+        std::vector<float> g(heads), beta(heads);
+        for (float& x : q) x = dist(rng);
+        for (float& x : k) x = dist(rng);
+        for (float& x : v) x = dist(rng);
+        for (float& x : g) x = gate(rng);
+        for (float& x : beta) x = beta_dist(rng);
+
+        cudaMemcpy(dev.q, q.data(), q.size() * sizeof(float), cudaMemcpyHostToDevice);
+        cudaMemcpy(dev.k, k.data(), k.size() * sizeof(float), cudaMemcpyHostToDevice);
+        cudaMemcpy(dev.v, v.data(), v.size() * sizeof(float), cudaMemcpyHostToDevice);
+        cudaMemcpy(dev.g, g.data(), g.size() * sizeof(float), cudaMemcpyHostToDevice);
+        cudaMemcpy(dev.beta, beta.data(), beta.size() * sizeof(float), cudaMemcpyHostToDevice);
+
+        if (!dsv4::qwen_gated_delta_step_cuda(dev.state, dev.q, dev.k, dev.v, dev.g,
+                                              dev.beta, dev.out, heads, key_heads,
+                                              key_dim, value_dim, q_scale)) {
+            fail("gated_delta_step launch failed");
+            return true;
+        }
+        if (cudaDeviceSynchronize() != cudaSuccess) {
+            fail("gated_delta_step sync failed");
+            return true;
+        }
+
+        std::vector<float> got_out(out_size);
+        std::vector<float> got_state(state_size);
+        cudaMemcpy(got_out.data(), dev.out, got_out.size() * sizeof(float), cudaMemcpyDeviceToHost);
+        cudaMemcpy(got_state.data(), dev.state, got_state.size() * sizeof(float), cudaMemcpyDeviceToHost);
+
+        std::vector<float> want_out(out_size);
+        delta_step_reference(ref_state, q, k, v, g, beta, want_out, heads, key_heads,
+                             key_dim, value_dim, q_scale);
+
+        for (size_t i = 0; i < out_size; ++i) {
+            worst_out = std::max(worst_out, static_cast<double>(std::fabs(got_out[i] - want_out[i])));
+        }
+        for (size_t i = 0; i < state_size; ++i) {
+            worst_state = std::max(worst_state,
+                                   static_cast<double>(std::fabs(got_state[i] - ref_state[i])));
+        }
+    }
+
+    // The kernel reorders the fp32 reductions relative to the scalar reference,
+    // so exact equality is not expected; 2e-4 still catches a wrong norm, a
+    // dropped decay, or a stale state cell.
+    if (worst_out > 2.0e-4 || worst_state > 2.0e-4) {
+        fail("delta_rule drift out=" + std::to_string(worst_out) +
+             " state=" + std::to_string(worst_state));
+    } else {
+        std::printf("  delta_rule steps=%d heads=%d worst_out=%.3e worst_state=%.3e\n",
+                    steps, heads, worst_out, worst_state);
+    }
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    if (!dsv4::cuda_runtime_available()) {
+        std::printf("[SKIP] test_qwen_delta_rule requires a CUDA device\n");
+        return 0;
+    }
+    if (!check_delta_rule()) {
+        std::printf("[SKIP] device allocation failed\n");
+        return 0;
+    }
+    if (failures != 0) {
+        std::printf("test_qwen_delta_rule failures=%d\n", failures);
+        return 1;
+    }
+    std::printf("[PASS] test_qwen_delta_rule\n");
+    return 0;
+}

--- a/cpp_engine/tests/test_qwen_engine.cpp
+++ b/cpp_engine/tests/test_qwen_engine.cpp
@@ -1,0 +1,213 @@
+// Minimal Qwen engine lifecycle test with a one-layer linear-attention fixture.
+// All weights are zero, so the greedy result is deterministic while the test
+// still exercises FP8 online projection, FP16 materialization, conv tail,
+// recurrent state, residual/MLP wiring, and the decode cache continuation.
+
+#include "cuda_ops.hpp"
+#include "qwen_config.hpp"
+#include "qwen_engine.hpp"
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct TensorSpec {
+    std::string name;
+    std::string dtype;
+    std::vector<uint64_t> shape;
+};
+
+uint64_t numel(const std::vector<uint64_t>& shape) {
+    uint64_t out = 1;
+    for (uint64_t dim : shape) out *= dim;
+    return out;
+}
+
+uint64_t dtype_size(const std::string& dtype) {
+    if (dtype == "F8_E4M3") return 1;
+    if (dtype == "BF16") return 2;
+    throw std::runtime_error("unsupported fixture dtype: " + dtype);
+}
+
+std::string shape_json(const std::vector<uint64_t>& shape) {
+    std::ostringstream out;
+    out << '[';
+    for (size_t i = 0; i < shape.size(); ++i) {
+        if (i) out << ',';
+        out << shape[i];
+    }
+    out << ']';
+    return out.str();
+}
+
+std::string fixture_dir() {
+    const char* base = std::getenv("CLAUDE_JOB_DIR");
+    const std::string root = base != nullptr ? std::string(base) + "/tmp" : std::string("/tmp");
+    return root + "/qwen_engine_fixture";
+}
+
+std::string config_json() {
+    return R"JSON({
+  "architectures": ["Qwen3_5ForConditionalGeneration"],
+  "model_type": "qwen3_5",
+  "text_config": {
+    "model_type": "qwen3_5_text",
+    "vocab_size": 64,
+    "hidden_size": 128,
+    "intermediate_size": 128,
+    "num_hidden_layers": 1,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 4,
+    "head_dim": 128,
+    "attn_output_gate": true,
+    "linear_num_key_heads": 4,
+    "linear_num_value_heads": 4,
+    "linear_key_head_dim": 128,
+    "linear_value_head_dim": 128,
+    "linear_conv_kernel_dim": 4,
+    "max_position_embeddings": 32,
+    "rms_norm_eps": 1e-6,
+    "partial_rotary_factor": 0.25,
+    "rope_parameters": {"rope_type": "default", "rope_theta": 10000000},
+    "layer_types": ["linear_attention"]
+  }
+})JSON";
+}
+
+std::vector<TensorSpec> specs() {
+    const std::vector<uint64_t> hidden = {128};
+    const std::vector<uint64_t> vocab = {64, 128};
+    const std::vector<uint64_t> qkv = {1536, 128};
+    const std::vector<uint64_t> qkv_scale = {12, 1};
+    const std::vector<uint64_t> value_proj = {512, 128};
+    const std::vector<uint64_t> value_scale = {4, 1};
+    const std::vector<uint64_t> out_proj = {128, 512};
+    const std::vector<uint64_t> out_scale = {1, 4};
+    const std::vector<uint64_t> heads = {4, 128};
+    const std::vector<uint64_t> vector4 = {4};
+    const std::vector<uint64_t> mlp = {128, 128};
+    const std::vector<uint64_t> mlp_scale = {1, 1};
+    const std::string p = "model.language_model.layers.0.";
+    return {
+        {"model.language_model.embed_tokens.weight", "BF16", vocab},
+        {"model.language_model.norm.weight", "BF16", hidden},
+        {"lm_head.weight", "BF16", vocab},
+        {p + "input_layernorm.weight", "BF16", hidden},
+        {p + "post_attention_layernorm.weight", "BF16", hidden},
+        {p + "linear_attn.in_proj_qkv.weight", "F8_E4M3", qkv},
+        {p + "linear_attn.in_proj_qkv.weight_scale_inv", "BF16", qkv_scale},
+        {p + "linear_attn.in_proj_z.weight", "F8_E4M3", value_proj},
+        {p + "linear_attn.in_proj_z.weight_scale_inv", "BF16", value_scale},
+        {p + "linear_attn.out_proj.weight", "F8_E4M3", out_proj},
+        {p + "linear_attn.out_proj.weight_scale_inv", "BF16", out_scale},
+        {p + "linear_attn.in_proj_a.weight", "BF16", heads},
+        {p + "linear_attn.in_proj_b.weight", "BF16", heads},
+        {p + "linear_attn.conv1d.weight", "BF16", {1536, 1, 4}},
+        {p + "linear_attn.A_log", "BF16", vector4},
+        {p + "linear_attn.dt_bias", "BF16", vector4},
+        {p + "linear_attn.norm.weight", "BF16", {128}},
+        {p + "mlp.gate_proj.weight", "F8_E4M3", mlp},
+        {p + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale},
+        {p + "mlp.up_proj.weight", "F8_E4M3", mlp},
+        {p + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale},
+        {p + "mlp.down_proj.weight", "F8_E4M3", mlp},
+        {p + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale},
+    };
+}
+
+bool write_fixture(const std::string& dir) {
+    const std::string mkdir_cmd = "mkdir -p '" + dir + "'";
+    if (std::system(mkdir_cmd.c_str()) != 0) return false;
+    std::ofstream config(dir + "/config.json", std::ios::binary | std::ios::trunc);
+    if (!config) return false;
+    config << config_json();
+    if (!config) return false;
+
+    const auto tensors = specs();
+    std::ostringstream header;
+    header << '{';
+    uint64_t offset = 0;
+    for (size_t i = 0; i < tensors.size(); ++i) {
+        if (i) header << ',';
+        const auto& tensor = tensors[i];
+        const uint64_t bytes = numel(tensor.shape) * dtype_size(tensor.dtype);
+        header << '"' << tensor.name << "\":{\"dtype\":\"" << tensor.dtype
+               << "\",\"shape\":" << shape_json(tensor.shape)
+               << ",\"data_offsets\":[" << offset << ',' << offset + bytes << "]}";
+        offset += bytes;
+    }
+    header << '}';
+    const std::string header_text = header.str();
+    std::ofstream shard(dir + "/model.safetensors", std::ios::binary | std::ios::trunc);
+    if (!shard) return false;
+    const uint64_t header_len = header_text.size();
+    shard.write(reinterpret_cast<const char*>(&header_len), sizeof(header_len));
+    shard.write(header_text.data(), static_cast<std::streamsize>(header_text.size()));
+    std::vector<uint8_t> zeros(static_cast<size_t>(offset), 0);
+    shard.write(reinterpret_cast<const char*>(zeros.data()), static_cast<std::streamsize>(zeros.size()));
+    if (!shard) return false;
+
+    std::ofstream index(dir + "/model.safetensors.index.json", std::ios::binary | std::ios::trunc);
+    if (!index) return false;
+    index << "{\"metadata\":{\"total_size\":" << offset << "},\"weight_map\":{";
+    for (size_t i = 0; i < tensors.size(); ++i) {
+        if (i) index << ',';
+        index << '"' << tensors[i].name << "\":\"model.safetensors\"";
+    }
+    index << "}}";
+    return static_cast<bool>(index);
+}
+
+void require(bool condition, const std::string& message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+}  // namespace
+
+int main() {
+    if (!dsv4::cuda_runtime_available()) {
+        std::cout << "[SKIP] test_qwen_engine requires a CUDA device\n";
+        return 0;
+    }
+    try {
+        const std::string dir = fixture_dir();
+        require(write_fixture(dir), "could not create Qwen engine fixture");
+        dsv4::QwenEngineOptions options;
+        options.tp_world = 1;
+        options.tp_rank = 0;
+        options.device = 0;
+        dsv4::QwenEngine engine(dir, options, 1, 8);
+        require(engine.resident_weight_bytes() > 0, "resident Qwen weights missing");
+        require(engine.resident_scale_bytes() > 0, "resident Qwen scales missing");
+
+        const dsv4::QwenForwardResult prefill = engine.prefill({1, 2});
+        require(prefill.layers == 1 && prefill.dim == 128, "prefill metadata");
+        require(prefill.position == 2, "prefill position");
+        require(prefill.top_token == 0, "zero fixture prefill greedy token");
+
+        const dsv4::QwenForwardResult decoded = engine.decode_step(3);
+        require(decoded.position == 3, "decode position");
+        require(decoded.top_token == 0, "zero fixture decode greedy token");
+
+        engine.reset();
+        require(engine.position() == 0, "reset position");
+        const dsv4::QwenForwardResult second = engine.prefill({4});
+        require(second.position == 1 && second.top_token == 0, "reset and second prefill");
+        std::cout << "[PASS] test_qwen_engine layers=" << second.layers
+                  << " resident_weight_bytes=" << engine.resident_weight_bytes()
+                  << " resident_scale_bytes=" << engine.resident_scale_bytes() << "\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cout << "[FAIL] test_qwen_engine " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_qwen_fp8_online.cpp
+++ b/cpp_engine/tests/test_qwen_fp8_online.cpp
@@ -1,0 +1,341 @@
+// Qwen FP8 E4M3 + BF16 block-scale online-unpack numerics.
+//
+// Builds random FP8 codes and BF16 128x128 block scales on the host, computes
+// the reference product in double precision from the same decoded values, and
+// compares against the CUDA kernels. Shapes deliberately cross block
+// boundaries and include a TP-style shard offset so a mis-indexed scale block
+// shows up as an error rather than as noise.
+
+#include "cuda_ops.hpp"
+#include "qwen_cuda_ops.hpp"
+#include "qwen_weights.hpp"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void fail(const std::string& what) {
+    std::cout << "[FAIL] " << what << "\n";
+    ++failures;
+}
+
+float fp8_e4m3_to_float(uint8_t code) {
+    const int sign = (code >> 7) & 1;
+    const int exponent = (code >> 3) & 0xf;
+    const int mantissa = code & 0x7;
+    float value;
+    if (exponent == 0) {
+        value = std::ldexp(static_cast<float>(mantissa) * (1.0f / 8.0f), -6);
+    } else {
+        value = std::ldexp(1.0f + static_cast<float>(mantissa) * (1.0f / 8.0f), exponent - 7);
+    }
+    return sign ? -value : value;
+}
+
+uint16_t float_to_bf16_bits(float value) {
+    uint32_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    // Round-to-nearest-even on the truncated mantissa so the host reference and
+    // the kernel see bit-identical scales.
+    const uint32_t rounding_bias = 0x7fff + ((bits >> 16) & 1);
+    return static_cast<uint16_t>((bits + rounding_bias) >> 16);
+}
+
+float bf16_bits_to_float(uint16_t bits) {
+    const uint32_t widened = static_cast<uint32_t>(bits) << 16;
+    float value;
+    std::memcpy(&value, &widened, sizeof(value));
+    return value;
+}
+
+// IEEE FP16 -> FP32, matching the device-side decode of converted Qwen scales.
+float fp16_bits_to_float(uint16_t bits) {
+    const uint32_t sign = static_cast<uint32_t>(bits & 0x8000u) << 16;
+    const uint32_t exponent = (bits >> 10) & 0x1fu;
+    const uint32_t mantissa = bits & 0x03ffu;
+    uint32_t widened;
+    if (exponent == 0) {
+        if (mantissa == 0) {
+            widened = sign;
+        } else {
+            uint32_t normalized = mantissa;
+            int exp = -14;
+            while ((normalized & 0x400u) == 0) {
+                normalized <<= 1;
+                --exp;
+            }
+            widened = sign | (static_cast<uint32_t>(exp + 127) << 23) | ((normalized & 0x3ffu) << 13);
+        }
+    } else if (exponent == 0x1fu) {
+        widened = sign | 0x7f800000u | (mantissa << 13);
+    } else {
+        widened = sign | ((exponent - 15 + 127) << 23) | (mantissa << 13);
+    }
+    float value;
+    std::memcpy(&value, &widened, sizeof(value));
+    return value;
+}
+
+struct DeviceBuffers {
+    float* x = nullptr;
+    uint8_t* weight = nullptr;
+    uint16_t* scale = nullptr;
+    float* y = nullptr;
+
+    ~DeviceBuffers() {
+        cudaFree(x);
+        cudaFree(weight);
+        cudaFree(scale);
+        cudaFree(y);
+    }
+};
+
+bool run_case(int batch, int rows, int cols, uint64_t seed, const std::string& label) {
+    constexpr int kBlock = 128;
+    const int scale_rows = (rows + kBlock - 1) / kBlock;
+    const int scale_cols = (cols + kBlock - 1) / kBlock;
+
+    std::mt19937_64 rng(seed);
+    std::uniform_int_distribution<int> code_dist(0, 255);
+    std::uniform_real_distribution<float> x_dist(-1.5f, 1.5f);
+    std::uniform_real_distribution<float> scale_dist(0.01f, 0.4f);
+
+    std::vector<float> h_x(static_cast<size_t>(batch) * cols);
+    for (float& value : h_x) value = x_dist(rng);
+
+    std::vector<uint8_t> h_weight(static_cast<size_t>(rows) * cols);
+    for (uint8_t& code : h_weight) {
+        int value = code_dist(rng);
+        // 0x7f/0xff are E4M3 NaN in the OCP encoding; the checkpoint never
+        // stores them and including them would make the comparison meaningless.
+        if ((value & 0x7f) == 0x7f) value = 0x70;
+        code = static_cast<uint8_t>(value);
+    }
+
+    std::vector<uint16_t> h_scale_bf16(static_cast<size_t>(scale_rows) * scale_cols);
+    std::vector<uint16_t> h_scale_fp16(h_scale_bf16.size());
+    for (uint16_t& bits : h_scale_bf16) bits = float_to_bf16_bits(scale_dist(rng));
+    for (size_t i = 0; i < h_scale_bf16.size(); ++i) {
+        h_scale_fp16[i] = dsv4::qwen_bf16_to_fp16_bits(h_scale_bf16[i]);
+    }
+
+    std::vector<double> expected(static_cast<size_t>(batch) * rows, 0.0);
+    for (int sample = 0; sample < batch; ++sample) {
+        for (int row = 0; row < rows; ++row) {
+            double sum = 0.0;
+            for (int col = 0; col < cols; ++col) {
+                const float w = fp8_e4m3_to_float(h_weight[static_cast<size_t>(row) * cols + col]);
+                const float s = fp16_bits_to_float(
+                    h_scale_fp16[static_cast<size_t>(row / kBlock) * scale_cols + col / kBlock]);
+                sum += static_cast<double>(h_x[static_cast<size_t>(sample) * cols + col]) *
+                       static_cast<double>(w) * static_cast<double>(s);
+            }
+            expected[static_cast<size_t>(sample) * rows + row] = sum;
+        }
+    }
+
+    DeviceBuffers dev;
+    if (cudaMalloc(&dev.x, h_x.size() * sizeof(float)) != cudaSuccess) return false;
+    if (cudaMalloc(&dev.weight, h_weight.size()) != cudaSuccess) return false;
+    if (cudaMalloc(&dev.scale, h_scale_fp16.size() * sizeof(uint16_t)) != cudaSuccess) return false;
+    if (cudaMalloc(&dev.y, static_cast<size_t>(batch) * rows * sizeof(float)) != cudaSuccess) return false;
+    cudaMemcpy(dev.x, h_x.data(), h_x.size() * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(dev.weight, h_weight.data(), h_weight.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(dev.scale, h_scale_fp16.data(), h_scale_fp16.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
+
+    std::vector<float> actual(static_cast<size_t>(batch) * rows, 0.0f);
+    if (batch == 1) {
+        if (!dsv4::qwen_fp8_e4m3_fp16scale_matvec_cuda(dev.x, dev.weight, dev.scale, dev.y,
+                                                       rows, cols, cols, scale_cols)) {
+            fail(label + ": FP16-scale matvec kernel launch failed");
+            return true;
+        }
+    } else {
+        if (!dsv4::qwen_fp8_e4m3_fp16scale_matmul_rows_cuda(dev.x, dev.weight, dev.scale, dev.y,
+                                                            batch, rows, cols, cols, rows,
+                                                            cols, scale_cols)) {
+            fail(label + ": FP16-scale matmul kernel launch failed");
+            return true;
+        }
+    }
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        fail(label + ": kernel sync failed");
+        return true;
+    }
+    cudaMemcpy(actual.data(), dev.y, actual.size() * sizeof(float), cudaMemcpyDeviceToHost);
+
+    double max_abs = 0.0;
+    double max_rel = 0.0;
+    for (size_t i = 0; i < actual.size(); ++i) {
+        const double want = expected[i];
+        const double got = static_cast<double>(actual[i]);
+        const double abs_err = std::fabs(got - want);
+        max_abs = std::max(max_abs, abs_err);
+        const double denom = std::max(1.0, std::fabs(want));
+        max_rel = std::max(max_rel, abs_err / denom);
+    }
+    // fp32 accumulation over up to 640 terms; 2e-4 relative is well inside
+    // fp32 rounding while still catching a wrong scale block or stride.
+    const bool ok = max_rel < 2.0e-4;
+    if (!ok) {
+        fail(label + ": max_rel=" + std::to_string(max_rel) + " max_abs=" + std::to_string(max_abs));
+    } else {
+        std::cout << "  " << label << " batch=" << batch << " rows=" << rows << " cols=" << cols
+                  << " max_abs=" << max_abs << " max_rel=" << max_rel << "\n";
+    }
+    return true;
+}
+
+bool run_norm_cases() {
+    const int rows = 3;
+    const int cols = 256;
+    std::mt19937_64 rng(20260815);
+    std::uniform_real_distribution<float> dist(-2.0f, 2.0f);
+    std::vector<float> h_x(static_cast<size_t>(rows) * cols);
+    std::vector<float> h_gate(h_x.size());
+    std::vector<float> h_w(cols);
+    for (float& v : h_x) v = dist(rng);
+    for (float& v : h_gate) v = dist(rng);
+    for (float& v : h_w) v = dist(rng) * 0.1f;
+
+    float *d_x = nullptr, *d_gate = nullptr, *d_w = nullptr, *d_y = nullptr;
+    if (cudaMalloc(&d_x, h_x.size() * sizeof(float)) != cudaSuccess) return false;
+    if (cudaMalloc(&d_gate, h_gate.size() * sizeof(float)) != cudaSuccess) return false;
+    if (cudaMalloc(&d_w, h_w.size() * sizeof(float)) != cudaSuccess) return false;
+    if (cudaMalloc(&d_y, h_x.size() * sizeof(float)) != cudaSuccess) return false;
+    cudaMemcpy(d_x, h_x.data(), h_x.size() * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_gate, h_gate.data(), h_gate.size() * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_w, h_w.data(), h_w.size() * sizeof(float), cudaMemcpyHostToDevice);
+
+    const float eps = 1.0e-6f;
+    std::vector<float> got(h_x.size());
+
+    // Qwen rms_norm multiplies by (1 + weight), unlike the DSV4 convention.
+    if (!dsv4::qwen_rmsnorm_f32_cuda(d_x, d_w, d_y, rows, cols, eps)) {
+        fail("qwen_rmsnorm launch failed");
+    } else {
+        cudaDeviceSynchronize();
+        cudaMemcpy(got.data(), d_y, got.size() * sizeof(float), cudaMemcpyDeviceToHost);
+        double max_err = 0.0;
+        for (int r = 0; r < rows; ++r) {
+            double sq = 0.0;
+            for (int c = 0; c < cols; ++c) {
+                const double v = h_x[static_cast<size_t>(r) * cols + c];
+                sq += v * v;
+            }
+            const double inv = 1.0 / std::sqrt(sq / cols + eps);
+            for (int c = 0; c < cols; ++c) {
+                const double want = h_x[static_cast<size_t>(r) * cols + c] * inv * (1.0 + h_w[c]);
+                max_err = std::max(max_err, std::fabs(want - got[static_cast<size_t>(r) * cols + c]));
+            }
+        }
+        if (max_err > 1.0e-4) fail("qwen_rmsnorm max_err=" + std::to_string(max_err));
+        else std::cout << "  rms_norm(1+w) max_err=" << max_err << "\n";
+    }
+
+    // Gated variant: weight * normalized * silu(gate), with no (1 + weight).
+    if (!dsv4::qwen_gated_rmsnorm_f32_cuda(d_x, d_w, d_gate, d_y, rows, cols, eps)) {
+        fail("qwen_gated_rmsnorm launch failed");
+    } else {
+        cudaDeviceSynchronize();
+        cudaMemcpy(got.data(), d_y, got.size() * sizeof(float), cudaMemcpyDeviceToHost);
+        double max_err = 0.0;
+        for (int r = 0; r < rows; ++r) {
+            double sq = 0.0;
+            for (int c = 0; c < cols; ++c) {
+                const double v = h_x[static_cast<size_t>(r) * cols + c];
+                sq += v * v;
+            }
+            const double inv = 1.0 / std::sqrt(sq / cols + eps);
+            for (int c = 0; c < cols; ++c) {
+                const double g = h_gate[static_cast<size_t>(r) * cols + c];
+                const double silu = g / (1.0 + std::exp(-g));
+                const double want = h_w[c] * h_x[static_cast<size_t>(r) * cols + c] * inv * silu;
+                max_err = std::max(max_err, std::fabs(want - got[static_cast<size_t>(r) * cols + c]));
+            }
+        }
+        if (max_err > 1.0e-4) fail("qwen_gated_rmsnorm max_err=" + std::to_string(max_err));
+        else std::cout << "  gated_rms_norm(w*norm*silu(z)) max_err=" << max_err << "\n";
+    }
+
+    if (!dsv4::qwen_l2_norm_f32_cuda(d_x, d_y, rows, cols)) {
+        fail("qwen_l2_norm launch failed");
+    } else {
+        cudaDeviceSynchronize();
+        cudaMemcpy(got.data(), d_y, got.size() * sizeof(float), cudaMemcpyDeviceToHost);
+        double max_err = 0.0;
+        for (int r = 0; r < rows; ++r) {
+            double sq = 0.0;
+            for (int c = 0; c < cols; ++c) {
+                const double v = h_x[static_cast<size_t>(r) * cols + c];
+                sq += v * v;
+            }
+            const double inv = 1.0 / std::sqrt(sq + 1.0e-6);
+            for (int c = 0; c < cols; ++c) {
+                const double want = h_x[static_cast<size_t>(r) * cols + c] * inv;
+                max_err = std::max(max_err, std::fabs(want - got[static_cast<size_t>(r) * cols + c]));
+            }
+        }
+        if (max_err > 1.0e-5) fail("qwen_l2_norm max_err=" + std::to_string(max_err));
+        else std::cout << "  l2_norm max_err=" << max_err << "\n";
+    }
+
+    cudaFree(d_x);
+    cudaFree(d_gate);
+    cudaFree(d_w);
+    cudaFree(d_y);
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    if (!dsv4::cuda_runtime_available()) {
+        std::cout << "[SKIP] test_qwen_fp8_online requires a CUDA device\n";
+        return 0;
+    }
+
+    struct Case {
+        int batch;
+        int rows;
+        int cols;
+        const char* label;
+    };
+    // 640 crosses five scale blocks along k; 384 rows crosses three along the
+    // output dim; the 130/300 case is deliberately not block-aligned.
+    const Case cases[] = {
+        {1, 384, 640, "decode matvec block-aligned"},
+        {1, 130, 300, "decode matvec unaligned"},
+        {4, 256, 512, "small-batch verify"},
+        {9, 128, 256, "prefill multi-row"},
+    };
+    for (const Case& c : cases) {
+        if (!run_case(c.batch, c.rows, c.cols, 0x5eed1234u + static_cast<uint64_t>(c.rows), c.label)) {
+            std::cout << "[SKIP] device allocation failed for " << c.label << "\n";
+            return 0;
+        }
+    }
+    if (!run_norm_cases()) {
+        std::cout << "[SKIP] device allocation failed for norm cases\n";
+        return 0;
+    }
+
+    if (failures != 0) {
+        std::cout << "test_qwen_fp8_online failures=" << failures << "\n";
+        return 1;
+    }
+    std::cout << "[PASS] test_qwen_fp8_online\n";
+    return 0;
+}

--- a/cpp_engine/tests/test_qwen_gqa_attention.cpp
+++ b/cpp_engine/tests/test_qwen_gqa_attention.cpp
@@ -1,0 +1,151 @@
+// Numerical check for the online-softmax GQA kernels (decode + prefill) against
+// a two-pass CPU softmax reference.
+//
+// The kernels stream the KV cache once and rescale a running max/denominator.
+// head_dim=256 and 24-over-4 heads match the Qwen3.8 TP1 full-attention layout.
+
+#include "cuda_ops.hpp"
+#include "qwen_cuda_ops.hpp"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void fail(const std::string& what) {
+    std::printf("[FAIL] %s\n", what.c_str());
+    ++failures;
+}
+
+// Reference: explicit max, exp, normalize over the causal window.
+void attention_reference(const std::vector<float>& q, const std::vector<float>& k_cache,
+                         const std::vector<float>& v_cache, std::vector<float>& out,
+                         int q_heads, int kv_heads, int head_dim, int context_len) {
+    const int repeat = q_heads / kv_heads;
+    const float scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+    for (int head = 0; head < q_heads; ++head) {
+        const int kv_head = head / repeat;
+        const float* q_row = q.data() + static_cast<size_t>(head) * head_dim;
+        std::vector<double> scores(context_len);
+        double max_score = -1.0e300;
+        for (int pos = 0; pos < context_len; ++pos) {
+            const float* key = k_cache.data() +
+                               static_cast<size_t>(pos) * kv_heads * head_dim +
+                               static_cast<size_t>(kv_head) * head_dim;
+            double dot = 0.0;
+            for (int d = 0; d < head_dim; ++d) dot += static_cast<double>(q_row[d]) * key[d];
+            scores[pos] = dot * scale;
+            max_score = std::max(max_score, scores[pos]);
+        }
+        double denom = 0.0;
+        for (int pos = 0; pos < context_len; ++pos) {
+            scores[pos] = std::exp(scores[pos] - max_score);
+            denom += scores[pos];
+        }
+        for (int d = 0; d < head_dim; ++d) {
+            double acc = 0.0;
+            for (int pos = 0; pos < context_len; ++pos) {
+                const float* value = v_cache.data() +
+                                     static_cast<size_t>(pos) * kv_heads * head_dim +
+                                     static_cast<size_t>(kv_head) * head_dim;
+                acc += scores[pos] * value[d];
+            }
+            out[static_cast<size_t>(head) * head_dim + d] =
+                static_cast<float>(acc / (denom > 0.0 ? denom : 1.0));
+        }
+    }
+}
+
+struct Device {
+    float* q = nullptr;
+    float* k = nullptr;
+    float* v = nullptr;
+    float* out = nullptr;
+    ~Device() {
+        cudaFree(q);
+        cudaFree(k);
+        cudaFree(v);
+        cudaFree(out);
+    }
+};
+
+bool run_decode(int q_heads, int kv_heads, int head_dim, int context_len, int max_context) {
+    std::mt19937 rng(24680);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<float> q(static_cast<size_t>(q_heads) * head_dim);
+    std::vector<float> k(static_cast<size_t>(max_context) * kv_heads * head_dim, 0.0f);
+    std::vector<float> v(k.size(), 0.0f);
+    for (float& x : q) x = dist(rng);
+    for (size_t i = 0; i < static_cast<size_t>(context_len) * kv_heads * head_dim; ++i) {
+        k[i] = dist(rng);
+        v[i] = dist(rng);
+    }
+
+    Device dev;
+    if (cudaMalloc(&dev.q, q.size() * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&dev.k, k.size() * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&dev.v, v.size() * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&dev.out, q.size() * sizeof(float)) != cudaSuccess) {
+        return false;
+    }
+    cudaMemcpy(dev.q, q.data(), q.size() * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(dev.k, k.data(), k.size() * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(dev.v, v.data(), v.size() * sizeof(float), cudaMemcpyHostToDevice);
+
+    if (!dsv4::qwen_gqa_decode_attention_cuda(dev.q, dev.k, dev.v, dev.out, q_heads,
+                                              kv_heads, head_dim, context_len, max_context)) {
+        fail("gqa decode launch failed");
+        return true;
+    }
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        fail("gqa decode sync failed");
+        return true;
+    }
+    std::vector<float> got(q.size());
+    cudaMemcpy(got.data(), dev.out, got.size() * sizeof(float), cudaMemcpyDeviceToHost);
+
+    std::vector<float> want(q.size());
+    attention_reference(q, k, v, want, q_heads, kv_heads, head_dim, context_len);
+    double worst = 0.0;
+    for (size_t i = 0; i < got.size(); ++i) {
+        worst = std::max(worst, static_cast<double>(std::fabs(got[i] - want[i])));
+    }
+    if (worst > 1.0e-4) {
+        fail("gqa decode ctx=" + std::to_string(context_len) + " worst=" + std::to_string(worst));
+    } else {
+        std::printf("  gqa decode heads=%d/%d head_dim=%d ctx=%4d worst=%.3e\n",
+                    q_heads, kv_heads, head_dim, context_len, worst);
+    }
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    if (!dsv4::cuda_runtime_available()) {
+        std::printf("[SKIP] test_qwen_gqa_attention requires a CUDA device\n");
+        return 0;
+    }
+    // Qwen3.8 TP1 full attention: 24 q heads over 4 kv heads, head_dim 256.
+    const int contexts[] = {1, 7, 128, 333};
+    for (int ctx : contexts) {
+        if (!run_decode(24, 4, 256, ctx, 512)) {
+            std::printf("[SKIP] device allocation failed\n");
+            return 0;
+        }
+    }
+    if (failures != 0) {
+        std::printf("test_qwen_gqa_attention failures=%d\n", failures);
+        return 1;
+    }
+    std::printf("[PASS] test_qwen_gqa_attention\n");
+    return 0;
+}

--- a/cpp_engine/tests/test_qwen_weights.cpp
+++ b/cpp_engine/tests/test_qwen_weights.cpp
@@ -1,0 +1,325 @@
+// Qwen Safetensors mapping test with a small synthetic TP4 checkpoint.
+//
+// The fixture preserves the real 128-row FP8 scale block contract while using
+// one linear-attention layer, so it can verify packed QKV/conv segment offsets
+// without requiring a model download.
+
+#include "cuda_ops.hpp"
+#include "qwen_config.hpp"
+#include "qwen_weights.hpp"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+struct TensorSpec {
+    std::string name;
+    std::string dtype;
+    std::vector<uint64_t> shape;
+};
+
+uint64_t numel(const std::vector<uint64_t>& shape) {
+    uint64_t total = 1;
+    for (uint64_t dim : shape) total *= dim;
+    return total;
+}
+
+uint64_t dtype_size(const std::string& dtype) {
+    if (dtype == "F8_E4M3") return 1;
+    if (dtype == "BF16") return 2;
+    throw std::runtime_error("unsupported fixture dtype: " + dtype);
+}
+
+std::string shape_json(const std::vector<uint64_t>& shape) {
+    std::ostringstream out;
+    out << '[';
+    for (size_t i = 0; i < shape.size(); ++i) {
+        if (i) out << ',';
+        out << shape[i];
+    }
+    out << ']';
+    return out.str();
+}
+
+std::string fixture_dir() {
+    const char* base = std::getenv("CLAUDE_JOB_DIR");
+    const std::string root = base != nullptr ? std::string(base) + "/tmp" : std::string("/tmp");
+    return root + "/qwen_weights_fixture";
+}
+
+std::string config_json() {
+    return R"JSON({
+  "architectures": ["Qwen3_5ForConditionalGeneration"],
+  "model_type": "qwen3_5",
+  "text_config": {
+    "model_type": "qwen3_5_text",
+    "vocab_size": 512,
+    "hidden_size": 128,
+    "intermediate_size": 512,
+    "num_hidden_layers": 1,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 4,
+    "head_dim": 128,
+    "attn_output_gate": true,
+    "linear_num_key_heads": 4,
+    "linear_num_value_heads": 4,
+    "linear_key_head_dim": 128,
+    "linear_value_head_dim": 128,
+    "linear_conv_kernel_dim": 4,
+    "max_position_embeddings": 1024,
+    "rms_norm_eps": 1e-6,
+    "partial_rotary_factor": 0.25,
+    "rope_parameters": {"rope_type": "default", "rope_theta": 10000000},
+    "layer_types": ["linear_attention"]
+  }
+})JSON";
+}
+
+std::vector<TensorSpec> tensor_specs() {
+    const std::vector<uint64_t> hidden = {128};
+    const std::vector<uint64_t> vocab_weight = {512, 128};
+    const std::vector<uint64_t> qkv = {1536, 128};
+    const std::vector<uint64_t> qkv_scale = {12, 1};
+    const std::vector<uint64_t> value_proj = {512, 128};
+    const std::vector<uint64_t> value_proj_scale = {4, 1};
+    const std::vector<uint64_t> out_proj = {128, 512};
+    const std::vector<uint64_t> out_proj_scale = {1, 4};
+    const std::vector<uint64_t> vector4 = {4};
+    const std::vector<uint64_t> value_heads_weight = {4, 128};
+    const std::vector<uint64_t> mlp = {512, 128};
+    const std::vector<uint64_t> mlp_scale = {4, 1};
+    const std::vector<uint64_t> down = {128, 512};
+    const std::vector<uint64_t> down_scale = {1, 4};
+
+    std::vector<TensorSpec> out;
+    auto add = [&out](const std::string& name, const std::string& dtype,
+                      const std::vector<uint64_t>& shape) {
+        out.push_back({name, dtype, shape});
+    };
+    add("model.language_model.embed_tokens.weight", "BF16", vocab_weight);
+    add("model.language_model.norm.weight", "BF16", hidden);
+    add("lm_head.weight", "BF16", vocab_weight);
+
+    const std::string prefix = "model.language_model.layers.0.";
+    add(prefix + "input_layernorm.weight", "BF16", hidden);
+    add(prefix + "post_attention_layernorm.weight", "BF16", hidden);
+    add(prefix + "linear_attn.in_proj_qkv.weight", "F8_E4M3", qkv);
+    add(prefix + "linear_attn.in_proj_qkv.weight_scale_inv", "BF16", qkv_scale);
+    add(prefix + "linear_attn.in_proj_z.weight", "F8_E4M3", value_proj);
+    add(prefix + "linear_attn.in_proj_z.weight_scale_inv", "BF16", value_proj_scale);
+    add(prefix + "linear_attn.out_proj.weight", "F8_E4M3", out_proj);
+    add(prefix + "linear_attn.out_proj.weight_scale_inv", "BF16", out_proj_scale);
+    add(prefix + "linear_attn.in_proj_a.weight", "BF16", value_heads_weight);
+    add(prefix + "linear_attn.in_proj_b.weight", "BF16", value_heads_weight);
+    add(prefix + "linear_attn.conv1d.weight", "BF16", {1536, 1, 4});
+    add(prefix + "linear_attn.A_log", "BF16", vector4);
+    add(prefix + "linear_attn.dt_bias", "BF16", vector4);
+    add(prefix + "linear_attn.norm.weight", "BF16", {128});
+    add(prefix + "mlp.gate_proj.weight", "F8_E4M3", mlp);
+    add(prefix + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale);
+    add(prefix + "mlp.up_proj.weight", "F8_E4M3", mlp);
+    add(prefix + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale);
+    add(prefix + "mlp.down_proj.weight", "F8_E4M3", down);
+    add(prefix + "mlp.down_proj.weight_scale_inv", "BF16", down_scale);
+    return out;
+}
+
+bool write_file(const std::string& path, const std::string& contents) {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) return false;
+    out.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+    return static_cast<bool>(out);
+}
+
+bool write_fixture(const std::string& dir) {
+    const std::string mkdir_cmd = "mkdir -p '" + dir + "'";
+    if (std::system(mkdir_cmd.c_str()) != 0) return false;
+    if (!write_file(dir + "/config.json", config_json())) return false;
+
+    const std::vector<TensorSpec> specs = tensor_specs();
+    std::ostringstream header;
+    header << '{';
+    uint64_t offset = 0;
+    for (size_t i = 0; i < specs.size(); ++i) {
+        if (i) header << ',';
+        const TensorSpec& spec = specs[i];
+        const uint64_t bytes = numel(spec.shape) * dtype_size(spec.dtype);
+        header << '"' << spec.name << "\":{\"dtype\":\"" << spec.dtype
+               << "\",\"shape\":" << shape_json(spec.shape)
+               << ",\"data_offsets\":[" << offset << ',' << (offset + bytes) << "]}";
+        offset += bytes;
+    }
+    header << '}';
+
+    std::ofstream shard(dir + "/model.safetensors", std::ios::binary | std::ios::trunc);
+    if (!shard) return false;
+    const uint64_t header_len = header.str().size();
+    shard.write(reinterpret_cast<const char*>(&header_len), sizeof(header_len));
+    shard.write(header.str().data(), static_cast<std::streamsize>(header.str().size()));
+    std::vector<uint8_t> zeros(static_cast<size_t>(offset), 0);
+    shard.write(reinterpret_cast<const char*>(zeros.data()), static_cast<std::streamsize>(zeros.size()));
+    if (!shard) return false;
+
+    std::ostringstream index;
+    index << "{\"metadata\":{\"total_size\":" << offset
+          << "},\"weight_map\":{";
+    for (size_t i = 0; i < specs.size(); ++i) {
+        if (i) index << ',';
+        index << '"' << specs[i].name << "\":\"model.safetensors\"";
+    }
+    index << "}}";
+    return write_file(dir + "/model.safetensors.index.json", index.str());
+}
+
+void require(bool condition, const std::string& message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+void require_segment(const dsv4::QwenTensorRef& ref, size_t index,
+                     uint64_t start, uint64_t size, const std::string& label) {
+    require(index < ref.segments.size(), label + " missing segment");
+    require(ref.segments[index].first == start && ref.segments[index].second == size,
+            label + " wrong segment");
+}
+
+void check_rank(const dsv4::SafeTensorsIndex& index, const dsv4::QwenConfig& config, int rank) {
+    dsv4::QwenWeightMap map(index, config, 4, rank);
+    require(map.layers().size() == 1, "expected one mapped layer");
+    const auto& linear = map.layers()[0].linear_attention;
+
+    require(linear.in_proj_a.weight.dtype == dsv4::SafeDType::BF16,
+            "in_proj_a must remain BF16 in storage");
+    require(linear.in_proj_a.weight.local_shape == std::vector<uint64_t>({1, 128}),
+            "in_proj_a local shape");
+    require(linear.in_proj_a.weight.device_dtype == dsv4::SafeDType::F16,
+            "in_proj_a must upload as FP16 on Turing");
+    require(linear.in_proj_b.weight.dtype == dsv4::SafeDType::BF16,
+            "in_proj_b must remain BF16 in storage");
+    require(linear.in_proj_b.weight.device_dtype == dsv4::SafeDType::F16,
+            "in_proj_b must upload as FP16 on Turing");
+    require(linear.in_proj_qkv.weight.dtype == dsv4::SafeDType::F8_E4M3 &&
+                linear.in_proj_qkv.weight.device_dtype == dsv4::SafeDType::F8_E4M3,
+            "QKV FP8 must remain compressed on device");
+    require(linear.in_proj_qkv.scale.dtype == dsv4::SafeDType::BF16 &&
+                linear.in_proj_qkv.scale.device_dtype == dsv4::SafeDType::F16,
+            "FP8 scale must upload as FP16 on Turing");
+    require(!linear.in_proj_a.has_scale && !linear.in_proj_b.has_scale,
+            "BF16 in_proj_a/b must not have FP8 scales");
+
+    require(linear.in_proj_qkv.weight.local_shape == std::vector<uint64_t>({384, 128}),
+            "QKV local shape");
+    require(linear.in_proj_qkv.weight.segments.size() == 3, "QKV weight segment count");
+    require(linear.in_proj_qkv.scale.local_shape == std::vector<uint64_t>({3, 1}),
+            "QKV scale local shape");
+    require(linear.in_proj_qkv.scale.segments.size() == 3, "QKV scale segment count");
+
+    const uint64_t row_start = static_cast<uint64_t>(rank) * 128;
+    require_segment(linear.in_proj_qkv.weight, 0, row_start, 128, "QKV weight Q");
+    require_segment(linear.in_proj_qkv.weight, 1, 512 + row_start, 128, "QKV weight K");
+    require_segment(linear.in_proj_qkv.weight, 2, 1024 + row_start, 128, "QKV weight V");
+    const uint64_t block_start = static_cast<uint64_t>(rank);
+    require_segment(linear.in_proj_qkv.scale, 0, block_start, 1, "QKV scale Q");
+    require_segment(linear.in_proj_qkv.scale, 1, 4 + block_start, 1, "QKV scale K");
+    require_segment(linear.in_proj_qkv.scale, 2, 8 + block_start, 1, "QKV scale V");
+
+    require(linear.conv1d.local_shape == std::vector<uint64_t>({384, 1, 4}),
+            "conv local shape");
+    require(linear.conv1d.segments.size() == 3, "conv segment count");
+    require_segment(linear.conv1d, 0, row_start, 128, "conv Q");
+    require_segment(linear.conv1d, 1, 512 + row_start, 128, "conv K");
+    require_segment(linear.conv1d, 2, 1024 + row_start, 128, "conv V");
+
+    require(linear.in_proj_z.weight.local_shape == std::vector<uint64_t>({128, 128}),
+            "in_proj_z local shape");
+    require(linear.in_proj_z.scale.local_shape == std::vector<uint64_t>({1, 1}),
+            "in_proj_z scale local shape");
+    require(linear.in_proj_z.weight.shard_start == row_start &&
+                linear.in_proj_z.scale.shard_start == static_cast<uint64_t>(rank),
+            "in_proj_z shard offsets");
+
+    require(linear.out_proj.weight.local_shape == std::vector<uint64_t>({128, 128}),
+            "out_proj local shape");
+    require(linear.out_proj.scale.local_shape == std::vector<uint64_t>({1, 1}),
+            "out_proj scale local shape");
+    require(linear.out_proj.weight.shard_start == row_start &&
+                linear.out_proj.scale.shard_start == static_cast<uint64_t>(rank),
+            "out_proj shard offsets");
+
+    require(map.embed_tokens().local_shape == std::vector<uint64_t>({128, 128}),
+            "embedding local shape");
+    require(map.embed_tokens().device_dtype == dsv4::SafeDType::F16,
+            "embedding must upload as FP16");
+    require(map.lm_head().local_shape == std::vector<uint64_t>({128, 128}),
+            "head local shape");
+    require(map.lm_head().device_dtype == dsv4::SafeDType::F16,
+            "head must upload as FP16");
+
+    const dsv4::QwenHostTensor qkv_host =
+        dsv4::qwen_materialize_host_tensor(index, linear.in_proj_qkv.weight);
+    require(qkv_host.storage_dtype == dsv4::SafeDType::F8_E4M3 &&
+                qkv_host.device_dtype == dsv4::SafeDType::F8_E4M3,
+            "QKV host materializer must preserve FP8");
+    require(qkv_host.bytes.size() == 384u * 128u, "QKV host bytes");
+    const dsv4::QwenHostTensor scale_host =
+        dsv4::qwen_materialize_host_tensor(index, linear.in_proj_qkv.scale);
+    require(scale_host.storage_dtype == dsv4::SafeDType::BF16 &&
+                scale_host.device_dtype == dsv4::SafeDType::F16,
+            "scale host materializer must convert to FP16");
+    require(scale_host.bytes.size() == 3u * sizeof(uint16_t), "scale host bytes");
+    const dsv4::QwenHostTensor a_host =
+        dsv4::qwen_materialize_host_tensor(index, linear.in_proj_a.weight);
+    require(a_host.device_dtype == dsv4::SafeDType::F16 &&
+                a_host.bytes.size() == 128u * sizeof(uint16_t),
+            "in_proj_a host materializer must convert local BF16 shard");
+
+    require(dsv4::qwen_bf16_to_fp16_bits(0x3f80u) == 0x3c00u,
+            "BF16 1.0 converts to FP16 1.0");
+    require(dsv4::qwen_bf16_to_fp16_bits(0xbf80u) == 0xbc00u,
+            "BF16 -1.0 converts to FP16 -1.0");
+    if (dsv4::cuda_runtime_available()) {
+        dsv4::QwenDeviceTensor device_scale =
+            dsv4::qwen_upload_tensor_cuda(index, linear.in_proj_qkv.scale);
+        require(device_scale.device_dtype == dsv4::SafeDType::F16,
+                "uploaded scale dtype");
+        std::vector<uint8_t> device_bytes(scale_host.bytes.size(), 0);
+        require(cudaDeviceSynchronize() == cudaSuccess, "scale upload sync");
+        require(cudaMemcpy(device_bytes.data(), device_scale.data, device_bytes.size(),
+                           cudaMemcpyDeviceToHost) == cudaSuccess,
+                "scale device readback");
+        require(device_bytes == scale_host.bytes,
+                "scale device bytes are FP16 materialized bytes");
+    }
+    require(map.local_weight_bytes() > 0 && map.local_scale_bytes() > 0,
+            "weight byte accounting");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        const std::string dir = fixture_dir();
+        if (!write_fixture(dir)) {
+            std::cout << "[SKIP] could not create Qwen weight fixture\n";
+            return 0;
+        }
+        const dsv4::QwenConfig config = dsv4::QwenConfig::from_hf_config(dir);
+        dsv4::SafeTensorsIndex index(dir);
+        for (int rank = 0; rank < 4; ++rank) check_rank(index, config, rank);
+        std::cout << "[PASS] test_qwen_weights tp=4 layers=" << config.num_hidden_layers << "\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cout << "[FAIL] test_qwen_weights " << ex.what() << "\n";
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

- add an independent Qwen3.5/Qwen3.8 text runtime for the C++ engine
- load Qwen FP8 E4M3 weights with online unpacking and convert checkpoint BF16 tensors to FP16 for RTX 2080 Ti
- add TP-aware Safetensors mapping, hybrid Gated DeltaNet/GQA attention, dense SwiGLU, CLI dispatch, audit and benchmark output
- add CUDA/config/weight/runtime regression coverage

## Validation

- full Qwen CMake targets build successfully
- `test_qwen_config`
- `test_qwen_weights`
- `test_qwen_fp8_online`
- `test_qwen_engine`
- `test_qwen_delta_rule`
- `test_qwen_gqa_attention`
- `test_qwen_conv_tail`
- real Qwen3.8-27B-FP8 TP4 64-layer generation on four RTX 2080 Ti
- exact Transformers parity on the Fibonacci prompt (24/24 tokens)
- colors prompt produced a legal tie-break at a pair of equal HF logits
- measured peak GPU usage stayed below 8.2 GiB per rank in the tested prompts

## Scope notes

- Qwen text-only inference is supported through smoke/generation CLI paths
- Qwen OpenAI server, visual tower, and MTP are not included in this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
