### PR TITLE
Optimize Qwen3.8 TP4 decode runtime

### DIFF
--- a/cpp_engine/cuda/qwen_attention_ops.cu
+++ b/cpp_engine/cuda/qwen_attention_ops.cu
@@ -557,18 +557,112 @@ __device__ __forceinline__ void gqa_attention_body(const float* __restrict__ q_r
 }
 
 template <int kThreads>
-__global__ void gqa_decode_attention_kernel(const float* __restrict__ q,
-                                            const float* __restrict__ k_cache,
-                                            const float* __restrict__ v_cache,
-                                            float* __restrict__ out, int q_heads,
-                                            int kv_heads, int head_dim, int context_len,
-                                            int max_context) {
+__global__ void gqa_decode_scores_kernel(const float* __restrict__ q,
+                                         const float* __restrict__ k_cache,
+                                         float* __restrict__ scores, int q_heads,
+                                         int kv_heads, int head_dim, int context_len) {
+    const int head = static_cast<int>(blockIdx.x);
+    const int pos = static_cast<int>(blockIdx.y);
+    if (head >= q_heads || pos >= context_len) return;
+    const int kv_head = head / (q_heads / kv_heads);
+    const float* q_row = q + static_cast<size_t>(head) * head_dim;
+    const float* key = k_cache +
+                       (static_cast<size_t>(pos) * kv_heads + kv_head) * head_dim;
+    float partial = 0.0f;
+    for (int d = static_cast<int>(threadIdx.x); d < head_dim; d += kThreads) {
+        partial += q_row[d] * key[d];
+    }
+    extern __shared__ float reduce[];
+    reduce[threadIdx.x] = partial;
+    __syncthreads();
+    for (int stride = kThreads / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) reduce[threadIdx.x] += reduce[threadIdx.x + stride];
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) {
+        scores[static_cast<size_t>(head) * context_len + pos] =
+            reduce[0] * rsqrtf(static_cast<float>(head_dim));
+    }
+}
+
+template <int kThreads>
+__global__ void gqa_decode_softmax_kernel(float* __restrict__ scores,
+                                          int q_heads, int context_len) {
     const int head = static_cast<int>(blockIdx.x);
     if (head >= q_heads) return;
-    const int kv_head = head / (q_heads / kv_heads);
-    gqa_attention_body<kThreads>(q + static_cast<size_t>(head) * head_dim, k_cache, v_cache,
-                                 out + static_cast<size_t>(head) * head_dim, kv_head,
-                                 kv_heads, head_dim, context_len);
+    float* head_scores = scores + static_cast<size_t>(head) * context_len;
+    const int tid = static_cast<int>(threadIdx.x);
+    __shared__ float reduce[kThreads];
+
+    float local_max = -INFINITY;
+    for (int pos = tid; pos < context_len; pos += kThreads) {
+        local_max = fmaxf(local_max, head_scores[pos]);
+    }
+    reduce[tid] = local_max;
+    __syncthreads();
+    for (int stride = kThreads / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) reduce[tid] = fmaxf(reduce[tid], reduce[tid + stride]);
+        __syncthreads();
+    }
+    const float max_score = reduce[0];
+
+    float local_sum = 0.0f;
+    for (int pos = tid; pos < context_len; pos += kThreads) {
+        const float probability = expf(head_scores[pos] - max_score);
+        head_scores[pos] = probability;
+        local_sum += probability;
+    }
+    reduce[tid] = local_sum;
+    __syncthreads();
+    for (int stride = kThreads / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) reduce[tid] += reduce[tid + stride];
+        __syncthreads();
+    }
+    const float inv_sum = reduce[0] > 0.0f ? 1.0f / reduce[0] : 0.0f;
+    for (int pos = tid; pos < context_len; pos += kThreads) {
+        head_scores[pos] *= inv_sum;
+    }
+}
+
+// Q heads sharing one KV head consume the same V row. Accumulate a small Q-head
+// group together so each V element is loaded once per group instead of per head.
+template <int kThreads, int kHeadsPerGroup>
+__global__ void gqa_decode_grouped_values_kernel(
+    const float* __restrict__ probabilities,
+    const float* __restrict__ v_cache,
+    float* __restrict__ out,
+    int q_heads,
+    int kv_heads,
+    int head_dim,
+    int context_len) {
+    const int q_per_kv = q_heads / kv_heads;
+    const int groups_per_kv = (q_per_kv + kHeadsPerGroup - 1) / kHeadsPerGroup;
+    const int kv_head = static_cast<int>(blockIdx.x) / groups_per_kv;
+    const int group = static_cast<int>(blockIdx.x) % groups_per_kv;
+    const int first_head = kv_head * q_per_kv + group * kHeadsPerGroup;
+    const int d = static_cast<int>(blockIdx.y) * kThreads + static_cast<int>(threadIdx.x);
+    if (kv_head >= kv_heads || first_head >= (kv_head + 1) * q_per_kv || d >= head_dim) return;
+
+    float acc[kHeadsPerGroup] = {};
+    const size_t kv_stride = static_cast<size_t>(kv_heads) * head_dim;
+    for (int pos = 0; pos < context_len; ++pos) {
+        const float value = v_cache[static_cast<size_t>(pos) * kv_stride +
+                                    static_cast<size_t>(kv_head) * head_dim + d];
+#pragma unroll
+        for (int i = 0; i < kHeadsPerGroup; ++i) {
+            const int head = first_head + i;
+            if (head < (kv_head + 1) * q_per_kv) {
+                acc[i] += probabilities[static_cast<size_t>(head) * context_len + pos] * value;
+            }
+        }
+    }
+#pragma unroll
+    for (int i = 0; i < kHeadsPerGroup; ++i) {
+        const int head = first_head + i;
+        if (head < (kv_head + 1) * q_per_kv) {
+            out[static_cast<size_t>(head) * head_dim + d] = acc[i];
+        }
+    }
 }
 
 template <int kThreads>
@@ -803,18 +897,30 @@ bool qwen_append_kv_cache_cuda(const float* d_k_rows, const float* d_v_rows,
 
 bool qwen_gqa_decode_attention_cuda(const float* d_q, const float* d_k_cache,
                                     const float* d_v_cache, float* d_out,
+                                    float* d_score_scratch,
                                     int q_heads, int kv_heads, int head_dim,
                                     int context_len, int max_context,
                                     void* stream) {
-    if (!d_q || !d_k_cache || !d_v_cache || !d_out || q_heads <= 0 || kv_heads <= 0 ||
-        head_dim <= 0 || context_len <= 0 || context_len > max_context || q_heads % kv_heads != 0) return false;
+    if (!d_q || !d_k_cache || !d_v_cache || !d_out || !d_score_scratch ||
+        q_heads <= 0 || kv_heads <= 0 || head_dim <= 0 || context_len <= 0 ||
+        context_len > max_context || q_heads % kv_heads != 0) return false;
     constexpr int kThreads = 128;
     if ((head_dim + kThreads - 1) / kThreads > 8) return false;
     const cudaStream_t s = static_cast<cudaStream_t>(stream);
-    const size_t shmem = (static_cast<size_t>(head_dim) + kThreads) * sizeof(float);
-    gqa_decode_attention_kernel<kThreads><<<q_heads, kThreads, shmem, s>>>(
-        d_q, d_k_cache, d_v_cache, d_out, q_heads, kv_heads, head_dim,
-        context_len, max_context);
+    dim3 score_grid(static_cast<unsigned>(q_heads), static_cast<unsigned>(context_len), 1);
+    gqa_decode_scores_kernel<kThreads><<<score_grid, kThreads, kThreads * sizeof(float), s>>>(
+        d_q, d_k_cache, d_score_scratch, q_heads, kv_heads, head_dim, context_len);
+    if (cudaGetLastError() != cudaSuccess) return false;
+    gqa_decode_softmax_kernel<kThreads><<<q_heads, kThreads, 0, s>>>(
+        d_score_scratch, q_heads, context_len);
+    if (cudaGetLastError() != cudaSuccess) return false;
+    constexpr int kHeadsPerGroup = 3;
+    const int groups_per_kv = ((q_heads / kv_heads) + kHeadsPerGroup - 1) / kHeadsPerGroup;
+    const int dim_blocks = (head_dim + kThreads - 1) / kThreads;
+    dim3 value_grid(static_cast<unsigned>(kv_heads * groups_per_kv),
+                    static_cast<unsigned>(dim_blocks), 1);
+    gqa_decode_grouped_values_kernel<kThreads, kHeadsPerGroup><<<value_grid, kThreads, 0, s>>>(
+        d_score_scratch, d_v_cache, d_out, q_heads, kv_heads, head_dim, context_len);
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/cuda/qwen_fp8_ops.cu
+++ b/cpp_engine/cuda/qwen_fp8_ops.cu
@@ -809,6 +809,92 @@ __global__ void fp8_matvec_multirow_kernel(
     }
 }
 
+// Each warp evaluates the same output rows from the MLP gate and up matrices.
+// This halves x traffic versus two independent matvec launches and avoids both
+// projection outputs, while preserving each dot product's accumulation order.
+template <int kWarpsPerBlock, int kRowsPerWarp>
+__global__ void fp8_swiglu_matvec_kernel(
+    const float* __restrict__ x,
+    const uint8_t* __restrict__ gate_weight,
+    const uint16_t* __restrict__ gate_scale,
+    const uint8_t* __restrict__ up_weight,
+    const uint16_t* __restrict__ up_scale,
+    float* __restrict__ y,
+    int rows,
+    int cols,
+    int weight_stride,
+    int scale_stride) {
+    __shared__ float lut[256];
+    for (int i = static_cast<int>(threadIdx.x); i < 256; i += static_cast<int>(blockDim.x)) {
+        lut[i] = fp8_e4m3_to_float(static_cast<uint8_t>(i));
+    }
+    __syncthreads();
+
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int lane = static_cast<int>(threadIdx.x) & 31;
+    const int row_base = (static_cast<int>(blockIdx.x) * kWarpsPerBlock + warp) * kRowsPerWarp;
+    if (row_base >= rows) return;
+    const int active = min(kRowsPerWarp, rows - row_base);
+
+    const uint8_t* gate_rows[kRowsPerWarp];
+    const uint8_t* up_rows[kRowsPerWarp];
+    const uint16_t* gate_scale_rows[kRowsPerWarp];
+    const uint16_t* up_scale_rows[kRowsPerWarp];
+#pragma unroll
+    for (int r = 0; r < kRowsPerWarp; ++r) {
+        const int row = min(row_base + r, rows - 1);
+        gate_rows[r] = gate_weight + static_cast<size_t>(row) * weight_stride;
+        up_rows[r] = up_weight + static_cast<size_t>(row) * weight_stride;
+        gate_scale_rows[r] = gate_scale + static_cast<size_t>(row / kBlock) * scale_stride;
+        up_scale_rows[r] = up_scale + static_cast<size_t>(row / kBlock) * scale_stride;
+    }
+
+    float gate_sum[kRowsPerWarp] = {};
+    float up_sum[kRowsPerWarp] = {};
+    const int vec_cols = cols & ~3;
+    for (int col = lane * 4; col < vec_cols; col += 128) {
+        const float4 xv = *reinterpret_cast<const float4*>(x + col);
+        const int block_col = col / kBlock;
+#pragma unroll
+        for (int r = 0; r < kRowsPerWarp; ++r) {
+            if (r >= active) break;
+            const uchar4 gate_codes = *reinterpret_cast<const uchar4*>(gate_rows[r] + col);
+            const uchar4 up_codes = *reinterpret_cast<const uchar4*>(up_rows[r] + col);
+            const float gate_scale_value = fp16_bits_to_float(gate_scale_rows[r][block_col]);
+            const float up_scale_value = fp16_bits_to_float(up_scale_rows[r][block_col]);
+            gate_sum[r] += (xv.x * lut[gate_codes.x] + xv.y * lut[gate_codes.y] +
+                            xv.z * lut[gate_codes.z] + xv.w * lut[gate_codes.w]) * gate_scale_value;
+            up_sum[r] += (xv.x * lut[up_codes.x] + xv.y * lut[up_codes.y] +
+                          xv.z * lut[up_codes.z] + xv.w * lut[up_codes.w]) * up_scale_value;
+        }
+    }
+    for (int col = vec_cols + lane; col < cols; col += 32) {
+        const float xv = x[col];
+#pragma unroll
+        for (int r = 0; r < kRowsPerWarp; ++r) {
+            if (r >= active) break;
+            gate_sum[r] += xv * lut[gate_rows[r][col]] *
+                           fp16_bits_to_float(gate_scale_rows[r][col / kBlock]);
+            up_sum[r] += xv * lut[up_rows[r][col]] *
+                         fp16_bits_to_float(up_scale_rows[r][col / kBlock]);
+        }
+    }
+#pragma unroll
+    for (int r = 0; r < kRowsPerWarp; ++r) {
+        if (r >= active) break;
+        float gate_value = gate_sum[r];
+        float up_value = up_sum[r];
+        for (int off = 16; off > 0; off >>= 1) {
+            gate_value += __shfl_xor_sync(0xffffffffu, gate_value, off);
+            up_value += __shfl_xor_sync(0xffffffffu, up_value, off);
+        }
+        if (lane == 0) {
+            const float gate_silu = gate_value * (1.0f / (1.0f + expf(-gate_value)));
+            y[row_base + r] = gate_silu * up_value;
+        }
+    }
+}
+
 __global__ void rmsnorm_kernel(const float* __restrict__ x,
                                const float* __restrict__ weight,
                                float* __restrict__ y,
@@ -915,6 +1001,32 @@ bool qwen_fp8_e4m3_fp16scale_matvec_cuda(
     }
     fp8_matvec_kernel<true><<<rows, 256, 256 * sizeof(float), s>>>(
         d_x, d_weight, d_scale_fp16, d_y, rows, cols, weight_stride, scale_stride);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_fp8_e4m3_fp16scale_swiglu_matvec_cuda(
+    const float* d_x,
+    const uint8_t* d_gate_weight,
+    const uint16_t* d_gate_scale_fp16,
+    const uint8_t* d_up_weight,
+    const uint16_t* d_up_scale_fp16,
+    float* d_y,
+    int rows,
+    int cols,
+    int weight_stride,
+    int scale_stride,
+    void* stream) {
+    if (!valid_common(d_x, d_gate_weight, d_gate_scale_fp16, d_y, rows, cols, scale_stride) ||
+        !d_up_weight || !d_up_scale_fp16 || weight_stride < cols || weight_stride % 4 != 0) {
+        return false;
+    }
+    constexpr int kWarps = 8;
+    constexpr int kRowsPerWarp = 1;
+    const int blocks = (rows + kWarps * kRowsPerWarp - 1) / (kWarps * kRowsPerWarp);
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    fp8_swiglu_matvec_kernel<kWarps, kRowsPerWarp><<<blocks, kWarps * 32, 0, s>>>(
+        d_x, d_gate_weight, d_gate_scale_fp16, d_up_weight, d_up_scale_fp16,
+        d_y, rows, cols, weight_stride, scale_stride);
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/include/qwen_cuda_ops.hpp
+++ b/cpp_engine/include/qwen_cuda_ops.hpp
@@ -20,6 +20,21 @@ bool qwen_fp8_e4m3_fp16scale_matvec_cuda(
     int scale_stride,
     void* stream = nullptr);
 
+// Decode-only fused gate/up projection. The two matvecs retain independent FP32
+// accumulation, then write silu(gate) * up without materializing either input.
+bool qwen_fp8_e4m3_fp16scale_swiglu_matvec_cuda(
+    const float* d_x,
+    const uint8_t* d_gate_weight,
+    const uint16_t* d_gate_scale_fp16,
+    const uint8_t* d_up_weight,
+    const uint16_t* d_up_scale_fp16,
+    float* d_y,
+    int rows,
+    int cols,
+    int weight_stride,
+    int scale_stride,
+    void* stream = nullptr);
+
 bool qwen_fp8_e4m3_fp16scale_matmul_rows_cuda(
     const float* d_x,
     const uint8_t* d_weight,
@@ -178,9 +193,10 @@ bool qwen_append_kv_cache_cuda(const float* d_k_rows, const float* d_v_rows,
                                int max_context, void* stream = nullptr);
 
 // Single-token GQA attention against the cache. Query head h reads KV head
-// h / (q_heads / kv_heads).
+// h / (q_heads / kv_heads). d_score_scratch holds q_heads * context_len floats.
 bool qwen_gqa_decode_attention_cuda(const float* d_q, const float* d_k_cache,
                                     const float* d_v_cache, float* d_out,
+                                    float* d_score_scratch,
                                     int q_heads, int kv_heads, int head_dim,
                                     int context_len, int max_context,
                                     void* stream = nullptr);

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -411,21 +411,16 @@ struct QwenEngine::Impl {
     void full_attention(DeviceLayer& layer, float* hidden, float* output, int rows,
                         int position_offset) {
         const int q_heads = static_cast<int>(config.full_attention.num_heads / options.tp_world);
-        const int total_kv_heads = static_cast<int>(config.full_attention.num_key_value_heads);
-        const int kv_heads = total_kv_heads / options.tp_world;
+        const int kv_heads = static_cast<int>(config.full_attention.num_key_value_heads / options.tp_world);
         const int head_dim = static_cast<int>(config.full_attention.head_dim);
         const int attention_dim = q_heads * head_dim;
         const int q_proj_dim = attention_dim * 2;
-        const int kv_dim = total_kv_heads * head_dim;
         const size_t q_proj_elements = static_cast<size_t>(rows) * q_proj_dim;
         const size_t attention_elements = static_cast<size_t>(rows) * attention_dim;
-        const size_t kv_full_elements = static_cast<size_t>(rows) * kv_dim;
         const size_t kv_elements = static_cast<size_t>(rows) * kv_heads * head_dim;
         QwenDeviceTensor& q_proj = workspace_float(q_proj_elements, {static_cast<uint64_t>(rows), static_cast<uint64_t>(q_proj_dim)});
         QwenDeviceTensor& q = workspace_float(attention_elements, {static_cast<uint64_t>(rows), static_cast<uint64_t>(attention_dim)});
         QwenDeviceTensor& gate = workspace_float(attention_elements, q.shape);
-        QwenDeviceTensor& k_full = workspace_float(kv_full_elements, {static_cast<uint64_t>(rows), static_cast<uint64_t>(kv_dim)});
-        QwenDeviceTensor& v_full = workspace_float(kv_full_elements, k_full.shape);
         QwenDeviceTensor& k = workspace_float(kv_elements, {static_cast<uint64_t>(rows), static_cast<uint64_t>(kv_heads), static_cast<uint64_t>(head_dim)});
         QwenDeviceTensor& v = workspace_float(kv_elements, k.shape);
         QwenDeviceTensor& q_norm = workspace_float(attention_elements, q.shape);
@@ -434,13 +429,8 @@ struct QwenEngine::Impl {
         QwenDeviceTensor& merged = workspace_float(attention_elements, q.shape);
         projection(layer.full.q, hidden, fp32(q_proj), rows);
         require_launch(qwen_split_q_gate_cuda(fp32(q_proj), fp32(q), fp32(gate), rows, q_heads, head_dim), "full Q/gate split");
-        projection(layer.full.k, hidden, fp32(k_full), rows);
-        projection(layer.full.v, hidden, fp32(v_full), rows);
-        const int head_offset = (options.tp_rank * kv_heads);
-        require_launch(qwen_select_kv_heads_cuda(fp32(k_full), fp32(k), rows, total_kv_heads, kv_heads,
-                                                 head_dim, head_offset), "full K head select");
-        require_launch(qwen_select_kv_heads_cuda(fp32(v_full), fp32(v), rows, total_kv_heads, kv_heads,
-                                                 head_dim, head_offset), "full V head select");
+        projection(layer.full.k, hidden, fp32(k), rows);
+        projection(layer.full.v, hidden, fp32(v), rows);
         norm(layer.full.q_norm, fp32(q), fp32(q_norm), rows * q_heads, head_dim);
         norm(layer.full.k_norm, fp32(k), fp32(k_norm), rows * kv_heads, head_dim);
         if (rows == 1) {
@@ -461,9 +451,14 @@ struct QwenEngine::Impl {
                            rows, kv_heads, head_dim, position_offset, max_context),
                        "append full KV cache");
         if (rows == 1) {
+            const int context_len = position_offset + 1;
+            QwenDeviceTensor& scores = workspace_float(
+                static_cast<size_t>(q_heads) * max_context,
+                {static_cast<uint64_t>(q_heads), static_cast<uint64_t>(max_context)});
             require_launch(qwen_gqa_decode_attention_cuda(
                                fp32(q_norm), fp32(layer.full.k_cache), fp32(layer.full.v_cache),
-                               fp32(attn), q_heads, kv_heads, head_dim, position_offset + 1, max_context),
+                               fp32(attn), fp32(scores), q_heads, kv_heads, head_dim,
+                               context_len, max_context),
                            "decode GQA");
         } else {
             require_launch(qwen_gqa_prefill_attention_cuda(
@@ -485,9 +480,19 @@ struct QwenEngine::Impl {
         QwenDeviceTensor& normed = workspace_float(hidden_elements, {static_cast<uint64_t>(rows), static_cast<uint64_t>(hidden_size)});
         QwenDeviceTensor& attn = workspace_float(hidden_elements, normed.shape);
         QwenDeviceTensor& post = workspace_float(hidden_elements, normed.shape);
-        QwenDeviceTensor& gate = workspace_float(intermediate_elements, {static_cast<uint64_t>(rows), layer.gate.weight.shape[0]});
-        QwenDeviceTensor& up = workspace_float(intermediate_elements, gate.shape);
-        QwenDeviceTensor& intermediate = workspace_float(intermediate_elements, gate.shape);
+        const bool fused_swiglu = rows == 1 && layer.gate.fp8 && layer.up.fp8 &&
+                                  layer.gate.weight.shape == layer.up.weight.shape &&
+                                  layer.gate.scale.shape == layer.up.scale.shape;
+        QwenDeviceTensor* gate_ptr = nullptr;
+        QwenDeviceTensor* up_ptr = nullptr;
+        if (!fused_swiglu) {
+            gate_ptr = &workspace_float(intermediate_elements,
+                                        {static_cast<uint64_t>(rows), layer.gate.weight.shape[0]});
+            up_ptr = &workspace_float(intermediate_elements, gate_ptr->shape);
+        }
+        QwenDeviceTensor& intermediate = workspace_float(
+            intermediate_elements,
+            {static_cast<uint64_t>(rows), layer.gate.weight.shape[0]});
         QwenDeviceTensor& mlp = workspace_float(hidden_elements, normed.shape);
         norm(layer.input_norm, hidden, fp32(normed), rows, hidden_size);
         if (layer.linear.qkv.weight.data != nullptr) {
@@ -499,11 +504,21 @@ struct QwenEngine::Impl {
                    "Qwen residual copy");
         add(work, fp32(attn), rows * hidden_size);
         norm(layer.post_norm, work, fp32(post), rows, hidden_size);
-        projection(layer.gate, fp32(post), fp32(gate), rows);
-        projection(layer.up, fp32(post), fp32(up), rows);
-        require_launch(qwen_silu_mul_rows_cuda(fp32(gate), fp32(up), fp32(intermediate), rows,
-                                               static_cast<int>(layer.gate.weight.shape[0])),
-                       "Qwen SwiGLU");
+        if (fused_swiglu) {
+            require_launch(qwen_fp8_e4m3_fp16scale_swiglu_matvec_cuda(
+                               fp32(post), fp8(layer.gate.weight), fp16(layer.gate.scale),
+                               fp8(layer.up.weight), fp16(layer.up.scale), fp32(intermediate),
+                               static_cast<int>(layer.gate.weight.shape[0]), hidden_size,
+                               hidden_size, static_cast<int>(layer.gate.scale.shape[1])),
+                           "Qwen fused decode SwiGLU");
+        } else {
+            projection(layer.gate, fp32(post), fp32(*gate_ptr), rows);
+            projection(layer.up, fp32(post), fp32(*up_ptr), rows);
+            require_launch(qwen_silu_mul_rows_cuda(
+                               fp32(*gate_ptr), fp32(*up_ptr), fp32(intermediate), rows,
+                               static_cast<int>(layer.gate.weight.shape[0])),
+                           "Qwen SwiGLU");
+        }
         projection(layer.down, fp32(intermediate), fp32(mlp), rows);
         all_reduce(fp32(mlp), rows * hidden_size);
         add(work, fp32(mlp), rows * hidden_size);

--- a/cpp_engine/src/qwen_weights.cpp
+++ b/cpp_engine/src/qwen_weights.cpp
@@ -345,10 +345,10 @@ QwenWeightMap::QwenWeightMap(const SafeTensorsIndex& index, const QwenConfig& co
                 QwenShardRule::ColumnParallel, 0);
             layer.full_attention.k_proj = require_linear(
                 prefix + "self_attn.k_proj.weight", {kv_dim, config_.hidden_size},
-                QwenShardRule::Replicated, -1);
+                QwenShardRule::ColumnParallel, 0);
             layer.full_attention.v_proj = require_linear(
                 prefix + "self_attn.v_proj.weight", {kv_dim, config_.hidden_size},
-                QwenShardRule::Replicated, -1);
+                QwenShardRule::ColumnParallel, 0);
             layer.full_attention.o_proj = require_linear(
                 prefix + "self_attn.o_proj.weight", {config_.hidden_size, attention_dim},
                 QwenShardRule::RowParallel, 1);

--- a/cpp_engine/tests/bench_qwen_fp8_kernels.cpp
+++ b/cpp_engine/tests/bench_qwen_fp8_kernels.cpp
@@ -20,13 +20,21 @@ constexpr int kBlock = 128;
 struct Buffers {
     float* x = nullptr;
     uint8_t* w = nullptr;
+    uint8_t* w2 = nullptr;
     uint16_t* s = nullptr;
+    uint16_t* s2 = nullptr;
     float* y = nullptr;
+    float* y2 = nullptr;
+    float* y3 = nullptr;
     ~Buffers() {
         cudaFree(x);
         cudaFree(w);
+        cudaFree(w2);
         cudaFree(s);
+        cudaFree(s2);
         cudaFree(y);
+        cudaFree(y2);
+        cudaFree(y3);
     }
 };
 
@@ -80,6 +88,19 @@ void run_simt(const Buffers& b, int batch, int rows, int cols, int scale_cols) {
     }
 }
 
+void run_swiglu_separate(const Buffers& b, int batch, int rows, int cols, int scale_cols) {
+    if (batch != 1) return;
+    dsv4::qwen_fp8_e4m3_fp16scale_matvec_cuda(b.x, b.w, b.s, b.y, rows, cols, cols, scale_cols);
+    dsv4::qwen_fp8_e4m3_fp16scale_matvec_cuda(b.x, b.w2, b.s2, b.y2, rows, cols, cols, scale_cols);
+    dsv4::qwen_silu_mul_rows_cuda(b.y, b.y2, b.y3, 1, rows);
+}
+
+void run_swiglu_fused(const Buffers& b, int batch, int rows, int cols, int scale_cols) {
+    if (batch != 1) return;
+    dsv4::qwen_fp8_e4m3_fp16scale_swiglu_matvec_cuda(
+        b.x, b.w, b.s, b.w2, b.s2, b.y3, rows, cols, cols, scale_cols);
+}
+
 }  // namespace
 
 int main() {
@@ -103,6 +124,7 @@ int main() {
         {"mlp_gate     decode", 1, 4352, 5120},
         {"mlp_down     decode", 1, 5120, 4352},
         {"full_q       decode", 1, 1536, 5120},
+        {"full_kv      decode", 1, 256, 5120},
         {"mlp_gate    prefill", 64, 4352, 5120},
         {"mlp_down    prefill", 64, 5120, 4352},
         {"mlp_gate    pf-512 ", 512, 4352, 5120},
@@ -119,8 +141,12 @@ int main() {
         const size_t w_bytes = static_cast<size_t>(c.rows) * (c.cols + 4);
         if (cudaMalloc(&b.x, static_cast<size_t>(c.batch) * c.cols * sizeof(float)) != cudaSuccess ||
             cudaMalloc(&b.w, w_bytes) != cudaSuccess ||
+            cudaMalloc(&b.w2, w_bytes) != cudaSuccess ||
             cudaMalloc(&b.s, static_cast<size_t>(scale_rows) * scale_cols * sizeof(uint16_t)) != cudaSuccess ||
-            cudaMalloc(&b.y, static_cast<size_t>(c.batch) * c.rows * sizeof(float)) != cudaSuccess) {
+            cudaMalloc(&b.s2, static_cast<size_t>(scale_rows) * scale_cols * sizeof(uint16_t)) != cudaSuccess ||
+            cudaMalloc(&b.y, static_cast<size_t>(c.batch) * c.rows * sizeof(float)) != cudaSuccess ||
+            cudaMalloc(&b.y2, static_cast<size_t>(c.batch) * c.rows * sizeof(float)) != cudaSuccess ||
+            cudaMalloc(&b.y3, static_cast<size_t>(c.batch) * c.rows * sizeof(float)) != cudaSuccess) {
             std::printf("[SKIP] allocation failed for %s\n", c.label);
             return 0;
         }
@@ -133,7 +159,9 @@ int main() {
         std::vector<uint16_t> hs(static_cast<size_t>(scale_rows) * scale_cols, 0x3800);
         cudaMemcpy(b.x, hx.data(), hx.size() * sizeof(float), cudaMemcpyHostToDevice);
         cudaMemcpy(b.w, hw.data(), hw.size(), cudaMemcpyHostToDevice);
+        cudaMemcpy(b.w2, hw.data(), hw.size(), cudaMemcpyHostToDevice);
         cudaMemcpy(b.s, hs.data(), hs.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
+        cudaMemcpy(b.s2, hs.data(), hs.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
 
         const int iters = c.batch == 1 ? 200 : 30;
         const double ref = time_ms(run_ref, b, c.batch, c.rows, c.cols, scale_cols, iters);
@@ -143,6 +171,12 @@ int main() {
         std::printf("%s batch=%3d rows=%5d cols=%5d  baseline=%7.3f ms  old=%7.3f ms  simt=%7.3f ms  old/simt=%5.2fx  eff=%6.1f GB/s\n",
                     c.label, c.batch, c.rows, c.cols, ref, opt, simt, opt / simt,
                     bytes / (simt * 1e-3) / 1e9);
+        if (c.batch == 1 && c.rows == 4352 && c.cols == 5120) {
+            const double separate = time_ms(run_swiglu_separate, b, c.batch, c.rows, c.cols, scale_cols, iters);
+            const double fused = time_ms(run_swiglu_fused, b, c.batch, c.rows, c.cols, scale_cols, iters);
+            std::printf("mlp_swiglu fused                      separate=%7.3f ms  fused=%7.3f ms  speedup=%5.2fx\n",
+                        separate, fused, separate / fused);
+        }
     }
     return 0;
 }

--- a/cpp_engine/tests/test_qwen_fp8_online.cpp
+++ b/cpp_engine/tests/test_qwen_fp8_online.cpp
@@ -102,6 +102,30 @@ struct DeviceBuffers {
     }
 };
 
+struct SwiGLUDeviceBuffers {
+    float* x = nullptr;
+    uint8_t* gate_weight = nullptr;
+    uint8_t* up_weight = nullptr;
+    uint16_t* gate_scale = nullptr;
+    uint16_t* up_scale = nullptr;
+    float* gate = nullptr;
+    float* up = nullptr;
+    float* reference = nullptr;
+    float* fused = nullptr;
+
+    ~SwiGLUDeviceBuffers() {
+        cudaFree(x);
+        cudaFree(gate_weight);
+        cudaFree(up_weight);
+        cudaFree(gate_scale);
+        cudaFree(up_scale);
+        cudaFree(gate);
+        cudaFree(up);
+        cudaFree(reference);
+        cudaFree(fused);
+    }
+};
+
 bool run_case(int batch, int rows, int cols, uint64_t seed, const std::string& label) {
     constexpr int kBlock = 128;
     const int scale_rows = (rows + kBlock - 1) / kBlock;
@@ -200,6 +224,76 @@ bool run_case(int batch, int rows, int cols, uint64_t seed, const std::string& l
         fail(label + ": max_rel=" + std::to_string(max_rel) + " max_abs=" + std::to_string(max_abs));
     } else {
         std::cout << "  " << label << " batch=" << batch << " rows=" << rows << " cols=" << cols
+                  << " max_abs=" << max_abs << " max_rel=" << max_rel << "\n";
+    }
+    return true;
+}
+
+bool run_swiglu_case() {
+    constexpr int rows = 4352;
+    constexpr int cols = 5120;
+    constexpr int block = 128;
+    const int scale_cols = cols / block;
+    const int scale_rows = rows / block;
+    std::mt19937_64 rng(0x1234abcd);
+    std::uniform_int_distribution<int> code_dist(0, 255);
+    std::uniform_real_distribution<float> x_dist(-1.0f, 1.0f);
+    SwiGLUDeviceBuffers dev;
+    std::vector<float> x(cols);
+    std::vector<uint8_t> gate_weight(static_cast<size_t>(rows) * cols);
+    std::vector<uint8_t> up_weight(gate_weight.size());
+    std::vector<uint16_t> gate_scale(static_cast<size_t>(scale_rows) * scale_cols, 0x3800);
+    std::vector<uint16_t> up_scale(gate_scale.size(), 0x3a00);
+    for (float& value : x) value = x_dist(rng);
+    for (size_t i = 0; i < gate_weight.size(); ++i) {
+        gate_weight[i] = static_cast<uint8_t>(code_dist(rng));
+        up_weight[i] = static_cast<uint8_t>(code_dist(rng));
+    }
+    if (cudaMalloc(&dev.x, x.size() * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&dev.gate_weight, gate_weight.size()) != cudaSuccess ||
+        cudaMalloc(&dev.up_weight, up_weight.size()) != cudaSuccess ||
+        cudaMalloc(&dev.gate_scale, gate_scale.size() * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&dev.up_scale, up_scale.size() * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&dev.gate, rows * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&dev.up, rows * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&dev.reference, rows * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&dev.fused, rows * sizeof(float)) != cudaSuccess) {
+        return false;
+    }
+    cudaMemcpy(dev.x, x.data(), x.size() * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(dev.gate_weight, gate_weight.data(), gate_weight.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(dev.up_weight, up_weight.data(), up_weight.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(dev.gate_scale, gate_scale.data(), gate_scale.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
+    cudaMemcpy(dev.up_scale, up_scale.data(), up_scale.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
+    if (!dsv4::qwen_fp8_e4m3_fp16scale_matvec_cuda(
+            dev.x, dev.gate_weight, dev.gate_scale, dev.gate, rows, cols, cols, scale_cols) ||
+        !dsv4::qwen_fp8_e4m3_fp16scale_matvec_cuda(
+            dev.x, dev.up_weight, dev.up_scale, dev.up, rows, cols, cols, scale_cols) ||
+        !dsv4::qwen_silu_mul_rows_cuda(dev.gate, dev.up, dev.reference, 1, rows) ||
+        !dsv4::qwen_fp8_e4m3_fp16scale_swiglu_matvec_cuda(
+            dev.x, dev.gate_weight, dev.gate_scale, dev.up_weight, dev.up_scale, dev.fused,
+            rows, cols, cols, scale_cols)) {
+        fail("fused SwiGLU launch failed");
+        return true;
+    }
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        fail("fused SwiGLU sync failed");
+        return true;
+    }
+    std::vector<float> reference(rows), fused(rows);
+    cudaMemcpy(reference.data(), dev.reference, reference.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(fused.data(), dev.fused, fused.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    double max_abs = 0.0;
+    double max_rel = 0.0;
+    for (int i = 0; i < rows; ++i) {
+        const double error = std::fabs(static_cast<double>(fused[i]) - reference[i]);
+        max_abs = std::max(max_abs, error);
+        max_rel = std::max(max_rel, error / std::max(1.0, std::fabs(static_cast<double>(reference[i]))));
+    }
+    if (max_rel > 2.0e-4) {
+        fail("fused SwiGLU max_rel=" + std::to_string(max_rel) + " max_abs=" + std::to_string(max_abs));
+    } else {
+        std::cout << "  fused SwiGLU rows=" << rows << " cols=" << cols
                   << " max_abs=" << max_abs << " max_rel=" << max_rel << "\n";
     }
     return true;
@@ -336,6 +430,10 @@ int main() {
             std::cout << "[SKIP] device allocation failed for " << c.label << "\n";
             return 0;
         }
+    }
+    if (!run_swiglu_case()) {
+        std::cout << "[SKIP] device allocation failed for fused SwiGLU\n";
+        return 0;
     }
     if (!run_norm_cases()) {
         std::cout << "[SKIP] device allocation failed for norm cases\n";

--- a/cpp_engine/tests/test_qwen_gqa_attention.cpp
+++ b/cpp_engine/tests/test_qwen_gqa_attention.cpp
@@ -69,11 +69,13 @@ struct Device {
     float* k = nullptr;
     float* v = nullptr;
     float* out = nullptr;
+    float* scores = nullptr;
     ~Device() {
         cudaFree(q);
         cudaFree(k);
         cudaFree(v);
         cudaFree(out);
+        cudaFree(scores);
     }
 };
 
@@ -93,15 +95,17 @@ bool run_decode(int q_heads, int kv_heads, int head_dim, int context_len, int ma
     if (cudaMalloc(&dev.q, q.size() * sizeof(float)) != cudaSuccess ||
         cudaMalloc(&dev.k, k.size() * sizeof(float)) != cudaSuccess ||
         cudaMalloc(&dev.v, v.size() * sizeof(float)) != cudaSuccess ||
-        cudaMalloc(&dev.out, q.size() * sizeof(float)) != cudaSuccess) {
+        cudaMalloc(&dev.out, q.size() * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&dev.scores, static_cast<size_t>(q_heads) * context_len * sizeof(float)) != cudaSuccess) {
         return false;
     }
     cudaMemcpy(dev.q, q.data(), q.size() * sizeof(float), cudaMemcpyHostToDevice);
     cudaMemcpy(dev.k, k.data(), k.size() * sizeof(float), cudaMemcpyHostToDevice);
     cudaMemcpy(dev.v, v.data(), v.size() * sizeof(float), cudaMemcpyHostToDevice);
 
-    if (!dsv4::qwen_gqa_decode_attention_cuda(dev.q, dev.k, dev.v, dev.out, q_heads,
-                                              kv_heads, head_dim, context_len, max_context)) {
+    if (!dsv4::qwen_gqa_decode_attention_cuda(dev.q, dev.k, dev.v, dev.out, dev.scores,
+                                              q_heads, kv_heads, head_dim, context_len,
+                                              max_context)) {
         fail("gqa decode launch failed");
         return true;
     }

--- a/cpp_engine/tests/test_qwen_weights.cpp
+++ b/cpp_engine/tests/test_qwen_weights.cpp
@@ -1,8 +1,8 @@
 // Qwen Safetensors mapping test with a small synthetic TP4 checkpoint.
 //
 // The fixture preserves the real 128-row FP8 scale block contract while using
-// one linear-attention layer, so it can verify packed QKV/conv segment offsets
-// without requiring a model download.
+// one linear-attention and one full-attention layer, so it can verify packed
+// QKV/conv segments and local full-attention KV heads without a model download.
 
 #include "cuda_ops.hpp"
 #include "qwen_config.hpp"
@@ -67,7 +67,7 @@ std::string config_json() {
     "vocab_size": 512,
     "hidden_size": 128,
     "intermediate_size": 512,
-    "num_hidden_layers": 1,
+    "num_hidden_layers": 2,
     "num_attention_heads": 4,
     "num_key_value_heads": 4,
     "head_dim": 128,
@@ -81,7 +81,7 @@ std::string config_json() {
     "rms_norm_eps": 1e-6,
     "partial_rotary_factor": 0.25,
     "rope_parameters": {"rope_type": "default", "rope_theta": 10000000},
-    "layer_types": ["linear_attention"]
+    "layer_types": ["linear_attention", "full_attention"]
   }
 })JSON";
 }
@@ -111,27 +111,48 @@ std::vector<TensorSpec> tensor_specs() {
     add("model.language_model.norm.weight", "BF16", hidden);
     add("lm_head.weight", "BF16", vocab_weight);
 
-    const std::string prefix = "model.language_model.layers.0.";
-    add(prefix + "input_layernorm.weight", "BF16", hidden);
-    add(prefix + "post_attention_layernorm.weight", "BF16", hidden);
-    add(prefix + "linear_attn.in_proj_qkv.weight", "F8_E4M3", qkv);
-    add(prefix + "linear_attn.in_proj_qkv.weight_scale_inv", "BF16", qkv_scale);
-    add(prefix + "linear_attn.in_proj_z.weight", "F8_E4M3", value_proj);
-    add(prefix + "linear_attn.in_proj_z.weight_scale_inv", "BF16", value_proj_scale);
-    add(prefix + "linear_attn.out_proj.weight", "F8_E4M3", out_proj);
-    add(prefix + "linear_attn.out_proj.weight_scale_inv", "BF16", out_proj_scale);
-    add(prefix + "linear_attn.in_proj_a.weight", "BF16", value_heads_weight);
-    add(prefix + "linear_attn.in_proj_b.weight", "BF16", value_heads_weight);
-    add(prefix + "linear_attn.conv1d.weight", "BF16", {1536, 1, 4});
-    add(prefix + "linear_attn.A_log", "BF16", vector4);
-    add(prefix + "linear_attn.dt_bias", "BF16", vector4);
-    add(prefix + "linear_attn.norm.weight", "BF16", {128});
-    add(prefix + "mlp.gate_proj.weight", "F8_E4M3", mlp);
-    add(prefix + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale);
-    add(prefix + "mlp.up_proj.weight", "F8_E4M3", mlp);
-    add(prefix + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale);
-    add(prefix + "mlp.down_proj.weight", "F8_E4M3", down);
-    add(prefix + "mlp.down_proj.weight_scale_inv", "BF16", down_scale);
+    const std::string linear_prefix = "model.language_model.layers.0.";
+    add(linear_prefix + "input_layernorm.weight", "BF16", hidden);
+    add(linear_prefix + "post_attention_layernorm.weight", "BF16", hidden);
+    add(linear_prefix + "linear_attn.in_proj_qkv.weight", "F8_E4M3", qkv);
+    add(linear_prefix + "linear_attn.in_proj_qkv.weight_scale_inv", "BF16", qkv_scale);
+    add(linear_prefix + "linear_attn.in_proj_z.weight", "F8_E4M3", value_proj);
+    add(linear_prefix + "linear_attn.in_proj_z.weight_scale_inv", "BF16", value_proj_scale);
+    add(linear_prefix + "linear_attn.out_proj.weight", "F8_E4M3", out_proj);
+    add(linear_prefix + "linear_attn.out_proj.weight_scale_inv", "BF16", out_proj_scale);
+    add(linear_prefix + "linear_attn.in_proj_a.weight", "BF16", value_heads_weight);
+    add(linear_prefix + "linear_attn.in_proj_b.weight", "BF16", value_heads_weight);
+    add(linear_prefix + "linear_attn.conv1d.weight", "BF16", {1536, 1, 4});
+    add(linear_prefix + "linear_attn.A_log", "BF16", vector4);
+    add(linear_prefix + "linear_attn.dt_bias", "BF16", vector4);
+    add(linear_prefix + "linear_attn.norm.weight", "BF16", {128});
+
+    const std::string full_prefix = "model.language_model.layers.1.";
+    const std::vector<uint64_t> q_proj = {1024, 128};
+    const std::vector<uint64_t> q_proj_scale = {8, 1};
+    add(full_prefix + "input_layernorm.weight", "BF16", hidden);
+    add(full_prefix + "post_attention_layernorm.weight", "BF16", hidden);
+    add(full_prefix + "self_attn.q_proj.weight", "F8_E4M3", q_proj);
+    add(full_prefix + "self_attn.q_proj.weight_scale_inv", "BF16", q_proj_scale);
+    add(full_prefix + "self_attn.k_proj.weight", "F8_E4M3", value_proj);
+    add(full_prefix + "self_attn.k_proj.weight_scale_inv", "BF16", value_proj_scale);
+    add(full_prefix + "self_attn.v_proj.weight", "F8_E4M3", value_proj);
+    add(full_prefix + "self_attn.v_proj.weight_scale_inv", "BF16", value_proj_scale);
+    add(full_prefix + "self_attn.o_proj.weight", "F8_E4M3", out_proj);
+    add(full_prefix + "self_attn.o_proj.weight_scale_inv", "BF16", out_proj_scale);
+    add(full_prefix + "self_attn.q_norm.weight", "BF16", {128});
+    add(full_prefix + "self_attn.k_norm.weight", "BF16", {128});
+
+    auto add_mlp = [&add, &mlp, &mlp_scale, &down, &down_scale](const std::string& prefix) {
+        add(prefix + "mlp.gate_proj.weight", "F8_E4M3", mlp);
+        add(prefix + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale);
+        add(prefix + "mlp.up_proj.weight", "F8_E4M3", mlp);
+        add(prefix + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale);
+        add(prefix + "mlp.down_proj.weight", "F8_E4M3", down);
+        add(prefix + "mlp.down_proj.weight_scale_inv", "BF16", down_scale);
+    };
+    add_mlp(linear_prefix);
+    add_mlp(full_prefix);
     return out;
 }
 
@@ -195,8 +216,9 @@ void require_segment(const dsv4::QwenTensorRef& ref, size_t index,
 
 void check_rank(const dsv4::SafeTensorsIndex& index, const dsv4::QwenConfig& config, int rank) {
     dsv4::QwenWeightMap map(index, config, 4, rank);
-    require(map.layers().size() == 1, "expected one mapped layer");
+    require(map.layers().size() == 2, "expected two mapped layers");
     const auto& linear = map.layers()[0].linear_attention;
+    const auto& full = map.layers()[1].full_attention;
 
     require(linear.in_proj_a.weight.dtype == dsv4::SafeDType::BF16,
             "in_proj_a must remain BF16 in storage");
@@ -255,6 +277,18 @@ void check_rank(const dsv4::SafeTensorsIndex& index, const dsv4::QwenConfig& con
     require(linear.out_proj.weight.shard_start == row_start &&
                 linear.out_proj.scale.shard_start == static_cast<uint64_t>(rank),
             "out_proj shard offsets");
+
+    for (const auto* kv : {&full.k_proj, &full.v_proj}) {
+        require(kv->weight.rule == dsv4::QwenShardRule::ColumnParallel,
+                "full KV weight must be column parallel");
+        require(kv->weight.local_shape == std::vector<uint64_t>({128, 128}),
+                "full KV local shape");
+        require(kv->scale.local_shape == std::vector<uint64_t>({1, 1}),
+                "full KV scale local shape");
+        require(kv->weight.shard_start == row_start &&
+                    kv->scale.shard_start == static_cast<uint64_t>(rank),
+                "full KV shard offsets");
+    }
 
     require(map.embed_tokens().local_shape == std::vector<uint64_t>({128, 128}),
             "embedding local shape");


### PR DESCRIPTION
## Summary

- shard full-attention K/V projections across TP ranks so each rank computes and stores only its local KV head
- split GQA decode into parallel score/softmax stages and group query heads that share a KV head in the value kernel
- fuse decode-only FP8 E4M3 gate/up projections with SwiGLU while keeping the prefill dispatch separate
- extend Qwen FP8, GQA, and TP weight-sharding tests with real Qwen3.8 TP4 shapes

## Real Qwen3.8-27B-FP8 TP4 results

Hardware: 4x RTX 2080 Ti, one single-request stream, real checkpoint and prompts.

| Case | Prefill | Decode |
| --- | ---: | ---: |
| 64-token short prompt | 138.61–138.69 tok/s | 36.82 tok/s |
| 512-token long prompt | 416.48 tok/s | 35.87 tok/s |

The prior stable decode baseline was approximately 22.4 tok/s. The optimized 512-token runs were repeatable at approximately 35.7–35.9 tok/s while preserving approximately 412–416 tok/s prefill.

Per-rank resident model storage remains within the 22 GiB budget:

- resident FP8 weights: 7,367,270,656 bytes/rank
- resident scales: 742,400 bytes/rank
- observed total GPU usage: approximately 8.0–8.6 GiB/rank

## Correctness and regression validation

- TP4 short- and long-prompt generated token sequences match on all four ranks
- GQA decode matches the CPU reference with worst absolute error `1.192e-07`
- fused FP8 SwiGLU matches the separate projection path with `max_abs=0`, `max_rel=0`
- Qwen RMSNorm, gated RMSNorm, L2 normalization, online FP8, GQA, and TP4 weight-sharding tests pass
- DSV4 FP8 matvec/matmul regression passes with worst absolute error `5.96046e-08`
- DSV4 minimum-layer smoke test passes
- `git diff --check` passes

Parallel GQA softmax changes floating-point reduction association, but the CPU-reference error remains near `1e-7` and real generated token sequences are unchanged.

## Profiling notes

After the grouped GQA change, GQA value aggregation is no longer a primary bottleneck. The remaining dominant costs are online FP8 projections and NCCL all-reduce. NCCL `Tree` was incompatible with the existing top-1 all-gather, while forcing `Simple` or `LL128` regressed decode or prefill, so this change leaves the default Ring/LL selection untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
