### PR TITLE
Add Qwen 256K memory-safe runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ for rank in 0 1 2 3; do
     --tp-world 4 --tp-rank $rank --device 0 \
     --nccl-id-path /tmp/pocketllm_qwen_nccl.id \
     --prompt "Explain tensor parallelism in one paragraph." \
-    --generate-token 123 --max-new-tokens 32 --resident-bench \
+    --generate-token 123 --max-new-tokens 32 --smoke-layers 0 --resident-bench \
     > /tmp/pocketllm_qwen_rank${rank}.log 2>&1 &
 done
 wait

--- a/README_CN.md
+++ b/README_CN.md
@@ -145,7 +145,7 @@ for rank in 0 1 2 3; do
     --tp-world 4 --tp-rank $rank --device 0 \
     --nccl-id-path /tmp/pocketllm_qwen_nccl.id \
     --prompt "请用一段话解释 tensor parallelism。" \
-    --generate-token 123 --max-new-tokens 32 --resident-bench \
+    --generate-token 123 --max-new-tokens 32 --smoke-layers 0 --resident-bench \
     > /tmp/pocketllm_qwen_rank${rank}.log 2>&1 &
 done
 wait

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(dsv4_cpp_core STATIC
     cuda/fp8_ops.cu
     cuda/qwen_fp8_ops.cu
     cuda/qwen_attention_ops.cu
+    cuda/qwen_half_ops.cu
     cuda/q2_ops.cu
     cuda/iq1_ops.cu
     cuda/rmsnorm_rope.cu
@@ -314,6 +315,10 @@ set_target_properties(test_qwen_delta_rule PROPERTIES RUNTIME_OUTPUT_DIRECTORY $
 add_executable(test_qwen_gqa_attention tests/test_qwen_gqa_attention.cpp)
 target_link_libraries(test_qwen_gqa_attention PRIVATE dsv4_cpp_core)
 set_target_properties(test_qwen_gqa_attention PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_half_ops tests/test_qwen_half_ops.cpp)
+target_link_libraries(test_qwen_half_ops PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_half_ops PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(test_qwen_conv_tail tests/test_qwen_conv_tail.cpp)
 target_link_libraries(test_qwen_conv_tail PRIVATE dsv4_cpp_core)

--- a/cpp_engine/cuda/qwen_half_ops.cu
+++ b/cpp_engine/cuda/qwen_half_ops.cu
@@ -1,0 +1,1155 @@
+#include "qwen_cuda_ops.hpp"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+
+namespace dsv4 {
+namespace {
+
+constexpr int kFp8WeightBlock = 128;
+constexpr int kThreads = 256;
+
+__device__ __forceinline__ float half_to_float(uint16_t bits) {
+    return __half2float(__ushort_as_half(bits));
+}
+
+__device__ __forceinline__ uint16_t float_to_half(float value) {
+    return __half_as_ushort(__float2half_rn(value));
+}
+
+__device__ __forceinline__ float sigmoid(float value) {
+    return 1.0f / (1.0f + expf(-value));
+}
+
+__device__ __forceinline__ float silu(float value) {
+    return value * sigmoid(value);
+}
+
+__device__ __forceinline__ float fp8_e4m3_to_float(uint8_t code) {
+    const uint32_t sign = static_cast<uint32_t>(code & 0x80u) << 24;
+    const uint32_t exponent = (code >> 3) & 0xfu;
+    const uint32_t mantissa = code & 0x7u;
+    uint32_t bits;
+    if (exponent != 0) {
+        bits = sign | ((exponent + 120u) << 23) | (mantissa << 20);
+    } else if (mantissa >= 4) {
+        bits = sign | (120u << 23) | ((mantissa - 4u) << 21);
+    } else if (mantissa >= 2) {
+        bits = sign | (119u << 23) | ((mantissa - 2u) << 22);
+    } else {
+        bits = sign | (mantissa == 0 ? 0u : (118u << 23));
+    }
+    return __uint_as_float(bits);
+}
+
+__device__ __forceinline__ uint8_t float_to_fp8_e4m3(float value) {
+    const bool negative = signbit(value);
+    float magnitude = fminf(fabsf(value), 448.0f);
+    uint8_t code = 0;
+    if (magnitude >= 0.0009765625f) {
+        if (magnitude < 0.015625f) {
+            int mantissa = __float2int_rn(magnitude * 512.0f);
+            mantissa = max(1, mantissa);
+            code = static_cast<uint8_t>(min(8, mantissa));
+        } else {
+            int exponent = static_cast<int>(floorf(log2f(magnitude)));
+            exponent = max(-6, min(8, exponent));
+            const float base = exp2f(static_cast<float>(exponent));
+            int mantissa = __float2int_rn((magnitude / base - 1.0f) * 8.0f);
+            if (mantissa == 8) {
+                mantissa = 0;
+                ++exponent;
+            }
+            int biased = exponent + 7;
+            if (biased >= 15 && mantissa > 6) mantissa = 6;
+            biased = min(15, biased);
+            code = static_cast<uint8_t>((biased << 3) | mantissa);
+        }
+    }
+    return static_cast<uint8_t>(code | (negative ? 0x80u : 0u));
+}
+
+__device__ __forceinline__ float block_reduce_sum(float value, float* scratch) {
+    scratch[threadIdx.x] = value;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) scratch[threadIdx.x] += scratch[threadIdx.x + stride];
+        __syncthreads();
+    }
+    return scratch[0];
+}
+
+// One warp owns one output row. This is the decode path; all products and the
+// warp reduction remain FP32 while the activation vector and result are FP16.
+template <int kWarps>
+__global__ void fp8_matvec_f16_kernel(
+    const uint16_t* __restrict__ x, const uint8_t* __restrict__ weight,
+    const uint16_t* __restrict__ scale, uint16_t* __restrict__ y,
+    int rows, int cols, int weight_stride, int scale_stride) {
+    __shared__ float lut[256];
+    for (int i = static_cast<int>(threadIdx.x); i < 256; i += blockDim.x) {
+        lut[i] = fp8_e4m3_to_float(static_cast<uint8_t>(i));
+    }
+    __syncthreads();
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int lane = static_cast<int>(threadIdx.x) & 31;
+    const int row = static_cast<int>(blockIdx.x) * kWarps + warp;
+    if (row >= rows) return;
+    const uint8_t* w = weight + static_cast<size_t>(row) * weight_stride;
+    const uint16_t* s = scale + static_cast<size_t>(row / kFp8WeightBlock) * scale_stride;
+    float sum = 0.0f;
+    for (int col = lane; col < cols; col += 32) {
+        sum += half_to_float(x[col]) * lut[w[col]] * half_to_float(s[col / kFp8WeightBlock]);
+    }
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        sum += __shfl_xor_sync(0xffffffffu, sum, offset);
+    }
+    if (lane == 0) y[row] = float_to_half(sum);
+}
+
+template <int kWarps, int kRowsPerWarp>
+__global__ void fp8_swiglu_matvec_f16_kernel(
+    const uint16_t* __restrict__ x,
+    const uint8_t* __restrict__ gate_weight,
+    const uint16_t* __restrict__ gate_scale,
+    const uint8_t* __restrict__ up_weight,
+    const uint16_t* __restrict__ up_scale,
+    uint16_t* __restrict__ y, int rows, int cols, int weight_stride,
+    int scale_stride) {
+    __shared__ float lut[256];
+    for (int i = static_cast<int>(threadIdx.x); i < 256; i += blockDim.x) {
+        lut[i] = fp8_e4m3_to_float(static_cast<uint8_t>(i));
+    }
+    __syncthreads();
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int lane = static_cast<int>(threadIdx.x) & 31;
+    const int row_base = (static_cast<int>(blockIdx.x) * kWarps + warp) * kRowsPerWarp;
+    if (row_base >= rows) return;
+    const int active = min(kRowsPerWarp, rows - row_base);
+    float gate_sum[kRowsPerWarp] = {};
+    float up_sum[kRowsPerWarp] = {};
+    for (int col = lane; col < cols; col += 32) {
+        const float xv = half_to_float(x[col]);
+#pragma unroll
+        for (int r = 0; r < kRowsPerWarp; ++r) {
+            if (r >= active) break;
+            const int row = row_base + r;
+            const size_t wi = static_cast<size_t>(row) * weight_stride + col;
+            const size_t si = static_cast<size_t>(row / kFp8WeightBlock) * scale_stride +
+                              col / kFp8WeightBlock;
+            gate_sum[r] += xv * lut[gate_weight[wi]] * half_to_float(gate_scale[si]);
+            up_sum[r] += xv * lut[up_weight[wi]] * half_to_float(up_scale[si]);
+        }
+    }
+#pragma unroll
+    for (int r = 0; r < kRowsPerWarp; ++r) {
+        if (r >= active) break;
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            gate_sum[r] += __shfl_xor_sync(0xffffffffu, gate_sum[r], offset);
+            up_sum[r] += __shfl_xor_sync(0xffffffffu, up_sum[r], offset);
+        }
+        if (lane == 0) y[row_base + r] = float_to_half(silu(gate_sum[r]) * up_sum[r]);
+    }
+}
+
+// A 64-token by 64-output tile reuses each online-decoded weight across all
+// tokens in the tile. Shared storage is FP32 so arithmetic association and
+// accumulation are independent of activation storage precision.
+template <int kK>
+__global__ void fp8_matmul_f16_tiled_kernel(
+    const uint16_t* __restrict__ x, const uint8_t* __restrict__ weight,
+    const uint16_t* __restrict__ scale, uint16_t* __restrict__ y,
+    int batch, int rows, int cols, int x_stride, int y_stride,
+    int weight_stride, int scale_stride) {
+    constexpr int kM = 64;
+    constexpr int kN = 64;
+    __shared__ float xs[kM][kK + 1];
+    __shared__ float ws[kN][kK + 1];
+    __shared__ float lut[256];
+    const int tid = static_cast<int>(threadIdx.x);
+    for (int i = tid; i < 256; i += blockDim.x) lut[i] = fp8_e4m3_to_float(static_cast<uint8_t>(i));
+    __syncthreads();
+    const int batch_base = static_cast<int>(blockIdx.y) * kM;
+    const int row_base = static_cast<int>(blockIdx.x) * kN;
+    const int tm = tid >> 4;
+    const int tn = tid & 15;
+    float acc[4][4] = {};
+    for (int col_base = 0; col_base < cols; col_base += kK) {
+        for (int index = tid; index < kM * kK; index += blockDim.x) {
+            const int m = index / kK;
+            const int k = index % kK;
+            const int gb = batch_base + m;
+            const int gc = col_base + k;
+            xs[m][k] = gb < batch && gc < cols
+                ? half_to_float(x[static_cast<size_t>(gb) * x_stride + gc]) : 0.0f;
+        }
+        for (int index = tid; index < kN * kK; index += blockDim.x) {
+            const int n = index / kK;
+            const int k = index % kK;
+            const int gr = row_base + n;
+            const int gc = col_base + k;
+            float value = 0.0f;
+            if (gr < rows && gc < cols) {
+                value = lut[weight[static_cast<size_t>(gr) * weight_stride + gc]] *
+                        half_to_float(scale[static_cast<size_t>(gr / kFp8WeightBlock) *
+                                                  scale_stride + gc / kFp8WeightBlock]);
+            }
+            ws[n][k] = value;
+        }
+        __syncthreads();
+        float tile[4][4] = {};
+#pragma unroll
+        for (int k = 0; k < kK; ++k) {
+            float a[4];
+            float b[4];
+#pragma unroll
+            for (int i = 0; i < 4; ++i) {
+                a[i] = xs[tm + i * 16][k];
+                b[i] = ws[tn + i * 16][k];
+            }
+#pragma unroll
+            for (int i = 0; i < 4; ++i) {
+#pragma unroll
+                for (int j = 0; j < 4; ++j) tile[i][j] += a[i] * b[j];
+            }
+        }
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+#pragma unroll
+            for (int j = 0; j < 4; ++j) acc[i][j] += tile[i][j];
+        }
+        __syncthreads();
+    }
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        const int gb = batch_base + tm + i * 16;
+        if (gb >= batch) continue;
+#pragma unroll
+        for (int j = 0; j < 4; ++j) {
+            const int gr = row_base + tn + j * 16;
+            if (gr < rows) y[static_cast<size_t>(gb) * y_stride + gr] = float_to_half(acc[i][j]);
+        }
+    }
+}
+
+template <bool kFloatOutput>
+__global__ void fp16_matmul_f16_kernel(
+    const uint16_t* __restrict__ x, const uint16_t* __restrict__ weight,
+    void* __restrict__ output, int batch, int rows, int cols,
+    int x_stride, int y_stride, int weight_stride) {
+    const int row = static_cast<int>(blockIdx.x);
+    const int sample = static_cast<int>(blockIdx.y);
+    if (row >= rows || sample >= batch) return;
+    const uint16_t* xr = x + static_cast<size_t>(sample) * x_stride;
+    const uint16_t* wr = weight + static_cast<size_t>(row) * weight_stride;
+    float sum = 0.0f;
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+        sum += half_to_float(xr[col]) * half_to_float(wr[col]);
+    }
+    extern __shared__ float scratch[];
+    const float total = block_reduce_sum(sum, scratch);
+    if (threadIdx.x == 0) {
+        const size_t index = static_cast<size_t>(sample) * y_stride + row;
+        if constexpr (kFloatOutput) static_cast<float*>(output)[index] = total;
+        else static_cast<uint16_t*>(output)[index] = float_to_half(total);
+    }
+}
+
+__global__ void embedding_f16_kernel(const uint16_t* table, const int* tokens,
+                                     uint16_t* output, int count, int cols,
+                                     int row_start, int row_count) {
+    const int token_index = static_cast<int>(blockIdx.x);
+    if (token_index >= count) return;
+    const int token = tokens[token_index];
+    uint16_t* dst = output + static_cast<size_t>(token_index) * cols;
+    if (token < row_start || token >= row_start + row_count) {
+        for (int col = threadIdx.x; col < cols; col += blockDim.x) dst[col] = 0;
+        return;
+    }
+    const uint16_t* src = table + static_cast<size_t>(token - row_start) * cols;
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) dst[col] = src[col];
+}
+
+__global__ void rmsnorm_f16_kernel(const uint16_t* x, const uint16_t* gamma,
+                                   uint16_t* y, int rows, int cols, float eps) {
+    const int row = static_cast<int>(blockIdx.x);
+    if (row >= rows) return;
+    const uint16_t* src = x + static_cast<size_t>(row) * cols;
+    uint16_t* dst = y + static_cast<size_t>(row) * cols;
+    float sum = 0.0f;
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+        const float value = half_to_float(src[col]);
+        sum += value * value;
+    }
+    extern __shared__ float scratch[];
+    const float inv = rsqrtf(block_reduce_sum(sum, scratch) / static_cast<float>(cols) + eps);
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+        dst[col] = float_to_half(half_to_float(src[col]) * inv * (1.0f + half_to_float(gamma[col])));
+    }
+}
+
+__global__ void gated_rmsnorm_f16_kernel(
+    const uint16_t* x, const uint16_t* gamma, const uint16_t* gate,
+    uint16_t* y, int rows, int cols, float eps) {
+    const int row = static_cast<int>(blockIdx.x);
+    if (row >= rows) return;
+    const uint16_t* src = x + static_cast<size_t>(row) * cols;
+    const uint16_t* gr = gate + static_cast<size_t>(row) * cols;
+    uint16_t* dst = y + static_cast<size_t>(row) * cols;
+    float sum = 0.0f;
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+        const float value = half_to_float(src[col]);
+        sum += value * value;
+    }
+    extern __shared__ float scratch[];
+    const float inv = rsqrtf(block_reduce_sum(sum, scratch) / static_cast<float>(cols) + eps);
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+        const float value = half_to_float(src[col]) * inv * half_to_float(gamma[col]);
+        dst[col] = float_to_half(value * silu(half_to_float(gr[col])));
+    }
+}
+
+__global__ void split_packed_qkv_f16_kernel(
+    const uint16_t* packed, uint16_t* q, uint16_t* k, uint16_t* v,
+    int rows, int key_dim, int value_dim) {
+    const int index = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int packed_dim = 2 * key_dim + value_dim;
+    const int total = rows * packed_dim;
+    if (index >= total) return;
+    const int row = index / packed_dim;
+    const int col = index % packed_dim;
+    if (col < key_dim) q[static_cast<size_t>(row) * key_dim + col] = packed[index];
+    else if (col < 2 * key_dim) k[static_cast<size_t>(row) * key_dim + col - key_dim] = packed[index];
+    else v[static_cast<size_t>(row) * value_dim + col - 2 * key_dim] = packed[index];
+}
+
+__global__ void conv_silu_f16_kernel(
+    const uint16_t* x, const uint16_t* weight, uint16_t* tail,
+    uint16_t* y, int seq_len, int channels, int kernel, bool update_tail) {
+    const int channel = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (channel >= channels) return;
+    const uint16_t* w = weight + static_cast<size_t>(channel) * kernel;
+    for (int t = 0; t < seq_len; ++t) {
+        float value = 0.0f;
+        for (int j = 0; j < kernel; ++j) {
+            const int source_t = t - (kernel - 1) + j;
+            float input = 0.0f;
+            if (source_t >= 0) input = half_to_float(x[static_cast<size_t>(source_t) * channels + channel]);
+            else if (tail != nullptr) input = half_to_float(tail[static_cast<size_t>(source_t + kernel - 1) * channels + channel]);
+            value += input * half_to_float(w[j]);
+        }
+        y[static_cast<size_t>(t) * channels + channel] = float_to_half(silu(value));
+    }
+    if (update_tail && tail != nullptr && kernel > 1) {
+        constexpr int kMaxTail = 8;
+        const int tail_len = kernel - 1;
+        uint16_t next[kMaxTail];
+        for (int j = 0; j < tail_len; ++j) {
+            const int source_t = seq_len - tail_len + j;
+            next[j] = source_t >= 0
+                ? x[static_cast<size_t>(source_t) * channels + channel]
+                : tail[static_cast<size_t>(source_t + tail_len) * channels + channel];
+        }
+        for (int j = 0; j < tail_len; ++j) tail[static_cast<size_t>(j) * channels + channel] = next[j];
+    }
+}
+
+__global__ void linear_gates_f16_kernel(
+    const uint16_t* a, const uint16_t* b, const uint16_t* a_log,
+    const uint16_t* dt_bias, uint16_t* g, uint16_t* beta,
+    int rows, int heads) {
+    const int head = static_cast<int>(blockIdx.x);
+    if (head >= heads) return;
+    const float al = half_to_float(a_log[head]);
+    const float dt = half_to_float(dt_bias[head]);
+    for (int row = threadIdx.x; row < rows; row += blockDim.x) {
+        const size_t index = static_cast<size_t>(row) * heads + head;
+        const float av = half_to_float(a[index]);
+        const float bv = half_to_float(b[index]);
+        g[index] = float_to_half(-expf(al) * log1pf(expf(av + dt)));
+        beta[index] = float_to_half(sigmoid(bv));
+    }
+}
+
+__global__ void gated_delta_step_f16_kernel(
+    float* state, const uint16_t* q, const uint16_t* k,
+    const uint16_t* v, const uint16_t* g, const uint16_t* beta,
+    uint16_t* output, int heads, int key_heads, int key_dim,
+    int value_dim, float q_scale) {
+    const int head = static_cast<int>(blockIdx.x);
+    const int value = static_cast<int>(threadIdx.x);
+    const int repeat = heads / key_heads;
+    const int key_head = head / repeat;
+    extern __shared__ float smem[];
+    float* k_shared = smem;
+    float* q_shared = smem + key_dim;
+    float* reduce = smem + 2 * key_dim;
+    const int tid = static_cast<int>(threadIdx.x);
+    float q_partial = 0.0f;
+    float k_partial = 0.0f;
+    for (int i = tid; i < key_dim; i += blockDim.x) {
+        const float qv = half_to_float(q[static_cast<size_t>(key_head) * key_dim + i]);
+        const float kv = half_to_float(k[static_cast<size_t>(key_head) * key_dim + i]);
+        q_partial += qv * qv;
+        k_partial += kv * kv;
+    }
+    reduce[tid] = q_partial;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) reduce[tid] += reduce[tid + stride];
+        __syncthreads();
+    }
+    const float q_inv = rsqrtf(reduce[0] + 1.0e-6f);
+    __syncthreads();
+    reduce[tid] = k_partial;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) reduce[tid] += reduce[tid + stride];
+        __syncthreads();
+    }
+    const float k_inv = rsqrtf(reduce[0] + 1.0e-6f);
+    for (int i = tid; i < key_dim; i += blockDim.x) {
+        q_shared[i] = half_to_float(q[static_cast<size_t>(key_head) * key_dim + i]) * q_inv;
+        k_shared[i] = half_to_float(k[static_cast<size_t>(key_head) * key_dim + i]) * k_inv;
+    }
+    __syncthreads();
+    if (head >= heads || value >= value_dim) return;
+    float* sh = state + static_cast<size_t>(head) * key_dim * value_dim;
+    const float decay = expf(half_to_float(g[head]));
+    const float b = half_to_float(beta[head]);
+    float kv_mem = 0.0f;
+    for (int i = 0; i < key_dim; ++i) {
+        const size_t index = static_cast<size_t>(i) * value_dim + value;
+        const float cell = sh[index] * decay;
+        sh[index] = cell;
+        kv_mem += cell * k_shared[i];
+    }
+    const float delta = (half_to_float(v[static_cast<size_t>(head) * value_dim + value]) - kv_mem) * b;
+    float result = 0.0f;
+    for (int i = 0; i < key_dim; ++i) {
+        const size_t index = static_cast<size_t>(i) * value_dim + value;
+        const float cell = sh[index] + k_shared[i] * delta;
+        sh[index] = cell;
+        result += cell * q_shared[i];
+    }
+    output[static_cast<size_t>(head) * value_dim + value] = float_to_half(result * q_scale);
+}
+
+template <int kKeyDim>
+__global__ void gated_delta_sequence_f16_kernel(
+    float* state, const uint16_t* q, const uint16_t* k,
+    const uint16_t* v, const uint16_t* g, const uint16_t* beta,
+    uint16_t* output, int rows, int heads, int key_heads,
+    int value_dim, float q_scale) {
+    const int head = static_cast<int>(blockIdx.x);
+    const int value = static_cast<int>(threadIdx.x);
+    const int repeat = heads / key_heads;
+    const int key_head = head / repeat;
+    const int key_stride = key_heads * kKeyDim;
+    __shared__ float q_shared[kKeyDim];
+    __shared__ float k_shared[kKeyDim];
+    extern __shared__ float reduce[];
+    float* sh = state + static_cast<size_t>(head) * kKeyDim * value_dim;
+    float st[kKeyDim];
+#pragma unroll
+    for (int i = 0; i < kKeyDim; ++i) st[i] = sh[static_cast<size_t>(i) * value_dim + value];
+    for (int token = 0; token < rows; ++token) {
+        const uint16_t* qr = q + static_cast<size_t>(token) * key_stride + static_cast<size_t>(key_head) * kKeyDim;
+        const uint16_t* kr = k + static_cast<size_t>(token) * key_stride + static_cast<size_t>(key_head) * kKeyDim;
+        float q_partial = 0.0f;
+        float k_partial = 0.0f;
+        for (int i = value; i < kKeyDim; i += blockDim.x) {
+            const float qv = half_to_float(qr[i]);
+            const float kv = half_to_float(kr[i]);
+            q_partial += qv * qv;
+            k_partial += kv * kv;
+        }
+        reduce[value] = q_partial;
+        __syncthreads();
+        for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+            if (value < stride) reduce[value] += reduce[value + stride];
+            __syncthreads();
+        }
+        const float q_inv = rsqrtf(reduce[0] + 1.0e-6f);
+        __syncthreads();
+        reduce[value] = k_partial;
+        __syncthreads();
+        for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+            if (value < stride) reduce[value] += reduce[value + stride];
+            __syncthreads();
+        }
+        const float k_inv = rsqrtf(reduce[0] + 1.0e-6f);
+        for (int i = value; i < kKeyDim; i += blockDim.x) {
+            q_shared[i] = half_to_float(qr[i]) * q_inv;
+            k_shared[i] = half_to_float(kr[i]) * k_inv;
+        }
+        __syncthreads();
+        const size_t gate_index = static_cast<size_t>(token) * heads + head;
+        const float decay = expf(half_to_float(g[gate_index]));
+        const float b = half_to_float(beta[gate_index]);
+        float kv_mem = 0.0f;
+#pragma unroll
+        for (int i = 0; i < kKeyDim; ++i) {
+            st[i] *= decay;
+            kv_mem += st[i] * k_shared[i];
+        }
+        const size_t value_index = static_cast<size_t>(token) * heads * value_dim +
+                                   static_cast<size_t>(head) * value_dim + value;
+        const float delta = (half_to_float(v[value_index]) - kv_mem) * b;
+        float result = 0.0f;
+#pragma unroll
+        for (int i = 0; i < kKeyDim; ++i) {
+            st[i] += k_shared[i] * delta;
+            result += st[i] * q_shared[i];
+        }
+        output[value_index] = float_to_half(result * q_scale);
+        __syncthreads();
+    }
+#pragma unroll
+    for (int i = 0; i < kKeyDim; ++i) sh[static_cast<size_t>(i) * value_dim + value] = st[i];
+}
+
+__device__ __forceinline__ float rope_inv_freq(int index, int rotary_dim, float theta) {
+    return powf(theta, -2.0f * static_cast<float>(index) / static_cast<float>(rotary_dim));
+}
+
+__global__ void partial_rope_f16_kernel(
+    uint16_t* q, uint16_t* k, int start_position, int rows,
+    int rotary_dim, float theta, int q_heads, int kv_heads, int head_dim) {
+    const int half = rotary_dim / 2;
+    const int index = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int row = static_cast<int>(blockIdx.y);
+    if (index >= half || row >= rows) return;
+    const float angle = static_cast<float>(start_position + row) * rope_inv_freq(index, rotary_dim, theta);
+    const float c = cosf(angle);
+    const float s = sinf(angle);
+    uint16_t* qr = q + static_cast<size_t>(row) * q_heads * head_dim;
+    uint16_t* kr = k + static_cast<size_t>(row) * kv_heads * head_dim;
+    for (int head = 0; head < q_heads; ++head) {
+        uint16_t* line = qr + static_cast<size_t>(head) * head_dim;
+        const float a = half_to_float(line[index]);
+        const float b = half_to_float(line[index + half]);
+        line[index] = float_to_half(a * c - b * s);
+        line[index + half] = float_to_half(b * c + a * s);
+    }
+    for (int head = 0; head < kv_heads; ++head) {
+        uint16_t* line = kr + static_cast<size_t>(head) * head_dim;
+        const float a = half_to_float(line[index]);
+        const float b = half_to_float(line[index + half]);
+        line[index] = float_to_half(a * c - b * s);
+        line[index + half] = float_to_half(b * c + a * s);
+    }
+}
+
+__global__ void split_q_gate_f16_kernel(
+    const uint16_t* source, uint16_t* q, uint16_t* gate,
+    int rows, int q_heads, int head_dim) {
+    const int index = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int total = rows * q_heads * head_dim;
+    if (index >= total) return;
+    const int d = index % head_dim;
+    const int head = (index / head_dim) % q_heads;
+    const int row = index / (q_heads * head_dim);
+    const size_t base = (static_cast<size_t>(row) * q_heads + head) * head_dim * 2;
+    q[index] = source[base + d];
+    gate[index] = source[base + head_dim + d];
+}
+
+__global__ void sigmoid_mul_f16_kernel(const uint16_t* x, const uint16_t* gate,
+                                       uint16_t* y, int count) {
+    const int index = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index < count) y[index] = float_to_half(half_to_float(x[index]) * sigmoid(half_to_float(gate[index])));
+}
+
+__global__ void add_f16_kernel(uint16_t* y, const uint16_t* x, int count) {
+    const int index = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index < count) y[index] = float_to_half(half_to_float(y[index]) + half_to_float(x[index]));
+}
+
+__global__ void silu_mul_f16_kernel(const uint16_t* gate, const uint16_t* up,
+                                    uint16_t* y, int count) {
+    const int index = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index < count) y[index] = float_to_half(silu(half_to_float(gate[index])) * half_to_float(up[index]));
+}
+
+__global__ void append_kv_f16_kernel(
+    const uint16_t* k_rows, const uint16_t* v_rows,
+    uint16_t* k_cache, uint16_t* v_cache, int total,
+    int kv_heads, int head_dim, int start_pos, int max_context) {
+    const int index = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index >= total) return;
+    const int token = index / (kv_heads * head_dim);
+    const int within = index % (kv_heads * head_dim);
+    const int destination_token = start_pos + token;
+    if (destination_token >= max_context) return;
+    const size_t destination = static_cast<size_t>(destination_token) * kv_heads * head_dim + within;
+    k_cache[destination] = k_rows[index];
+    v_cache[destination] = v_rows[index];
+}
+
+__global__ void append_kv_fp8_kernel(
+    const uint16_t* k_rows, const uint16_t* v_rows,
+    uint8_t* k_cache, uint8_t* v_cache,
+    uint16_t* k_scale, uint16_t* v_scale,
+    int seq_len, int kv_heads, int head_dim, int scale_block,
+    int start_pos, int max_context) {
+    const int block_index = static_cast<int>(blockIdx.x);
+    const int blocks_per_head = head_dim / scale_block;
+    const int token = block_index / (kv_heads * blocks_per_head);
+    const int within = block_index % (kv_heads * blocks_per_head);
+    const int head = within / blocks_per_head;
+    const int channel_block = within % blocks_per_head;
+    if (token >= seq_len || start_pos + token >= max_context) return;
+    const int source_base = (token * kv_heads + head) * head_dim + channel_block * scale_block;
+    float k_max = 0.0f;
+    float v_max = 0.0f;
+    for (int d = threadIdx.x; d < scale_block; d += blockDim.x) {
+        k_max = fmaxf(k_max, fabsf(half_to_float(k_rows[source_base + d])));
+        v_max = fmaxf(v_max, fabsf(half_to_float(v_rows[source_base + d])));
+    }
+    __shared__ float reduce_k[128];
+    __shared__ float reduce_v[128];
+    reduce_k[threadIdx.x] = k_max;
+    reduce_v[threadIdx.x] = v_max;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            reduce_k[threadIdx.x] = fmaxf(reduce_k[threadIdx.x], reduce_k[threadIdx.x + stride]);
+            reduce_v[threadIdx.x] = fmaxf(reduce_v[threadIdx.x], reduce_v[threadIdx.x + stride]);
+        }
+        __syncthreads();
+    }
+    const float ks = reduce_k[0] > 0.0f ? reduce_k[0] / 448.0f : 1.0f;
+    const float vs = reduce_v[0] > 0.0f ? reduce_v[0] / 448.0f : 1.0f;
+    const int destination_token = start_pos + token;
+    const size_t scale_index = (static_cast<size_t>(destination_token) * kv_heads + head) * blocks_per_head + channel_block;
+    if (threadIdx.x == 0) {
+        k_scale[scale_index] = float_to_half(ks);
+        v_scale[scale_index] = float_to_half(vs);
+    }
+    const size_t destination_base = (static_cast<size_t>(destination_token) * kv_heads + head) * head_dim + channel_block * scale_block;
+    for (int d = threadIdx.x; d < scale_block; d += blockDim.x) {
+        k_cache[destination_base + d] = float_to_fp8_e4m3(half_to_float(k_rows[source_base + d]) / ks);
+        v_cache[destination_base + d] = float_to_fp8_e4m3(half_to_float(v_rows[source_base + d]) / vs);
+    }
+}
+
+template <bool kFp8Cache>
+__device__ __forceinline__ float cache_value(
+    const void* cache, const uint16_t* scale, size_t value_index,
+    size_t scale_index) {
+    if constexpr (kFp8Cache) {
+        return fp8_e4m3_to_float(static_cast<const uint8_t*>(cache)[value_index]) *
+               half_to_float(scale[scale_index]);
+    }
+    return half_to_float(static_cast<const uint16_t*>(cache)[value_index]);
+}
+
+template <bool kFp8Cache, int kThreadsPerBlock>
+__global__ void gqa_scores_f16_kernel(
+    const uint16_t* q, const void* k_cache, const uint16_t* k_scale,
+    float* scores, int q_heads, int kv_heads, int head_dim,
+    int scale_block, int context_len) {
+    const uint64_t work = static_cast<uint64_t>(blockIdx.x);
+    const int head = static_cast<int>(work / static_cast<uint64_t>(context_len));
+    const int position = static_cast<int>(work % static_cast<uint64_t>(context_len));
+    if (head >= q_heads) return;
+    const int kv_head = head / (q_heads / kv_heads);
+    const uint16_t* qr = q + static_cast<size_t>(head) * head_dim;
+    const int blocks_per_head = head_dim / scale_block;
+    float partial = 0.0f;
+    for (int d = threadIdx.x; d < head_dim; d += kThreadsPerBlock) {
+        const size_t value_index = (static_cast<size_t>(position) * kv_heads + kv_head) * head_dim + d;
+        const size_t scale_index = (static_cast<size_t>(position) * kv_heads + kv_head) * blocks_per_head + d / scale_block;
+        partial += half_to_float(qr[d]) * cache_value<kFp8Cache>(k_cache, k_scale, value_index, scale_index);
+    }
+    extern __shared__ float reduce[];
+    reduce[threadIdx.x] = partial;
+    __syncthreads();
+    for (int stride = kThreadsPerBlock / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) reduce[threadIdx.x] += reduce[threadIdx.x + stride];
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) {
+        scores[static_cast<size_t>(head) * context_len + position] =
+            reduce[0] * rsqrtf(static_cast<float>(head_dim));
+    }
+}
+
+template <int kThreadsPerBlock>
+__global__ void softmax_scores_kernel(float* scores, int q_heads, int context_len) {
+    const int head = static_cast<int>(blockIdx.x);
+    if (head >= q_heads) return;
+    float* line = scores + static_cast<size_t>(head) * context_len;
+    __shared__ float reduce[kThreadsPerBlock];
+    float local_max = -INFINITY;
+    for (int pos = threadIdx.x; pos < context_len; pos += kThreadsPerBlock) local_max = fmaxf(local_max, line[pos]);
+    reduce[threadIdx.x] = local_max;
+    __syncthreads();
+    for (int stride = kThreadsPerBlock / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) reduce[threadIdx.x] = fmaxf(reduce[threadIdx.x], reduce[threadIdx.x + stride]);
+        __syncthreads();
+    }
+    const float maximum = reduce[0];
+    float sum = 0.0f;
+    for (int pos = threadIdx.x; pos < context_len; pos += kThreadsPerBlock) {
+        line[pos] = expf(line[pos] - maximum);
+        sum += line[pos];
+    }
+    reduce[threadIdx.x] = sum;
+    __syncthreads();
+    for (int stride = kThreadsPerBlock / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) reduce[threadIdx.x] += reduce[threadIdx.x + stride];
+        __syncthreads();
+    }
+    const float inverse = reduce[0] > 0.0f ? 1.0f / reduce[0] : 0.0f;
+    for (int pos = threadIdx.x; pos < context_len; pos += kThreadsPerBlock) line[pos] *= inverse;
+}
+
+template <bool kFp8Cache, int kThreadsPerBlock, int kHeadsPerGroup>
+__global__ void gqa_values_f16_kernel(
+    const float* probabilities, const void* v_cache, const uint16_t* v_scale,
+    uint16_t* output, int q_heads, int kv_heads, int head_dim,
+    int scale_block, int context_len) {
+    const int q_per_kv = q_heads / kv_heads;
+    const int groups_per_kv = (q_per_kv + kHeadsPerGroup - 1) / kHeadsPerGroup;
+    const int kv_head = static_cast<int>(blockIdx.x) / groups_per_kv;
+    const int group = static_cast<int>(blockIdx.x) % groups_per_kv;
+    const int first_head = kv_head * q_per_kv + group * kHeadsPerGroup;
+    const int d = static_cast<int>(blockIdx.y) * kThreadsPerBlock + threadIdx.x;
+    if (kv_head >= kv_heads || first_head >= (kv_head + 1) * q_per_kv || d >= head_dim) return;
+    const int blocks_per_head = head_dim / scale_block;
+    float acc[kHeadsPerGroup] = {};
+    for (int pos = 0; pos < context_len; ++pos) {
+        const size_t value_index = (static_cast<size_t>(pos) * kv_heads + kv_head) * head_dim + d;
+        const size_t scale_index = (static_cast<size_t>(pos) * kv_heads + kv_head) * blocks_per_head + d / scale_block;
+        const float value = cache_value<kFp8Cache>(v_cache, v_scale, value_index, scale_index);
+#pragma unroll
+        for (int i = 0; i < kHeadsPerGroup; ++i) {
+            const int head = first_head + i;
+            if (head < (kv_head + 1) * q_per_kv) acc[i] += probabilities[static_cast<size_t>(head) * context_len + pos] * value;
+        }
+    }
+#pragma unroll
+    for (int i = 0; i < kHeadsPerGroup; ++i) {
+        const int head = first_head + i;
+        if (head < (kv_head + 1) * q_per_kv) output[static_cast<size_t>(head) * head_dim + d] = float_to_half(acc[i]);
+    }
+}
+
+template <bool kFp8Cache, int kThreadsPerBlock>
+__global__ void gqa_prefill_f16_kernel(
+    const uint16_t* q_rows, const void* k_cache, const void* v_cache,
+    const uint16_t* k_scale, const uint16_t* v_scale,
+    uint16_t* output, int seq_len, int q_heads, int kv_heads,
+    int head_dim, int scale_block, int position_offset) {
+    const int head = static_cast<int>(blockIdx.x);
+    const int token = static_cast<int>(blockIdx.y);
+    if (head >= q_heads || token >= seq_len) return;
+    const int kv_head = head / (q_heads / kv_heads);
+    const int context_len = position_offset + token + 1;
+    const size_t query_offset = (static_cast<size_t>(token) * q_heads + head) * head_dim;
+    const uint16_t* query = q_rows + query_offset;
+    extern __shared__ float smem[];
+    float* q_shared = smem;
+    float* reduce = smem + head_dim;
+    for (int d = threadIdx.x; d < head_dim; d += kThreadsPerBlock) q_shared[d] = half_to_float(query[d]);
+    __syncthreads();
+    constexpr int kMaxSlice = 8;
+    float acc[kMaxSlice] = {};
+    const int slice = (head_dim + kThreadsPerBlock - 1) / kThreadsPerBlock;
+    float running_max = -INFINITY;
+    float running_sum = 0.0f;
+    const int blocks_per_head = head_dim / scale_block;
+    for (int pos = 0; pos < context_len; ++pos) {
+        float partial = 0.0f;
+        for (int d = threadIdx.x; d < head_dim; d += kThreadsPerBlock) {
+            const size_t value_index = (static_cast<size_t>(pos) * kv_heads + kv_head) * head_dim + d;
+            const size_t scale_index = (static_cast<size_t>(pos) * kv_heads + kv_head) * blocks_per_head + d / scale_block;
+            partial += q_shared[d] * cache_value<kFp8Cache>(k_cache, k_scale, value_index, scale_index);
+        }
+        reduce[threadIdx.x] = partial;
+        __syncthreads();
+        for (int stride = kThreadsPerBlock / 2; stride > 0; stride >>= 1) {
+            if (threadIdx.x < stride) reduce[threadIdx.x] += reduce[threadIdx.x + stride];
+            __syncthreads();
+        }
+        const float score = reduce[0] * rsqrtf(static_cast<float>(head_dim));
+        __syncthreads();
+        const float new_max = fmaxf(running_max, score);
+        const float rescale = running_max == -INFINITY ? 0.0f : expf(running_max - new_max);
+        const float probability = expf(score - new_max);
+        running_sum = running_sum * rescale + probability;
+        running_max = new_max;
+        for (int i = 0, d = threadIdx.x; i < slice && d < head_dim; ++i, d += kThreadsPerBlock) {
+            const size_t value_index = (static_cast<size_t>(pos) * kv_heads + kv_head) * head_dim + d;
+            const size_t scale_index = (static_cast<size_t>(pos) * kv_heads + kv_head) * blocks_per_head + d / scale_block;
+            acc[i] = acc[i] * rescale + probability * cache_value<kFp8Cache>(v_cache, v_scale, value_index, scale_index);
+        }
+    }
+    const float inverse = running_sum > 0.0f ? 1.0f / running_sum : 0.0f;
+    for (int i = 0, d = threadIdx.x; i < slice && d < head_dim; ++i, d += kThreadsPerBlock) {
+        output[query_offset + d] = float_to_half(acc[i] * inverse);
+    }
+}
+
+bool valid_attention(int q_heads, int kv_heads, int head_dim,
+                     int context_len, int max_context, int scale_block) {
+    return q_heads > 0 && kv_heads > 0 && q_heads % kv_heads == 0 &&
+           head_dim > 0 && context_len > 0 && context_len <= max_context &&
+           scale_block > 0 && head_dim % scale_block == 0;
+}
+
+template <bool kFp8Cache>
+bool launch_decode_attention(
+    const uint16_t* q, const void* k_cache, const void* v_cache,
+    const uint16_t* k_scale, const uint16_t* v_scale,
+    uint16_t* output, float* scores, int q_heads, int kv_heads,
+    int head_dim, int scale_block, int context_len, int max_context,
+    cudaStream_t stream) {
+    if (!q || !k_cache || !v_cache || !output || !scores ||
+        !valid_attention(q_heads, kv_heads, head_dim, context_len, max_context, scale_block)) return false;
+    if constexpr (kFp8Cache) {
+        if (!k_scale || !v_scale) return false;
+    }
+    constexpr int kAttentionThreads = 128;
+    const uint64_t score_blocks = static_cast<uint64_t>(q_heads) * context_len;
+    if (score_blocks > static_cast<uint64_t>(UINT32_MAX)) return false;
+    dim3 score_grid(static_cast<unsigned>(score_blocks), 1, 1);
+    gqa_scores_f16_kernel<kFp8Cache, kAttentionThreads><<<score_grid, kAttentionThreads,
+        kAttentionThreads * sizeof(float), stream>>>(q, k_cache, k_scale, scores,
+        q_heads, kv_heads, head_dim, scale_block, context_len);
+    if (cudaGetLastError() != cudaSuccess) return false;
+    softmax_scores_kernel<kAttentionThreads><<<q_heads, kAttentionThreads, 0, stream>>>(scores, q_heads, context_len);
+    if (cudaGetLastError() != cudaSuccess) return false;
+    constexpr int kHeadsPerGroup = 3;
+    const int groups_per_kv = ((q_heads / kv_heads) + kHeadsPerGroup - 1) / kHeadsPerGroup;
+    dim3 value_grid(static_cast<unsigned>(kv_heads * groups_per_kv),
+                    static_cast<unsigned>((head_dim + kAttentionThreads - 1) / kAttentionThreads), 1);
+    gqa_values_f16_kernel<kFp8Cache, kAttentionThreads, kHeadsPerGroup>
+        <<<value_grid, kAttentionThreads, 0, stream>>>(scores, v_cache, v_scale,
+        output, q_heads, kv_heads, head_dim, scale_block, context_len);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+template <bool kFp8Cache>
+bool launch_prefill_attention(
+    const uint16_t* q, const void* k_cache, const void* v_cache,
+    const uint16_t* k_scale, const uint16_t* v_scale,
+    uint16_t* output, int seq_len, int q_heads, int kv_heads,
+    int head_dim, int scale_block, int position_offset, int max_context,
+    cudaStream_t stream) {
+    if (!q || !k_cache || !v_cache || !output || seq_len <= 0 || position_offset < 0 ||
+        position_offset + seq_len > max_context ||
+        !valid_attention(q_heads, kv_heads, head_dim, position_offset + seq_len,
+                         max_context, scale_block)) return false;
+    if constexpr (kFp8Cache) {
+        if (!k_scale || !v_scale) return false;
+    }
+    constexpr int kAttentionThreads = 128;
+    if ((head_dim + kAttentionThreads - 1) / kAttentionThreads > 8) return false;
+    dim3 grid(static_cast<unsigned>(q_heads), static_cast<unsigned>(seq_len), 1);
+    const size_t shared = (static_cast<size_t>(head_dim) + kAttentionThreads) * sizeof(float);
+    gqa_prefill_f16_kernel<kFp8Cache, kAttentionThreads><<<grid, kAttentionThreads, shared, stream>>>(
+        q, k_cache, v_cache, k_scale, v_scale, output, seq_len, q_heads, kv_heads,
+        head_dim, scale_block, position_offset);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+}  // namespace
+
+bool qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+    const uint16_t* x, const uint8_t* weight, const uint16_t* scale,
+    uint16_t* y, int rows, int cols, int weight_stride, int scale_stride,
+    void* stream) {
+    if (!x || !weight || !scale || !y || rows <= 0 || cols <= 0 ||
+        weight_stride < cols || scale_stride < (cols + kFp8WeightBlock - 1) / kFp8WeightBlock) return false;
+    constexpr int kWarps = 8;
+    fp8_matvec_f16_kernel<kWarps><<<(rows + kWarps - 1) / kWarps,
+        kWarps * 32, 0, static_cast<cudaStream_t>(stream)>>>(x, weight, scale, y,
+        rows, cols, weight_stride, scale_stride);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
+    const uint16_t* x, const uint8_t* gate_weight,
+    const uint16_t* gate_scale, const uint8_t* up_weight,
+    const uint16_t* up_scale, uint16_t* y, int rows, int cols,
+    int weight_stride, int scale_stride, void* stream) {
+    if (!x || !gate_weight || !gate_scale || !up_weight || !up_scale || !y ||
+        rows <= 0 || cols <= 0 || weight_stride < cols ||
+        scale_stride < (cols + kFp8WeightBlock - 1) / kFp8WeightBlock) return false;
+    constexpr int kWarps = 8;
+    constexpr int kRowsPerWarp = 1;
+    fp8_swiglu_matvec_f16_kernel<kWarps, kRowsPerWarp>
+        <<<(rows + kWarps - 1) / kWarps, kWarps * 32, 0,
+           static_cast<cudaStream_t>(stream)>>>(x, gate_weight, gate_scale,
+           up_weight, up_scale, y, rows, cols, weight_stride, scale_stride);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
+    const uint16_t* x, const uint8_t* weight, const uint16_t* scale,
+    uint16_t* y, int batch, int rows, int cols, int x_stride,
+    int y_stride, int weight_stride, int scale_stride, void* stream) {
+    if (!x || !weight || !scale || !y || batch <= 0 || rows <= 0 || cols <= 0 ||
+        x_stride < cols || y_stride < rows || weight_stride < cols ||
+        scale_stride < (cols + kFp8WeightBlock - 1) / kFp8WeightBlock) return false;
+    dim3 grid(static_cast<unsigned>((rows + 63) / 64),
+              static_cast<unsigned>((batch + 63) / 64), 1);
+    fp8_matmul_f16_tiled_kernel<32><<<grid, 256, 0, static_cast<cudaStream_t>(stream)>>>(
+        x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+        weight_stride, scale_stride);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_fp16_matmul_rows_f16_cuda(
+    const uint16_t* x, const uint16_t* weight, uint16_t* y,
+    int batch, int rows, int cols, int x_stride, int y_stride,
+    int weight_stride, void* stream) {
+    if (!x || !weight || !y || batch <= 0 || rows <= 0 || cols <= 0 ||
+        x_stride < cols || y_stride < rows || weight_stride < cols) return false;
+    dim3 grid(static_cast<unsigned>(rows), static_cast<unsigned>(batch), 1);
+    fp16_matmul_f16_kernel<false><<<grid, kThreads, kThreads * sizeof(float),
+        static_cast<cudaStream_t>(stream)>>>(x, weight, y, batch, rows, cols,
+        x_stride, y_stride, weight_stride);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_fp16_matmul_rows_f16_f32_cuda(
+    const uint16_t* x, const uint16_t* weight, float* y,
+    int batch, int rows, int cols, int x_stride, int y_stride,
+    int weight_stride, void* stream) {
+    if (!x || !weight || !y || batch <= 0 || rows <= 0 || cols <= 0 ||
+        x_stride < cols || y_stride < rows || weight_stride < cols) return false;
+    dim3 grid(static_cast<unsigned>(rows), static_cast<unsigned>(batch), 1);
+    fp16_matmul_f16_kernel<true><<<grid, kThreads, kThreads * sizeof(float),
+        static_cast<cudaStream_t>(stream)>>>(x, weight, y, batch, rows, cols,
+        x_stride, y_stride, weight_stride);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_embedding_fp16_gather_f16_cuda(
+    const uint16_t* table, const int* tokens, uint16_t* output,
+    int count, int cols, int row_start, int row_count, void* stream) {
+    if (!table || !tokens || !output || count <= 0 || cols <= 0 ||
+        row_start < 0 || row_count <= 0) return false;
+    embedding_f16_kernel<<<count, kThreads, 0, static_cast<cudaStream_t>(stream)>>>(
+        table, tokens, output, count, cols, row_start, row_count);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_rmsnorm_fp16_gamma_rows_f16_cuda(
+    const uint16_t* x, const uint16_t* gamma, uint16_t* y,
+    int rows, int cols, float eps, void* stream) {
+    if (!x || !gamma || !y || rows <= 0 || cols <= 0 || eps < 0.0f) return false;
+    rmsnorm_f16_kernel<<<rows, kThreads, kThreads * sizeof(float),
+        static_cast<cudaStream_t>(stream)>>>(x, gamma, y, rows, cols, eps);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gated_rmsnorm_fp16_gamma_rows_f16_cuda(
+    const uint16_t* x, const uint16_t* gamma, const uint16_t* gate,
+    uint16_t* y, int rows, int cols, float eps, void* stream) {
+    if (!x || !gamma || !gate || !y || rows <= 0 || cols <= 0 || eps < 0.0f) return false;
+    gated_rmsnorm_f16_kernel<<<rows, kThreads, kThreads * sizeof(float),
+        static_cast<cudaStream_t>(stream)>>>(x, gamma, gate, y, rows, cols, eps);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_split_packed_qkv_f16_cuda(
+    const uint16_t* packed, uint16_t* q, uint16_t* k, uint16_t* v,
+    int rows, int key_dim, int value_dim, void* stream) {
+    if (!packed || !q || !k || !v || rows <= 0 || key_dim <= 0 || value_dim <= 0) return false;
+    const int total = rows * (2 * key_dim + value_dim);
+    split_packed_qkv_f16_kernel<<<(total + kThreads - 1) / kThreads, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(packed, q, k, v, rows, key_dim, value_dim);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_causal_depthwise_conv_silu_f16_cuda(
+    const uint16_t* x, const uint16_t* weight, uint16_t* tail,
+    uint16_t* y, int seq_len, int channels, int kernel,
+    bool update_tail, void* stream) {
+    if (!x || !weight || !y || seq_len <= 0 || channels <= 0 || kernel <= 0 || kernel - 1 > 8) return false;
+    conv_silu_f16_kernel<<<(channels + kThreads - 1) / kThreads, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(x, weight, tail, y, seq_len,
+        channels, kernel, update_tail);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_linear_attn_gates_f16_cuda(
+    const uint16_t* a, const uint16_t* b, const uint16_t* a_log,
+    const uint16_t* dt_bias, uint16_t* g, uint16_t* beta,
+    int rows, int heads, void* stream) {
+    if (!a || !b || !a_log || !dt_bias || !g || !beta || rows <= 0 || heads <= 0) return false;
+    linear_gates_f16_kernel<<<heads, kThreads, 0, static_cast<cudaStream_t>(stream)>>>(
+        a, b, a_log, dt_bias, g, beta, rows, heads);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gated_delta_step_f16_cuda(
+    float* state, const uint16_t* q, const uint16_t* k,
+    const uint16_t* v, const uint16_t* g, const uint16_t* beta,
+    uint16_t* output, int heads, int key_heads, int key_dim,
+    int value_dim, float q_scale, void* stream) {
+    if (!state || !q || !k || !v || !g || !beta || !output || heads <= 0 ||
+        key_heads <= 0 || heads % key_heads != 0 || key_dim <= 0 || value_dim <= 0 || q_scale <= 0.0f) return false;
+    int threads = 32;
+    while (threads < value_dim) threads <<= 1;
+    if (threads > 1024) return false;
+    const size_t shared = (2u * static_cast<size_t>(key_dim) + threads) * sizeof(float);
+    gated_delta_step_f16_kernel<<<heads, threads, shared, static_cast<cudaStream_t>(stream)>>>(
+        state, q, k, v, g, beta, output, heads, key_heads, key_dim, value_dim, q_scale);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gated_delta_sequence_f16_cuda(
+    float* state, const uint16_t* q, const uint16_t* k,
+    const uint16_t* v, const uint16_t* g, const uint16_t* beta,
+    uint16_t* output, int rows, int heads, int key_heads, int key_dim,
+    int value_dim, float q_scale, void* stream) {
+    if (!state || !q || !k || !v || !g || !beta || !output || rows <= 0 ||
+        heads <= 0 || key_heads <= 0 || heads % key_heads != 0 || key_dim != 128 ||
+        value_dim != 128 || q_scale <= 0.0f) return false;
+    gated_delta_sequence_f16_kernel<128><<<heads, value_dim,
+        static_cast<size_t>(value_dim) * sizeof(float), static_cast<cudaStream_t>(stream)>>>(
+        state, q, k, v, g, beta, output, rows, heads, key_heads, value_dim, q_scale);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_partial_rope_f16_cuda(
+    uint16_t* q, uint16_t* k, int position, int rotary_dim,
+    float theta, int q_heads, int kv_heads, int head_dim, void* stream) {
+    return qwen_partial_rope_rows_f16_cuda(q, k, position, 1, rotary_dim,
+        theta, q_heads, kv_heads, head_dim, stream);
+}
+
+bool qwen_partial_rope_rows_f16_cuda(
+    uint16_t* q, uint16_t* k, int start_position, int rows,
+    int rotary_dim, float theta, int q_heads, int kv_heads,
+    int head_dim, void* stream) {
+    if (!q || !k || start_position < 0 || rows <= 0 || rotary_dim <= 0 ||
+        (rotary_dim & 1) != 0 || rotary_dim > head_dim || theta <= 0.0f ||
+        q_heads <= 0 || kv_heads <= 0 || head_dim <= 0) return false;
+    dim3 grid(static_cast<unsigned>((rotary_dim / 2 + kThreads - 1) / kThreads),
+              static_cast<unsigned>(rows), 1);
+    partial_rope_f16_kernel<<<grid, kThreads, 0, static_cast<cudaStream_t>(stream)>>>(
+        q, k, start_position, rows, rotary_dim, theta, q_heads, kv_heads, head_dim);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_split_q_gate_f16_cuda(
+    const uint16_t* source, uint16_t* q, uint16_t* gate,
+    int rows, int q_heads, int head_dim, void* stream) {
+    if (!source || !q || !gate || rows <= 0 || q_heads <= 0 || head_dim <= 0) return false;
+    const int total = rows * q_heads * head_dim;
+    split_q_gate_f16_kernel<<<(total + kThreads - 1) / kThreads, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(source, q, gate, rows, q_heads, head_dim);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_sigmoid_mul_f16_cuda(
+    const uint16_t* x, const uint16_t* gate, uint16_t* y,
+    int count, void* stream) {
+    if (!x || !gate || !y || count <= 0) return false;
+    sigmoid_mul_f16_kernel<<<(count + kThreads - 1) / kThreads, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(x, gate, y, count);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_add_inplace_f16_cuda(
+    uint16_t* y, const uint16_t* x, int count, void* stream) {
+    if (!x || !y || count <= 0) return false;
+    add_f16_kernel<<<(count + kThreads - 1) / kThreads, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(y, x, count);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_silu_mul_rows_f16_cuda(
+    const uint16_t* gate, const uint16_t* up, uint16_t* y,
+    int rows, int cols, void* stream) {
+    if (!gate || !up || !y || rows <= 0 || cols <= 0) return false;
+    const int count = rows * cols;
+    silu_mul_f16_kernel<<<(count + kThreads - 1) / kThreads, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(gate, up, y, count);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_append_kv_cache_f16_cuda(
+    const uint16_t* k_rows, const uint16_t* v_rows,
+    uint16_t* k_cache, uint16_t* v_cache, int seq_len,
+    int kv_heads, int head_dim, int start_pos, int max_context,
+    void* stream) {
+    if (!k_rows || !v_rows || !k_cache || !v_cache || seq_len <= 0 ||
+        kv_heads <= 0 || head_dim <= 0 || start_pos < 0 || max_context <= 0 ||
+        start_pos + seq_len > max_context) return false;
+    const int total = seq_len * kv_heads * head_dim;
+    append_kv_f16_kernel<<<(total + kThreads - 1) / kThreads, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(k_rows, v_rows, k_cache, v_cache,
+        total, kv_heads, head_dim, start_pos, max_context);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_append_kv_cache_fp8_cuda(
+    const uint16_t* k_rows, const uint16_t* v_rows,
+    uint8_t* k_cache, uint8_t* v_cache, uint16_t* k_scale,
+    uint16_t* v_scale, int seq_len, int kv_heads, int head_dim,
+    int scale_block, int start_pos, int max_context, void* stream) {
+    if (!k_rows || !v_rows || !k_cache || !v_cache || !k_scale || !v_scale ||
+        seq_len <= 0 || kv_heads <= 0 || head_dim <= 0 || scale_block <= 0 ||
+        scale_block > 128 || head_dim % scale_block != 0 || start_pos < 0 ||
+        max_context <= 0 || start_pos + seq_len > max_context) return false;
+    const int blocks = seq_len * kv_heads * (head_dim / scale_block);
+    append_kv_fp8_kernel<<<blocks, 128, 0, static_cast<cudaStream_t>(stream)>>>(
+        k_rows, v_rows, k_cache, v_cache, k_scale, v_scale, seq_len,
+        kv_heads, head_dim, scale_block, start_pos, max_context);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gqa_decode_attention_f16_cuda(
+    const uint16_t* q, const uint16_t* k_cache,
+    const uint16_t* v_cache, uint16_t* output, float* scores,
+    int q_heads, int kv_heads, int head_dim, int context_len,
+    int max_context, void* stream) {
+    return launch_decode_attention<false>(q, k_cache, v_cache, nullptr,
+        nullptr, output, scores, q_heads, kv_heads, head_dim, head_dim,
+        context_len, max_context, static_cast<cudaStream_t>(stream));
+}
+
+bool qwen_gqa_prefill_attention_f16_cuda(
+    const uint16_t* q, const uint16_t* k_cache,
+    const uint16_t* v_cache, uint16_t* output, int seq_len,
+    int q_heads, int kv_heads, int head_dim, int position_offset,
+    int max_context, void* stream) {
+    return launch_prefill_attention<false>(q, k_cache, v_cache, nullptr,
+        nullptr, output, seq_len, q_heads, kv_heads, head_dim, head_dim,
+        position_offset, max_context, static_cast<cudaStream_t>(stream));
+}
+
+bool qwen_gqa_decode_attention_fp8_cuda(
+    const uint16_t* q, const uint8_t* k_cache,
+    const uint8_t* v_cache, const uint16_t* k_scale,
+    const uint16_t* v_scale, uint16_t* output, float* scores,
+    int q_heads, int kv_heads, int head_dim, int scale_block,
+    int context_len, int max_context, void* stream) {
+    return launch_decode_attention<true>(q, k_cache, v_cache, k_scale,
+        v_scale, output, scores, q_heads, kv_heads, head_dim, scale_block,
+        context_len, max_context, static_cast<cudaStream_t>(stream));
+}
+
+bool qwen_gqa_prefill_attention_fp8_cuda(
+    const uint16_t* q, const uint8_t* k_cache,
+    const uint8_t* v_cache, const uint16_t* k_scale,
+    const uint16_t* v_scale, uint16_t* output, int seq_len,
+    int q_heads, int kv_heads, int head_dim, int scale_block,
+    int position_offset, int max_context, void* stream) {
+    return launch_prefill_attention<true>(q, k_cache, v_cache, k_scale,
+        v_scale, output, seq_len, q_heads, kv_heads, head_dim, scale_block,
+        position_offset, max_context, static_cast<cudaStream_t>(stream));
+}
+
+}  // namespace dsv4

--- a/cpp_engine/include/qwen_cuda_ops.hpp
+++ b/cpp_engine/include/qwen_cuda_ops.hpp
@@ -49,6 +49,47 @@ bool qwen_fp8_e4m3_fp16scale_matmul_rows_cuda(
     int scale_stride,
     void* stream = nullptr);
 
+// FP16 activation-storage variants. Dot products and normalization statistics
+// still accumulate in FP32; only global activation traffic and workspace storage
+// use IEEE FP16.
+bool qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+    const uint16_t* d_x_fp16,
+    const uint8_t* d_weight,
+    const uint16_t* d_scale_fp16,
+    uint16_t* d_y_fp16,
+    int rows,
+    int cols,
+    int weight_stride,
+    int scale_stride,
+    void* stream = nullptr);
+
+bool qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
+    const uint16_t* d_x_fp16,
+    const uint8_t* d_gate_weight,
+    const uint16_t* d_gate_scale_fp16,
+    const uint8_t* d_up_weight,
+    const uint16_t* d_up_scale_fp16,
+    uint16_t* d_y_fp16,
+    int rows,
+    int cols,
+    int weight_stride,
+    int scale_stride,
+    void* stream = nullptr);
+
+bool qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
+    const uint16_t* d_x_fp16,
+    const uint8_t* d_weight,
+    const uint16_t* d_scale_fp16,
+    uint16_t* d_y_fp16,
+    int batch,
+    int rows,
+    int cols,
+    int x_stride,
+    int y_stride,
+    int weight_stride,
+    int scale_stride,
+    void* stream = nullptr);
+
 // Explicit experimental prefill path used by correctness/performance A/B.
 // It decodes only a block-local K tile and preserves FP32 accumulation.
 bool qwen_fp8_e4m3_fp16scale_matmul_simt_cuda(
@@ -217,5 +258,119 @@ bool qwen_add_inplace_cuda(float* d_y, const float* d_x, int count,
                            void* stream = nullptr);
 bool qwen_silu_mul_rows_cuda(const float* d_gate, const float* d_up, float* d_y,
                              int rows, int cols, void* stream = nullptr);
+
+// --- FP16 activation-storage runtime ----------------------------------------
+
+bool qwen_fp16_matmul_rows_f16_cuda(const uint16_t* d_x_fp16,
+                                    const uint16_t* d_w_fp16,
+                                    uint16_t* d_y_fp16, int batch, int rows,
+                                    int cols, int x_stride, int y_stride,
+                                    int weight_stride, void* stream = nullptr);
+bool qwen_fp16_matmul_rows_f16_f32_cuda(const uint16_t* d_x_fp16,
+                                        const uint16_t* d_w_fp16,
+                                        float* d_y, int batch, int rows,
+                                        int cols, int x_stride, int y_stride,
+                                        int weight_stride, void* stream = nullptr);
+bool qwen_embedding_fp16_gather_f16_cuda(const uint16_t* d_table_fp16,
+                                         const int* d_tokens,
+                                         uint16_t* d_out_fp16, int count,
+                                         int cols, int row_start, int row_count,
+                                         void* stream = nullptr);
+bool qwen_rmsnorm_fp16_gamma_rows_f16_cuda(const uint16_t* d_x_fp16,
+                                           const uint16_t* d_gamma_fp16,
+                                           uint16_t* d_y_fp16, int rows,
+                                           int cols, float eps,
+                                           void* stream = nullptr);
+bool qwen_gated_rmsnorm_fp16_gamma_rows_f16_cuda(
+    const uint16_t* d_x_fp16, const uint16_t* d_gamma_fp16,
+    const uint16_t* d_gate_fp16, uint16_t* d_y_fp16, int rows, int cols,
+    float eps, void* stream = nullptr);
+bool qwen_split_packed_qkv_f16_cuda(const uint16_t* d_packed_fp16,
+                                    uint16_t* d_q_fp16, uint16_t* d_k_fp16,
+                                    uint16_t* d_v_fp16, int rows,
+                                    int key_dim, int value_dim,
+                                    void* stream = nullptr);
+bool qwen_causal_depthwise_conv_silu_f16_cuda(
+    const uint16_t* d_x_fp16, const uint16_t* d_weight_fp16,
+    uint16_t* d_tail_fp16, uint16_t* d_y_fp16, int seq_len, int channels,
+    int kernel, bool update_tail, void* stream = nullptr);
+bool qwen_linear_attn_gates_f16_cuda(
+    const uint16_t* d_a_fp16, const uint16_t* d_b_fp16,
+    const uint16_t* d_a_log_fp16, const uint16_t* d_dt_bias_fp16,
+    uint16_t* d_g_fp16, uint16_t* d_beta_fp16, int rows, int heads,
+    void* stream = nullptr);
+bool qwen_gated_delta_step_f16_cuda(
+    float* d_state, const uint16_t* d_q_fp16, const uint16_t* d_k_fp16,
+    const uint16_t* d_v_fp16, const uint16_t* d_g_fp16,
+    const uint16_t* d_beta_fp16, uint16_t* d_out_fp16, int heads,
+    int key_heads, int key_dim, int value_dim, float q_scale,
+    void* stream = nullptr);
+bool qwen_gated_delta_sequence_f16_cuda(
+    float* d_state, const uint16_t* d_q_fp16, const uint16_t* d_k_fp16,
+    const uint16_t* d_v_fp16, const uint16_t* d_g_fp16,
+    const uint16_t* d_beta_fp16, uint16_t* d_out_fp16, int rows,
+    int heads, int key_heads, int key_dim, int value_dim, float q_scale,
+    void* stream = nullptr);
+bool qwen_partial_rope_f16_cuda(uint16_t* d_q_fp16, uint16_t* d_k_fp16,
+                                int position, int rotary_dim, float theta,
+                                int q_heads, int kv_heads, int head_dim,
+                                void* stream = nullptr);
+bool qwen_partial_rope_rows_f16_cuda(
+    uint16_t* d_q_fp16, uint16_t* d_k_fp16, int start_position, int rows,
+    int rotary_dim, float theta, int q_heads, int kv_heads, int head_dim,
+    void* stream = nullptr);
+bool qwen_split_q_gate_f16_cuda(const uint16_t* d_q_proj_fp16,
+                                uint16_t* d_q_fp16,
+                                uint16_t* d_gate_fp16, int rows,
+                                int q_heads, int head_dim,
+                                void* stream = nullptr);
+bool qwen_sigmoid_mul_f16_cuda(const uint16_t* d_x_fp16,
+                               const uint16_t* d_gate_fp16,
+                               uint16_t* d_y_fp16, int count,
+                               void* stream = nullptr);
+bool qwen_add_inplace_f16_cuda(uint16_t* d_y_fp16,
+                               const uint16_t* d_x_fp16, int count,
+                               void* stream = nullptr);
+bool qwen_silu_mul_rows_f16_cuda(const uint16_t* d_gate_fp16,
+                                 const uint16_t* d_up_fp16,
+                                 uint16_t* d_y_fp16, int rows, int cols,
+                                 void* stream = nullptr);
+
+// FP16 cache is the precision baseline. FP8 cache stores E4M3 codes plus one
+// IEEE FP16 scale for each token/head/64-channel block.
+bool qwen_append_kv_cache_f16_cuda(
+    const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
+    uint16_t* d_k_cache_fp16, uint16_t* d_v_cache_fp16, int seq_len,
+    int kv_heads, int head_dim, int start_pos, int max_context,
+    void* stream = nullptr);
+bool qwen_append_kv_cache_fp8_cuda(
+    const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
+    uint8_t* d_k_cache_fp8, uint8_t* d_v_cache_fp8,
+    uint16_t* d_k_scale_fp16, uint16_t* d_v_scale_fp16, int seq_len,
+    int kv_heads, int head_dim, int scale_block, int start_pos,
+    int max_context, void* stream = nullptr);
+bool qwen_gqa_decode_attention_f16_cuda(
+    const uint16_t* d_q_fp16, const uint16_t* d_k_cache_fp16,
+    const uint16_t* d_v_cache_fp16, uint16_t* d_out_fp16,
+    float* d_score_scratch, int q_heads, int kv_heads, int head_dim,
+    int context_len, int max_context, void* stream = nullptr);
+bool qwen_gqa_prefill_attention_f16_cuda(
+    const uint16_t* d_q_rows_fp16, const uint16_t* d_k_cache_fp16,
+    const uint16_t* d_v_cache_fp16, uint16_t* d_out_rows_fp16,
+    int seq_len, int q_heads, int kv_heads, int head_dim,
+    int position_offset, int max_context, void* stream = nullptr);
+bool qwen_gqa_decode_attention_fp8_cuda(
+    const uint16_t* d_q_fp16, const uint8_t* d_k_cache_fp8,
+    const uint8_t* d_v_cache_fp8, const uint16_t* d_k_scale_fp16,
+    const uint16_t* d_v_scale_fp16, uint16_t* d_out_fp16,
+    float* d_score_scratch, int q_heads, int kv_heads, int head_dim,
+    int scale_block, int context_len, int max_context,
+    void* stream = nullptr);
+bool qwen_gqa_prefill_attention_fp8_cuda(
+    const uint16_t* d_q_rows_fp16, const uint8_t* d_k_cache_fp8,
+    const uint8_t* d_v_cache_fp8, const uint16_t* d_k_scale_fp16,
+    const uint16_t* d_v_scale_fp16, uint16_t* d_out_rows_fp16,
+    int seq_len, int q_heads, int kv_heads, int head_dim, int scale_block,
+    int position_offset, int max_context, void* stream = nullptr);
 
 }  // namespace dsv4

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -9,10 +9,20 @@
 
 namespace dsv4 {
 
+enum class QwenKvCacheDType {
+    Fp16,
+    Fp8,
+};
+
+const char* qwen_kv_cache_dtype_name(QwenKvCacheDType dtype);
+QwenKvCacheDType parse_qwen_kv_cache_dtype(const std::string& value);
+
 struct QwenEngineOptions {
     int tp_world = 1;
     int tp_rank = 0;
     int device = 0;
+    int prefill_chunk_tokens = 512;
+    QwenKvCacheDType kv_cache_dtype = QwenKvCacheDType::Fp16;
     std::string nccl_id_path;
 };
 
@@ -46,6 +56,9 @@ public:
     int position() const { return position_; }
     uint64_t resident_weight_bytes() const { return resident_weight_bytes_; }
     uint64_t resident_scale_bytes() const { return resident_scale_bytes_; }
+    uint64_t activation_workspace_peak_bytes() const;
+    uint64_t kv_cache_bytes() const;
+    uint64_t kv_cache_scale_bytes() const;
 
     void reset();
     void warmup_tp();

--- a/cpp_engine/include/qwen_weights.hpp
+++ b/cpp_engine/include/qwen_weights.hpp
@@ -62,6 +62,13 @@ struct QwenDeviceTensor {
     QwenDeviceTensor& operator=(const QwenDeviceTensor&) = delete;
     QwenDeviceTensor(QwenDeviceTensor&& other) noexcept;
     QwenDeviceTensor& operator=(QwenDeviceTensor&& other) noexcept;
+
+    float* f32_data();
+    const float* f32_data() const;
+    uint16_t* f16_data();
+    const uint16_t* f16_data() const;
+    uint8_t* fp8_data();
+    const uint8_t* fp8_data() const;
 };
 
 struct QwenLinearRef {

--- a/cpp_engine/include/tp_comm.hpp
+++ b/cpp_engine/include/tp_comm.hpp
@@ -15,6 +15,7 @@ bool nccl_available();
 void run_nccl_float_sum_smoke(int world, int rank, int device, const char* id_path, float value);
 TpTopResult nccl_global_top1(int world, int rank, int device, const char* id_path, int local_token, float local_logit);
 void nccl_all_reduce_sum_float_inplace(int world, int rank, int device, const char* id_path, float* d_values, int count);
+void nccl_all_reduce_sum_f16_inplace(int world, int rank, int device, const char* id_path, uint16_t* d_values, int count);
 void nccl_all_reduce_sum_bf16_inplace(int world, int rank, int device, const char* id_path, uint16_t* d_values, int count);
 // Broadcast a small int32 buffer from rank `root` to all ranks. Synchronous.
 void nccl_broadcast_int32(int world, int rank, int device, const char* id_path, int32_t* buf, int count, int root);

--- a/cpp_engine/src/main.cpp
+++ b/cpp_engine/src/main.cpp
@@ -45,6 +45,8 @@ struct Args {
     bool smoke_forward = false;
     bool use_persistent = false;
     int max_context = 0;
+    int prefill_chunk_tokens = 512;
+    std::string kv_cache_dtype = "fp16";
     bool serve = false;
     int port = 8000;
     std::string host = "0.0.0.0";
@@ -121,6 +123,10 @@ Args parse_args(int argc, char** argv) {
             args.use_persistent = true;
         } else if (arg == "--max-context" && i + 1 < argc) {
             args.max_context = std::stoi(argv[++i]);
+        } else if (arg == "--prefill-chunk-tokens" && i + 1 < argc) {
+            args.prefill_chunk_tokens = std::stoi(argv[++i]);
+        } else if (arg == "--kv-cache-dtype" && i + 1 < argc) {
+            args.kv_cache_dtype = argv[++i];
         } else if (arg == "--serve") {
             args.serve = true;
         } else if (arg == "--port" && i + 1 < argc) {
@@ -141,6 +147,10 @@ Args parse_args(int argc, char** argv) {
     }
     if (args.tp_world <= 0) throw std::runtime_error("--tp-world must be positive");
     if (args.tp_rank < 0 || args.tp_rank >= args.tp_world) throw std::runtime_error("--tp-rank must be in [0, tp_world)");
+    if (args.prefill_chunk_tokens <= 0) throw std::runtime_error("--prefill-chunk-tokens must be positive");
+    if (args.kv_cache_dtype != "fp16" && args.kv_cache_dtype != "fp8") {
+        throw std::runtime_error("--kv-cache-dtype must be fp16 or fp8");
+    }
     if (args.model.empty() && args.ckpt.empty()) {
         throw std::runtime_error("--model or --ckpt is required");
     }
@@ -282,11 +292,23 @@ int main(int argc, char** argv) {
                     qwen_opts.tp_world = args.tp_world;
                     qwen_opts.tp_rank = args.tp_rank;
                     qwen_opts.device = args.device >= 0 ? args.device : args.tp_rank;
+                    qwen_opts.prefill_chunk_tokens = args.prefill_chunk_tokens;
+                    qwen_opts.kv_cache_dtype = dsv4::parse_qwen_kv_cache_dtype(args.kv_cache_dtype);
                     qwen_opts.nccl_id_path = args.nccl_id_path;
                     const int qwen_context = args.max_context > 0
                         ? args.max_context
                         : static_cast<int>(prompt_ids.size()) + std::max(1, args.max_new_tokens);
+                    if (static_cast<uint64_t>(prompt_ids.size()) +
+                            static_cast<uint64_t>(std::max(1, args.max_new_tokens)) >
+                        static_cast<uint64_t>(qwen_context)) {
+                        throw std::runtime_error("Qwen prompt plus generation exceeds --max-context");
+                    }
                     dsv4::QwenEngine qwen(args.ckpt, qwen_opts, args.smoke_layers, qwen_context);
+                    std::cout << "qwen_startup=1 layers=" << (args.smoke_layers > 0 ? args.smoke_layers : 64)
+                              << " prefill_chunk_tokens=" << qwen_opts.prefill_chunk_tokens
+                              << " kv_cache_dtype=" << dsv4::qwen_kv_cache_dtype_name(qwen_opts.kv_cache_dtype)
+                              << " prompt_tokens=" << prompt_ids.size()
+                              << " max_context=" << qwen_context << "\n";
                     if (args.generate_token) {
                         qwen.warmup_tp();
                         using Clock = std::chrono::steady_clock;
@@ -320,6 +342,12 @@ int main(int argc, char** argv) {
                         std::cout << "qwen_runtime=1 layers=" << generated.front().layers
                                   << " resident_weight_bytes=" << qwen.resident_weight_bytes()
                                   << " resident_scale_bytes=" << qwen.resident_scale_bytes()
+                                  << " activation_workspace_peak_bytes=" << qwen.activation_workspace_peak_bytes()
+                                  << " kv_cache_bytes=" << qwen.kv_cache_bytes()
+                                  << " kv_cache_scale_bytes=" << qwen.kv_cache_scale_bytes()
+                                  << " prefill_chunk_tokens=" << qwen.options().prefill_chunk_tokens
+                                  << " kv_cache_dtype=" << dsv4::qwen_kv_cache_dtype_name(qwen.options().kv_cache_dtype)
+                                  << " max_context=" << qwen.max_context()
                                   << " prompt_tokens=" << prompt_ids.size()
                                   << " generated_tokens=" << generated.size();
                         if (args.resident_bench) {
@@ -356,7 +384,13 @@ int main(int argc, char** argv) {
                                   << " checksum=" << result.checksum
                                   << " position=" << result.position
                                   << " resident_weight_bytes=" << qwen.resident_weight_bytes()
-                                  << " resident_scale_bytes=" << qwen.resident_scale_bytes() << "\n";
+                                  << " resident_scale_bytes=" << qwen.resident_scale_bytes()
+                                  << " activation_workspace_peak_bytes=" << qwen.activation_workspace_peak_bytes()
+                                  << " kv_cache_bytes=" << qwen.kv_cache_bytes()
+                                  << " kv_cache_scale_bytes=" << qwen.kv_cache_scale_bytes()
+                                  << " prefill_chunk_tokens=" << qwen.options().prefill_chunk_tokens
+                                  << " kv_cache_dtype=" << dsv4::qwen_kv_cache_dtype_name(qwen.options().kv_cache_dtype)
+                                  << " max_context=" << qwen.max_context() << "\n";
                     }
                     return 0;
                 }

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -8,44 +8,23 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstring>
-#include <memory>
+#include <cstdint>
 #include <stdexcept>
 #include <utility>
 
 namespace dsv4 {
 namespace {
 
+constexpr int kKvScaleBlock = 64;
+
 void check_cuda(cudaError_t status, const char* what) {
-    if (status != cudaSuccess) throw std::runtime_error(std::string(what) + ": " + cudaGetErrorString(status));
+    if (status != cudaSuccess) {
+        throw std::runtime_error(std::string(what) + ": " + cudaGetErrorString(status));
+    }
 }
 
 void require_launch(bool ok, const char* what) {
     if (!ok) throw std::runtime_error(std::string("Qwen CUDA launch failed: ") + what);
-}
-
-float* fp32(QwenDeviceTensor& tensor) {
-    return static_cast<float*>(tensor.data);
-}
-
-const float* fp32(const QwenDeviceTensor& tensor) {
-    return static_cast<const float*>(tensor.data);
-}
-
-uint16_t* fp16(QwenDeviceTensor& tensor) {
-    return static_cast<uint16_t*>(tensor.data);
-}
-
-const uint16_t* fp16(const QwenDeviceTensor& tensor) {
-    return static_cast<const uint16_t*>(tensor.data);
-}
-
-uint8_t* fp8(QwenDeviceTensor& tensor) {
-    return static_cast<uint8_t*>(tensor.data);
-}
-
-const uint8_t* fp8(const QwenDeviceTensor& tensor) {
-    return static_cast<const uint8_t*>(tensor.data);
 }
 
 struct DeviceLinear {
@@ -77,6 +56,8 @@ struct DeviceFullAttention {
     QwenDeviceTensor k_norm;
     QwenDeviceTensor k_cache;
     QwenDeviceTensor v_cache;
+    QwenDeviceTensor k_scale;
+    QwenDeviceTensor v_scale;
 };
 
 struct DeviceLayer {
@@ -94,16 +75,18 @@ QwenDeviceTensor upload(const SafeTensorsIndex& index, const QwenTensorRef& ref)
 }
 
 DeviceLinear upload_linear(const SafeTensorsIndex& index, const QwenLinearRef& ref) {
-    DeviceLinear out;
-    out.weight = upload(index, ref.weight);
-    out.fp8 = ref.weight.device_dtype == SafeDType::F8_E4M3;
-    if (ref.has_scale) out.scale = upload(index, ref.scale);
-    return out;
+    DeviceLinear output;
+    output.weight = upload(index, ref.weight);
+    output.fp8 = ref.weight.device_dtype == SafeDType::F8_E4M3;
+    if (ref.has_scale) output.scale = upload(index, ref.scale);
+    return output;
 }
 
-void allocate(QwenDeviceTensor& tensor, size_t bytes, const std::vector<uint64_t>& shape,
-              SafeDType dtype) {
-    if (bytes == 0) throw std::runtime_error("Qwen attempted to allocate an empty tensor");
+void allocate(QwenDeviceTensor& tensor, size_t bytes,
+              const std::vector<uint64_t>& shape, SafeDType dtype) {
+    if (bytes == 0 || safe_dtype_size(dtype) == 0) {
+        throw std::runtime_error("Qwen attempted to allocate an invalid tensor");
+    }
     if (tensor.data != nullptr && tensor.capacity >= bytes) {
         tensor.device_dtype = dtype;
         tensor.shape = shape;
@@ -121,17 +104,32 @@ void allocate(QwenDeviceTensor& tensor, size_t bytes, const std::vector<uint64_t
     tensor.capacity = bytes;
 }
 
-void allocate_float(QwenDeviceTensor& tensor, size_t elements, const std::vector<uint64_t>& shape) {
-    allocate(tensor, elements * sizeof(float), shape, SafeDType::F32);
+void allocate_elements(QwenDeviceTensor& tensor, size_t elements,
+                       const std::vector<uint64_t>& shape, SafeDType dtype) {
+    const uint64_t item_size = safe_dtype_size(dtype);
+    if (elements > static_cast<size_t>(UINT64_MAX / item_size)) {
+        throw std::runtime_error("Qwen tensor byte extent overflow");
+    }
+    allocate(tensor, elements * item_size, shape, dtype);
+}
+
+void allocate_float(QwenDeviceTensor& tensor, size_t elements,
+                    const std::vector<uint64_t>& shape) {
+    allocate_elements(tensor, elements, shape, SafeDType::F32);
+}
+
+void allocate_half(QwenDeviceTensor& tensor, size_t elements,
+                   const std::vector<uint64_t>& shape) {
+    allocate_elements(tensor, elements, shape, SafeDType::F16);
 }
 
 void zero_tensor(QwenDeviceTensor& tensor) {
-    check_cuda(cudaMemset(tensor.data, 0, tensor.nbytes), "cudaMemset Qwen runtime tensor");
+    if (tensor.data != nullptr && tensor.nbytes != 0) {
+        check_cuda(cudaMemset(tensor.data, 0, tensor.nbytes),
+                   "cudaMemset Qwen runtime tensor");
+    }
 }
 
-// One layer's temporaries are live concurrently, but layers themselves run in
-// strict sequence. Reusing slots across layers removes synchronous allocator
-// calls without changing any operator inputs.
 struct QwenWorkspace {
     std::vector<QwenDeviceTensor> slots;
     size_t cursor = 0;
@@ -140,15 +138,46 @@ struct QwenWorkspace {
 
     void begin() { cursor = 0; }
 
-    QwenDeviceTensor& float_tensor(size_t elements, const std::vector<uint64_t>& shape) {
+    QwenDeviceTensor& tensor(size_t elements, const std::vector<uint64_t>& shape,
+                             SafeDType dtype) {
         if (cursor == slots.size()) slots.emplace_back();
-        QwenDeviceTensor& tensor = slots[cursor++];
-        allocate_float(tensor, elements, shape);
-        return tensor;
+        QwenDeviceTensor& output = slots[cursor++];
+        allocate_elements(output, elements, shape, dtype);
+        return output;
+    }
+
+    QwenDeviceTensor& half_tensor(size_t elements,
+                                  const std::vector<uint64_t>& shape) {
+        return tensor(elements, shape, SafeDType::F16);
+    }
+
+    QwenDeviceTensor& float_tensor(size_t elements,
+                                   const std::vector<uint64_t>& shape) {
+        return tensor(elements, shape, SafeDType::F32);
+    }
+
+    uint64_t capacity_bytes() const {
+        uint64_t total = 0;
+        for (const QwenDeviceTensor& slot : slots) total += slot.capacity;
+        return total;
     }
 };
 
 }  // namespace
+
+const char* qwen_kv_cache_dtype_name(QwenKvCacheDType dtype) {
+    switch (dtype) {
+        case QwenKvCacheDType::Fp16: return "fp16";
+        case QwenKvCacheDType::Fp8: return "fp8";
+    }
+    return "unknown";
+}
+
+QwenKvCacheDType parse_qwen_kv_cache_dtype(const std::string& value) {
+    if (value == "fp16") return QwenKvCacheDType::Fp16;
+    if (value == "fp8") return QwenKvCacheDType::Fp8;
+    throw std::runtime_error("Qwen KV cache dtype must be fp16 or fp8");
+}
 
 struct QwenEngine::Impl {
     SafeTensorsIndex& index;
@@ -163,125 +192,172 @@ struct QwenEngine::Impl {
     QwenDeviceTensor d_tokens;
     QwenDeviceTensor hidden_a;
     QwenDeviceTensor hidden_b;
-    QwenDeviceTensor work_a;
-    QwenDeviceTensor work_b;
-    QwenDeviceTensor final_hidden;
-    QwenDeviceTensor logits;
     QwenDeviceTensor argmax_token;
     QwenDeviceTensor argmax_logit;
     QwenWorkspace workspace;
-
-    // active_layers bounds how many decoder layers are uploaded. A partial-depth
-    // smoke run must not stage the full 64-layer checkpoint: at TP1 that is
-    // 27.4 GiB and does not fit on a 22 GiB card.
-    // Bytes actually staged on this device, as opposed to what the full map
-    // describes; a partial-depth run uploads only a prefix of the layers.
     uint64_t uploaded_weight_bytes = 0;
     uint64_t uploaded_scale_bytes = 0;
+    uint64_t cache_data_bytes = 0;
+    uint64_t cache_scale_bytes = 0;
 
-    Impl(SafeTensorsIndex& index_, QwenConfig& config_, const QwenWeightMap& map,
-         const QwenEngineOptions& options_, int max_context_, int active_layers)
-        : index(index_), config(config_), options(options_), max_context(max_context_) {
+    Impl(SafeTensorsIndex& index_, QwenConfig& config_,
+         const QwenWeightMap& map, const QwenEngineOptions& options_,
+         int max_context_, int active_layers)
+        : index(index_), config(config_), options(options_),
+          max_context(max_context_) {
         embed = upload(index, map.embed_tokens());
         final_norm = upload(index, map.final_norm());
         lm_head = upload(index, map.lm_head());
         uploaded_weight_bytes += map.embed_tokens().device_nbytes +
-                                 map.final_norm().device_nbytes + map.lm_head().device_nbytes;
+                                 map.final_norm().device_nbytes +
+                                 map.lm_head().device_nbytes;
         const size_t layer_limit = active_layers > 0
             ? std::min(static_cast<size_t>(active_layers), map.layers().size())
             : map.layers().size();
         layers.reserve(layer_limit);
         const int world = options.tp_world;
-        const int rank = options.tp_rank;
-        const int local_key_heads = static_cast<int>(config.linear_attention.key_heads / world);
-        const int local_value_heads = static_cast<int>(config.linear_attention.value_heads / world);
-        const int local_key_dim = local_key_heads * static_cast<int>(config.linear_attention.key_head_dim);
-        const int local_value_dim = local_value_heads * static_cast<int>(config.linear_attention.value_head_dim);
+        const int local_key_heads =
+            static_cast<int>(config.linear_attention.key_heads / world);
+        const int local_value_heads =
+            static_cast<int>(config.linear_attention.value_heads / world);
+        const int local_key_dim = local_key_heads *
+            static_cast<int>(config.linear_attention.key_head_dim);
+        const int local_value_dim = local_value_heads *
+            static_cast<int>(config.linear_attention.value_head_dim);
         const int local_qkv_dim = 2 * local_key_dim + local_value_dim;
-        const int local_q_heads = static_cast<int>(config.full_attention.num_heads / world);
-        const int local_kv_heads = static_cast<int>(config.full_attention.num_key_value_heads / world);
+        const int local_kv_heads =
+            static_cast<int>(config.full_attention.num_key_value_heads / world);
+        const int head_dim = static_cast<int>(config.full_attention.head_dim);
+
         for (size_t layer_index = 0; layer_index < layer_limit; ++layer_index) {
-            const QwenLayerWeights& src = map.layers()[layer_index];
+            const QwenLayerWeights& source = map.layers()[layer_index];
             for (const QwenTensorRef* ref : {
-                     &src.input_layernorm, &src.post_attention_layernorm,
-                     &src.mlp.gate_proj.weight, &src.mlp.up_proj.weight, &src.mlp.down_proj.weight,
-                     &src.linear_attention.in_proj_qkv.weight, &src.linear_attention.in_proj_z.weight,
-                     &src.linear_attention.out_proj.weight, &src.linear_attention.in_proj_a.weight,
-                     &src.linear_attention.in_proj_b.weight, &src.linear_attention.conv1d,
-                     &src.linear_attention.a_log, &src.linear_attention.dt_bias,
-                     &src.linear_attention.norm,
-                     &src.full_attention.q_proj.weight, &src.full_attention.k_proj.weight,
-                     &src.full_attention.v_proj.weight, &src.full_attention.o_proj.weight,
-                     &src.full_attention.q_norm, &src.full_attention.k_norm}) {
+                     &source.input_layernorm, &source.post_attention_layernorm,
+                     &source.mlp.gate_proj.weight, &source.mlp.up_proj.weight,
+                     &source.mlp.down_proj.weight,
+                     &source.linear_attention.in_proj_qkv.weight,
+                     &source.linear_attention.in_proj_z.weight,
+                     &source.linear_attention.out_proj.weight,
+                     &source.linear_attention.in_proj_a.weight,
+                     &source.linear_attention.in_proj_b.weight,
+                     &source.linear_attention.conv1d,
+                     &source.linear_attention.a_log,
+                     &source.linear_attention.dt_bias,
+                     &source.linear_attention.norm,
+                     &source.full_attention.q_proj.weight,
+                     &source.full_attention.k_proj.weight,
+                     &source.full_attention.v_proj.weight,
+                     &source.full_attention.o_proj.weight,
+                     &source.full_attention.q_norm,
+                     &source.full_attention.k_norm}) {
                 if (ref->found) uploaded_weight_bytes += ref->device_nbytes;
             }
             for (const QwenLinearRef* ref : {
-                     &src.mlp.gate_proj, &src.mlp.up_proj, &src.mlp.down_proj,
-                     &src.linear_attention.in_proj_qkv, &src.linear_attention.in_proj_z,
-                     &src.linear_attention.out_proj,
-                     &src.full_attention.q_proj, &src.full_attention.k_proj,
-                     &src.full_attention.v_proj, &src.full_attention.o_proj}) {
-                if (ref->has_scale) uploaded_scale_bytes += ref->scale.device_nbytes;
+                     &source.mlp.gate_proj, &source.mlp.up_proj,
+                     &source.mlp.down_proj,
+                     &source.linear_attention.in_proj_qkv,
+                     &source.linear_attention.in_proj_z,
+                     &source.linear_attention.out_proj,
+                     &source.full_attention.q_proj,
+                     &source.full_attention.k_proj,
+                     &source.full_attention.v_proj,
+                     &source.full_attention.o_proj}) {
+                if (ref->has_scale) {
+                    uploaded_scale_bytes += ref->scale.device_nbytes;
+                }
             }
-            DeviceLayer dst;
-            dst.input_norm = upload(index, src.input_layernorm);
-            dst.post_norm = upload(index, src.post_attention_layernorm);
-            dst.gate = upload_linear(index, src.mlp.gate_proj);
-            dst.up = upload_linear(index, src.mlp.up_proj);
-            dst.down = upload_linear(index, src.mlp.down_proj);
-            if (src.linear_attention.in_proj_qkv.weight.found) {
-                dst.linear.qkv = upload_linear(index, src.linear_attention.in_proj_qkv);
-                dst.linear.z = upload_linear(index, src.linear_attention.in_proj_z);
-                dst.linear.out = upload_linear(index, src.linear_attention.out_proj);
-                dst.linear.a = upload_linear(index, src.linear_attention.in_proj_a);
-                dst.linear.b = upload_linear(index, src.linear_attention.in_proj_b);
-                dst.linear.conv = upload(index, src.linear_attention.conv1d);
-                dst.linear.a_log = upload(index, src.linear_attention.a_log);
-                dst.linear.dt_bias = upload(index, src.linear_attention.dt_bias);
-                dst.linear.norm = upload(index, src.linear_attention.norm);
-                allocate_float(dst.linear.state,
-                               static_cast<size_t>(local_value_heads) * config.linear_attention.key_head_dim *
-                                   config.linear_attention.value_head_dim,
-                               {static_cast<uint64_t>(local_value_heads), config.linear_attention.key_head_dim,
-                                config.linear_attention.value_head_dim});
-                allocate_float(dst.linear.conv_tail,
-                               static_cast<size_t>(std::max(0, static_cast<int>(config.linear_attention.conv_kernel_dim) - 1)) *
-                                   local_qkv_dim,
-                               {static_cast<uint64_t>(std::max(0, static_cast<int>(config.linear_attention.conv_kernel_dim) - 1)),
-                                static_cast<uint64_t>(local_qkv_dim)});
-                zero_tensor(dst.linear.state);
-                zero_tensor(dst.linear.conv_tail);
+
+            DeviceLayer destination;
+            destination.input_norm = upload(index, source.input_layernorm);
+            destination.post_norm = upload(index, source.post_attention_layernorm);
+            destination.gate = upload_linear(index, source.mlp.gate_proj);
+            destination.up = upload_linear(index, source.mlp.up_proj);
+            destination.down = upload_linear(index, source.mlp.down_proj);
+            if (source.linear_attention.in_proj_qkv.weight.found) {
+                destination.linear.qkv =
+                    upload_linear(index, source.linear_attention.in_proj_qkv);
+                destination.linear.z =
+                    upload_linear(index, source.linear_attention.in_proj_z);
+                destination.linear.out =
+                    upload_linear(index, source.linear_attention.out_proj);
+                destination.linear.a =
+                    upload_linear(index, source.linear_attention.in_proj_a);
+                destination.linear.b =
+                    upload_linear(index, source.linear_attention.in_proj_b);
+                destination.linear.conv =
+                    upload(index, source.linear_attention.conv1d);
+                destination.linear.a_log =
+                    upload(index, source.linear_attention.a_log);
+                destination.linear.dt_bias =
+                    upload(index, source.linear_attention.dt_bias);
+                destination.linear.norm =
+                    upload(index, source.linear_attention.norm);
+                allocate_float(destination.linear.state,
+                    static_cast<size_t>(local_value_heads) *
+                        config.linear_attention.key_head_dim *
+                        config.linear_attention.value_head_dim,
+                    {static_cast<uint64_t>(local_value_heads),
+                     config.linear_attention.key_head_dim,
+                     config.linear_attention.value_head_dim});
+                allocate_half(destination.linear.conv_tail,
+                    static_cast<size_t>(std::max(
+                        0, static_cast<int>(config.linear_attention.conv_kernel_dim) - 1)) *
+                        local_qkv_dim,
+                    {static_cast<uint64_t>(std::max(
+                         0, static_cast<int>(config.linear_attention.conv_kernel_dim) - 1)),
+                     static_cast<uint64_t>(local_qkv_dim)});
+                zero_tensor(destination.linear.state);
+                zero_tensor(destination.linear.conv_tail);
             } else {
-                dst.full.q = upload_linear(index, src.full_attention.q_proj);
-                dst.full.k = upload_linear(index, src.full_attention.k_proj);
-                dst.full.v = upload_linear(index, src.full_attention.v_proj);
-                dst.full.out = upload_linear(index, src.full_attention.o_proj);
-                dst.full.q_norm = upload(index, src.full_attention.q_norm);
-                dst.full.k_norm = upload(index, src.full_attention.k_norm);
-                allocate_float(dst.full.k_cache,
-                               static_cast<size_t>(max_context) * local_kv_heads * config.full_attention.head_dim,
-                               {static_cast<uint64_t>(max_context), static_cast<uint64_t>(local_kv_heads),
-                                config.full_attention.head_dim});
-                allocate_float(dst.full.v_cache,
-                               static_cast<size_t>(max_context) * local_kv_heads * config.full_attention.head_dim,
-                               {static_cast<uint64_t>(max_context), static_cast<uint64_t>(local_kv_heads),
-                                config.full_attention.head_dim});
-                zero_tensor(dst.full.k_cache);
-                zero_tensor(dst.full.v_cache);
+                destination.full.q = upload_linear(index, source.full_attention.q_proj);
+                destination.full.k = upload_linear(index, source.full_attention.k_proj);
+                destination.full.v = upload_linear(index, source.full_attention.v_proj);
+                destination.full.out = upload_linear(index, source.full_attention.o_proj);
+                destination.full.q_norm = upload(index, source.full_attention.q_norm);
+                destination.full.k_norm = upload(index, source.full_attention.k_norm);
+                const size_t cache_elements = static_cast<size_t>(max_context) *
+                    local_kv_heads * head_dim;
+                const std::vector<uint64_t> cache_shape = {
+                    static_cast<uint64_t>(max_context),
+                    static_cast<uint64_t>(local_kv_heads),
+                    static_cast<uint64_t>(head_dim)};
+                if (options.kv_cache_dtype == QwenKvCacheDType::Fp16) {
+                    allocate_half(destination.full.k_cache, cache_elements, cache_shape);
+                    allocate_half(destination.full.v_cache, cache_elements, cache_shape);
+                    cache_data_bytes += destination.full.k_cache.nbytes +
+                                        destination.full.v_cache.nbytes;
+                } else {
+                    allocate_elements(destination.full.k_cache, cache_elements,
+                                      cache_shape, SafeDType::F8_E4M3);
+                    allocate_elements(destination.full.v_cache, cache_elements,
+                                      cache_shape, SafeDType::F8_E4M3);
+                    const size_t scale_elements = static_cast<size_t>(max_context) *
+                        local_kv_heads * (head_dim / kKvScaleBlock);
+                    const std::vector<uint64_t> scale_shape = {
+                        static_cast<uint64_t>(max_context),
+                        static_cast<uint64_t>(local_kv_heads),
+                        static_cast<uint64_t>(head_dim / kKvScaleBlock)};
+                    allocate_half(destination.full.k_scale, scale_elements, scale_shape);
+                    allocate_half(destination.full.v_scale, scale_elements, scale_shape);
+                    cache_data_bytes += destination.full.k_cache.nbytes +
+                                        destination.full.v_cache.nbytes;
+                    cache_scale_bytes += destination.full.k_scale.nbytes +
+                                         destination.full.v_scale.nbytes;
+                }
             }
-            layers.push_back(std::move(dst));
+            layers.push_back(std::move(destination));
         }
-        (void)rank;
     }
 
-    ~Impl() = default;
-
-    void all_reduce(float* values, int count) {
+    void all_reduce_half(uint16_t* values, int count) {
         if (options.tp_world == 1) return;
 #ifdef DSV4_HAVE_NCCL
-        if (options.nccl_id_path.empty()) throw std::runtime_error("Qwen TP requires --nccl-id-path");
-        nccl_all_reduce_sum_float_inplace(options.tp_world, options.tp_rank, options.device,
-                                          options.nccl_id_path.c_str(), values, count);
+        if (options.nccl_id_path.empty()) {
+            throw std::runtime_error("Qwen TP requires --nccl-id-path");
+        }
+        nccl_all_reduce_sum_f16_inplace(
+            options.tp_world, options.tp_rank, options.device,
+            options.nccl_id_path.c_str(), values, count);
 #else
         (void)values;
         (void)count;
@@ -289,59 +365,66 @@ struct QwenEngine::Impl {
 #endif
     }
 
-    void projection(const DeviceLinear& linear, const float* x, float* y, int rows) {
-        const int out_rows = static_cast<int>(linear.weight.shape[0]);
-        const int cols = static_cast<int>(linear.weight.shape[1]);
+    void projection(const DeviceLinear& linear, const uint16_t* input,
+                    uint16_t* output, int rows) {
+        const int output_rows = static_cast<int>(linear.weight.shape[0]);
+        const int columns = static_cast<int>(linear.weight.shape[1]);
         if (linear.fp8) {
             if (rows == 1) {
-                // Decode: warp-per-row matvec avoids the block reduction.
-                require_launch(qwen_fp8_e4m3_fp16scale_matvec_cuda(
-                                   x, fp8(const_cast<QwenDeviceTensor&>(linear.weight)),
-                                   fp16(const_cast<QwenDeviceTensor&>(linear.scale)), fp32_view(y),
-                                   out_rows, cols, cols,
-                                   static_cast<int>(linear.scale.shape[1])),
-                               "FP8 decode projection");
-                return;
+                require_launch(qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+                    input, linear.weight.fp8_data(), linear.scale.f16_data(),
+                    output, output_rows, columns, columns,
+                    static_cast<int>(linear.scale.shape[1])),
+                    "FP8 FP16-activation decode projection");
+            } else {
+                require_launch(qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
+                    input, linear.weight.fp8_data(), linear.scale.f16_data(),
+                    output, rows, output_rows, columns, columns, output_rows,
+                    columns, static_cast<int>(linear.scale.shape[1])),
+                    "FP8 FP16-activation projection");
             }
-            require_launch(qwen_fp8_e4m3_fp16scale_matmul_rows_cuda(
-                               x, fp8(const_cast<QwenDeviceTensor&>(linear.weight)),
-                               fp16(const_cast<QwenDeviceTensor&>(linear.scale)), fp32_view(y),
-                               rows, out_rows, cols, cols, out_rows, cols,
-                               static_cast<int>(linear.scale.shape[1])),
-                           "FP8 projection");
         } else {
-            require_launch(qwen_fp16_matmul_rows_cuda(
-                               x, fp16(const_cast<QwenDeviceTensor&>(linear.weight)), fp32_view(y),
-                               rows, out_rows, cols, cols, out_rows, cols),
-                           "FP16 projection");
+            require_launch(qwen_fp16_matmul_rows_f16_cuda(
+                input, linear.weight.f16_data(), output, rows, output_rows,
+                columns, columns, output_rows, columns),
+                "FP16 activation/weight projection");
         }
     }
 
-    static float* fp32_view(float* p) { return p; }
-
-    void norm(const QwenDeviceTensor& gamma, const float* x, float* y, int rows, int cols) {
-        require_launch(qwen_rmsnorm_fp16_gamma_rows_cuda(
-                           x, fp16(const_cast<QwenDeviceTensor&>(gamma)), y, rows, cols,
-                           static_cast<float>(config.rms_norm_eps)),
-                       "Qwen RMSNorm");
+    void norm(const QwenDeviceTensor& gamma, const uint16_t* input,
+              uint16_t* output, int rows, int columns) {
+        require_launch(qwen_rmsnorm_fp16_gamma_rows_f16_cuda(
+            input, gamma.f16_data(), output, rows, columns,
+            static_cast<float>(config.rms_norm_eps)), "Qwen FP16 RMSNorm");
     }
 
-    void add(float* y, const float* x, int count) {
-        require_launch(qwen_add_inplace_cuda(y, x, count), "Qwen residual add");
+    void add(uint16_t* output, const uint16_t* input, int count) {
+        require_launch(qwen_add_inplace_f16_cuda(output, input, count),
+                       "Qwen FP16 residual add");
     }
 
     void begin_workspace() { workspace.begin(); }
 
-    QwenDeviceTensor& workspace_float(size_t elements, const std::vector<uint64_t>& shape) {
+    QwenDeviceTensor& workspace_half(size_t elements,
+                                     const std::vector<uint64_t>& shape) {
+        return workspace.half_tensor(elements, shape);
+    }
+
+    QwenDeviceTensor& workspace_float(size_t elements,
+                                      const std::vector<uint64_t>& shape) {
         return workspace.float_tensor(elements, shape);
     }
 
-    void linear_attention(DeviceLayer& layer, float* hidden, float* output, int rows,
-                          int position_offset) {
-        const int key_heads = static_cast<int>(config.linear_attention.key_heads / options.tp_world);
-        const int value_heads = static_cast<int>(config.linear_attention.value_heads / options.tp_world);
-        const int key_dim = key_heads * static_cast<int>(config.linear_attention.key_head_dim);
-        const int value_dim = value_heads * static_cast<int>(config.linear_attention.value_head_dim);
+    void linear_attention(DeviceLayer& layer, const uint16_t* hidden,
+                          uint16_t* output, int rows, int position_offset) {
+        const int key_heads = static_cast<int>(
+            config.linear_attention.key_heads / options.tp_world);
+        const int value_heads = static_cast<int>(
+            config.linear_attention.value_heads / options.tp_world);
+        const int key_dim = key_heads *
+            static_cast<int>(config.linear_attention.key_head_dim);
+        const int value_dim = value_heads *
+            static_cast<int>(config.linear_attention.value_head_dim);
         const int packed_dim = 2 * key_dim + value_dim;
         const int kernel = static_cast<int>(config.linear_attention.conv_kernel_dim);
         const int hidden_size = static_cast<int>(config.hidden_size);
@@ -349,300 +432,388 @@ struct QwenEngine::Impl {
         const size_t key_elements = static_cast<size_t>(rows) * key_dim;
         const size_t value_elements = static_cast<size_t>(rows) * value_dim;
         const size_t gate_elements = static_cast<size_t>(rows) * value_heads;
-        QwenDeviceTensor& packed = workspace_float(packed_elements, {static_cast<uint64_t>(rows), static_cast<uint64_t>(packed_dim)});
-        QwenDeviceTensor& conv = workspace_float(packed_elements, packed.shape);
-        QwenDeviceTensor& q = workspace_float(key_elements, {static_cast<uint64_t>(rows), static_cast<uint64_t>(key_dim)});
-        QwenDeviceTensor& k = workspace_float(key_elements, q.shape);
-        QwenDeviceTensor& v = workspace_float(value_elements, {static_cast<uint64_t>(rows), static_cast<uint64_t>(value_dim)});
-        QwenDeviceTensor& a = workspace_float(gate_elements, {static_cast<uint64_t>(rows), static_cast<uint64_t>(value_heads)});
-        QwenDeviceTensor& b = workspace_float(gate_elements, a.shape);
-        QwenDeviceTensor& gates = workspace_float(gate_elements, a.shape);
-        QwenDeviceTensor& beta = workspace_float(gate_elements, a.shape);
-        QwenDeviceTensor& core = workspace_float(value_elements, v.shape);
-        QwenDeviceTensor& z = workspace_float(value_elements, core.shape);
-        QwenDeviceTensor& normalized = workspace_float(value_elements, core.shape);
-        projection(layer.linear.qkv, hidden, fp32(packed), rows);
-        require_launch(qwen_causal_depthwise_conv_silu_cuda(
-                           fp32(packed), fp16(layer.linear.conv), fp32(layer.linear.conv_tail),
-                           fp32(conv), rows, packed_dim, kernel, true),
-                       "linear causal convolution");
-        require_launch(qwen_split_packed_qkv_cuda(fp32(conv), fp32(q), fp32(k), fp32(v), rows, key_dim, value_dim),
-                       "linear QKV split");
-        projection(layer.linear.a, hidden, fp32(a), rows);
-        projection(layer.linear.b, hidden, fp32(b), rows);
-        require_launch(qwen_linear_attn_gates_cuda(
-                           fp32(a), fp32(b), fp16(layer.linear.a_log), fp16(layer.linear.dt_bias),
-                           fp32(gates), fp32(beta), rows, value_heads),
-                       "linear gate projection");
-        const float q_scale = 1.0f / std::sqrt(static_cast<float>(config.linear_attention.key_head_dim));
-        // Prefill collapses the recurrence into one launch per layer; decode
-        // keeps the single-step kernel so its latency path is unchanged. The
-        // sequence kernel declines shapes it cannot hold, hence the fallback.
-        const bool sequenced =
-            rows > 1 &&
-            qwen_gated_delta_sequence_cuda(
-                fp32(layer.linear.state), fp32(q), fp32(k), fp32(v), fp32(gates), fp32(beta),
-                fp32(core), rows, value_heads, key_heads,
+        QwenDeviceTensor& packed = workspace_half(
+            packed_elements, {static_cast<uint64_t>(rows),
+                              static_cast<uint64_t>(packed_dim)});
+        QwenDeviceTensor& convolved = workspace_half(packed_elements, packed.shape);
+        QwenDeviceTensor& q = workspace_half(
+            key_elements, {static_cast<uint64_t>(rows),
+                           static_cast<uint64_t>(key_dim)});
+        QwenDeviceTensor& k = workspace_half(key_elements, q.shape);
+        QwenDeviceTensor& v = workspace_half(
+            value_elements, {static_cast<uint64_t>(rows),
+                             static_cast<uint64_t>(value_dim)});
+        QwenDeviceTensor& a = workspace_half(
+            gate_elements, {static_cast<uint64_t>(rows),
+                            static_cast<uint64_t>(value_heads)});
+        QwenDeviceTensor& b = workspace_half(gate_elements, a.shape);
+        QwenDeviceTensor& gates = workspace_half(gate_elements, a.shape);
+        QwenDeviceTensor& beta = workspace_half(gate_elements, a.shape);
+        QwenDeviceTensor& core = workspace_half(value_elements, v.shape);
+        QwenDeviceTensor& z = workspace_half(value_elements, v.shape);
+        QwenDeviceTensor& normalized = workspace_half(value_elements, v.shape);
+
+        projection(layer.linear.qkv, hidden, packed.f16_data(), rows);
+        require_launch(qwen_causal_depthwise_conv_silu_f16_cuda(
+            packed.f16_data(), layer.linear.conv.f16_data(),
+            layer.linear.conv_tail.f16_data(), convolved.f16_data(), rows,
+            packed_dim, kernel, true), "FP16 linear causal convolution");
+        require_launch(qwen_split_packed_qkv_f16_cuda(
+            convolved.f16_data(), q.f16_data(), k.f16_data(), v.f16_data(),
+            rows, key_dim, value_dim), "FP16 linear QKV split");
+        projection(layer.linear.a, hidden, a.f16_data(), rows);
+        projection(layer.linear.b, hidden, b.f16_data(), rows);
+        require_launch(qwen_linear_attn_gates_f16_cuda(
+            a.f16_data(), b.f16_data(), layer.linear.a_log.f16_data(),
+            layer.linear.dt_bias.f16_data(), gates.f16_data(), beta.f16_data(),
+            rows, value_heads), "FP16 linear attention gates");
+        const float q_scale = 1.0f / std::sqrt(
+            static_cast<float>(config.linear_attention.key_head_dim));
+        const bool sequenced = rows > 1 && qwen_gated_delta_sequence_f16_cuda(
+            layer.linear.state.f32_data(), q.f16_data(), k.f16_data(),
+            v.f16_data(), gates.f16_data(), beta.f16_data(), core.f16_data(),
+            rows, value_heads, key_heads,
+            static_cast<int>(config.linear_attention.key_head_dim),
+            static_cast<int>(config.linear_attention.value_head_dim), q_scale);
+        for (int token = 0; !sequenced && token < rows; ++token) {
+            require_launch(qwen_gated_delta_step_f16_cuda(
+                layer.linear.state.f32_data(),
+                q.f16_data() + static_cast<size_t>(token) * key_dim,
+                k.f16_data() + static_cast<size_t>(token) * key_dim,
+                v.f16_data() + static_cast<size_t>(token) * value_dim,
+                gates.f16_data() + static_cast<size_t>(token) * value_heads,
+                beta.f16_data() + static_cast<size_t>(token) * value_heads,
+                core.f16_data() + static_cast<size_t>(token) * value_dim,
+                value_heads, key_heads,
                 static_cast<int>(config.linear_attention.key_head_dim),
-                static_cast<int>(config.linear_attention.value_head_dim), q_scale);
-        for (int t = 0; sequenced ? false : t < rows; ++t) {
-            require_launch(qwen_gated_delta_step_cuda(
-                               fp32(layer.linear.state), fp32(q) + static_cast<size_t>(t) * key_dim,
-                               fp32(k) + static_cast<size_t>(t) * key_dim,
-                               fp32(v) + static_cast<size_t>(t) * value_dim,
-                               fp32(gates) + static_cast<size_t>(t) * value_heads,
-                               fp32(beta) + static_cast<size_t>(t) * value_heads,
-                               fp32(core) + static_cast<size_t>(t) * value_dim,
-                               value_heads, key_heads, static_cast<int>(config.linear_attention.key_head_dim),
-                               static_cast<int>(config.linear_attention.value_head_dim), q_scale),
-                           "linear recurrent state");
+                static_cast<int>(config.linear_attention.value_head_dim), q_scale),
+                "FP16 linear recurrent state");
         }
-        projection(layer.linear.z, hidden, fp32(z), rows);
-        require_launch(qwen_gated_rmsnorm_fp16_gamma_rows_cuda(
-                           fp32(core), fp16(layer.linear.norm), fp32(z), fp32(normalized),
-                           rows * value_heads, static_cast<int>(config.linear_attention.value_head_dim),
-                           static_cast<float>(config.rms_norm_eps)),
-                       "linear gated RMSNorm");
-        projection(layer.linear.out, fp32(normalized), output, rows);
-        all_reduce(output, rows * hidden_size);
+        projection(layer.linear.z, hidden, z.f16_data(), rows);
+        require_launch(qwen_gated_rmsnorm_fp16_gamma_rows_f16_cuda(
+            core.f16_data(), layer.linear.norm.f16_data(), z.f16_data(),
+            normalized.f16_data(), rows * value_heads,
+            static_cast<int>(config.linear_attention.value_head_dim),
+            static_cast<float>(config.rms_norm_eps)),
+            "FP16 linear gated RMSNorm");
+        projection(layer.linear.out, normalized.f16_data(), output, rows);
+        all_reduce_half(output, rows * hidden_size);
         (void)position_offset;
     }
 
-    void full_attention(DeviceLayer& layer, float* hidden, float* output, int rows,
-                        int position_offset) {
-        const int q_heads = static_cast<int>(config.full_attention.num_heads / options.tp_world);
-        const int kv_heads = static_cast<int>(config.full_attention.num_key_value_heads / options.tp_world);
+    void full_attention(DeviceLayer& layer, const uint16_t* hidden,
+                        uint16_t* output, int rows, int position_offset) {
+        const int q_heads = static_cast<int>(
+            config.full_attention.num_heads / options.tp_world);
+        const int kv_heads = static_cast<int>(
+            config.full_attention.num_key_value_heads / options.tp_world);
         const int head_dim = static_cast<int>(config.full_attention.head_dim);
         const int attention_dim = q_heads * head_dim;
-        const int q_proj_dim = attention_dim * 2;
-        const size_t q_proj_elements = static_cast<size_t>(rows) * q_proj_dim;
-        const size_t attention_elements = static_cast<size_t>(rows) * attention_dim;
-        const size_t kv_elements = static_cast<size_t>(rows) * kv_heads * head_dim;
-        QwenDeviceTensor& q_proj = workspace_float(q_proj_elements, {static_cast<uint64_t>(rows), static_cast<uint64_t>(q_proj_dim)});
-        QwenDeviceTensor& q = workspace_float(attention_elements, {static_cast<uint64_t>(rows), static_cast<uint64_t>(attention_dim)});
-        QwenDeviceTensor& gate = workspace_float(attention_elements, q.shape);
-        QwenDeviceTensor& k = workspace_float(kv_elements, {static_cast<uint64_t>(rows), static_cast<uint64_t>(kv_heads), static_cast<uint64_t>(head_dim)});
-        QwenDeviceTensor& v = workspace_float(kv_elements, k.shape);
-        QwenDeviceTensor& q_norm = workspace_float(attention_elements, q.shape);
-        QwenDeviceTensor& k_norm = workspace_float(kv_elements, k.shape);
-        QwenDeviceTensor& attn = workspace_float(attention_elements, q.shape);
-        QwenDeviceTensor& merged = workspace_float(attention_elements, q.shape);
-        projection(layer.full.q, hidden, fp32(q_proj), rows);
-        require_launch(qwen_split_q_gate_cuda(fp32(q_proj), fp32(q), fp32(gate), rows, q_heads, head_dim), "full Q/gate split");
-        projection(layer.full.k, hidden, fp32(k), rows);
-        projection(layer.full.v, hidden, fp32(v), rows);
-        norm(layer.full.q_norm, fp32(q), fp32(q_norm), rows * q_heads, head_dim);
-        norm(layer.full.k_norm, fp32(k), fp32(k_norm), rows * kv_heads, head_dim);
-        if (rows == 1) {
-            require_launch(qwen_partial_rope_cuda(
-                               fp32(q_norm), fp32(k_norm), position_offset,
-                               static_cast<int>(config.partial_rotary_dim()),
-                               static_cast<float>(config.rope_theta), q_heads, kv_heads, head_dim),
-                           "partial RoPE");
+        const int q_projection_dim = attention_dim * 2;
+        const size_t q_projection_elements =
+            static_cast<size_t>(rows) * q_projection_dim;
+        const size_t attention_elements =
+            static_cast<size_t>(rows) * attention_dim;
+        const size_t kv_elements =
+            static_cast<size_t>(rows) * kv_heads * head_dim;
+        QwenDeviceTensor& q_projection = workspace_half(
+            q_projection_elements, {static_cast<uint64_t>(rows),
+                                    static_cast<uint64_t>(q_projection_dim)});
+        QwenDeviceTensor& q = workspace_half(
+            attention_elements, {static_cast<uint64_t>(rows),
+                                 static_cast<uint64_t>(attention_dim)});
+        QwenDeviceTensor& gate = workspace_half(attention_elements, q.shape);
+        QwenDeviceTensor& k = workspace_half(
+            kv_elements, {static_cast<uint64_t>(rows),
+                          static_cast<uint64_t>(kv_heads),
+                          static_cast<uint64_t>(head_dim)});
+        QwenDeviceTensor& v = workspace_half(kv_elements, k.shape);
+        QwenDeviceTensor& q_norm = workspace_half(attention_elements, q.shape);
+        QwenDeviceTensor& k_norm = workspace_half(kv_elements, k.shape);
+        QwenDeviceTensor& attention = workspace_half(attention_elements, q.shape);
+        QwenDeviceTensor& merged = workspace_half(attention_elements, q.shape);
+
+        projection(layer.full.q, hidden, q_projection.f16_data(), rows);
+        require_launch(qwen_split_q_gate_f16_cuda(
+            q_projection.f16_data(), q.f16_data(), gate.f16_data(), rows,
+            q_heads, head_dim), "FP16 full Q/gate split");
+        projection(layer.full.k, hidden, k.f16_data(), rows);
+        projection(layer.full.v, hidden, v.f16_data(), rows);
+        norm(layer.full.q_norm, q.f16_data(), q_norm.f16_data(),
+             rows * q_heads, head_dim);
+        norm(layer.full.k_norm, k.f16_data(), k_norm.f16_data(),
+             rows * kv_heads, head_dim);
+        require_launch(qwen_partial_rope_rows_f16_cuda(
+            q_norm.f16_data(), k_norm.f16_data(), position_offset, rows,
+            static_cast<int>(config.partial_rotary_dim()),
+            static_cast<float>(config.rope_theta), q_heads, kv_heads, head_dim),
+            "FP16 partial RoPE");
+
+        const bool fp8_cache = options.kv_cache_dtype == QwenKvCacheDType::Fp8;
+        if (fp8_cache) {
+            require_launch(qwen_append_kv_cache_fp8_cuda(
+                k_norm.f16_data(), v.f16_data(), layer.full.k_cache.fp8_data(),
+                layer.full.v_cache.fp8_data(), layer.full.k_scale.f16_data(),
+                layer.full.v_scale.f16_data(), rows, kv_heads, head_dim,
+                kKvScaleBlock, position_offset, max_context),
+                "append FP8 full KV cache");
         } else {
-            require_launch(qwen_partial_rope_rows_cuda(
-                               fp32(q_norm), fp32(k_norm), position_offset, rows,
-                               static_cast<int>(config.partial_rotary_dim()),
-                               static_cast<float>(config.rope_theta), q_heads, kv_heads, head_dim),
-                           "prefill partial RoPE");
+            require_launch(qwen_append_kv_cache_f16_cuda(
+                k_norm.f16_data(), v.f16_data(), layer.full.k_cache.f16_data(),
+                layer.full.v_cache.f16_data(), rows, kv_heads, head_dim,
+                position_offset, max_context), "append FP16 full KV cache");
         }
-        require_launch(qwen_append_kv_cache_cuda(
-                           fp32(k_norm), fp32(v), fp32(layer.full.k_cache), fp32(layer.full.v_cache),
-                           rows, kv_heads, head_dim, position_offset, max_context),
-                       "append full KV cache");
+
         if (rows == 1) {
-            const int context_len = position_offset + 1;
+            const int context_length = position_offset + 1;
             QwenDeviceTensor& scores = workspace_float(
-                static_cast<size_t>(q_heads) * max_context,
-                {static_cast<uint64_t>(q_heads), static_cast<uint64_t>(max_context)});
-            require_launch(qwen_gqa_decode_attention_cuda(
-                               fp32(q_norm), fp32(layer.full.k_cache), fp32(layer.full.v_cache),
-                               fp32(attn), fp32(scores), q_heads, kv_heads, head_dim,
-                               context_len, max_context),
-                           "decode GQA");
+                static_cast<size_t>(q_heads) * context_length,
+                {static_cast<uint64_t>(q_heads),
+                 static_cast<uint64_t>(context_length)});
+            if (fp8_cache) {
+                require_launch(qwen_gqa_decode_attention_fp8_cuda(
+                    q_norm.f16_data(), layer.full.k_cache.fp8_data(),
+                    layer.full.v_cache.fp8_data(), layer.full.k_scale.f16_data(),
+                    layer.full.v_scale.f16_data(), attention.f16_data(),
+                    scores.f32_data(), q_heads, kv_heads, head_dim,
+                    kKvScaleBlock, context_length, max_context),
+                    "decode FP8-cache GQA");
+            } else {
+                require_launch(qwen_gqa_decode_attention_f16_cuda(
+                    q_norm.f16_data(), layer.full.k_cache.f16_data(),
+                    layer.full.v_cache.f16_data(), attention.f16_data(),
+                    scores.f32_data(), q_heads, kv_heads, head_dim,
+                    context_length, max_context), "decode FP16-cache GQA");
+            }
+        } else if (fp8_cache) {
+            require_launch(qwen_gqa_prefill_attention_fp8_cuda(
+                q_norm.f16_data(), layer.full.k_cache.fp8_data(),
+                layer.full.v_cache.fp8_data(), layer.full.k_scale.f16_data(),
+                layer.full.v_scale.f16_data(), attention.f16_data(), rows,
+                q_heads, kv_heads, head_dim, kKvScaleBlock, position_offset,
+                max_context), "prefill FP8-cache GQA");
         } else {
-            require_launch(qwen_gqa_prefill_attention_cuda(
-                               fp32(q_norm), fp32(layer.full.k_cache), fp32(layer.full.v_cache),
-                               fp32(attn), rows, q_heads, kv_heads, head_dim, position_offset, max_context),
-                           "prefill GQA");
+            require_launch(qwen_gqa_prefill_attention_f16_cuda(
+                q_norm.f16_data(), layer.full.k_cache.f16_data(),
+                layer.full.v_cache.f16_data(), attention.f16_data(), rows,
+                q_heads, kv_heads, head_dim, position_offset, max_context),
+                "prefill FP16-cache GQA");
         }
-        require_launch(qwen_sigmoid_mul_cuda(fp32(attn), fp32(gate), fp32(merged), rows * attention_dim),
-                       "full attention output gate");
-        projection(layer.full.out, fp32(merged), output, rows);
-        all_reduce(output, rows * static_cast<int>(config.hidden_size));
+        require_launch(qwen_sigmoid_mul_f16_cuda(
+            attention.f16_data(), gate.f16_data(), merged.f16_data(),
+            rows * attention_dim), "FP16 full attention output gate");
+        projection(layer.full.out, merged.f16_data(), output, rows);
+        all_reduce_half(output, rows * static_cast<int>(config.hidden_size));
     }
 
-    void layer_forward(DeviceLayer& layer, float* hidden, float* work, int rows, int position_offset) {
+    void layer_forward(DeviceLayer& layer, const uint16_t* hidden,
+                       uint16_t* output, int rows, int position_offset) {
         const int hidden_size = static_cast<int>(config.hidden_size);
         begin_workspace();
         const size_t hidden_elements = static_cast<size_t>(rows) * hidden_size;
-        const size_t intermediate_elements = static_cast<size_t>(rows) * layer.gate.weight.shape[0];
-        QwenDeviceTensor& normed = workspace_float(hidden_elements, {static_cast<uint64_t>(rows), static_cast<uint64_t>(hidden_size)});
-        QwenDeviceTensor& attn = workspace_float(hidden_elements, normed.shape);
-        QwenDeviceTensor& post = workspace_float(hidden_elements, normed.shape);
+        const size_t intermediate_elements = static_cast<size_t>(rows) *
+            layer.gate.weight.shape[0];
+        QwenDeviceTensor& normalized = workspace_half(
+            hidden_elements, {static_cast<uint64_t>(rows),
+                              static_cast<uint64_t>(hidden_size)});
+        QwenDeviceTensor& attention = workspace_half(hidden_elements, normalized.shape);
+        QwenDeviceTensor& post = workspace_half(hidden_elements, normalized.shape);
         const bool fused_swiglu = rows == 1 && layer.gate.fp8 && layer.up.fp8 &&
-                                  layer.gate.weight.shape == layer.up.weight.shape &&
-                                  layer.gate.scale.shape == layer.up.scale.shape;
-        QwenDeviceTensor* gate_ptr = nullptr;
-        QwenDeviceTensor* up_ptr = nullptr;
+            layer.gate.weight.shape == layer.up.weight.shape &&
+            layer.gate.scale.shape == layer.up.scale.shape;
+        QwenDeviceTensor* gate = nullptr;
+        QwenDeviceTensor* up = nullptr;
         if (!fused_swiglu) {
-            gate_ptr = &workspace_float(intermediate_elements,
-                                        {static_cast<uint64_t>(rows), layer.gate.weight.shape[0]});
-            up_ptr = &workspace_float(intermediate_elements, gate_ptr->shape);
+            gate = &workspace_half(intermediate_elements,
+                {static_cast<uint64_t>(rows), layer.gate.weight.shape[0]});
+            up = &workspace_half(intermediate_elements, gate->shape);
         }
-        QwenDeviceTensor& intermediate = workspace_float(
+        QwenDeviceTensor& intermediate = workspace_half(
             intermediate_elements,
             {static_cast<uint64_t>(rows), layer.gate.weight.shape[0]});
-        QwenDeviceTensor& mlp = workspace_float(hidden_elements, normed.shape);
-        norm(layer.input_norm, hidden, fp32(normed), rows, hidden_size);
+        QwenDeviceTensor& mlp = workspace_half(hidden_elements, normalized.shape);
+
+        norm(layer.input_norm, hidden, normalized.f16_data(), rows, hidden_size);
         if (layer.linear.qkv.weight.data != nullptr) {
-            linear_attention(layer, fp32(normed), fp32(attn), rows, position_offset);
+            linear_attention(layer, normalized.f16_data(), attention.f16_data(),
+                             rows, position_offset);
         } else {
-            full_attention(layer, fp32(normed), fp32(attn), rows, position_offset);
+            full_attention(layer, normalized.f16_data(), attention.f16_data(),
+                           rows, position_offset);
         }
-        check_cuda(cudaMemcpy(work, hidden, static_cast<size_t>(rows) * hidden_size * sizeof(float), cudaMemcpyDeviceToDevice),
-                   "Qwen residual copy");
-        add(work, fp32(attn), rows * hidden_size);
-        norm(layer.post_norm, work, fp32(post), rows, hidden_size);
+        check_cuda(cudaMemcpy(output, hidden,
+            hidden_elements * sizeof(uint16_t), cudaMemcpyDeviceToDevice),
+            "Qwen FP16 residual copy");
+        add(output, attention.f16_data(), rows * hidden_size);
+        norm(layer.post_norm, output, post.f16_data(), rows, hidden_size);
         if (fused_swiglu) {
-            require_launch(qwen_fp8_e4m3_fp16scale_swiglu_matvec_cuda(
-                               fp32(post), fp8(layer.gate.weight), fp16(layer.gate.scale),
-                               fp8(layer.up.weight), fp16(layer.up.scale), fp32(intermediate),
-                               static_cast<int>(layer.gate.weight.shape[0]), hidden_size,
-                               hidden_size, static_cast<int>(layer.gate.scale.shape[1])),
-                           "Qwen fused decode SwiGLU");
+            require_launch(qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
+                post.f16_data(), layer.gate.weight.fp8_data(),
+                layer.gate.scale.f16_data(), layer.up.weight.fp8_data(),
+                layer.up.scale.f16_data(), intermediate.f16_data(),
+                static_cast<int>(layer.gate.weight.shape[0]), hidden_size,
+                hidden_size, static_cast<int>(layer.gate.scale.shape[1])),
+                "FP16 fused decode SwiGLU");
         } else {
-            projection(layer.gate, fp32(post), fp32(*gate_ptr), rows);
-            projection(layer.up, fp32(post), fp32(*up_ptr), rows);
-            require_launch(qwen_silu_mul_rows_cuda(
-                               fp32(*gate_ptr), fp32(*up_ptr), fp32(intermediate), rows,
-                               static_cast<int>(layer.gate.weight.shape[0])),
-                           "Qwen SwiGLU");
+            projection(layer.gate, post.f16_data(), gate->f16_data(), rows);
+            projection(layer.up, post.f16_data(), up->f16_data(), rows);
+            require_launch(qwen_silu_mul_rows_f16_cuda(
+                gate->f16_data(), up->f16_data(), intermediate.f16_data(), rows,
+                static_cast<int>(layer.gate.weight.shape[0])), "FP16 SwiGLU");
         }
-        projection(layer.down, fp32(intermediate), fp32(mlp), rows);
-        all_reduce(fp32(mlp), rows * hidden_size);
-        add(work, fp32(mlp), rows * hidden_size);
-        check_cuda(cudaMemcpy(hidden, work, static_cast<size_t>(rows) * hidden_size * sizeof(float), cudaMemcpyDeviceToDevice),
-                   "Qwen layer output copy");
+        projection(layer.down, intermediate.f16_data(), mlp.f16_data(), rows);
+        all_reduce_half(mlp.f16_data(), rows * hidden_size);
+        add(output, mlp.f16_data(), rows * hidden_size);
     }
 
-    void run_layers(float*& hidden, float*& work, int rows, int position_offset, int active_layers) {
-        for (int i = 0; i < active_layers; ++i) {
-            layer_forward(layers[static_cast<size_t>(i)], hidden, work, rows, position_offset);
-            std::swap(hidden, work);
-        }
-    }
-
-    QwenForwardResult logits_for(float* hidden, int rows, int last_row, int position_after, int active_layers) {
+    QwenForwardResult logits_for(const uint16_t* hidden, int last_row,
+                                 int position_after, int active_layers) {
         const int hidden_size = static_cast<int>(config.hidden_size);
         const int local_vocab = static_cast<int>(lm_head.shape[0]);
         begin_workspace();
-        QwenDeviceTensor& normed = workspace_float(static_cast<size_t>(rows) * hidden_size,
-                                                    {static_cast<uint64_t>(rows), static_cast<uint64_t>(hidden_size)});
-        norm(final_norm, hidden, fp32(normed), rows, hidden_size);
-        QwenDeviceTensor& selected = workspace_float(hidden_size, {static_cast<uint64_t>(hidden_size)});
-        check_cuda(cudaMemcpy(selected.data, static_cast<uint8_t*>(normed.data) +
-                                  static_cast<size_t>(last_row) * hidden_size * sizeof(float),
-                              hidden_size * sizeof(float), cudaMemcpyDeviceToDevice),
-                   "Qwen final row copy");
-        QwenDeviceTensor& local_logits = workspace_float(local_vocab, {static_cast<uint64_t>(local_vocab)});
-        if (lm_head.device_dtype == SafeDType::F16) {
-            require_launch(qwen_fp16_matmul_rows_cuda(
-                               fp32(selected), fp16(lm_head), fp32(local_logits), 1, local_vocab,
-                               hidden_size, hidden_size, local_vocab, hidden_size),
-                           "Qwen lm head");
-        } else {
-            throw std::runtime_error("Qwen lm_head must be FP16 on Turing");
-        }
+        QwenDeviceTensor& normalized = workspace_half(
+            hidden_size, {static_cast<uint64_t>(hidden_size)});
+        norm(final_norm, hidden + static_cast<size_t>(last_row) * hidden_size,
+             normalized.f16_data(), 1, hidden_size);
+        QwenDeviceTensor& local_logits = workspace_float(
+            local_vocab, {static_cast<uint64_t>(local_vocab)});
+        require_launch(qwen_fp16_matmul_rows_f16_f32_cuda(
+            normalized.f16_data(), lm_head.f16_data(), local_logits.f32_data(),
+            1, local_vocab, hidden_size, hidden_size, local_vocab, hidden_size),
+            "Qwen final FP32 logits");
         allocate(argmax_token, sizeof(int), {1}, SafeDType::I64);
-        allocate(argmax_logit, sizeof(float), {1}, SafeDType::F32);
+        allocate_float(argmax_logit, 1, {1});
         const int vocab_start = static_cast<int>(weights_vocab_start());
-        require_launch(argmax_fp32_cuda(fp32(local_logits), static_cast<int*>(argmax_token.data),
-                                        fp32(argmax_logit), local_vocab, vocab_start),
-                       "Qwen local argmax");
+        require_launch(argmax_fp32_cuda(
+            local_logits.f32_data(), static_cast<int*>(argmax_token.data),
+            argmax_logit.f32_data(), local_vocab, vocab_start),
+            "Qwen local argmax");
         check_cuda(cudaDeviceSynchronize(), "Qwen logits synchronization");
         int local_token = 0;
         float local_logit = 0.0f;
-        check_cuda(cudaMemcpy(&local_token, argmax_token.data, sizeof(local_token), cudaMemcpyDeviceToHost),
+        check_cuda(cudaMemcpy(&local_token, argmax_token.data, sizeof(local_token),
+                              cudaMemcpyDeviceToHost),
                    "Qwen argmax token copy");
-        check_cuda(cudaMemcpy(&local_logit, argmax_logit.data, sizeof(local_logit), cudaMemcpyDeviceToHost),
+        check_cuda(cudaMemcpy(&local_logit, argmax_logit.data, sizeof(local_logit),
+                              cudaMemcpyDeviceToHost),
                    "Qwen argmax logit copy");
         int top_token = local_token;
         float top_logit = local_logit;
 #ifdef DSV4_HAVE_NCCL
         if (options.tp_world > 1) {
-            if (options.nccl_id_path.empty()) throw std::runtime_error("Qwen TP requires --nccl-id-path");
-            const TpTopResult global = nccl_global_top1(options.tp_world, options.tp_rank, options.device,
-                                                        options.nccl_id_path.c_str(), local_token, local_logit);
+            if (options.nccl_id_path.empty()) {
+                throw std::runtime_error("Qwen TP requires --nccl-id-path");
+            }
+            const TpTopResult global = nccl_global_top1(
+                options.tp_world, options.tp_rank, options.device,
+                options.nccl_id_path.c_str(), local_token, local_logit);
             top_token = global.token;
             top_logit = global.logit;
         }
 #else
-        if (options.tp_world > 1) throw std::runtime_error("Qwen TP requires an NCCL-enabled build");
+        if (options.tp_world > 1) {
+            throw std::runtime_error("Qwen TP requires an NCCL-enabled build");
+        }
 #endif
-        float checksum = local_logit;
         QwenForwardResult result;
-        result.token = last_row >= 0 ? 0 : 0;
         result.layers = active_layers;
         result.dim = hidden_size;
         result.logits = static_cast<int>(config.vocab_size);
         result.top_token = top_token;
         result.top_logit = top_logit;
-        result.checksum = checksum;
+        result.checksum = local_logit;
         result.position = position_after;
         return result;
     }
 
     uint64_t weights_vocab_start() const {
-        return static_cast<uint64_t>(options.tp_rank) * config.vocab_size / options.tp_world;
+        return static_cast<uint64_t>(options.tp_rank) *
+               config.vocab_size / options.tp_world;
     }
 
-    QwenForwardResult run(const std::vector<int>& token_ids, int position_offset, int active_layers,
-                          int last_row) {
-        if (token_ids.empty()) throw std::runtime_error("Qwen forward requires at least one token");
-        if (position_offset < 0 || position_offset + static_cast<int>(token_ids.size()) > max_context) {
+    QwenForwardResult run_chunk(const std::vector<int>& token_ids,
+                                int position_offset, int active_layers,
+                                bool compute_logits) {
+        if (token_ids.empty()) {
+            throw std::runtime_error("Qwen forward requires at least one token");
+        }
+        if (position_offset < 0 ||
+            position_offset + static_cast<int>(token_ids.size()) > max_context) {
             throw std::runtime_error("Qwen context length exceeded");
         }
         const int rows = static_cast<int>(token_ids.size());
         local_tokens = token_ids;
-        allocate(d_tokens, local_tokens.size() * sizeof(int), {static_cast<uint64_t>(rows)}, SafeDType::I64);
-        check_cuda(cudaMemcpy(d_tokens.data, local_tokens.data(), local_tokens.size() * sizeof(int), cudaMemcpyHostToDevice),
-                   "Qwen token upload");
+        allocate(d_tokens, local_tokens.size() * sizeof(int),
+                 {static_cast<uint64_t>(rows)}, SafeDType::I64);
+        check_cuda(cudaMemcpy(d_tokens.data, local_tokens.data(),
+                              local_tokens.size() * sizeof(int),
+                              cudaMemcpyHostToDevice), "Qwen token upload");
         const int hidden_size = static_cast<int>(config.hidden_size);
-        allocate_float(hidden_a, static_cast<size_t>(rows) * hidden_size, {static_cast<uint64_t>(rows), static_cast<uint64_t>(hidden_size)});
-        allocate_float(hidden_b, hidden_a.nbytes / sizeof(float), hidden_a.shape);
-        allocate_float(work_a, hidden_a.nbytes / sizeof(float), hidden_a.shape);
-        allocate_float(work_b, hidden_a.nbytes / sizeof(float), hidden_a.shape);
-        require_launch(qwen_embedding_fp16_gather_cuda(
-                           fp16(embed), static_cast<int*>(d_tokens.data), fp32(hidden_a), rows, hidden_size,
-                           static_cast<int>(weights_vocab_start()), static_cast<int>(embed.shape[0])),
-                       "Qwen embedding lookup");
-        all_reduce(fp32(hidden_a), rows * hidden_size);
-        float* hidden = fp32(hidden_a);
-        float* work = fp32(hidden_b);
-        for (int i = 0; i < active_layers; ++i) {
-            layer_forward(layers[static_cast<size_t>(i)], hidden, work, rows, position_offset);
-            std::swap(hidden, work);
+        const size_t hidden_elements = static_cast<size_t>(rows) * hidden_size;
+        const std::vector<uint64_t> hidden_shape = {
+            static_cast<uint64_t>(rows), static_cast<uint64_t>(hidden_size)};
+        allocate_half(hidden_a, hidden_elements, hidden_shape);
+        allocate_half(hidden_b, hidden_elements, hidden_shape);
+        require_launch(qwen_embedding_fp16_gather_f16_cuda(
+            embed.f16_data(), static_cast<int*>(d_tokens.data),
+            hidden_a.f16_data(), rows, hidden_size,
+            static_cast<int>(weights_vocab_start()),
+            static_cast<int>(embed.shape[0])), "Qwen FP16 embedding lookup");
+        all_reduce_half(hidden_a.f16_data(), rows * hidden_size);
+        uint16_t* hidden = hidden_a.f16_data();
+        uint16_t* output = hidden_b.f16_data();
+        for (int layer_index = 0; layer_index < active_layers; ++layer_index) {
+            layer_forward(layers[static_cast<size_t>(layer_index)], hidden,
+                          output, rows, position_offset);
+            std::swap(hidden, output);
         }
-        QwenForwardResult result = logits_for(hidden, rows, last_row, position_offset + rows, active_layers);
+        if (compute_logits) {
+            return logits_for(hidden, rows - 1, position_offset + rows,
+                              active_layers);
+        }
+        QwenForwardResult result;
+        result.layers = active_layers;
+        result.dim = hidden_size;
+        result.logits = static_cast<int>(config.vocab_size);
+        result.position = position_offset + rows;
         return result;
+    }
+
+    uint64_t activation_capacity_bytes() const {
+        return hidden_a.capacity + hidden_b.capacity + d_tokens.capacity +
+               argmax_token.capacity + argmax_logit.capacity +
+               workspace.capacity_bytes();
     }
 };
 
-QwenEngine::QwenEngine(const std::string& ckpt_dir, const QwenEngineOptions& options,
-                       int layer_count, int max_context)
-    : ckpt_dir_(ckpt_dir), options_(options), config_(QwenConfig::from_hf_config(ckpt_dir)),
-      index_(ckpt_dir), weights_(index_, config_, options.tp_world, options.tp_rank) {
+QwenEngine::QwenEngine(const std::string& ckpt_dir,
+                       const QwenEngineOptions& options, int layer_count,
+                       int max_context)
+    : ckpt_dir_(ckpt_dir), options_(options),
+      config_(QwenConfig::from_hf_config(ckpt_dir)), index_(ckpt_dir),
+      weights_(index_, config_, options.tp_world, options.tp_rank) {
     if (options_.device < 0) options_.device = options_.tp_rank;
-    if (cudaSetDevice(options_.device) != cudaSuccess) throw std::runtime_error("failed to set Qwen CUDA device");
-    if (layer_count <= 0) active_layers_ = static_cast<int>(config_.num_hidden_layers);
-    else if (layer_count <= static_cast<int>(config_.num_hidden_layers)) active_layers_ = layer_count;
-    else throw std::runtime_error("Qwen layer count exceeds model depth");
-    max_context_ = max_context > 0 ? max_context : static_cast<int>(config_.max_position_embeddings);
-    if (max_context_ > static_cast<int>(config_.max_position_embeddings)) {
+    if (options_.prefill_chunk_tokens <= 0) {
+        throw std::runtime_error("Qwen prefill chunk size must be positive");
+    }
+    if (cudaSetDevice(options_.device) != cudaSuccess) {
+        throw std::runtime_error("failed to set Qwen CUDA device");
+    }
+    if (layer_count <= 0) {
+        active_layers_ = static_cast<int>(config_.num_hidden_layers);
+    } else if (layer_count <= static_cast<int>(config_.num_hidden_layers)) {
+        active_layers_ = layer_count;
+    } else {
+        throw std::runtime_error("Qwen layer count exceeds model depth");
+    }
+    max_context_ = max_context > 0
+        ? max_context : static_cast<int>(config_.max_position_embeddings);
+    if (max_context_ <= 0 ||
+        max_context_ > static_cast<int>(config_.max_position_embeddings)) {
         throw std::runtime_error("Qwen max context exceeds model configuration");
     }
-    impl_ = new Impl(index_, config_, weights_, options_, max_context_, active_layers_);
+    impl_ = new Impl(index_, config_, weights_, options_, max_context_,
+                     active_layers_);
     resident_weight_bytes_ = impl_->uploaded_weight_bytes;
     resident_scale_bytes_ = impl_->uploaded_scale_bytes;
 }
@@ -652,12 +823,24 @@ QwenEngine::~QwenEngine() {
     impl_ = nullptr;
 }
 
+uint64_t QwenEngine::activation_workspace_peak_bytes() const {
+    return impl_->activation_capacity_bytes();
+}
+
+uint64_t QwenEngine::kv_cache_bytes() const {
+    return impl_->cache_data_bytes;
+}
+
+uint64_t QwenEngine::kv_cache_scale_bytes() const {
+    return impl_->cache_scale_bytes;
+}
+
 void QwenEngine::warmup_tp() {
     if (options_.tp_world == 1) return;
     QwenDeviceTensor scratch;
-    allocate_float(scratch, 1, {1});
+    allocate_half(scratch, 1, {1});
     zero_tensor(scratch);
-    impl_->all_reduce(fp32(scratch), 1);
+    impl_->all_reduce_half(scratch.f16_data(), 1);
     check_cuda(cudaDeviceSynchronize(), "Qwen TP warmup synchronization");
 }
 
@@ -668,35 +851,54 @@ void QwenEngine::reset() {
             zero_tensor(layer.linear.state);
             zero_tensor(layer.linear.conv_tail);
         }
-        if (layer.full.k_cache.data != nullptr) {
-            zero_tensor(layer.full.k_cache);
-            zero_tensor(layer.full.v_cache);
-        }
+        // KV storage is overwritten before it is read. Avoid clearing several
+        // GiB on every request; position_ bounds all attention reads.
     }
 }
 
 QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids) {
+    if (token_ids.empty()) {
+        throw std::runtime_error("Qwen prefill requires at least one token");
+    }
+    if (token_ids.size() > static_cast<size_t>(max_context_)) {
+        throw std::runtime_error("Qwen context length exceeded");
+    }
     reset();
-    QwenForwardResult result = impl_->run(token_ids, 0, active_layers_, static_cast<int>(token_ids.size()) - 1);
+    QwenForwardResult result;
+    const int chunk_size = options_.prefill_chunk_tokens;
+    for (size_t offset = 0; offset < token_ids.size();
+         offset += static_cast<size_t>(chunk_size)) {
+        const size_t end = std::min(token_ids.size(),
+                                    offset + static_cast<size_t>(chunk_size));
+        std::vector<int> chunk(token_ids.begin() + static_cast<ptrdiff_t>(offset),
+                               token_ids.begin() + static_cast<ptrdiff_t>(end));
+        const bool last = end == token_ids.size();
+        result = impl_->run_chunk(chunk, static_cast<int>(offset),
+                                  active_layers_, last);
+    }
     position_ = static_cast<int>(token_ids.size());
     return result;
 }
 
 QwenForwardResult QwenEngine::decode_step(int token_id) {
-    QwenForwardResult result = impl_->run({token_id}, position_, active_layers_, 0);
+    if (position_ >= max_context_) {
+        throw std::runtime_error("Qwen context length exceeded");
+    }
+    QwenForwardResult result = impl_->run_chunk(
+        {token_id}, position_, active_layers_, true);
     ++position_;
     return result;
 }
 
-std::vector<QwenForwardResult> QwenEngine::generate(const std::vector<int>& prompt_ids,
-                                                    int max_new_tokens) {
+std::vector<QwenForwardResult> QwenEngine::generate(
+    const std::vector<int>& prompt_ids, int max_new_tokens) {
     if (max_new_tokens <= 0) return {};
     QwenForwardResult next = prefill(prompt_ids);
     std::vector<QwenForwardResult> results;
     results.reserve(static_cast<size_t>(max_new_tokens));
-    for (int i = 0; i < max_new_tokens; ++i) {
+    for (int index = 0; index < max_new_tokens; ++index) {
         results.push_back(next);
-        if (i + 1 < max_new_tokens) next = decode_step(next.top_token);
+        if (index + 1 < max_new_tokens) next = decode_step(next.top_token);
     }
     return results;
 }

--- a/cpp_engine/src/qwen_weights.cpp
+++ b/cpp_engine/src/qwen_weights.cpp
@@ -112,6 +112,36 @@ QwenDeviceTensor& QwenDeviceTensor::operator=(QwenDeviceTensor&& other) noexcept
     return *this;
 }
 
+float* QwenDeviceTensor::f32_data() {
+    if (device_dtype != SafeDType::F32) throw std::runtime_error("Qwen tensor is not F32");
+    return static_cast<float*>(data);
+}
+
+const float* QwenDeviceTensor::f32_data() const {
+    if (device_dtype != SafeDType::F32) throw std::runtime_error("Qwen tensor is not F32");
+    return static_cast<const float*>(data);
+}
+
+uint16_t* QwenDeviceTensor::f16_data() {
+    if (device_dtype != SafeDType::F16) throw std::runtime_error("Qwen tensor is not F16");
+    return static_cast<uint16_t*>(data);
+}
+
+const uint16_t* QwenDeviceTensor::f16_data() const {
+    if (device_dtype != SafeDType::F16) throw std::runtime_error("Qwen tensor is not F16");
+    return static_cast<const uint16_t*>(data);
+}
+
+uint8_t* QwenDeviceTensor::fp8_data() {
+    if (device_dtype != SafeDType::F8_E4M3) throw std::runtime_error("Qwen tensor is not FP8 E4M3");
+    return static_cast<uint8_t*>(data);
+}
+
+const uint8_t* QwenDeviceTensor::fp8_data() const {
+    if (device_dtype != SafeDType::F8_E4M3) throw std::runtime_error("Qwen tensor is not FP8 E4M3");
+    return static_cast<const uint8_t*>(data);
+}
+
 QwenHostTensor qwen_materialize_host_tensor(const SafeTensorsIndex& index,
                                             const QwenTensorRef& ref) {
     if (!ref.found) throw std::runtime_error("cannot materialize an absent Qwen tensor: " + ref.name);

--- a/cpp_engine/src/tp_comm.cpp
+++ b/cpp_engine/src/tp_comm.cpp
@@ -118,6 +118,12 @@ void nccl_all_reduce_sum_float_inplace(int world, int rank, int device, const ch
     check_nccl(ncclAllReduce(d_values, d_values, count, ncclFloat, ncclSum, comm, nullptr), "ncclAllReduce inplace");
 }
 
+void nccl_all_reduce_sum_f16_inplace(int world, int rank, int device, const char* id_path, uint16_t* d_values, int count) {
+    if (world <= 0 || rank < 0 || rank >= world || d_values == nullptr || count <= 0) throw std::runtime_error("invalid NCCL fp16 all-reduce args");
+    ncclComm_t comm = cached_comm(world, rank, device, id_path);
+    check_nccl(ncclAllReduce(d_values, d_values, count, ncclHalf, ncclSum, comm, nullptr), "ncclAllReduce fp16 inplace");
+}
+
 void nccl_all_reduce_sum_bf16_inplace(int world, int rank, int device, const char* id_path, uint16_t* d_values, int count) {
     if (world <= 0 || rank < 0 || rank >= world || d_values == nullptr || count <= 0) throw std::runtime_error("invalid NCCL bf16 all-reduce args");
     ncclComm_t comm = cached_comm(world, rank, device, id_path);

--- a/cpp_engine/tests/test_qwen_engine.cpp
+++ b/cpp_engine/tests/test_qwen_engine.cpp
@@ -1,7 +1,7 @@
-// Minimal Qwen engine lifecycle test with a one-layer linear-attention fixture.
+// Minimal Qwen engine lifecycle test with linear-attention and full-GQA layers.
 // All weights are zero, so the greedy result is deterministic while the test
 // still exercises FP8 online projection, FP16 materialization, conv tail,
-// recurrent state, residual/MLP wiring, and the decode cache continuation.
+// recurrent state, residual/MLP wiring, and FP16/FP8 cache continuation.
 
 #include "cuda_ops.hpp"
 #include "qwen_config.hpp"
@@ -64,7 +64,7 @@ std::string config_json() {
     "vocab_size": 64,
     "hidden_size": 128,
     "intermediate_size": 128,
-    "num_hidden_layers": 1,
+    "num_hidden_layers": 2,
     "num_attention_heads": 4,
     "num_key_value_heads": 4,
     "head_dim": 128,
@@ -78,7 +78,7 @@ std::string config_json() {
     "rms_norm_eps": 1e-6,
     "partial_rotary_factor": 0.25,
     "rope_parameters": {"rope_type": "default", "rope_theta": 10000000},
-    "layer_types": ["linear_attention"]
+    "layer_types": ["linear_attention", "full_attention"]
   }
 })JSON";
 }
@@ -96,32 +96,56 @@ std::vector<TensorSpec> specs() {
     const std::vector<uint64_t> vector4 = {4};
     const std::vector<uint64_t> mlp = {128, 128};
     const std::vector<uint64_t> mlp_scale = {1, 1};
-    const std::string p = "model.language_model.layers.0.";
-    return {
+    const std::vector<uint64_t> q_proj = {1024, 128};
+    const std::vector<uint64_t> q_proj_scale = {8, 1};
+    const std::string linear = "model.language_model.layers.0.";
+    const std::string full = "model.language_model.layers.1.";
+    std::vector<TensorSpec> out = {
         {"model.language_model.embed_tokens.weight", "BF16", vocab},
         {"model.language_model.norm.weight", "BF16", hidden},
         {"lm_head.weight", "BF16", vocab},
-        {p + "input_layernorm.weight", "BF16", hidden},
-        {p + "post_attention_layernorm.weight", "BF16", hidden},
-        {p + "linear_attn.in_proj_qkv.weight", "F8_E4M3", qkv},
-        {p + "linear_attn.in_proj_qkv.weight_scale_inv", "BF16", qkv_scale},
-        {p + "linear_attn.in_proj_z.weight", "F8_E4M3", value_proj},
-        {p + "linear_attn.in_proj_z.weight_scale_inv", "BF16", value_scale},
-        {p + "linear_attn.out_proj.weight", "F8_E4M3", out_proj},
-        {p + "linear_attn.out_proj.weight_scale_inv", "BF16", out_scale},
-        {p + "linear_attn.in_proj_a.weight", "BF16", heads},
-        {p + "linear_attn.in_proj_b.weight", "BF16", heads},
-        {p + "linear_attn.conv1d.weight", "BF16", {1536, 1, 4}},
-        {p + "linear_attn.A_log", "BF16", vector4},
-        {p + "linear_attn.dt_bias", "BF16", vector4},
-        {p + "linear_attn.norm.weight", "BF16", {128}},
-        {p + "mlp.gate_proj.weight", "F8_E4M3", mlp},
-        {p + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale},
-        {p + "mlp.up_proj.weight", "F8_E4M3", mlp},
-        {p + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale},
-        {p + "mlp.down_proj.weight", "F8_E4M3", mlp},
-        {p + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale},
+        {linear + "input_layernorm.weight", "BF16", hidden},
+        {linear + "post_attention_layernorm.weight", "BF16", hidden},
+        {linear + "linear_attn.in_proj_qkv.weight", "F8_E4M3", qkv},
+        {linear + "linear_attn.in_proj_qkv.weight_scale_inv", "BF16", qkv_scale},
+        {linear + "linear_attn.in_proj_z.weight", "F8_E4M3", value_proj},
+        {linear + "linear_attn.in_proj_z.weight_scale_inv", "BF16", value_scale},
+        {linear + "linear_attn.out_proj.weight", "F8_E4M3", out_proj},
+        {linear + "linear_attn.out_proj.weight_scale_inv", "BF16", out_scale},
+        {linear + "linear_attn.in_proj_a.weight", "BF16", heads},
+        {linear + "linear_attn.in_proj_b.weight", "BF16", heads},
+        {linear + "linear_attn.conv1d.weight", "BF16", {1536, 1, 4}},
+        {linear + "linear_attn.A_log", "BF16", vector4},
+        {linear + "linear_attn.dt_bias", "BF16", vector4},
+        {linear + "linear_attn.norm.weight", "BF16", hidden},
+        {linear + "mlp.gate_proj.weight", "F8_E4M3", mlp},
+        {linear + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale},
+        {linear + "mlp.up_proj.weight", "F8_E4M3", mlp},
+        {linear + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale},
+        {linear + "mlp.down_proj.weight", "F8_E4M3", mlp},
+        {linear + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale},
     };
+    out.insert(out.end(), {
+        {full + "input_layernorm.weight", "BF16", hidden},
+        {full + "post_attention_layernorm.weight", "BF16", hidden},
+        {full + "self_attn.q_proj.weight", "F8_E4M3", q_proj},
+        {full + "self_attn.q_proj.weight_scale_inv", "BF16", q_proj_scale},
+        {full + "self_attn.k_proj.weight", "F8_E4M3", value_proj},
+        {full + "self_attn.k_proj.weight_scale_inv", "BF16", value_scale},
+        {full + "self_attn.v_proj.weight", "F8_E4M3", value_proj},
+        {full + "self_attn.v_proj.weight_scale_inv", "BF16", value_scale},
+        {full + "self_attn.o_proj.weight", "F8_E4M3", out_proj},
+        {full + "self_attn.o_proj.weight_scale_inv", "BF16", out_scale},
+        {full + "self_attn.q_norm.weight", "BF16", hidden},
+        {full + "self_attn.k_norm.weight", "BF16", hidden},
+        {full + "mlp.gate_proj.weight", "F8_E4M3", mlp},
+        {full + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale},
+        {full + "mlp.up_proj.weight", "F8_E4M3", mlp},
+        {full + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale},
+        {full + "mlp.down_proj.weight", "F8_E4M3", mlp},
+        {full + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale},
+    });
+    return out;
 }
 
 bool write_fixture(const std::string& dir) {
@@ -171,6 +195,56 @@ void require(bool condition, const std::string& message) {
     if (!condition) throw std::runtime_error(message);
 }
 
+void exercise_cache_lifecycle(const std::string& dir,
+                              dsv4::QwenKvCacheDType cache_dtype) {
+    dsv4::QwenEngineOptions options;
+    options.tp_world = 1;
+    options.tp_rank = 0;
+    options.device = 0;
+    options.prefill_chunk_tokens = 2;
+    options.kv_cache_dtype = cache_dtype;
+    dsv4::QwenEngine engine(dir, options, 2, 8);
+    require(engine.resident_weight_bytes() > 0, "resident Qwen weights missing");
+    require(engine.resident_scale_bytes() > 0, "resident Qwen scales missing");
+
+    const uint64_t fp16_cache_bytes = 2ULL * 8 * 4 * 128 * sizeof(uint16_t);
+    const uint64_t fp8_cache_bytes = 2ULL * 8 * 4 * 128;
+    const uint64_t fp8_scale_bytes =
+        2ULL * 8 * 4 * (128 / 64) * sizeof(uint16_t);
+    if (cache_dtype == dsv4::QwenKvCacheDType::Fp16) {
+        require(engine.kv_cache_bytes() == fp16_cache_bytes,
+                "FP16 KV cache accounting");
+        require(engine.kv_cache_scale_bytes() == 0,
+                "FP16 KV cache must not allocate scales");
+    } else {
+        require(engine.kv_cache_bytes() == fp8_cache_bytes,
+                "FP8 KV cache accounting");
+        require(engine.kv_cache_scale_bytes() == fp8_scale_bytes,
+                "FP8 KV scale accounting");
+    }
+
+    const dsv4::QwenForwardResult prefill = engine.prefill({1, 2, 3});
+    require(prefill.layers == 2 && prefill.dim == 128, "prefill metadata");
+    require(prefill.position == 3, "chunked prefill position");
+    require(prefill.top_token == 0, "zero fixture prefill greedy token");
+    require(engine.activation_workspace_peak_bytes() > 0, "activation accounting");
+
+    const dsv4::QwenForwardResult decoded = engine.decode_step(4);
+    require(decoded.position == 4, "decode position");
+    require(decoded.top_token == 0, "zero fixture decode greedy token");
+
+    engine.reset();
+    require(engine.position() == 0, "reset position");
+    const dsv4::QwenForwardResult second = engine.prefill({4, 5});
+    require(second.position == 2 && second.top_token == 0,
+            "reset and second chunked prefill");
+    std::cout << "  cache_dtype=" << dsv4::qwen_kv_cache_dtype_name(cache_dtype)
+              << " kv_cache_bytes=" << engine.kv_cache_bytes()
+              << " kv_cache_scale_bytes=" << engine.kv_cache_scale_bytes()
+              << " activation_workspace_peak_bytes="
+              << engine.activation_workspace_peak_bytes() << "\n";
+}
+
 }  // namespace
 
 int main() {
@@ -181,30 +255,9 @@ int main() {
     try {
         const std::string dir = fixture_dir();
         require(write_fixture(dir), "could not create Qwen engine fixture");
-        dsv4::QwenEngineOptions options;
-        options.tp_world = 1;
-        options.tp_rank = 0;
-        options.device = 0;
-        dsv4::QwenEngine engine(dir, options, 1, 8);
-        require(engine.resident_weight_bytes() > 0, "resident Qwen weights missing");
-        require(engine.resident_scale_bytes() > 0, "resident Qwen scales missing");
-
-        const dsv4::QwenForwardResult prefill = engine.prefill({1, 2});
-        require(prefill.layers == 1 && prefill.dim == 128, "prefill metadata");
-        require(prefill.position == 2, "prefill position");
-        require(prefill.top_token == 0, "zero fixture prefill greedy token");
-
-        const dsv4::QwenForwardResult decoded = engine.decode_step(3);
-        require(decoded.position == 3, "decode position");
-        require(decoded.top_token == 0, "zero fixture decode greedy token");
-
-        engine.reset();
-        require(engine.position() == 0, "reset position");
-        const dsv4::QwenForwardResult second = engine.prefill({4});
-        require(second.position == 1 && second.top_token == 0, "reset and second prefill");
-        std::cout << "[PASS] test_qwen_engine layers=" << second.layers
-                  << " resident_weight_bytes=" << engine.resident_weight_bytes()
-                  << " resident_scale_bytes=" << engine.resident_scale_bytes() << "\n";
+        exercise_cache_lifecycle(dir, dsv4::QwenKvCacheDType::Fp16);
+        exercise_cache_lifecycle(dir, dsv4::QwenKvCacheDType::Fp8);
+        std::cout << "[PASS] test_qwen_engine layers=2\n";
         return 0;
     } catch (const std::exception& ex) {
         std::cout << "[FAIL] test_qwen_engine " << ex.what() << "\n";

--- a/cpp_engine/tests/test_qwen_half_ops.cpp
+++ b/cpp_engine/tests/test_qwen_half_ops.cpp
@@ -1,0 +1,280 @@
+#include "cuda_ops.hpp"
+#include "qwen_cuda_ops.hpp"
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <random>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void fail(const char* message) {
+    std::printf("[FAIL] %s\n", message);
+    ++failures;
+}
+
+uint16_t to_half(float value) {
+    return __half_as_ushort(__float2half(value));
+}
+
+float from_half(uint16_t bits) {
+    return __half2float(__ushort_as_half(bits));
+}
+
+float from_fp8_e4m3(uint8_t code) {
+    const uint32_t sign = static_cast<uint32_t>(code & 0x80u) << 24;
+    const uint32_t exponent = (code >> 3) & 0xfu;
+    const uint32_t mantissa = code & 0x7u;
+    uint32_t bits;
+    if (exponent != 0) {
+        bits = sign | ((exponent + 120u) << 23) | (mantissa << 20);
+    } else if (mantissa >= 4) {
+        bits = sign | (120u << 23) | ((mantissa - 4u) << 21);
+    } else if (mantissa >= 2) {
+        bits = sign | (119u << 23) | ((mantissa - 2u) << 22);
+    } else {
+        bits = sign | (mantissa == 0 ? 0u : (118u << 23));
+    }
+    float output;
+    std::memcpy(&output, &bits, sizeof(output));
+    return output;
+}
+
+struct DeviceBuffer {
+    void* data = nullptr;
+    ~DeviceBuffer() { cudaFree(data); }
+    template <typename T>
+    T* allocate(size_t count) {
+        if (cudaMalloc(&data, count * sizeof(T)) != cudaSuccess) return nullptr;
+        return static_cast<T*>(data);
+    }
+};
+
+bool check_fp16_cache(int context_len) {
+    constexpr int q_heads = 6;
+    constexpr int kv_heads = 1;
+    constexpr int head_dim = 64;
+    const int max_context = context_len + 3;
+    std::mt19937 rng(1234 + context_len);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<uint16_t> q(q_heads * head_dim);
+    std::vector<uint16_t> k(context_len * kv_heads * head_dim);
+    std::vector<uint16_t> v(k.size());
+    for (uint16_t& item : q) item = to_half(dist(rng));
+    for (uint16_t& item : k) item = to_half(dist(rng));
+    for (uint16_t& item : v) item = to_half(dist(rng));
+    DeviceBuffer dq, dk_rows, dv_rows, dk_cache, dv_cache, dout, dscores;
+    uint16_t* d_q = dq.allocate<uint16_t>(q.size());
+    uint16_t* d_k_rows = dk_rows.allocate<uint16_t>(k.size());
+    uint16_t* d_v_rows = dv_rows.allocate<uint16_t>(v.size());
+    uint16_t* d_k_cache = dk_cache.allocate<uint16_t>(max_context * kv_heads * head_dim);
+    uint16_t* d_v_cache = dv_cache.allocate<uint16_t>(max_context * kv_heads * head_dim);
+    uint16_t* d_out = dout.allocate<uint16_t>(q.size());
+    float* d_scores = dscores.allocate<float>(q_heads * context_len);
+    if (!d_q || !d_k_rows || !d_v_rows || !d_k_cache || !d_v_cache || !d_out || !d_scores) return false;
+    cudaMemcpy(d_q, q.data(), q.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_k_rows, k.data(), k.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_v_rows, v.data(), v.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
+    if (!dsv4::qwen_append_kv_cache_f16_cuda(d_k_rows, d_v_rows, d_k_cache, d_v_cache,
+                                              context_len, kv_heads, head_dim, 0, max_context) ||
+        !dsv4::qwen_gqa_decode_attention_f16_cuda(d_q, d_k_cache, d_v_cache, d_out, d_scores,
+                                                   q_heads, kv_heads, head_dim, context_len,
+                                                   max_context) || cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP16 cache launch");
+        return true;
+    }
+    std::vector<uint16_t> got(q.size());
+    cudaMemcpy(got.data(), d_out, got.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    const float scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+    double worst = 0.0;
+    for (int head = 0; head < q_heads; ++head) {
+        std::vector<double> scores(context_len);
+        double maximum = -1.0e300;
+        for (int pos = 0; pos < context_len; ++pos) {
+            double dot = 0.0;
+            for (int d = 0; d < head_dim; ++d) {
+                dot += static_cast<double>(from_half(q[head * head_dim + d])) *
+                       from_half(k[pos * head_dim + d]);
+            }
+            scores[pos] = dot * scale;
+            maximum = std::max(maximum, scores[pos]);
+        }
+        double denominator = 0.0;
+        for (double& score : scores) {
+            score = std::exp(score - maximum);
+            denominator += score;
+        }
+        for (int d = 0; d < head_dim; ++d) {
+            double value = 0.0;
+            for (int pos = 0; pos < context_len; ++pos) value += scores[pos] * from_half(v[pos * head_dim + d]);
+            const float expected = static_cast<float>(value / denominator);
+            worst = std::max(worst, std::fabs(static_cast<double>(from_half(got[head * head_dim + d])) - expected));
+        }
+    }
+    if (worst > 3.0e-3) {
+        fail("FP16 cache numerical check");
+    } else {
+        std::printf("  FP16 cache context=%d worst=%.3e\n", context_len, worst);
+    }
+    return true;
+}
+
+bool check_decode_grid_256k() {
+    constexpr int q_heads = 6;
+    constexpr int kv_heads = 1;
+    constexpr int head_dim = 64;
+    constexpr int context_len = 262144;
+    DeviceBuffer dq, dk_cache, dv_cache, dout, dscores;
+    uint16_t* d_q = dq.allocate<uint16_t>(q_heads * head_dim);
+    uint16_t* d_k_cache = dk_cache.allocate<uint16_t>(context_len * kv_heads * head_dim);
+    uint16_t* d_v_cache = dv_cache.allocate<uint16_t>(context_len * kv_heads * head_dim);
+    uint16_t* d_out = dout.allocate<uint16_t>(q_heads * head_dim);
+    float* d_scores = dscores.allocate<float>(q_heads * context_len);
+    if (!d_q || !d_k_cache || !d_v_cache || !d_out || !d_scores) return false;
+    if (cudaMemset(d_q, 0, q_heads * head_dim * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMemset(d_k_cache, 0, context_len * kv_heads * head_dim * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMemset(d_v_cache, 0, context_len * kv_heads * head_dim * sizeof(uint16_t)) != cudaSuccess ||
+        !dsv4::qwen_gqa_decode_attention_f16_cuda(
+            d_q, d_k_cache, d_v_cache, d_out, d_scores, q_heads, kv_heads,
+            head_dim, context_len, context_len) ||
+        cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP16 256K decode grid launch");
+        return true;
+    }
+    std::vector<uint16_t> got(q_heads * head_dim);
+    cudaMemcpy(got.data(), d_out, got.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    for (uint16_t value : got) {
+        if (value != 0) {
+            fail("FP16 256K decode zero output");
+            break;
+        }
+    }
+    std::printf("  FP16 decode context=%d grid=flattened PASS\n", context_len);
+    return true;
+}
+
+bool check_fp8_cache() {
+    constexpr int q_heads = 6;
+    constexpr int kv_heads = 1;
+    constexpr int head_dim = 64;
+    constexpr int context_len = 17;
+    constexpr int max_context = 32;
+    constexpr int scale_block = 64;
+    std::mt19937 rng(5678);
+    std::uniform_real_distribution<float> dist(-2.0f, 2.0f);
+    std::vector<uint16_t> q(q_heads * head_dim);
+    std::vector<uint16_t> k(context_len * head_dim);
+    std::vector<uint16_t> v(k.size());
+    for (uint16_t& item : q) item = to_half(dist(rng));
+    for (uint16_t& item : k) item = to_half(dist(rng));
+    for (uint16_t& item : v) item = to_half(dist(rng));
+    DeviceBuffer dq, dk_rows, dv_rows, dk_cache, dv_cache, dks, dvs, dout, dscores;
+    uint16_t* d_q = dq.allocate<uint16_t>(q.size());
+    uint16_t* d_k_rows = dk_rows.allocate<uint16_t>(k.size());
+    uint16_t* d_v_rows = dv_rows.allocate<uint16_t>(v.size());
+    uint8_t* d_k_cache = dk_cache.allocate<uint8_t>(max_context * head_dim);
+    uint8_t* d_v_cache = dv_cache.allocate<uint8_t>(max_context * head_dim);
+    uint16_t* d_k_scale = dks.allocate<uint16_t>(max_context);
+    uint16_t* d_v_scale = dvs.allocate<uint16_t>(max_context);
+    uint16_t* d_out = dout.allocate<uint16_t>(q.size());
+    float* d_scores = dscores.allocate<float>(q_heads * context_len);
+    if (!d_q || !d_k_rows || !d_v_rows || !d_k_cache || !d_v_cache || !d_k_scale || !d_v_scale || !d_out || !d_scores) return false;
+    cudaMemcpy(d_q, q.data(), q.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_k_rows, k.data(), k.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_v_rows, v.data(), v.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
+    if (!dsv4::qwen_append_kv_cache_fp8_cuda(d_k_rows, d_v_rows, d_k_cache, d_v_cache,
+                                               d_k_scale, d_v_scale, context_len,
+                                               kv_heads, head_dim, scale_block, 0,
+                                               max_context) ||
+        !dsv4::qwen_gqa_decode_attention_fp8_cuda(d_q, d_k_cache, d_v_cache,
+                                                   d_k_scale, d_v_scale, d_out,
+                                                   d_scores, q_heads, kv_heads,
+                                                   head_dim, scale_block,
+                                                   context_len, max_context) ||
+        cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP8 cache launch");
+        return true;
+    }
+    std::vector<uint16_t> got(q.size());
+    cudaMemcpy(got.data(), d_out, got.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    std::vector<uint8_t> kq(k.size()), vq(v.size());
+    std::vector<uint16_t> ks(context_len), vs(context_len);
+    cudaMemcpy(ks.data(), d_k_scale, ks.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    cudaMemcpy(vs.data(), d_v_scale, vs.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    cudaMemcpy(kq.data(), d_k_cache, kq.size() * sizeof(uint8_t), cudaMemcpyDeviceToHost);
+    cudaMemcpy(vq.data(), d_v_cache, vq.size() * sizeof(uint8_t), cudaMemcpyDeviceToHost);
+    double worst = 0.0;
+    const float query_scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+    for (int head = 0; head < q_heads; ++head) {
+        std::vector<double> scores(context_len);
+        double maximum = -1.0e300;
+        for (int pos = 0; pos < context_len; ++pos) {
+            double dot = 0.0;
+            const float key_scale = from_half(ks[pos]);
+            for (int d = 0; d < head_dim; ++d) {
+                dot += static_cast<double>(from_half(q[head * head_dim + d])) *
+                       (from_fp8_e4m3(kq[pos * head_dim + d]) * key_scale);
+            }
+            scores[pos] = dot * query_scale;
+            maximum = std::max(maximum, scores[pos]);
+        }
+        double denominator = 0.0;
+        for (double& score : scores) {
+            score = std::exp(score - maximum);
+            denominator += score;
+        }
+        for (int d = 0; d < head_dim; ++d) {
+            double value = 0.0;
+            for (int pos = 0; pos < context_len; ++pos) {
+                value += scores[pos] * (from_fp8_e4m3(vq[pos * head_dim + d]) * from_half(vs[pos]));
+            }
+            const float expected = static_cast<float>(value / denominator);
+            worst = std::max(worst, std::fabs(static_cast<double>(from_half(got[head * head_dim + d])) - expected));
+        }
+    }
+    // The quantization itself is checked against the exact max-abs scale.
+    for (int pos = 0; pos < context_len; ++pos) {
+        float max_k = 0.0f;
+        float max_v = 0.0f;
+        for (int d = 0; d < head_dim; ++d) {
+            max_k = std::max(max_k, std::fabs(from_half(k[pos * head_dim + d])));
+            max_v = std::max(max_v, std::fabs(from_half(v[pos * head_dim + d])));
+        }
+        if (std::fabs(from_half(ks[pos]) - (max_k > 0.0f ? max_k / 448.0f : 1.0f)) > 2.0e-3f ||
+            std::fabs(from_half(vs[pos]) - (max_v > 0.0f ? max_v / 448.0f : 1.0f)) > 2.0e-3f) {
+            fail("FP8 cache scale check");
+            break;
+        }
+    }
+    if (worst > 0.35) fail("FP8 cache numerical check");
+    else std::printf("  FP8 cache context=%d worst=%.3e\n", context_len, worst);
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    if (!dsv4::cuda_runtime_available()) {
+        std::printf("[SKIP] test_qwen_half_ops requires a CUDA device\n");
+        return 0;
+    }
+    check_fp16_cache(1);
+    check_fp16_cache(17);
+    check_fp16_cache(333);
+    check_decode_grid_256k();
+    check_fp8_cache();
+    if (failures != 0) {
+        std::printf("test_qwen_half_ops failures=%d\n", failures);
+        return 1;
+    }
+    std::printf("[PASS] test_qwen_half_ops\n");
+    return 0;
+}

--- a/docs/models/qwen3.8-27b-fp8.md
+++ b/docs/models/qwen3.8-27b-fp8.md
@@ -42,6 +42,9 @@ The root config also contains a vision tower, but PocketLLM deliberately dispatc
 - Separate multi-row prefill and single-token decode projection kernels.
 - 48-layer Gated DeltaNet sequence/recurrent kernels with persistent state and convolution tails.
 - 16-layer GQA prefill and KV-cache decode with local K/V heads.
+- FP16 activation storage with FP32 local accumulation/state where required; no prompt-length FP32 activation expansion.
+- Chunked prefill (default 512 tokens) that retains only recurrent state, convolution tails, and full-attention KV cache between chunks.
+- FP16 KV cache by default, plus explicit opt-in FP8 E4M3 cache with per-token/KV-head FP16 scales over 64-channel blocks.
 - Decode-only fused FP8 gate/up projection plus SwiGLU.
 - TP4 NCCL reductions and global greedy top-1 selection.
 
@@ -55,6 +58,43 @@ Hardware: 4×RTX 2080 Ti 22 GiB, TP4, single request, real Qwen3.8-27B-FP8 check
 | 512 tokens | 24 | 416.48 tok/s | 35.87 tok/s | ~8.18–8.60 GiB |
 
 Additional repeat runs on the 512-token fixture measured approximately 411.8–416.4 tok/s prefill and 35.66–35.85 tok/s decode.
+
+### Long-context TP4 baseline
+
+The following recent serial runs use the real checkpoint, deterministic natural-language tokenizer IDs, four generated tokens, complete 64-layer execution, 512-token prefill chunks, and greedy-token parity across all four ranks. Decode TPS excludes the first generated token, which is produced by prefill. The activation workspace is the peak capacity of the reusable chunk workspace, not a prompt-length buffer.
+
+| Cache | Prompt | Prefill | Decode | Activation workspace | KV data / scales | Highest rank memory | Rank parity |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| FP16 | 32,768 | 99.32 tok/s | 10.39 tok/s | 63.97 MB | 512.0 / 0 MB | 8.47 GiB | PASS |
+| FP8 | 32,768 | 81.58 tok/s | 4.44 tok/s | 63.97 MB | 256.0 / 8.00 MB | 8.22 GiB | PASS |
+| FP16 | 65,536 | 60.42 tok/s | 6.48 tok/s | 63.97 MB | 1,024.0 / 0 MB | 8.97 GiB | PASS |
+| FP8 | 65,536 | 47.91 tok/s | 2.41 tok/s | 63.97 MB | 512.0 / 16.00 MB | 8.48 GiB | PASS |
+| FP16 | 131,072 | 33.80 tok/s | 3.58 tok/s | 62.50 MB | 2,048.0 / 0 MB | 9.97 GiB | PASS |
+| FP8 | 131,072 | 26.03 tok/s | 1.25 tok/s | 62.50 MB | 1,024.0 / 32.00 MB | 9.01 GiB | PASS |
+| FP16 | 262,140 | 17.88 tok/s | 1.92 tok/s | 65.50 MB | 4,096.0 / 0 MB | 11.91 GiB | PASS |
+
+The 32K, 64K, and 128K FP16/FP8 runs produced identical four-token sequences for each cache-dtype pair. The FP16 262,140-token boundary run generated `[321, 5979, 13914, 13]` with `max_context=262144`, completed without OOM, and preserved TP-rank token parity. FP8 cache is retained as an explicit memory-saving option, not the default: on this RTX 2080 Ti setup, online cache dequantization materially reduces prefill and decode throughput. FP16 KV cache remains the precision/performance baseline.
+
+These measurements establish that chunked prefill removes the previous prompt-length FP32 activation allocation and that a 262,140-token prompt plus four generated positions completes within the 22 GiB/rank budget using the FP16 cache. The FP8 262,140-token boundary run is still being evaluated separately.
+
+### Decode Context Parallelism feasibility on four GPUs
+
+**Rejected for the current four-GPU topology.** DCP can directly shard only the 16 full-GQA layers. The 48 Gated DeltaNet layers retain complete recurrent state on every replica and do not benefit from ordinary KV position sharding.
+
+Keeping four GPUs constrains the proposed topology to TP2xDCP2. For a context length `C`, the per-GPU full-attention decode work is unchanged: TP4 performs `6` local Q heads over `C` positions, while TP2xDCP2 performs `12` local Q heads over `C/2` positions. Both equal `6C` head-position evaluations per device; the DCP topology then adds two DCP all-reduces per full-attention layer and doubles the local TP2 weights.
+
+This was tested with a deliberately favorable upper bound: plain TP2 at half the TP4 context length, without the two DCP collectives or cache compaction. It was already slower and used substantially more memory:
+
+| TP4 context / result | TP2 half-context, no DCP communication | Result |
+| --- | --- | --- |
+| 512 / 35.84 decode tok/s | 256 / 22.56 decode tok/s | 37% slower upper bound |
+| 4,096 / 29.43 decode tok/s | 2,048 / 20.87 decode tok/s | 29% slower upper bound |
+| 8,192 / 24.24 decode tok/s | 4,096 / 19.07 decode tok/s | 21% slower upper bound |
+| 32,768 / 11.57 decode tok/s | 16,384 / OOM before prefill | infeasible |
+
+TP2 local resident weights measured 13.72 GiB per rank, versus 6.86 GiB under TP4. Therefore an actual TP2xDCP2 implementation would be slower than these already-negative upper bounds and would introduce numerical/communicator complexity without reducing per-device attention work. The default TP4 path remains unchanged; no DCP code is enabled.
+
+A useful context-parallel experiment requires at least eight ranks/GPUs for TP4xDCP2, which preserves the TP4 weight shard while halving per-device full-attention context. Even there, it would apply only to the 16 full-GQA layers and must beat the added two DCP collectives per such layer.
 
 Per rank, the engine reported:
 
@@ -88,13 +128,29 @@ for rank in 0 1 2 3; do
     --tp-world 4 --tp-rank $rank --device 0 \
     --nccl-id-path /tmp/pocketllm_qwen_nccl.id \
     --prompt "Explain tensor parallelism in one paragraph." \
-    --generate-token 123 --max-new-tokens 24 --resident-bench \
+    --generate-token 123 --max-new-tokens 24 --smoke-layers 0 --resident-bench \
     > /tmp/pocketllm_qwen_rank${rank}.log 2>&1 &
 done
 wait
 ```
 
-The numeric value passed to `--generate-token` is ignored once `--prompt` supplies the prompt IDs; it currently activates the generation mode in the compatibility CLI parser. Rank 0 prints the timed result and all ranks print their local runtime/accounting lines.
+The numeric value passed to `--generate-token` is ignored once `--prompt` supplies the prompt IDs; it currently activates the generation mode in the compatibility CLI parser. Rank 0 prints the timed result and all ranks print their local runtime/accounting lines. The CLI defaults to one smoke layer; use `--smoke-layers 0` for a complete 64-layer performance claim.
+
+For reproducible serial long-context TP4 measurements:
+
+```bash
+python scripts/bench_qwen_long_context.py \
+  --ckpt /path/to/Qwen3.8-27B-FP8 \
+  --tp-world 4 --devices 0,1,2,3 \
+  --lengths 512,4096,8192,32768,65536 \
+  --max-new-tokens 4 \
+  --prefill-chunk-tokens 512 \
+  --kv-cache-dtype fp16 \
+  --layers 0 \
+  --tokenizer-python /path/to/deepseek/bin/python
+```
+
+The harness persists one log per rank, records rank-local timing and memory fields, checks greedy-token parity across TP ranks, and writes `results.json` after every successful context length. FP16-versus-FP8 cache parity is a separate comparison of the generated sequences from two serial runs.
 
 Audit only the rank-local weight mapping:
 
@@ -110,7 +166,7 @@ build/cpp_engine/dsv4_cpp_engine \
 - Text-only: no image/video preprocessing or vision-tower execution.
 - CLI/smoke integration only: Qwen is explicitly rejected by the current DSV4 OpenAI server path.
 - Greedy generation only in the current Qwen engine API.
-- The 262K model limit is checkpoint metadata, not a validated 262K runtime benchmark or memory claim.
+- The model limit is 262,144 positions; with four generated tokens, the longest valid benchmark prompt is 262,140 tokens. This boundary is validated with the default FP16 KV cache; the separate FP8 boundary validation is reported only when complete.
 - The executable and internal C++ namespace retain DSV4 compatibility names.
 - CUDA Graph, a decode megakernel, and DSpark integration remain future work; none is included in the reported TPS.
 
@@ -121,9 +177,11 @@ build/cpp_engine/dsv4_cpp_engine \
 - `cpp_engine/src/qwen_weights.cpp`
 - `cpp_engine/src/qwen_engine.cpp`
 - `cpp_engine/cuda/qwen_fp8_ops.cu`
+- `cpp_engine/cuda/qwen_half_ops.cu`
 - `cpp_engine/cuda/qwen_attention_ops.cu`
 - `cpp_engine/tests/test_qwen_config.cpp`
 - `cpp_engine/tests/test_qwen_fp8_online.cpp`
 - `cpp_engine/tests/test_qwen_gqa_attention.cpp`
+- `cpp_engine/tests/test_qwen_half_ops.cpp`
 - `cpp_engine/tests/test_qwen_weights.cpp`
 - [Benchmark reporting rules](../benchmarking.md)

--- a/scripts/bench_qwen_long_context.py
+++ b/scripts/bench_qwen_long_context.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Run serial real-checkpoint Qwen tensor-parallel context benchmarks.
+
+Each context length launches the requested TP ranks, records rank-local logs,
+parses the rank-0 timing line, and verifies that every rank generated the same
+greedy token sequence. The token fixtures are deterministic natural-language
+tokenizer IDs, not synthetic random tensors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_TEXT = (
+    "Decode context parallelism partitions the key-value history across devices "
+    "while tensor parallelism partitions attention heads and matrix weights. "
+    "A correct implementation must merge the distributed softmax maximum, "
+    "denominator, and weighted value sum without changing greedy generation. "
+    "Long-context inference on PCIe-connected GPUs is useful only when the "
+    "reduced attention scan costs more than the added collectives. This benchmark "
+    "uses deterministic tokenizer output from a natural-language systems paragraph. "
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt", required=True, help="Qwen checkpoint directory")
+    parser.add_argument(
+        "--binary",
+        default="build/cpp_engine/dsv4_cpp_engine",
+        help="built C++ engine executable",
+    )
+    parser.add_argument(
+        "--lengths",
+        default="512,4096,8192,32768,65536",
+        help="comma-separated prompt lengths",
+    )
+    parser.add_argument("--max-new-tokens", type=int, default=16)
+    parser.add_argument("--prefill-chunk-tokens", type=int, default=512)
+    parser.add_argument("--kv-cache-dtype", choices=("fp16", "fp8"), default="fp16")
+    parser.add_argument("--tp-world", type=int, default=4)
+    parser.add_argument(
+        "--devices",
+        default="",
+        help="comma-separated physical GPU IDs; defaults to 0..tp_world-1",
+    )
+    parser.add_argument(
+        "--layers",
+        type=int,
+        default=0,
+        help="Qwen layer limit; keep 0 for the complete 64-layer model",
+    )
+    parser.add_argument(
+        "--work-dir",
+        default=".tmp/qwen_long_context",
+        help="directory for token fixtures, NCCL IDs, logs, and results",
+    )
+    parser.add_argument(
+        "--tokenizer-python",
+        default=sys.executable,
+        help="Python interpreter used to create tokenizer fixtures",
+    )
+    return parser.parse_args()
+
+
+def make_token_fixture(
+    ckpt: Path, path: Path, length: int, tokenizer_python: str
+) -> list[int]:
+    """Encode a deterministic real-text fixture using the checkpoint tokenizer."""
+    if path.exists():
+        tokens = [int(item) for item in path.read_text(encoding="ascii").split(",") if item]
+        if len(tokens) >= length:
+            return tokens[:length]
+
+    # Keep tokenizer loading in the requested interpreter so the benchmark can
+    # run from the project's deepseek environment without importing it here.
+    code = """
+from transformers import AutoTokenizer
+import json
+import sys
+ckpt, target = sys.argv[1], int(sys.argv[2])
+text = (
+    "Decode context parallelism partitions the key-value history across devices "
+    "while tensor parallelism partitions attention heads and matrix weights. "
+    "A correct implementation must merge the distributed softmax maximum, "
+    "denominator, and weighted value sum without changing greedy generation. "
+    "Long-context inference on PCIe-connected GPUs is useful only when the "
+    "reduced attention scan costs more than the added collectives. This benchmark "
+    "uses deterministic tokenizer output from a natural-language systems paragraph. "
+) * 4000
+tok = AutoTokenizer.from_pretrained(ckpt, local_files_only=True)
+ids = tok.encode(text, add_special_tokens=False)
+if len(ids) < target:
+    raise RuntimeError(f"fixture text produced {len(ids)} tokens, need {target}")
+print(json.dumps(ids[:target]))
+"""
+    completed = subprocess.run(
+        [tokenizer_python, "-c", code, str(ckpt), str(length)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    # transformers may print informational warnings to stderr; stdout is JSON.
+    tokens = json.loads(completed.stdout)
+    if not isinstance(tokens, list) or len(tokens) != length:
+        raise RuntimeError(f"invalid tokenizer fixture length for {length}: {len(tokens)}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(",".join(str(int(token)) for token in tokens), encoding="ascii")
+    return [int(token) for token in tokens]
+
+
+def parse_runtime_line(line: str) -> dict[str, Any] | None:
+    if not line.startswith("qwen_runtime=1 "):
+        return None
+    result: dict[str, Any] = {}
+    for key, value in re.findall(r"(\w+)=([^\s]+)", line):
+        try:
+            result[key] = int(value)
+        except ValueError:
+            try:
+                result[key] = float(value)
+            except ValueError:
+                result[key] = value
+    return result
+
+
+def parse_log(path: Path) -> tuple[dict[str, Any], list[int]]:
+    runtime: dict[str, Any] | None = None
+    tokens: list[int] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        parsed = parse_runtime_line(line)
+        if parsed is not None:
+            runtime = parsed
+        match = re.match(r"generate_step=(\d+) token=(-?\d+)", line)
+        if match:
+            tokens.append(int(match.group(2)))
+    if runtime is None:
+        raise RuntimeError(f"rank log has no qwen_runtime line: {path}")
+    if not tokens:
+        raise RuntimeError(f"rank log has no generated tokens: {path}")
+    return runtime, tokens
+
+
+def run_case(
+    binary: Path,
+    ckpt: Path,
+    work_dir: Path,
+    length: int,
+    max_new_tokens: int,
+    layers: int,
+    tp_world: int,
+    devices: list[int],
+    tokenizer_python: str,
+    prefill_chunk_tokens: int,
+    kv_cache_dtype: str,
+) -> dict[str, Any]:
+    token_path = work_dir / f"tokens_{length}.txt"
+    tokens = make_token_fixture(ckpt, token_path, length, tokenizer_python)
+    case_dir = work_dir / f"run_{length}"
+    case_dir.mkdir(parents=True, exist_ok=True)
+    id_path = case_dir / "nccl.id"
+    if id_path.exists():
+        id_path.unlink()
+    for old_log in case_dir.glob("rank*.log"):
+        old_log.unlink()
+
+    processes: list[tuple[int, subprocess.Popen[bytes]]] = []
+    started = time.monotonic()
+    statuses: dict[int, int] = {}
+    try:
+        for rank in range(tp_world):
+            log = (case_dir / f"rank{rank}.log").open("wb")
+            command = [
+                str(binary),
+                "--ckpt",
+                str(ckpt),
+                "--tp-world",
+                str(tp_world),
+                "--tp-rank",
+                str(rank),
+                "--device",
+                "0",
+                "--nccl-id-path",
+                str(id_path),
+                "--token-ids-file",
+                str(token_path),
+                "--generate-token",
+                "123",
+                "--max-new-tokens",
+                str(max_new_tokens),
+                "--max-context",
+                str(length + max_new_tokens),
+                "--prefill-chunk-tokens",
+                str(prefill_chunk_tokens),
+                "--kv-cache-dtype",
+                kv_cache_dtype,
+                "--smoke-layers",
+                str(layers),
+                "--resident-bench",
+            ]
+            env = os.environ.copy()
+            env["CUDA_VISIBLE_DEVICES"] = str(devices[rank])
+            processes.append((rank, subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, env=env)))
+            log.close()
+        while len(statuses) < len(processes):
+            for rank, process in processes:
+                if rank in statuses:
+                    continue
+                status = process.poll()
+                if status is None:
+                    continue
+                statuses[rank] = status
+                if status != 0:
+                    for other_rank, other in processes:
+                        if other_rank not in statuses and other.poll() is None:
+                            other.terminate()
+                    break
+            if any(status != 0 for status in statuses.values()):
+                break
+            time.sleep(0.1)
+    finally:
+        for rank, process in processes:
+            if process.poll() is None:
+                process.terminate()
+            try:
+                statuses[rank] = process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                statuses[rank] = process.wait(timeout=30)
+
+    ordered_statuses = [(rank, statuses[rank]) for rank in range(tp_world)]
+    if any(status != 0 for _, status in ordered_statuses):
+        details = ", ".join(f"rank{rank}={status}" for rank, status in ordered_statuses)
+        raise RuntimeError(f"Qwen TP{tp_world} case {length} failed: {details}")
+
+    parsed = [parse_log(case_dir / f"rank{rank}.log") for rank in range(tp_world)]
+    rank_runtime = [item[0] for item in parsed]
+    rank_tokens = [item[1] for item in parsed]
+    if any(rank_tokens[0] != other for other in rank_tokens[1:]):
+        raise RuntimeError(f"token parity failure at prompt length {length}")
+    runtime = rank_runtime[0]
+    if runtime.get("layers") != 64 and layers == 0:
+        raise RuntimeError(f"complete-model run did not load 64 layers: {runtime}")
+    elapsed = time.monotonic() - started
+    result = {
+        "prompt_tokens": length,
+        "generated_tokens": len(rank_tokens[0]),
+        "tokens": rank_tokens[0],
+        "elapsed_wall_seconds": elapsed,
+        "runtime": runtime,
+        "rank_runtime": rank_runtime,
+        "rank_token_parity": True,
+        "rank_wall_seconds": [item.get("wall") for item in rank_runtime],
+        "rank_gpu_memory_used_bytes": [item.get("gpu_memory_used_bytes") for item in rank_runtime],
+        "log_dir": str(case_dir),
+    }
+    print(
+        f"length={length} layers={runtime.get('layers')} "
+        f"prefill_tps={runtime.get('prefill_tokens_per_s')} "
+        f"decode_tps={runtime.get('decode_tokens_per_s')} "
+        f"gpu_used_bytes={max(result['rank_gpu_memory_used_bytes'])} "
+        f"rank_token_parity=PASS"
+    )
+    return result
+
+
+def main() -> int:
+    args = parse_args()
+    binary = Path(args.binary).resolve()
+    ckpt = Path(args.ckpt).resolve()
+    work_dir = Path(args.work_dir).resolve()
+    if not binary.is_file():
+        raise SystemExit(f"binary not found: {binary}")
+    if not ckpt.is_dir():
+        raise SystemExit(f"checkpoint directory not found: {ckpt}")
+    if args.max_new_tokens < 2:
+        raise SystemExit("--max-new-tokens must be at least 2 to measure decode")
+    if args.prefill_chunk_tokens <= 0:
+        raise SystemExit("--prefill-chunk-tokens must be positive")
+    lengths = [int(item) for item in args.lengths.split(",") if item.strip()]
+    if not lengths or any(length <= 0 for length in lengths):
+        raise SystemExit("--lengths must contain positive integers")
+    if args.layers < 0:
+        raise SystemExit("--layers must be non-negative")
+    if args.tp_world <= 0:
+        raise SystemExit("--tp-world must be positive")
+    devices = (
+        [int(item) for item in args.devices.split(",") if item.strip()]
+        if args.devices
+        else list(range(args.tp_world))
+    )
+    if len(devices) != args.tp_world:
+        raise SystemExit("--devices count must match --tp-world")
+    if len(set(devices)) != len(devices):
+        raise SystemExit("--devices must not contain duplicates")
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    results = []
+    output = {
+        "mode": "qwen_tp_long_context_baseline",
+        "checkpoint": str(ckpt),
+        "binary": str(binary),
+        "tp_world": args.tp_world,
+        "devices": devices,
+        "layers": args.layers,
+        "max_new_tokens": args.max_new_tokens,
+        "prefill_chunk_tokens": args.prefill_chunk_tokens,
+        "kv_cache_dtype": args.kv_cache_dtype,
+        "results": results,
+    }
+    result_path = work_dir / "results.json"
+    for length in lengths:
+        results.append(
+            run_case(
+                binary,
+                ckpt,
+                work_dir,
+                length,
+                args.max_new_tokens,
+                args.layers,
+                args.tp_world,
+                devices,
+                args.tokenizer_python,
+                args.prefill_chunk_tokens,
+                args.kv_cache_dtype,
+            )
+        )
+        result_path.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+    print(f"results={result_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr or exc.stdout or str(exc), file=sys.stderr)
+        raise


### PR DESCRIPTION
## Summary
- store Qwen activations in FP16 while retaining FP32 accumulation and recurrent state
- add reusable 512-token chunked prefill with FP16 default and opt-in FP8 KV caches
- validate the complete TP4 64-layer model at the 262,144-position boundary

## Validation
- test_qwen_config
- test_qwen_fp8_online
- test_qwen_weights
- test_qwen_gqa_attention
- test_qwen_half_ops
- test_qwen_engine
- real TP4 262,140-token FP16 prompt + 4 generated positions: PASS, rank parity PASS, 11.91 GiB peak/rank

🤖 Generated with [Claude Code](https://claude.com/claude-code)