### PR TITLE
Optimize Qwen FP16 activation FP8 projection kernels

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(dsv4_cpp_core STATIC
     cuda/qwen_fp8_ops.cu
     cuda/qwen_attention_ops.cu
     cuda/qwen_half_ops.cu
+    cuda/qwen_gqa_optimized.cu
     cuda/q2_ops.cu
     cuda/iq1_ops.cu
     cuda/rmsnorm_rope.cu

--- a/cpp_engine/cuda/qwen_gqa_optimized.cu
+++ b/cpp_engine/cuda/qwen_gqa_optimized.cu
@@ -1,0 +1,412 @@
+#include "qwen_cuda_ops.hpp"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+
+namespace dsv4 {
+namespace {
+
+constexpr int kThreads = 128;
+constexpr int kWarps = kThreads / 32;
+constexpr int kHeadsPerGroup = 3;
+constexpr int kQueryRows = 2;
+constexpr int kMaxHeadDim = 256;
+constexpr int kValuesPerThread = kMaxHeadDim / kThreads;
+constexpr int kPrefillCombos = kHeadsPerGroup * kQueryRows;
+constexpr int kDecodeMaxSplits = 64;
+constexpr int kDecodeTargetPositions = 2048;
+constexpr int kDecodeMinContext = 4096;
+
+__device__ __forceinline__ float half_to_float(uint16_t bits) {
+    return __half2float(__ushort_as_half(bits));
+}
+
+__device__ __forceinline__ uint16_t float_to_half(float value) {
+    return __half_as_ushort(__float2half_rn(value));
+}
+
+__device__ __forceinline__ float warp_sum(float value) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        value += __shfl_down_sync(0xffffffffu, value, offset);
+    }
+    return value;
+}
+
+template <int kCombos>
+__device__ __forceinline__ void reduce_dot_products(
+    const float (&partial)[kCombos], float (&warp_sums)[kCombos][kWarps],
+    float (&scores)[kCombos], float scale) {
+    const int lane = static_cast<int>(threadIdx.x) & 31;
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+#pragma unroll
+    for (int combo = 0; combo < kCombos; ++combo) {
+        const float sum = warp_sum(partial[combo]);
+        if (lane == 0) warp_sums[combo][warp] = sum;
+    }
+    __syncthreads();
+    if (static_cast<int>(threadIdx.x) < kCombos) {
+        float sum = 0.0f;
+#pragma unroll
+        for (int w = 0; w < kWarps; ++w) {
+            sum += warp_sums[threadIdx.x][w];
+        }
+        scores[threadIdx.x] = sum * scale;
+    }
+    __syncthreads();
+}
+
+// Two adjacent query rows and three Q heads sharing a KV head are processed by
+// one CTA. Each K/V element is loaded once for six exact attention outputs.
+__global__ void gqa_prefill_tiled_f16_kernel(
+    const uint16_t* __restrict__ q_rows,
+    const uint16_t* __restrict__ k_cache,
+    const uint16_t* __restrict__ v_cache,
+    uint16_t* __restrict__ output,
+    int seq_len,
+    int q_heads,
+    int kv_heads,
+    int head_dim,
+    int position_offset) {
+    const int q_per_kv = q_heads / kv_heads;
+    const int groups_per_kv =
+        (q_per_kv + kHeadsPerGroup - 1) / kHeadsPerGroup;
+    const int kv_head = static_cast<int>(blockIdx.x) / groups_per_kv;
+    const int group = static_cast<int>(blockIdx.x) % groups_per_kv;
+    const int first_head = kv_head * q_per_kv + group * kHeadsPerGroup;
+    const int first_token = static_cast<int>(blockIdx.y) * kQueryRows;
+    if (kv_head >= kv_heads || first_token >= seq_len) return;
+
+    __shared__ float warp_sums[kPrefillCombos][kWarps];
+    __shared__ float scores[kPrefillCombos];
+    __shared__ float running_max[kPrefillCombos];
+    __shared__ float running_sum[kPrefillCombos];
+    __shared__ float rescale[kPrefillCombos];
+    __shared__ float probability[kPrefillCombos];
+
+    const int tid = static_cast<int>(threadIdx.x);
+    float query[kPrefillCombos][kValuesPerThread];
+    float accumulator[kPrefillCombos][kValuesPerThread];
+    bool active[kPrefillCombos];
+    int context_limit[kPrefillCombos];
+
+#pragma unroll
+    for (int combo = 0; combo < kPrefillCombos; ++combo) {
+        const int query_row = combo / kHeadsPerGroup;
+        const int head_in_group = combo % kHeadsPerGroup;
+        const int token = first_token + query_row;
+        const int head = first_head + head_in_group;
+        active[combo] = token < seq_len &&
+            head < (kv_head + 1) * q_per_kv && head < q_heads;
+        context_limit[combo] = position_offset + token + 1;
+#pragma unroll
+        for (int i = 0; i < kValuesPerThread; ++i) {
+            const int d = tid + i * kThreads;
+            query[combo][i] = active[combo] && d < head_dim
+                ? half_to_float(q_rows[
+                      (static_cast<size_t>(token) * q_heads + head) * head_dim + d])
+                : 0.0f;
+            accumulator[combo][i] = 0.0f;
+        }
+        if (tid == combo) {
+            running_max[combo] = -INFINITY;
+            running_sum[combo] = 0.0f;
+        }
+    }
+    __syncthreads();
+
+    const int last_token = min(first_token + kQueryRows - 1, seq_len - 1);
+    const int tile_context = position_offset + last_token + 1;
+    const float attention_scale = rsqrtf(static_cast<float>(head_dim));
+    const size_t kv_stride = static_cast<size_t>(kv_heads) * head_dim;
+    for (int position = 0; position < tile_context; ++position) {
+        const size_t kv_base = static_cast<size_t>(position) * kv_stride +
+            static_cast<size_t>(kv_head) * head_dim;
+        float key[kValuesPerThread];
+        float value[kValuesPerThread];
+#pragma unroll
+        for (int i = 0; i < kValuesPerThread; ++i) {
+            const int d = tid + i * kThreads;
+            key[i] = d < head_dim ? half_to_float(k_cache[kv_base + d]) : 0.0f;
+            value[i] = d < head_dim ? half_to_float(v_cache[kv_base + d]) : 0.0f;
+        }
+
+        float partial[kPrefillCombos] = {};
+#pragma unroll
+        for (int combo = 0; combo < kPrefillCombos; ++combo) {
+            if (active[combo] && position < context_limit[combo]) {
+#pragma unroll
+                for (int i = 0; i < kValuesPerThread; ++i) {
+                    partial[combo] += query[combo][i] * key[i];
+                }
+            }
+        }
+        reduce_dot_products(partial, warp_sums, scores, attention_scale);
+
+        if (tid < kPrefillCombos) {
+            if (active[tid] && position < context_limit[tid]) {
+                const float old_max = running_max[tid];
+                const float new_max = fmaxf(old_max, scores[tid]);
+                const float old_scale = old_max == -INFINITY
+                    ? 0.0f : expf(old_max - new_max);
+                const float weight = expf(scores[tid] - new_max);
+                running_max[tid] = new_max;
+                running_sum[tid] = running_sum[tid] * old_scale + weight;
+                rescale[tid] = old_scale;
+                probability[tid] = weight;
+            } else {
+                rescale[tid] = 1.0f;
+                probability[tid] = 0.0f;
+            }
+        }
+        __syncthreads();
+#pragma unroll
+        for (int combo = 0; combo < kPrefillCombos; ++combo) {
+#pragma unroll
+            for (int i = 0; i < kValuesPerThread; ++i) {
+                accumulator[combo][i] = accumulator[combo][i] * rescale[combo] +
+                    probability[combo] * value[i];
+            }
+        }
+        __syncthreads();
+    }
+
+#pragma unroll
+    for (int combo = 0; combo < kPrefillCombos; ++combo) {
+        if (!active[combo]) continue;
+        const int query_row = combo / kHeadsPerGroup;
+        const int head_in_group = combo % kHeadsPerGroup;
+        const int token = first_token + query_row;
+        const int head = first_head + head_in_group;
+        const float inverse = running_sum[combo] > 0.0f
+            ? 1.0f / running_sum[combo] : 0.0f;
+#pragma unroll
+        for (int i = 0; i < kValuesPerThread; ++i) {
+            const int d = tid + i * kThreads;
+            if (d < head_dim) {
+                output[(static_cast<size_t>(token) * q_heads + head) * head_dim + d] =
+                    float_to_half(accumulator[combo][i] * inverse);
+            }
+        }
+    }
+}
+
+// Each CTA computes exact online-softmax partials for three Q heads over one
+// context split while loading their shared K/V row only once.
+__global__ void gqa_decode_split_f16_kernel(
+    const uint16_t* __restrict__ q,
+    const uint16_t* __restrict__ k_cache,
+    const uint16_t* __restrict__ v_cache,
+    float* __restrict__ partial_output,
+    int q_heads,
+    int kv_heads,
+    int head_dim,
+    int context_len,
+    int splits,
+    int positions_per_split) {
+    const int q_per_kv = q_heads / kv_heads;
+    const int groups_per_kv =
+        (q_per_kv + kHeadsPerGroup - 1) / kHeadsPerGroup;
+    const int grouped = static_cast<int>(blockIdx.x) / splits;
+    const int split = static_cast<int>(blockIdx.x) % splits;
+    const int kv_head = grouped / groups_per_kv;
+    const int group = grouped % groups_per_kv;
+    const int first_head = kv_head * q_per_kv + group * kHeadsPerGroup;
+    const int start = split * positions_per_split;
+    const int end = min(context_len, start + positions_per_split);
+    if (kv_head >= kv_heads || start >= end) return;
+
+    __shared__ float warp_sums[kHeadsPerGroup][kWarps];
+    __shared__ float scores[kHeadsPerGroup];
+    __shared__ float running_max[kHeadsPerGroup];
+    __shared__ float running_sum[kHeadsPerGroup];
+    __shared__ float rescale[kHeadsPerGroup];
+    __shared__ float probability[kHeadsPerGroup];
+
+    const int tid = static_cast<int>(threadIdx.x);
+    float query[kHeadsPerGroup][kValuesPerThread];
+    float accumulator[kHeadsPerGroup][kValuesPerThread] = {};
+    bool active[kHeadsPerGroup];
+#pragma unroll
+    for (int h = 0; h < kHeadsPerGroup; ++h) {
+        const int head = first_head + h;
+        active[h] = head < (kv_head + 1) * q_per_kv && head < q_heads;
+#pragma unroll
+        for (int i = 0; i < kValuesPerThread; ++i) {
+            const int d = tid + i * kThreads;
+            query[h][i] = active[h] && d < head_dim
+                ? half_to_float(q[static_cast<size_t>(head) * head_dim + d])
+                : 0.0f;
+        }
+        if (tid == h) {
+            running_max[h] = -INFINITY;
+            running_sum[h] = 0.0f;
+        }
+    }
+    __syncthreads();
+
+    const float attention_scale = rsqrtf(static_cast<float>(head_dim));
+    const size_t kv_stride = static_cast<size_t>(kv_heads) * head_dim;
+    for (int position = start; position < end; ++position) {
+        const size_t kv_base = static_cast<size_t>(position) * kv_stride +
+            static_cast<size_t>(kv_head) * head_dim;
+        float key[kValuesPerThread];
+        float value[kValuesPerThread];
+#pragma unroll
+        for (int i = 0; i < kValuesPerThread; ++i) {
+            const int d = tid + i * kThreads;
+            key[i] = d < head_dim ? half_to_float(k_cache[kv_base + d]) : 0.0f;
+            value[i] = d < head_dim ? half_to_float(v_cache[kv_base + d]) : 0.0f;
+        }
+        float dot[kHeadsPerGroup] = {};
+#pragma unroll
+        for (int h = 0; h < kHeadsPerGroup; ++h) {
+#pragma unroll
+            for (int i = 0; i < kValuesPerThread; ++i) {
+                dot[h] += query[h][i] * key[i];
+            }
+        }
+        reduce_dot_products(dot, warp_sums, scores, attention_scale);
+        if (tid < kHeadsPerGroup) {
+            if (active[tid]) {
+                const float old_max = running_max[tid];
+                const float new_max = fmaxf(old_max, scores[tid]);
+                const float old_scale = old_max == -INFINITY
+                    ? 0.0f : expf(old_max - new_max);
+                const float weight = expf(scores[tid] - new_max);
+                running_max[tid] = new_max;
+                running_sum[tid] = running_sum[tid] * old_scale + weight;
+                rescale[tid] = old_scale;
+                probability[tid] = weight;
+            } else {
+                rescale[tid] = 1.0f;
+                probability[tid] = 0.0f;
+            }
+        }
+        __syncthreads();
+#pragma unroll
+        for (int h = 0; h < kHeadsPerGroup; ++h) {
+#pragma unroll
+            for (int i = 0; i < kValuesPerThread; ++i) {
+                accumulator[h][i] = accumulator[h][i] * rescale[h] +
+                    probability[h] * value[i];
+            }
+        }
+        __syncthreads();
+    }
+
+    const int partial_stride = head_dim + 2;
+#pragma unroll
+    for (int h = 0; h < kHeadsPerGroup; ++h) {
+        if (!active[h]) continue;
+        const int head = first_head + h;
+        float* destination = partial_output +
+            (static_cast<size_t>(head) * splits + split) * partial_stride;
+        if (tid == 0) {
+            destination[0] = running_max[h];
+            destination[1] = running_sum[h];
+        }
+#pragma unroll
+        for (int i = 0; i < kValuesPerThread; ++i) {
+            const int d = tid + i * kThreads;
+            if (d < head_dim) destination[2 + d] = accumulator[h][i];
+        }
+    }
+}
+
+__global__ void gqa_decode_merge_f16_kernel(
+    const float* __restrict__ partial_output,
+    uint16_t* __restrict__ output,
+    int q_heads,
+    int head_dim,
+    int splits) {
+    const int head = static_cast<int>(blockIdx.x);
+    if (head >= q_heads) return;
+    __shared__ float weights[kDecodeMaxSplits];
+    if (threadIdx.x == 0) {
+        const int stride = head_dim + 2;
+        float maximum = -INFINITY;
+        for (int split = 0; split < splits; ++split) {
+            maximum = fmaxf(maximum,
+                partial_output[(static_cast<size_t>(head) * splits + split) * stride]);
+        }
+        float denominator = 0.0f;
+        for (int split = 0; split < splits; ++split) {
+            const float* source = partial_output +
+                (static_cast<size_t>(head) * splits + split) * stride;
+            weights[split] = expf(source[0] - maximum);
+            denominator += weights[split] * source[1];
+        }
+        const float inverse = denominator > 0.0f ? 1.0f / denominator : 0.0f;
+        for (int split = 0; split < splits; ++split) weights[split] *= inverse;
+    }
+    __syncthreads();
+    for (int d = static_cast<int>(threadIdx.x); d < head_dim; d += kThreads) {
+        float value = 0.0f;
+        const int stride = head_dim + 2;
+        for (int split = 0; split < splits; ++split) {
+            const float* source = partial_output +
+                (static_cast<size_t>(head) * splits + split) * stride;
+            value += weights[split] * source[2 + d];
+        }
+        output[static_cast<size_t>(head) * head_dim + d] = float_to_half(value);
+    }
+}
+
+bool valid_shape(int q_heads, int kv_heads, int head_dim) {
+    return q_heads > 0 && kv_heads > 0 && q_heads % kv_heads == 0 &&
+        head_dim > 0 && head_dim <= kMaxHeadDim;
+}
+
+}  // namespace
+
+bool qwen_gqa_prefill_attention_f16_tiled_cuda(
+    const uint16_t* q, const uint16_t* k_cache,
+    const uint16_t* v_cache, uint16_t* output, int seq_len,
+    int q_heads, int kv_heads, int head_dim, int position_offset,
+    int max_context, void* stream) {
+    if (!q || !k_cache || !v_cache || !output || seq_len <= 0 ||
+        position_offset < 0 || position_offset + seq_len > max_context ||
+        !valid_shape(q_heads, kv_heads, head_dim)) return false;
+    const int groups_per_kv =
+        (q_heads / kv_heads + kHeadsPerGroup - 1) / kHeadsPerGroup;
+    const dim3 grid(static_cast<unsigned>(kv_heads * groups_per_kv),
+                    static_cast<unsigned>((seq_len + kQueryRows - 1) / kQueryRows), 1);
+    gqa_prefill_tiled_f16_kernel<<<grid, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(q, k_cache, v_cache, output,
+        seq_len, q_heads, kv_heads, head_dim, position_offset);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gqa_decode_attention_f16_fused_cuda(
+    const uint16_t* q, const uint16_t* k_cache,
+    const uint16_t* v_cache, uint16_t* output, float* partial_scratch,
+    int q_heads, int kv_heads, int head_dim, int context_len,
+    int max_context, void* stream) {
+    if (!q || !k_cache || !v_cache || !output || !partial_scratch ||
+        context_len < kDecodeMinContext || context_len > max_context ||
+        !valid_shape(q_heads, kv_heads, head_dim)) return false;
+    int splits = std::min(kDecodeMaxSplits,
+        (context_len + kDecodeTargetPositions - 1) / kDecodeTargetPositions);
+    const int positions_per_split = (context_len + splits - 1) / splits;
+    const size_t partial_count = static_cast<size_t>(q_heads) * splits *
+        (head_dim + 2);
+    const size_t available_count = static_cast<size_t>(q_heads) * context_len;
+    if (partial_count > available_count) return false;
+    const int groups_per_kv =
+        (q_heads / kv_heads + kHeadsPerGroup - 1) / kHeadsPerGroup;
+    const int blocks = kv_heads * groups_per_kv * splits;
+    const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
+    gqa_decode_split_f16_kernel<<<blocks, kThreads, 0, cuda_stream>>>(
+        q, k_cache, v_cache, partial_scratch, q_heads, kv_heads, head_dim,
+        context_len, splits, positions_per_split);
+    if (cudaGetLastError() != cudaSuccess) return false;
+    gqa_decode_merge_f16_kernel<<<q_heads, kThreads, 0, cuda_stream>>>(
+        partial_scratch, output, q_heads, head_dim, splits);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+}  // namespace dsv4

--- a/cpp_engine/cuda/qwen_gqa_optimized.cu
+++ b/cpp_engine/cuda/qwen_gqa_optimized.cu
@@ -20,6 +20,39 @@ constexpr int kDecodeMaxSplits = 64;
 constexpr int kDecodeTargetPositions = 2048;
 constexpr int kDecodeMinContext = 4096;
 
+// A window of 0 keeps exact full attention. Otherwise every query attends to
+// the leading sink prefix plus the most recent window positions, expressed as
+// two logical ranges over the unmodified KV cache.
+struct SparseRanges {
+    int sink_count;
+    int window_start;
+    int window_count;
+
+    __host__ __device__ int total() const { return sink_count + window_count; }
+
+    __host__ __device__ int position(int logical) const {
+        return logical < sink_count
+            ? logical
+            : window_start + (logical - sink_count);
+    }
+};
+
+__host__ __device__ SparseRanges sparse_ranges(
+    int context_len, int window, int sink) {
+    SparseRanges ranges;
+    if (window <= 0) {
+        ranges.sink_count = 0;
+        ranges.window_start = 0;
+        ranges.window_count = context_len;
+        return ranges;
+    }
+    ranges.sink_count = sink < context_len ? sink : context_len;
+    const int tail = context_len - window;
+    ranges.window_start = tail > ranges.sink_count ? tail : ranges.sink_count;
+    ranges.window_count = context_len - ranges.window_start;
+    return ranges;
+}
+
 __device__ __forceinline__ float half_to_float(uint16_t bits) {
     return __half2float(__ushort_as_half(bits));
 }
@@ -59,8 +92,16 @@ __device__ __forceinline__ void reduce_dot_products(
     __syncthreads();
 }
 
+__host__ __device__ bool attends(
+    int position, int context_limit, int window, int sink) {
+    if (position >= context_limit) return false;
+    if (window <= 0 || position < sink) return true;
+    const int start = context_limit - window;
+    return position >= (start > sink ? start : sink);
+}
+
 // Two adjacent query rows and three Q heads sharing a KV head are processed by
-// one CTA. Each K/V element is loaded once for six exact attention outputs.
+// one CTA. Each K/V element is loaded once for six attention outputs.
 __global__ void gqa_prefill_tiled_f16_kernel(
     const uint16_t* __restrict__ q_rows,
     const uint16_t* __restrict__ k_cache,
@@ -70,7 +111,9 @@ __global__ void gqa_prefill_tiled_f16_kernel(
     int q_heads,
     int kv_heads,
     int head_dim,
-    int position_offset) {
+    int position_offset,
+    int window,
+    int sink) {
     const int q_per_kv = q_heads / kv_heads;
     const int groups_per_kv =
         (q_per_kv + kHeadsPerGroup - 1) / kHeadsPerGroup;
@@ -120,9 +163,17 @@ __global__ void gqa_prefill_tiled_f16_kernel(
 
     const int last_token = min(first_token + kQueryRows - 1, seq_len - 1);
     const int tile_context = position_offset + last_token + 1;
+    // The earliest query in this tile bounds the shared window; positions
+    // between the sink prefix and that bound are attended by no query row.
+    const int tile_window_start = window > 0
+        ? max(sink, position_offset + first_token + 1 - window) : 0;
     const float attention_scale = rsqrtf(static_cast<float>(head_dim));
     const size_t kv_stride = static_cast<size_t>(kv_heads) * head_dim;
     for (int position = 0; position < tile_context; ++position) {
+        if (window > 0 && position >= sink && position < tile_window_start) {
+            position = tile_window_start - 1;
+            continue;
+        }
         const size_t kv_base = static_cast<size_t>(position) * kv_stride +
             static_cast<size_t>(kv_head) * head_dim;
         float key[kValuesPerThread];
@@ -137,7 +188,8 @@ __global__ void gqa_prefill_tiled_f16_kernel(
         float partial[kPrefillCombos] = {};
 #pragma unroll
         for (int combo = 0; combo < kPrefillCombos; ++combo) {
-            if (active[combo] && position < context_limit[combo]) {
+            if (active[combo] &&
+                attends(position, context_limit[combo], window, sink)) {
 #pragma unroll
                 for (int i = 0; i < kValuesPerThread; ++i) {
                     partial[combo] += query[combo][i] * key[i];
@@ -147,7 +199,8 @@ __global__ void gqa_prefill_tiled_f16_kernel(
         reduce_dot_products(partial, warp_sums, scores, attention_scale);
 
         if (tid < kPrefillCombos) {
-            if (active[tid] && position < context_limit[tid]) {
+            if (active[tid] &&
+                attends(position, context_limit[tid], window, sink)) {
                 const float old_max = running_max[tid];
                 const float new_max = fmaxf(old_max, scores[tid]);
                 const float old_scale = old_max == -INFINITY
@@ -206,7 +259,9 @@ __global__ void gqa_decode_split_f16_kernel(
     int head_dim,
     int context_len,
     int splits,
-    int positions_per_split) {
+    int positions_per_split,
+    int window,
+    int sink) {
     const int q_per_kv = q_heads / kv_heads;
     const int groups_per_kv =
         (q_per_kv + kHeadsPerGroup - 1) / kHeadsPerGroup;
@@ -215,8 +270,9 @@ __global__ void gqa_decode_split_f16_kernel(
     const int kv_head = grouped / groups_per_kv;
     const int group = grouped % groups_per_kv;
     const int first_head = kv_head * q_per_kv + group * kHeadsPerGroup;
+    const SparseRanges ranges = sparse_ranges(context_len, window, sink);
     const int start = split * positions_per_split;
-    const int end = min(context_len, start + positions_per_split);
+    const int end = min(ranges.total(), start + positions_per_split);
     if (kv_head >= kv_heads || start >= end) return;
 
     __shared__ float warp_sums[kHeadsPerGroup][kWarps];
@@ -250,7 +306,8 @@ __global__ void gqa_decode_split_f16_kernel(
 
     const float attention_scale = rsqrtf(static_cast<float>(head_dim));
     const size_t kv_stride = static_cast<size_t>(kv_heads) * head_dim;
-    for (int position = start; position < end; ++position) {
+    for (int logical = start; logical < end; ++logical) {
+        const int position = ranges.position(logical);
         const size_t kv_base = static_cast<size_t>(position) * kv_stride +
             static_cast<size_t>(kv_head) * head_dim;
         float key[kValuesPerThread];
@@ -367,9 +424,10 @@ bool qwen_gqa_prefill_attention_f16_tiled_cuda(
     const uint16_t* q, const uint16_t* k_cache,
     const uint16_t* v_cache, uint16_t* output, int seq_len,
     int q_heads, int kv_heads, int head_dim, int position_offset,
-    int max_context, void* stream) {
+    int max_context, int attention_window, int sink_tokens, void* stream) {
     if (!q || !k_cache || !v_cache || !output || seq_len <= 0 ||
         position_offset < 0 || position_offset + seq_len > max_context ||
+        attention_window < 0 || sink_tokens < 0 ||
         !valid_shape(q_heads, kv_heads, head_dim)) return false;
     const int groups_per_kv =
         (q_heads / kv_heads + kHeadsPerGroup - 1) / kHeadsPerGroup;
@@ -377,7 +435,8 @@ bool qwen_gqa_prefill_attention_f16_tiled_cuda(
                     static_cast<unsigned>((seq_len + kQueryRows - 1) / kQueryRows), 1);
     gqa_prefill_tiled_f16_kernel<<<grid, kThreads, 0,
         static_cast<cudaStream_t>(stream)>>>(q, k_cache, v_cache, output,
-        seq_len, q_heads, kv_heads, head_dim, position_offset);
+        seq_len, q_heads, kv_heads, head_dim, position_offset,
+        attention_window, sink_tokens);
     return cudaGetLastError() == cudaSuccess;
 }
 
@@ -385,24 +444,27 @@ bool qwen_gqa_decode_attention_f16_fused_cuda(
     const uint16_t* q, const uint16_t* k_cache,
     const uint16_t* v_cache, uint16_t* output, float* partial_scratch,
     int q_heads, int kv_heads, int head_dim, int context_len,
-    int max_context, void* stream) {
+    int max_context, int attention_window, int sink_tokens, void* stream) {
     if (!q || !k_cache || !v_cache || !output || !partial_scratch ||
-        context_len < kDecodeMinContext || context_len > max_context ||
+        context_len > max_context ||
+        attention_window < 0 || sink_tokens < 0 ||
+        (attention_window <= 0 && context_len < kDecodeMinContext) ||
         !valid_shape(q_heads, kv_heads, head_dim)) return false;
+    const SparseRanges ranges =
+        sparse_ranges(context_len, attention_window, sink_tokens);
+    const int attended = ranges.total();
     int splits = std::min(kDecodeMaxSplits,
-        (context_len + kDecodeTargetPositions - 1) / kDecodeTargetPositions);
-    const int positions_per_split = (context_len + splits - 1) / splits;
-    const size_t partial_count = static_cast<size_t>(q_heads) * splits *
-        (head_dim + 2);
-    const size_t available_count = static_cast<size_t>(q_heads) * context_len;
-    if (partial_count > available_count) return false;
+        (attended + kDecodeTargetPositions - 1) / kDecodeTargetPositions);
+    splits = std::max(splits, 1);
+    const int positions_per_split = (attended + splits - 1) / splits;
     const int groups_per_kv =
         (q_heads / kv_heads + kHeadsPerGroup - 1) / kHeadsPerGroup;
     const int blocks = kv_heads * groups_per_kv * splits;
     const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
     gqa_decode_split_f16_kernel<<<blocks, kThreads, 0, cuda_stream>>>(
         q, k_cache, v_cache, partial_scratch, q_heads, kv_heads, head_dim,
-        context_len, splits, positions_per_split);
+        context_len, splits, positions_per_split, attention_window,
+        sink_tokens);
     if (cudaGetLastError() != cudaSuccess) return false;
     gqa_decode_merge_f16_kernel<<<q_heads, kThreads, 0, cuda_stream>>>(
         partial_scratch, output, q_heads, head_dim, splits);

--- a/cpp_engine/cuda/qwen_half_ops.cu
+++ b/cpp_engine/cuda/qwen_half_ops.cu
@@ -5,6 +5,8 @@
 
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 
 namespace dsv4 {
 namespace {
@@ -108,6 +110,73 @@ __global__ void fp8_matvec_f16_kernel(
         sum += __shfl_xor_sync(0xffffffffu, sum, offset);
     }
     if (lane == 0) y[row] = float_to_half(sum);
+}
+
+// Same decode arithmetic as fp8_matvec_f16_kernel, but each warp owns
+// kRowsPerWarp output rows and reads every FP16 activation element once for
+// all of them. Column order and per-row accumulation order are unchanged, so
+// only the number of activation loads differs.
+template <int kWarps, int kRowsPerWarp>
+__global__ void fp8_matvec_f16_multirow_kernel(
+    const uint16_t* __restrict__ x, const uint8_t* __restrict__ weight,
+    const uint16_t* __restrict__ scale, uint16_t* __restrict__ y,
+    int rows, int cols, int weight_stride, int scale_stride) {
+    __shared__ float lut[256];
+    for (int i = static_cast<int>(threadIdx.x); i < 256; i += blockDim.x) {
+        lut[i] = fp8_e4m3_to_float(static_cast<uint8_t>(i));
+    }
+    __syncthreads();
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int lane = static_cast<int>(threadIdx.x) & 31;
+    const int row_base = (static_cast<int>(blockIdx.x) * kWarps + warp) * kRowsPerWarp;
+    if (row_base >= rows) return;
+    const int active = min(kRowsPerWarp, rows - row_base);
+
+    const uint8_t* weight_rows[kRowsPerWarp];
+    const uint16_t* scale_rows[kRowsPerWarp];
+#pragma unroll
+    for (int r = 0; r < kRowsPerWarp; ++r) {
+        const int row = min(row_base + r, rows - 1);
+        weight_rows[r] = weight + static_cast<size_t>(row) * weight_stride;
+        scale_rows[r] = scale + static_cast<size_t>(row / kFp8WeightBlock) * scale_stride;
+    }
+
+    float sums[kRowsPerWarp] = {};
+    const int vec_cols = cols & ~3;
+    for (int col = lane * 4; col < vec_cols; col += 128) {
+        const uint2 packed = *reinterpret_cast<const uint2*>(x + col);
+        const float x0 = half_to_float(static_cast<uint16_t>(packed.x));
+        const float x1 = half_to_float(static_cast<uint16_t>(packed.x >> 16));
+        const float x2 = half_to_float(static_cast<uint16_t>(packed.y));
+        const float x3 = half_to_float(static_cast<uint16_t>(packed.y >> 16));
+        const int block_col = col / kFp8WeightBlock;
+#pragma unroll
+        for (int r = 0; r < kRowsPerWarp; ++r) {
+            if (r >= active) break;
+            const uchar4 codes = *reinterpret_cast<const uchar4*>(weight_rows[r] + col);
+            const float s = half_to_float(scale_rows[r][block_col]);
+            sums[r] += (x0 * lut[codes.x] + x1 * lut[codes.y] +
+                        x2 * lut[codes.z] + x3 * lut[codes.w]) * s;
+        }
+    }
+    for (int col = vec_cols + lane; col < cols; col += 32) {
+        const float xv = half_to_float(x[col]);
+#pragma unroll
+        for (int r = 0; r < kRowsPerWarp; ++r) {
+            if (r >= active) break;
+            sums[r] += xv * lut[weight_rows[r][col]] *
+                       half_to_float(scale_rows[r][col / kFp8WeightBlock]);
+        }
+    }
+#pragma unroll
+    for (int r = 0; r < kRowsPerWarp; ++r) {
+        if (r >= active) break;
+        float sum = sums[r];
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            sum += __shfl_xor_sync(0xffffffffu, sum, offset);
+        }
+        if (lane == 0) y[row_base + r] = float_to_half(sum);
+    }
 }
 
 template <int kWarps, int kRowsPerWarp>
@@ -231,6 +300,135 @@ __global__ void fp8_matmul_f16_tiled_kernel(
         for (int j = 0; j < 4; ++j) {
             const int gr = row_base + tn + j * 16;
             if (gr < rows) y[static_cast<size_t>(gb) * y_stride + gr] = float_to_half(acc[i][j]);
+        }
+    }
+}
+
+// Lower-register FP16-activation variant of the wide N64 prefill tile. The
+// layout matches the validated FP32 kernel: 128 input tokens by 64 output
+// rows, with FP8 weights decoded once per K tile and reused across tokens.
+__global__ void fp8_matmul_f16_wide_n64_kernel(
+    const uint16_t* __restrict__ x,
+    const uint8_t* __restrict__ weight,
+    const uint16_t* __restrict__ scale,
+    uint16_t* __restrict__ y,
+    int batch, int rows, int cols, int x_stride, int y_stride,
+    int weight_stride, int scale_stride) {
+    constexpr int kM = 128;
+    constexpr int kN = 64;
+    constexpr int kK = 16;
+    constexpr int kThreads = 256;
+    __shared__ float as[kK][kM];
+    __shared__ float bs[kK][kN];
+    __shared__ float lut[256];
+
+    const int tid = static_cast<int>(threadIdx.x);
+    for (int i = tid; i < 256; i += kThreads) {
+        lut[i] = fp8_e4m3_to_float(static_cast<uint8_t>(i));
+    }
+    __syncthreads();
+
+    const int batch_base = static_cast<int>(blockIdx.y) * kM;
+    const int row_base = static_cast<int>(blockIdx.x) * kN;
+    const int tx = tid & 15;
+    const int ty = tid >> 4;
+    const int m0 = ty * 4;
+    const int m1 = 64 + ty * 4;
+    const int n0 = tx * 4;
+    const int load_lane = (tid & 3) * 4;
+    const int load_line = tid >> 2;
+    float acc[8][4] = {};
+
+    for (int col_base = 0; col_base < cols; col_base += kK) {
+#pragma unroll
+        for (int it = 0; it < 2; ++it) {
+            const int local_batch = load_line + it * 64;
+            const int global_batch = batch_base + local_batch;
+            const int global_col = col_base + load_lane;
+            float values[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+            if (global_batch < batch) {
+                const uint16_t* src = x + static_cast<size_t>(global_batch) * x_stride;
+                if (global_col + 3 < cols) {
+                    const uint2 packed = *reinterpret_cast<const uint2*>(src + global_col);
+                    values[0] = half_to_float(static_cast<uint16_t>(packed.x));
+                    values[1] = half_to_float(static_cast<uint16_t>(packed.x >> 16));
+                    values[2] = half_to_float(static_cast<uint16_t>(packed.y));
+                    values[3] = half_to_float(static_cast<uint16_t>(packed.y >> 16));
+                } else {
+#pragma unroll
+                    for (int t = 0; t < 4; ++t) {
+                        if (global_col + t < cols) values[t] = half_to_float(src[global_col + t]);
+                    }
+                }
+            }
+            as[load_lane + 0][local_batch] = values[0];
+            as[load_lane + 1][local_batch] = values[1];
+            as[load_lane + 2][local_batch] = values[2];
+            as[load_lane + 3][local_batch] = values[3];
+        }
+#pragma unroll
+        for (int it = 0; it < 1; ++it) {
+            const int local_row = load_line;
+            const int global_row = row_base + local_row;
+            const int global_col = col_base + load_lane;
+            float values[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+            if (global_row < rows && global_col < cols) {
+                const uint8_t* src = weight + static_cast<size_t>(global_row) * weight_stride;
+                const float s = half_to_float(
+                    scale[static_cast<size_t>(global_row / kFp8WeightBlock) * scale_stride +
+                          global_col / kFp8WeightBlock]);
+                if (global_col + 3 < cols) {
+                    const uchar4 codes = *reinterpret_cast<const uchar4*>(src + global_col);
+                    values[0] = lut[codes.x] * s;
+                    values[1] = lut[codes.y] * s;
+                    values[2] = lut[codes.z] * s;
+                    values[3] = lut[codes.w] * s;
+                } else {
+#pragma unroll
+                    for (int t = 0; t < 4; ++t) {
+                        if (global_col + t < cols) values[t] = lut[src[global_col + t]] * s;
+                    }
+                }
+            }
+            bs[load_lane + 0][local_row] = values[0];
+            bs[load_lane + 1][local_row] = values[1];
+            bs[load_lane + 2][local_row] = values[2];
+            bs[load_lane + 3][local_row] = values[3];
+        }
+        __syncthreads();
+
+        float tile[8][4] = {};
+#pragma unroll
+        for (int k = 0; k < kK; ++k) {
+            float a[8];
+            float b[4];
+            *reinterpret_cast<float4*>(&a[0]) = *reinterpret_cast<const float4*>(&as[k][m0]);
+            *reinterpret_cast<float4*>(&a[4]) = *reinterpret_cast<const float4*>(&as[k][m1]);
+            *reinterpret_cast<float4*>(&b[0]) = *reinterpret_cast<const float4*>(&bs[k][n0]);
+#pragma unroll
+            for (int i = 0; i < 8; ++i) {
+#pragma unroll
+                for (int j = 0; j < 4; ++j) tile[i][j] += a[i] * b[j];
+            }
+        }
+#pragma unroll
+        for (int i = 0; i < 8; ++i) {
+#pragma unroll
+            for (int j = 0; j < 4; ++j) acc[i][j] += tile[i][j];
+        }
+        __syncthreads();
+    }
+
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        const int local_batch = i < 4 ? m0 + i : m1 + (i - 4);
+        const int global_batch = batch_base + local_batch;
+        if (global_batch >= batch) continue;
+        uint16_t* dst = y + static_cast<size_t>(global_batch) * y_stride;
+#pragma unroll
+        for (int j = 0; j < 4; ++j) {
+            const int global_row = row_base + n0 + j;
+            if (global_row < rows) dst[global_row] = float_to_half(acc[i][j]);
         }
     }
 }
@@ -868,9 +1066,37 @@ bool qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
     if (!x || !weight || !scale || !y || rows <= 0 || cols <= 0 ||
         weight_stride < cols || scale_stride < (cols + kFp8WeightBlock - 1) / kFp8WeightBlock) return false;
     constexpr int kWarps = 8;
-    fp8_matvec_f16_kernel<kWarps><<<(rows + kWarps - 1) / kWarps,
-        kWarps * 32, 0, static_cast<cudaStream_t>(stream)>>>(x, weight, scale, y,
-        rows, cols, weight_stride, scale_stride);
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    const char* multirow = std::getenv("QWEN_FP8_F16_MULTIROW");
+    const char* rows_env = std::getenv("QWEN_FP8_F16_MULTIROW_ROWS");
+    const char* vectorized = std::getenv("QWEN_FP8_F16_VECTORIZE");
+    const bool multirow_disabled =
+        multirow != nullptr && std::strcmp(multirow, "0") == 0;
+    const bool use_multirow = multirow != nullptr && !multirow_disabled;
+    const bool use_vectorized =
+        !multirow_disabled &&
+        (vectorized == nullptr || std::strcmp(vectorized, "0") != 0);
+    const int requested_rows = rows_env != nullptr ? std::atoi(rows_env) : 0;
+    constexpr int kMinBlocks = 136;
+    auto blocks_for = [&](int rows_per_warp) {
+        return (rows + kWarps * rows_per_warp - 1) / (kWarps * rows_per_warp);
+    };
+    if (use_multirow && weight_stride % 4 == 0 && requested_rows == 4 &&
+        blocks_for(4) >= kMinBlocks) {
+        fp8_matvec_f16_multirow_kernel<kWarps, 4><<<blocks_for(4), kWarps * 32, 0, s>>>(
+            x, weight, scale, y, rows, cols, weight_stride, scale_stride);
+    } else if (use_multirow && weight_stride % 4 == 0 && requested_rows == 2 &&
+               blocks_for(2) >= kMinBlocks) {
+        fp8_matvec_f16_multirow_kernel<kWarps, 2><<<blocks_for(2), kWarps * 32, 0, s>>>(
+            x, weight, scale, y, rows, cols, weight_stride, scale_stride);
+    } else if (use_vectorized && weight_stride % 4 == 0) {
+        fp8_matvec_f16_multirow_kernel<kWarps, 1><<<blocks_for(1), kWarps * 32, 0, s>>>(
+            x, weight, scale, y, rows, cols, weight_stride, scale_stride);
+    } else {
+        fp8_matvec_f16_kernel<kWarps><<<(rows + kWarps - 1) / kWarps,
+            kWarps * 32, 0, s>>>(x, weight, scale, y, rows, cols,
+            weight_stride, scale_stride);
+    }
     return cudaGetLastError() == cudaSuccess;
 }
 
@@ -883,11 +1109,32 @@ bool qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
         rows <= 0 || cols <= 0 || weight_stride < cols ||
         scale_stride < (cols + kFp8WeightBlock - 1) / kFp8WeightBlock) return false;
     constexpr int kWarps = 8;
-    constexpr int kRowsPerWarp = 1;
-    fp8_swiglu_matvec_f16_kernel<kWarps, kRowsPerWarp>
-        <<<(rows + kWarps - 1) / kWarps, kWarps * 32, 0,
-           static_cast<cudaStream_t>(stream)>>>(x, gate_weight, gate_scale,
-           up_weight, up_scale, y, rows, cols, weight_stride, scale_stride);
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    const char* multirow = std::getenv("QWEN_FP8_F16_MULTIROW");
+    const char* rows_env = std::getenv("QWEN_FP8_F16_MULTIROW_ROWS");
+    const bool use_multirow = multirow != nullptr && std::strcmp(multirow, "0") != 0;
+    const int requested_rows = rows_env != nullptr ? std::atoi(rows_env) : 0;
+    constexpr int kMinBlocks = 136;
+    auto blocks_for = [&](int rows_per_warp) {
+        return (rows + kWarps * rows_per_warp - 1) / (kWarps * rows_per_warp);
+    };
+    if (use_multirow && weight_stride % 4 == 0 && requested_rows == 4 &&
+        blocks_for(4) >= kMinBlocks) {
+        fp8_swiglu_matvec_f16_kernel<kWarps, 4><<<blocks_for(4), kWarps * 32, 0, s>>>(
+            x, gate_weight, gate_scale, up_weight, up_scale, y, rows, cols,
+            weight_stride, scale_stride);
+    } else if (use_multirow && weight_stride % 4 == 0 && requested_rows == 2 &&
+               blocks_for(2) >= kMinBlocks) {
+        fp8_swiglu_matvec_f16_kernel<kWarps, 2><<<blocks_for(2), kWarps * 32, 0, s>>>(
+            x, gate_weight, gate_scale, up_weight, up_scale, y, rows, cols,
+            weight_stride, scale_stride);
+    } else {
+        // The fused gate/up kernel has no aligned vectorized variant yet; keep
+        // its one-row path independent of the weight stride alignment.
+        fp8_swiglu_matvec_f16_kernel<kWarps, 1><<<blocks_for(1), kWarps * 32, 0, s>>>(
+            x, gate_weight, gate_scale, up_weight, up_scale, y, rows, cols,
+            weight_stride, scale_stride);
+    }
     return cudaGetLastError() == cudaSuccess;
 }
 
@@ -898,11 +1145,22 @@ bool qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
     if (!x || !weight || !scale || !y || batch <= 0 || rows <= 0 || cols <= 0 ||
         x_stride < cols || y_stride < rows || weight_stride < cols ||
         scale_stride < (cols + kFp8WeightBlock - 1) / kFp8WeightBlock) return false;
-    dim3 grid(static_cast<unsigned>((rows + 63) / 64),
-              static_cast<unsigned>((batch + 63) / 64), 1);
-    fp8_matmul_f16_tiled_kernel<32><<<grid, 256, 0, static_cast<cudaStream_t>(stream)>>>(
-        x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
-        weight_stride, scale_stride);
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    const char* wide = std::getenv("QWEN_FP8_F16_PREFILL_WIDE_N64");
+    const bool use_wide = wide == nullptr || std::strcmp(wide, "0") != 0;
+    if (use_wide && batch >= 96 && x_stride % 4 == 0 && weight_stride % 4 == 0) {
+        dim3 grid(static_cast<unsigned>((rows + 63) / 64),
+                  static_cast<unsigned>((batch + 127) / 128), 1);
+        fp8_matmul_f16_wide_n64_kernel<<<grid, 256, 0, s>>>(
+            x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+            weight_stride, scale_stride);
+    } else {
+        dim3 grid(static_cast<unsigned>((rows + 63) / 64),
+                  static_cast<unsigned>((batch + 63) / 64), 1);
+        fp8_matmul_f16_tiled_kernel<32><<<grid, 256, 0, s>>>(
+            x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+            weight_stride, scale_stride);
+    }
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/include/qwen_cuda_ops.hpp
+++ b/cpp_engine/include/qwen_cuda_ops.hpp
@@ -365,12 +365,14 @@ bool qwen_gqa_decode_attention_f16_fused_cuda(
     const uint16_t* d_q_fp16, const uint16_t* d_k_cache_fp16,
     const uint16_t* d_v_cache_fp16, uint16_t* d_out_fp16,
     float* d_partial_scratch, int q_heads, int kv_heads, int head_dim,
-    int context_len, int max_context, void* stream = nullptr);
+    int context_len, int max_context, int attention_window = 0,
+    int sink_tokens = 0, void* stream = nullptr);
 bool qwen_gqa_prefill_attention_f16_tiled_cuda(
     const uint16_t* d_q_rows_fp16, const uint16_t* d_k_cache_fp16,
     const uint16_t* d_v_cache_fp16, uint16_t* d_out_rows_fp16,
     int seq_len, int q_heads, int kv_heads, int head_dim,
-    int position_offset, int max_context, void* stream = nullptr);
+    int position_offset, int max_context, int attention_window = 0,
+    int sink_tokens = 0, void* stream = nullptr);
 bool qwen_gqa_decode_attention_fp8_cuda(
     const uint16_t* d_q_fp16, const uint8_t* d_k_cache_fp8,
     const uint8_t* d_v_cache_fp8, const uint16_t* d_k_scale_fp16,

--- a/cpp_engine/include/qwen_cuda_ops.hpp
+++ b/cpp_engine/include/qwen_cuda_ops.hpp
@@ -359,6 +359,18 @@ bool qwen_gqa_prefill_attention_f16_cuda(
     const uint16_t* d_v_cache_fp16, uint16_t* d_out_rows_fp16,
     int seq_len, int q_heads, int kv_heads, int head_dim,
     int position_offset, int max_context, void* stream = nullptr);
+// Exact optimized paths. Decode reuses the existing score scratch for compact
+// split partials; prefill shares each K/V load across GQA heads and query rows.
+bool qwen_gqa_decode_attention_f16_fused_cuda(
+    const uint16_t* d_q_fp16, const uint16_t* d_k_cache_fp16,
+    const uint16_t* d_v_cache_fp16, uint16_t* d_out_fp16,
+    float* d_partial_scratch, int q_heads, int kv_heads, int head_dim,
+    int context_len, int max_context, void* stream = nullptr);
+bool qwen_gqa_prefill_attention_f16_tiled_cuda(
+    const uint16_t* d_q_rows_fp16, const uint16_t* d_k_cache_fp16,
+    const uint16_t* d_v_cache_fp16, uint16_t* d_out_rows_fp16,
+    int seq_len, int q_heads, int kv_heads, int head_dim,
+    int position_offset, int max_context, void* stream = nullptr);
 bool qwen_gqa_decode_attention_fp8_cuda(
     const uint16_t* d_q_fp16, const uint8_t* d_k_cache_fp8,
     const uint8_t* d_v_cache_fp8, const uint16_t* d_k_scale_fp16,

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -23,6 +23,10 @@ struct QwenEngineOptions {
     int device = 0;
     int prefill_chunk_tokens = 512;
     QwenKvCacheDType kv_cache_dtype = QwenKvCacheDType::Fp16;
+    // 0 preserves exact full attention. Nonzero values enable the explicit
+    // sink-plus-sliding-window attention path in the optimized FP16 kernels.
+    int attention_window = 0;
+    int attention_sink_tokens = 0;
     std::string nccl_id_path;
 };
 

--- a/cpp_engine/src/main.cpp
+++ b/cpp_engine/src/main.cpp
@@ -47,6 +47,8 @@ struct Args {
     int max_context = 0;
     int prefill_chunk_tokens = 512;
     std::string kv_cache_dtype = "fp16";
+    int qwen_attention_window = 0;
+    int qwen_attention_sink_tokens = 0;
     bool serve = false;
     int port = 8000;
     std::string host = "0.0.0.0";
@@ -127,6 +129,10 @@ Args parse_args(int argc, char** argv) {
             args.prefill_chunk_tokens = std::stoi(argv[++i]);
         } else if (arg == "--kv-cache-dtype" && i + 1 < argc) {
             args.kv_cache_dtype = argv[++i];
+        } else if (arg == "--qwen-attention-window" && i + 1 < argc) {
+            args.qwen_attention_window = std::stoi(argv[++i]);
+        } else if (arg == "--qwen-attention-sink-tokens" && i + 1 < argc) {
+            args.qwen_attention_sink_tokens = std::stoi(argv[++i]);
         } else if (arg == "--serve") {
             args.serve = true;
         } else if (arg == "--port" && i + 1 < argc) {
@@ -150,6 +156,16 @@ Args parse_args(int argc, char** argv) {
     if (args.prefill_chunk_tokens <= 0) throw std::runtime_error("--prefill-chunk-tokens must be positive");
     if (args.kv_cache_dtype != "fp16" && args.kv_cache_dtype != "fp8") {
         throw std::runtime_error("--kv-cache-dtype must be fp16 or fp8");
+    }
+    if (args.qwen_attention_window < 0) {
+        throw std::runtime_error("--qwen-attention-window must not be negative");
+    }
+    if (args.qwen_attention_sink_tokens < 0) {
+        throw std::runtime_error("--qwen-attention-sink-tokens must not be negative");
+    }
+    if (args.qwen_attention_window == 0 && args.qwen_attention_sink_tokens != 0) {
+        throw std::runtime_error(
+            "--qwen-attention-sink-tokens requires --qwen-attention-window");
     }
     if (args.model.empty() && args.ckpt.empty()) {
         throw std::runtime_error("--model or --ckpt is required");
@@ -294,6 +310,8 @@ int main(int argc, char** argv) {
                     qwen_opts.device = args.device >= 0 ? args.device : args.tp_rank;
                     qwen_opts.prefill_chunk_tokens = args.prefill_chunk_tokens;
                     qwen_opts.kv_cache_dtype = dsv4::parse_qwen_kv_cache_dtype(args.kv_cache_dtype);
+                    qwen_opts.attention_window = args.qwen_attention_window;
+                    qwen_opts.attention_sink_tokens = args.qwen_attention_sink_tokens;
                     qwen_opts.nccl_id_path = args.nccl_id_path;
                     const int qwen_context = args.max_context > 0
                         ? args.max_context
@@ -307,6 +325,8 @@ int main(int argc, char** argv) {
                     std::cout << "qwen_startup=1 layers=" << (args.smoke_layers > 0 ? args.smoke_layers : 64)
                               << " prefill_chunk_tokens=" << qwen_opts.prefill_chunk_tokens
                               << " kv_cache_dtype=" << dsv4::qwen_kv_cache_dtype_name(qwen_opts.kv_cache_dtype)
+                              << " attention_window=" << qwen_opts.attention_window
+                              << " attention_sink_tokens=" << qwen_opts.attention_sink_tokens
                               << " prompt_tokens=" << prompt_ids.size()
                               << " max_context=" << qwen_context << "\n";
                     if (args.generate_token) {
@@ -347,6 +367,8 @@ int main(int argc, char** argv) {
                                   << " kv_cache_scale_bytes=" << qwen.kv_cache_scale_bytes()
                                   << " prefill_chunk_tokens=" << qwen.options().prefill_chunk_tokens
                                   << " kv_cache_dtype=" << dsv4::qwen_kv_cache_dtype_name(qwen.options().kv_cache_dtype)
+                                  << " attention_window=" << qwen.options().attention_window
+                                  << " attention_sink_tokens=" << qwen.options().attention_sink_tokens
                                   << " max_context=" << qwen.max_context()
                                   << " prompt_tokens=" << prompt_ids.size()
                                   << " generated_tokens=" << generated.size();
@@ -390,6 +412,8 @@ int main(int argc, char** argv) {
                                   << " kv_cache_scale_bytes=" << qwen.kv_cache_scale_bytes()
                                   << " prefill_chunk_tokens=" << qwen.options().prefill_chunk_tokens
                                   << " kv_cache_dtype=" << dsv4::qwen_kv_cache_dtype_name(qwen.options().kv_cache_dtype)
+                                  << " attention_window=" << qwen.options().attention_window
+                                  << " attention_sink_tokens=" << qwen.options().attention_sink_tokens
                                   << " max_context=" << qwen.max_context() << "\n";
                     }
                     return 0;

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -562,6 +562,8 @@ struct QwenEngine::Impl {
             "FP16 partial RoPE");
 
         const bool fp8_cache = options.kv_cache_dtype == QwenKvCacheDType::Fp8;
+        const int attention_window = options.attention_window;
+        const int sink_tokens = options.attention_sink_tokens;
         if (fp8_cache) {
             require_launch(qwen_append_kv_cache_fp8_cuda(
                 k_norm.f16_data(), v.f16_data(), layer.full.k_cache.fp8_data(),
@@ -578,11 +580,20 @@ struct QwenEngine::Impl {
 
         if (rows == 1) {
             const int context_length = position_offset + 1;
-            const bool optimized_decode = !fp8_cache &&
-                qwen_env_enabled("DSV4_QWEN_GQA_OPTIMIZED") &&
-                context_length >= 4096;
-            const int optimized_splits = std::min(
-                64, (context_length + 2048 - 1) / 2048);
+            const bool optimized_attention =
+                qwen_env_enabled("DSV4_QWEN_GQA_OPTIMIZED") ||
+                attention_window > 0;
+            const bool optimized_decode = !fp8_cache && optimized_attention &&
+                (context_length >= 4096 || attention_window > 0);
+            int attended_positions = context_length;
+            if (attention_window > 0) {
+                const int sink_count = std::min(sink_tokens, context_length);
+                const int window_start = std::max(
+                    context_length - attention_window, sink_count);
+                attended_positions = sink_count + (context_length - window_start);
+            }
+            const int optimized_splits = std::max(1, std::min(
+                64, (attended_positions + 2048 - 1) / 2048));
             const size_t score_elements = optimized_decode
                 ? static_cast<size_t>(q_heads) * optimized_splits *
                       static_cast<size_t>(head_dim + 2)
@@ -608,7 +619,7 @@ struct QwenEngine::Impl {
                     q_norm.f16_data(), layer.full.k_cache.f16_data(),
                     layer.full.v_cache.f16_data(), attention.f16_data(),
                     scores.f32_data(), q_heads, kv_heads, head_dim,
-                    context_length, max_context),
+                    context_length, max_context, attention_window, sink_tokens),
                     "decode optimized FP16-cache GQA");
             } else {
                 require_launch(qwen_gqa_decode_attention_f16_cuda(
@@ -624,11 +635,13 @@ struct QwenEngine::Impl {
                 layer.full.v_scale.f16_data(), attention.f16_data(), rows,
                 q_heads, kv_heads, head_dim, kKvScaleBlock, position_offset,
                 max_context), "prefill FP8-cache GQA");
-        } else if (qwen_env_enabled("DSV4_QWEN_GQA_OPTIMIZED")) {
+        } else if (qwen_env_enabled("DSV4_QWEN_GQA_OPTIMIZED") ||
+                   attention_window > 0) {
             require_launch(qwen_gqa_prefill_attention_f16_tiled_cuda(
                 q_norm.f16_data(), layer.full.k_cache.f16_data(),
                 layer.full.v_cache.f16_data(), attention.f16_data(), rows,
-                q_heads, kv_heads, head_dim, position_offset, max_context),
+                q_heads, kv_heads, head_dim, position_offset, max_context,
+                attention_window, sink_tokens),
                 "prefill optimized FP16-cache GQA");
         } else {
             require_launch(qwen_gqa_prefill_attention_f16_cuda(
@@ -833,6 +846,18 @@ QwenEngine::QwenEngine(const std::string& ckpt_dir,
     if (options_.device < 0) options_.device = options_.tp_rank;
     if (options_.prefill_chunk_tokens <= 0) {
         throw std::runtime_error("Qwen prefill chunk size must be positive");
+    }
+    if (options_.attention_window < 0 || options_.attention_sink_tokens < 0) {
+        throw std::runtime_error("Qwen attention window and sink must not be negative");
+    }
+    if (options_.attention_window == 0 && options_.attention_sink_tokens != 0) {
+        throw std::runtime_error(
+            "Qwen attention sink requires a nonzero attention window");
+    }
+    if (options_.kv_cache_dtype == QwenKvCacheDType::Fp8 &&
+        options_.attention_window > 0) {
+        throw std::runtime_error(
+            "Qwen sparse attention currently requires an FP16 KV cache");
     }
     if (cudaSetDevice(options_.device) != cudaSuccess) {
         throw std::runtime_error("failed to set Qwen CUDA device");

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -9,6 +9,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <stdexcept>
 #include <utility>
 
@@ -25,6 +27,16 @@ void check_cuda(cudaError_t status, const char* what) {
 
 void require_launch(bool ok, const char* what) {
     if (!ok) throw std::runtime_error(std::string("Qwen CUDA launch failed: ") + what);
+}
+
+bool qwen_env_enabled(const char* name) {
+    const char* value = std::getenv(name);
+    if (value == nullptr || *value == '\0') return false;
+    return std::strcmp(value, "0") != 0 &&
+           std::strcmp(value, "false") != 0 &&
+           std::strcmp(value, "FALSE") != 0 &&
+           std::strcmp(value, "off") != 0 &&
+           std::strcmp(value, "OFF") != 0;
 }
 
 struct DeviceLinear {
@@ -566,10 +578,23 @@ struct QwenEngine::Impl {
 
         if (rows == 1) {
             const int context_length = position_offset + 1;
+            const bool optimized_decode = !fp8_cache &&
+                qwen_env_enabled("DSV4_QWEN_GQA_OPTIMIZED") &&
+                context_length >= 4096;
+            const int optimized_splits = std::min(
+                64, (context_length + 2048 - 1) / 2048);
+            const size_t score_elements = optimized_decode
+                ? static_cast<size_t>(q_heads) * optimized_splits *
+                      static_cast<size_t>(head_dim + 2)
+                : static_cast<size_t>(q_heads) * context_length;
             QwenDeviceTensor& scores = workspace_float(
-                static_cast<size_t>(q_heads) * context_length,
-                {static_cast<uint64_t>(q_heads),
-                 static_cast<uint64_t>(context_length)});
+                score_elements,
+                optimized_decode
+                    ? std::vector<uint64_t>{static_cast<uint64_t>(q_heads),
+                                            static_cast<uint64_t>(optimized_splits),
+                                            static_cast<uint64_t>(head_dim + 2)}
+                    : std::vector<uint64_t>{static_cast<uint64_t>(q_heads),
+                                             static_cast<uint64_t>(context_length)});
             if (fp8_cache) {
                 require_launch(qwen_gqa_decode_attention_fp8_cuda(
                     q_norm.f16_data(), layer.full.k_cache.fp8_data(),
@@ -578,6 +603,13 @@ struct QwenEngine::Impl {
                     scores.f32_data(), q_heads, kv_heads, head_dim,
                     kKvScaleBlock, context_length, max_context),
                     "decode FP8-cache GQA");
+            } else if (optimized_decode) {
+                require_launch(qwen_gqa_decode_attention_f16_fused_cuda(
+                    q_norm.f16_data(), layer.full.k_cache.f16_data(),
+                    layer.full.v_cache.f16_data(), attention.f16_data(),
+                    scores.f32_data(), q_heads, kv_heads, head_dim,
+                    context_length, max_context),
+                    "decode optimized FP16-cache GQA");
             } else {
                 require_launch(qwen_gqa_decode_attention_f16_cuda(
                     q_norm.f16_data(), layer.full.k_cache.f16_data(),
@@ -592,6 +624,12 @@ struct QwenEngine::Impl {
                 layer.full.v_scale.f16_data(), attention.f16_data(), rows,
                 q_heads, kv_heads, head_dim, kKvScaleBlock, position_offset,
                 max_context), "prefill FP8-cache GQA");
+        } else if (qwen_env_enabled("DSV4_QWEN_GQA_OPTIMIZED")) {
+            require_launch(qwen_gqa_prefill_attention_f16_tiled_cuda(
+                q_norm.f16_data(), layer.full.k_cache.f16_data(),
+                layer.full.v_cache.f16_data(), attention.f16_data(), rows,
+                q_heads, kv_heads, head_dim, position_offset, max_context),
+                "prefill optimized FP16-cache GQA");
         } else {
             require_launch(qwen_gqa_prefill_attention_f16_cuda(
                 q_norm.f16_data(), layer.full.k_cache.f16_data(),

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -583,8 +583,12 @@ struct QwenEngine::Impl {
             const bool optimized_attention =
                 qwen_env_enabled("DSV4_QWEN_GQA_OPTIMIZED") ||
                 attention_window > 0;
+            // The compact split/merge decode path crosses over the reference
+            // score/value kernels only at long contexts on SM75.
+            constexpr int kOptimizedDecodeMinContext = 16384;
             const bool optimized_decode = !fp8_cache && optimized_attention &&
-                (context_length >= 4096 || attention_window > 0);
+                (context_length >= kOptimizedDecodeMinContext ||
+                 attention_window > 0);
             int attended_positions = context_length;
             if (attention_window > 0) {
                 const int sink_count = std::min(sink_tokens, context_length);

--- a/cpp_engine/tests/test_qwen_half_ops.cpp
+++ b/cpp_engine/tests/test_qwen_half_ops.cpp
@@ -269,6 +269,87 @@ bool check_decode_fused(int context_len, int head_dim) {
     return true;
 }
 
+bool check_decode_window_reference() {
+    constexpr int q_heads = 6;
+    constexpr int kv_heads = 1;
+    constexpr int head_dim = 64;
+    constexpr int context_len = 8192;
+    constexpr int window = 257;
+    constexpr int sink = 3;
+    const int window_start = context_len - window;
+    std::mt19937 rng(18000);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<uint16_t> q(static_cast<size_t>(q_heads) * head_dim);
+    std::vector<uint16_t> k(static_cast<size_t>(context_len) * head_dim);
+    std::vector<uint16_t> v(k.size());
+    for (uint16_t& item : q) item = to_half(dist(rng));
+    for (uint16_t& item : k) item = to_half(dist(rng));
+    for (uint16_t& item : v) item = to_half(dist(rng));
+
+    const int attended = sink + (context_len - window_start);
+    DeviceBuffer dq, dk, dv, dout, dpartial;
+    uint16_t* d_q = dq.allocate<uint16_t>(q.size());
+    uint16_t* d_k = dk.allocate<uint16_t>(k.size());
+    uint16_t* d_v = dv.allocate<uint16_t>(v.size());
+    uint16_t* d_out = dout.allocate<uint16_t>(q.size());
+    float* d_partial = dpartial.allocate<float>(
+        static_cast<size_t>(q_heads) * (head_dim + 2));
+    if (!d_q || !d_k || !d_v || !d_out || !d_partial) return false;
+    if (cudaMemcpy(d_q, q.data(), q.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_k, k.data(), k.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_v, v.data(), v.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        !dsv4::qwen_gqa_decode_attention_f16_fused_cuda(
+            d_q, d_k, d_v, d_out, d_partial, q_heads, kv_heads, head_dim,
+            context_len, context_len, window, sink) ||
+        cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP16 sparse decode launch");
+        return true;
+    }
+    std::vector<uint16_t> got(q.size());
+    if (cudaMemcpy(got.data(), d_out, got.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess) {
+        fail("FP16 sparse decode copy");
+        return true;
+    }
+    const float scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+    double worst = 0.0;
+    for (int head = 0; head < q_heads; ++head) {
+        std::vector<double> scores;
+        std::vector<int> positions;
+        for (int pos = 0; pos < context_len; ++pos) {
+            if (pos < sink || pos >= window_start) positions.push_back(pos);
+        }
+        scores.reserve(positions.size());
+        double maximum = -1.0e300;
+        for (int pos : positions) {
+            double dot = 0.0;
+            for (int d = 0; d < head_dim; ++d) {
+                dot += static_cast<double>(from_half(q[head * head_dim + d])) *
+                       from_half(k[pos * head_dim + d]);
+            }
+            scores.push_back(dot * scale);
+            maximum = std::max(maximum, scores.back());
+        }
+        double denominator = 0.0;
+        for (double& score : scores) {
+            score = std::exp(score - maximum);
+            denominator += score;
+        }
+        for (int d = 0; d < head_dim; ++d) {
+            double value = 0.0;
+            for (size_t i = 0; i < positions.size(); ++i) {
+                value += scores[i] * from_half(v[positions[i] * head_dim + d]);
+            }
+            const double expected = value / denominator;
+            worst = std::max(worst, std::fabs(
+                static_cast<double>(from_half(got[head * head_dim + d])) - expected));
+        }
+    }
+    if (worst > 4.0e-3) fail("FP16 sparse decode reference check");
+    else std::printf("  FP16 sparse decode context=%d sink=%d window=%d attended=%d worst=%.3e\n",
+                     context_len, sink, window, attended, worst);
+    return true;
+}
+
 bool check_decode_grid_256k() {
     constexpr int q_heads = 6;
     constexpr int kv_heads = 1;
@@ -434,6 +515,7 @@ int main() {
     check_decode_fused(4096, 64);
     check_decode_fused(8192, 256);
     check_decode_fused(32768, 64);
+    check_decode_window_reference();
     check_decode_grid_256k();
     check_fp8_cache();
     if (failures != 0) {

--- a/cpp_engine/tests/test_qwen_half_ops.cpp
+++ b/cpp_engine/tests/test_qwen_half_ops.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <random>
 #include <vector>
@@ -398,6 +399,197 @@ bool check_decode_grid_256k() {
     return true;
 }
 
+bool check_fp8_f16_projection() {
+    std::mt19937 rng(24000);
+    std::uniform_real_distribution<float> x_dist(-0.75f, 0.75f);
+    std::uniform_real_distribution<float> scale_dist(0.005f, 0.02f);
+    auto random_code = [&]() {
+        // Keep the direct gate finite and away from the E4M3 NaN encodings.
+        return static_cast<uint8_t>(32 + (rng() % 192));
+    };
+    auto max_error = [](const std::vector<uint16_t>& got,
+                        const std::vector<float>& expected, int stride,
+                        int rows, int batch) {
+        double worst = 0.0;
+        for (int b = 0; b < batch; ++b) {
+            for (int r = 0; r < rows; ++r) {
+                worst = std::max(worst, std::fabs(
+                    static_cast<double>(from_half(got[static_cast<size_t>(b) * stride + r])) -
+                    expected[static_cast<size_t>(b) * rows + r]));
+            }
+        }
+        return worst;
+    };
+
+    // Decode shape crosses the multi-row occupancy threshold (4352 rows ->
+    // 136 blocks at four rows per warp) and uses a non-power-of-two block count.
+    constexpr int decode_rows = 4352;
+    constexpr int decode_cols = 512;
+    constexpr int decode_weight_stride = 512;
+    constexpr int decode_scale_stride = 4;
+    std::vector<uint16_t> decode_x(decode_cols);
+    std::vector<uint8_t> decode_weight(static_cast<size_t>(decode_rows) * decode_weight_stride);
+    std::vector<uint16_t> decode_scale(static_cast<size_t>(decode_rows / 128) * decode_scale_stride);
+    for (uint16_t& value : decode_x) value = to_half(x_dist(rng));
+    for (uint8_t& value : decode_weight) value = random_code();
+    for (uint16_t& value : decode_scale) value = to_half(scale_dist(rng));
+    std::vector<float> decode_expected(decode_rows);
+    for (int r = 0; r < decode_rows; ++r) {
+        float sum = 0.0f;
+        for (int c = 0; c < decode_cols; ++c) {
+            sum += from_half(decode_x[c]) * from_fp8_e4m3(decode_weight[
+                static_cast<size_t>(r) * decode_weight_stride + c]) *
+                   from_half(decode_scale[static_cast<size_t>(r / 128) * decode_scale_stride + c / 128]);
+        }
+        decode_expected[r] = sum;
+    }
+    DeviceBuffer d_decode_x, d_decode_weight, d_decode_scale, d_decode_multi,
+        d_decode_vector, d_decode_fallback;
+    uint16_t* dx = d_decode_x.allocate<uint16_t>(decode_x.size());
+    uint8_t* dw = d_decode_weight.allocate<uint8_t>(decode_weight.size());
+    uint16_t* ds = d_decode_scale.allocate<uint16_t>(decode_scale.size());
+    uint16_t* dy_multi = d_decode_multi.allocate<uint16_t>(decode_rows);
+    uint16_t* dy_vector = d_decode_vector.allocate<uint16_t>(decode_rows);
+    uint16_t* dy_fallback = d_decode_fallback.allocate<uint16_t>(decode_rows);
+    if (!dx || !dw || !ds || !dy_multi || !dy_vector || !dy_fallback ||
+        cudaMemcpy(dx, decode_x.data(), decode_x.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(dw, decode_weight.data(), decode_weight.size() * sizeof(uint8_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(ds, decode_scale.data(), decode_scale.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess) {
+        fail("FP16 FP8 decode gate allocation/copy");
+        return false;
+    }
+    setenv("QWEN_FP8_F16_MULTIROW", "1", 1);
+    setenv("QWEN_FP8_F16_MULTIROW_ROWS", "4", 1);
+    if (!dsv4::qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+            dx, dw, ds, dy_multi, decode_rows, decode_cols,
+            decode_weight_stride, decode_scale_stride) ||
+        cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP16 FP8 multi-row decode launch");
+        return false;
+    }
+    setenv("QWEN_FP8_F16_MULTIROW", "0", 1);
+    unsetenv("QWEN_FP8_F16_MULTIROW_ROWS");
+    setenv("QWEN_FP8_F16_VECTORIZE", "1", 1);
+    if (!dsv4::qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+            dx, dw, ds, dy_vector, decode_rows, decode_cols,
+            decode_weight_stride, decode_scale_stride) ||
+        cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP16 FP8 vectorized decode launch");
+        return false;
+    }
+    setenv("QWEN_FP8_F16_MULTIROW", "0", 1);
+    setenv("QWEN_FP8_F16_VECTORIZE", "0", 1);
+    if (!dsv4::qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+            dx, dw, ds, dy_fallback, decode_rows, decode_cols,
+            decode_weight_stride, decode_scale_stride) ||
+        cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP16 FP8 scalar decode launch");
+        return false;
+    }
+    std::vector<uint16_t> decode_multi(decode_rows), decode_vector(decode_rows),
+        decode_fallback(decode_rows);
+    cudaMemcpy(decode_multi.data(), dy_multi, decode_multi.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    cudaMemcpy(decode_vector.data(), dy_vector, decode_vector.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    cudaMemcpy(decode_fallback.data(), dy_fallback, decode_fallback.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    double decode_vector_dispatch_error = 0.0;
+    double decode_multi_dispatch_error = 0.0;
+    for (int r = 0; r < decode_rows; ++r) {
+        decode_vector_dispatch_error = std::max(decode_vector_dispatch_error,
+            std::fabs(static_cast<double>(from_half(decode_vector[r])) - from_half(decode_fallback[r])));
+        decode_multi_dispatch_error = std::max(decode_multi_dispatch_error,
+            std::fabs(static_cast<double>(from_half(decode_multi[r])) - from_half(decode_fallback[r])));
+    }
+    const double decode_error = max_error(decode_vector, decode_expected, 1, decode_rows, 1);
+    const double decode_multi_error = max_error(decode_multi, decode_expected, 1, decode_rows, 1);
+    if (decode_error > 2.0e-2 || decode_multi_error > 2.0e-2 ||
+        decode_vector_dispatch_error > 2.0e-2 || decode_multi_dispatch_error > 2.0e-2) {
+        fail("FP16 FP8 decode dispatch numerical check");
+    } else {
+        std::printf("  FP16 FP8 decode rows=%d cols=%d vector=%.3e multi=%.3e "
+                    "vector_vs_scalar=%.3e multi_vs_scalar=%.3e\n",
+                    decode_rows, decode_cols, decode_error, decode_multi_error,
+                    decode_vector_dispatch_error, decode_multi_dispatch_error);
+    }
+
+    // Prefill shape triggers the 128-token x 64-row N64 tile and has padded
+    // strides so both aligned vector loads and output indexing are exercised.
+    constexpr int batch = 128;
+    constexpr int rows = 130;
+    constexpr int cols = 300;
+    constexpr int x_stride = 304;
+    constexpr int y_stride = 136;
+    constexpr int weight_stride = 304;
+    constexpr int scale_stride = 3;
+    std::vector<uint16_t> prefill_x(static_cast<size_t>(batch) * x_stride);
+    std::vector<uint8_t> prefill_weight(static_cast<size_t>(rows) * weight_stride);
+    std::vector<uint16_t> prefill_scale(static_cast<size_t>((rows + 127) / 128) * scale_stride);
+    for (uint16_t& value : prefill_x) value = to_half(x_dist(rng));
+    for (uint8_t& value : prefill_weight) value = random_code();
+    for (uint16_t& value : prefill_scale) value = to_half(scale_dist(rng));
+    std::vector<float> prefill_expected(static_cast<size_t>(batch) * rows);
+    for (int b = 0; b < batch; ++b) {
+        for (int r = 0; r < rows; ++r) {
+            float sum = 0.0f;
+            for (int c = 0; c < cols; ++c) {
+                sum += from_half(prefill_x[static_cast<size_t>(b) * x_stride + c]) *
+                       from_fp8_e4m3(prefill_weight[static_cast<size_t>(r) * weight_stride + c]) *
+                       from_half(prefill_scale[static_cast<size_t>(r / 128) * scale_stride + c / 128]);
+            }
+            prefill_expected[static_cast<size_t>(b) * rows + r] = sum;
+        }
+    }
+    DeviceBuffer d_prefill_x, d_prefill_weight, d_prefill_scale, d_prefill_wide, d_prefill_fallback;
+    uint16_t* px = d_prefill_x.allocate<uint16_t>(prefill_x.size());
+    uint8_t* pw = d_prefill_weight.allocate<uint8_t>(prefill_weight.size());
+    uint16_t* ps = d_prefill_scale.allocate<uint16_t>(prefill_scale.size());
+    uint16_t* py_wide = d_prefill_wide.allocate<uint16_t>(static_cast<size_t>(batch) * y_stride);
+    uint16_t* py_fallback = d_prefill_fallback.allocate<uint16_t>(static_cast<size_t>(batch) * y_stride);
+    if (!px || !pw || !ps || !py_wide || !py_fallback ||
+        cudaMemcpy(px, prefill_x.data(), prefill_x.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(pw, prefill_weight.data(), prefill_weight.size() * sizeof(uint8_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(ps, prefill_scale.data(), prefill_scale.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess) {
+        fail("FP16 FP8 wide prefill allocation/copy");
+        return false;
+    }
+    setenv("QWEN_FP8_F16_PREFILL_WIDE_N64", "1", 1);
+    if (!dsv4::qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
+            px, pw, ps, py_wide, batch, rows, cols, x_stride, y_stride,
+            weight_stride, scale_stride) || cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP16 FP8 wide prefill launch");
+        return false;
+    }
+    setenv("QWEN_FP8_F16_PREFILL_WIDE_N64", "0", 1);
+    if (!dsv4::qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
+            px, pw, ps, py_fallback, batch, rows, cols, x_stride, y_stride,
+            weight_stride, scale_stride) || cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP16 FP8 fallback prefill launch");
+        return false;
+    }
+    std::vector<uint16_t> prefill_wide(static_cast<size_t>(batch) * y_stride);
+    std::vector<uint16_t> prefill_fallback(prefill_wide.size());
+    cudaMemcpy(prefill_wide.data(), py_wide, prefill_wide.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    cudaMemcpy(prefill_fallback.data(), py_fallback, prefill_fallback.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    double prefill_dispatch_error = 0.0;
+    for (int b = 0; b < batch; ++b) {
+        for (int r = 0; r < rows; ++r) {
+            prefill_dispatch_error = std::max(prefill_dispatch_error,
+                std::fabs(static_cast<double>(from_half(prefill_wide[static_cast<size_t>(b) * y_stride + r])) -
+                          from_half(prefill_fallback[static_cast<size_t>(b) * y_stride + r])));
+        }
+    }
+    const double prefill_error = max_error(prefill_wide, prefill_expected, y_stride, rows, batch);
+    unsetenv("QWEN_FP8_F16_MULTIROW");
+    unsetenv("QWEN_FP8_F16_MULTIROW_ROWS");
+    unsetenv("QWEN_FP8_F16_PREFILL_WIDE_N64");
+    if (prefill_error > 3.0e-2 || prefill_dispatch_error > 3.0e-2) {
+        fail("FP16 FP8 wide prefill numerical check");
+    } else {
+        std::printf("  FP16 FP8 prefill batch=%d rows=%d cols=%d error=%.3e dispatch=%.3e\n",
+                    batch, rows, cols, prefill_error, prefill_dispatch_error);
+    }
+    return true;
+}
+
 bool check_fp8_cache() {
     constexpr int q_heads = 6;
     constexpr int kv_heads = 1;
@@ -517,6 +709,7 @@ int main() {
     check_decode_fused(32768, 64);
     check_decode_window_reference();
     check_decode_grid_256k();
+    check_fp8_f16_projection();
     check_fp8_cache();
     if (failures != 0) {
         std::printf("test_qwen_half_ops failures=%d\n", failures);

--- a/cpp_engine/tests/test_qwen_half_ops.cpp
+++ b/cpp_engine/tests/test_qwen_half_ops.cpp
@@ -127,37 +127,176 @@ bool check_fp16_cache(int context_len) {
     return true;
 }
 
+double max_half_difference(const std::vector<uint16_t>& lhs,
+                          const std::vector<uint16_t>& rhs,
+                          bool* finite) {
+    if (lhs.size() != rhs.size()) {
+        *finite = false;
+        return INFINITY;
+    }
+    double worst = 0.0;
+    *finite = true;
+    for (size_t i = 0; i < lhs.size(); ++i) {
+        const float left = from_half(lhs[i]);
+        const float right = from_half(rhs[i]);
+        if (!std::isfinite(left) || !std::isfinite(right)) *finite = false;
+        worst = std::max(worst, std::fabs(static_cast<double>(left) - right));
+    }
+    return worst;
+}
+
+bool check_prefill_tiled(int seq_len, int head_dim, int position_offset) {
+    constexpr int q_heads = 6;
+    constexpr int kv_heads = 1;
+    const int max_context = position_offset + seq_len + 3;
+    std::mt19937 rng(9000 + seq_len * 17 + head_dim + position_offset);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<uint16_t> q(static_cast<size_t>(seq_len) * q_heads * head_dim);
+    std::vector<uint16_t> k(static_cast<size_t>(max_context) * kv_heads * head_dim);
+    std::vector<uint16_t> v(k.size());
+    for (uint16_t& item : q) item = to_half(dist(rng));
+    for (uint16_t& item : k) item = to_half(dist(rng));
+    for (uint16_t& item : v) item = to_half(dist(rng));
+
+    DeviceBuffer dq, dk, dv, dold, dnew;
+    uint16_t* d_q = dq.allocate<uint16_t>(q.size());
+    uint16_t* d_k = dk.allocate<uint16_t>(k.size());
+    uint16_t* d_v = dv.allocate<uint16_t>(v.size());
+    uint16_t* d_old = dold.allocate<uint16_t>(q.size());
+    uint16_t* d_new = dnew.allocate<uint16_t>(q.size());
+    if (!d_q || !d_k || !d_v || !d_old || !d_new) return false;
+    if (cudaMemcpy(d_q, q.data(), q.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_k, k.data(), k.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_v, v.data(), v.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        !dsv4::qwen_gqa_prefill_attention_f16_cuda(
+            d_q, d_k, d_v, d_old, seq_len, q_heads, kv_heads, head_dim,
+            position_offset, max_context) ||
+        !dsv4::qwen_gqa_prefill_attention_f16_tiled_cuda(
+            d_q, d_k, d_v, d_new, seq_len, q_heads, kv_heads, head_dim,
+            position_offset, max_context) ||
+        cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP16 tiled prefill launch");
+        return true;
+    }
+    std::vector<uint16_t> old_output(q.size());
+    std::vector<uint16_t> new_output(q.size());
+    if (cudaMemcpy(old_output.data(), d_old, old_output.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(new_output.data(), d_new, new_output.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess) {
+        fail("FP16 tiled prefill copy");
+        return true;
+    }
+    bool finite = true;
+    const double worst = max_half_difference(old_output, new_output, &finite);
+    if (!finite || worst > 4.0e-3) {
+        fail("FP16 tiled prefill numerical check");
+    } else {
+        std::printf("  FP16 tiled prefill seq=%d dim=%d offset=%d worst=%.3e\n",
+                    seq_len, head_dim, position_offset, worst);
+    }
+    return true;
+}
+
+bool check_decode_fused(int context_len, int head_dim) {
+    constexpr int q_heads = 6;
+    constexpr int kv_heads = 1;
+    std::mt19937 rng(12000 + context_len + head_dim);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<uint16_t> q(static_cast<size_t>(q_heads) * head_dim);
+    std::vector<uint16_t> k(static_cast<size_t>(context_len) * kv_heads * head_dim);
+    std::vector<uint16_t> v(k.size());
+    for (uint16_t& item : q) item = to_half(dist(rng));
+    for (uint16_t& item : k) item = to_half(dist(rng));
+    for (uint16_t& item : v) item = to_half(dist(rng));
+
+    DeviceBuffer dq, dk, dv, dold, dnew, dscores, dpartial;
+    uint16_t* d_q = dq.allocate<uint16_t>(q.size());
+    uint16_t* d_k = dk.allocate<uint16_t>(k.size());
+    uint16_t* d_v = dv.allocate<uint16_t>(v.size());
+    uint16_t* d_old = dold.allocate<uint16_t>(q.size());
+    uint16_t* d_new = dnew.allocate<uint16_t>(q.size());
+    float* d_scores = dscores.allocate<float>(static_cast<size_t>(q_heads) * context_len);
+    const int splits = std::min(64, (context_len + 2048 - 1) / 2048);
+    float* d_partial = dpartial.allocate<float>(
+        static_cast<size_t>(q_heads) * splits * (head_dim + 2));
+    if (!d_q || !d_k || !d_v || !d_old || !d_new || !d_scores || !d_partial) return false;
+    if (cudaMemcpy(d_q, q.data(), q.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_k, k.data(), k.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_v, v.data(), v.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        !dsv4::qwen_gqa_decode_attention_f16_cuda(
+            d_q, d_k, d_v, d_old, d_scores, q_heads, kv_heads, head_dim,
+            context_len, context_len) ||
+        !dsv4::qwen_gqa_decode_attention_f16_fused_cuda(
+            d_q, d_k, d_v, d_new, d_partial, q_heads, kv_heads, head_dim,
+            context_len, context_len) ||
+        cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP16 fused decode launch");
+        return true;
+    }
+    std::vector<uint16_t> old_output(q.size());
+    std::vector<uint16_t> new_output(q.size());
+    if (cudaMemcpy(old_output.data(), d_old, old_output.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(new_output.data(), d_new, new_output.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess) {
+        fail("FP16 fused decode copy");
+        return true;
+    }
+    bool finite = true;
+    const double worst = max_half_difference(old_output, new_output, &finite);
+    if (!finite || worst > 4.0e-3) {
+        std::printf("  FP16 fused decode context=%d dim=%d worst=%.3e finite=%d\n",
+                    context_len, head_dim, worst, finite ? 1 : 0);
+        fail("FP16 fused decode numerical check");
+    } else {
+        std::printf("  FP16 fused decode context=%d dim=%d worst=%.3e\n",
+                    context_len, head_dim, worst);
+    }
+    return true;
+}
+
 bool check_decode_grid_256k() {
     constexpr int q_heads = 6;
     constexpr int kv_heads = 1;
     constexpr int head_dim = 64;
     constexpr int context_len = 262144;
-    DeviceBuffer dq, dk_cache, dv_cache, dout, dscores;
+    DeviceBuffer dq, dk_cache, dv_cache, dout, dfused, dscores, dpartial;
     uint16_t* d_q = dq.allocate<uint16_t>(q_heads * head_dim);
     uint16_t* d_k_cache = dk_cache.allocate<uint16_t>(context_len * kv_heads * head_dim);
     uint16_t* d_v_cache = dv_cache.allocate<uint16_t>(context_len * kv_heads * head_dim);
     uint16_t* d_out = dout.allocate<uint16_t>(q_heads * head_dim);
+    uint16_t* d_fused = dfused.allocate<uint16_t>(q_heads * head_dim);
     float* d_scores = dscores.allocate<float>(q_heads * context_len);
-    if (!d_q || !d_k_cache || !d_v_cache || !d_out || !d_scores) return false;
+    const int splits = std::min(64, (context_len + 2048 - 1) / 2048);
+    float* d_partial = dpartial.allocate<float>(
+        static_cast<size_t>(q_heads) * splits * (head_dim + 2));
+    if (!d_q || !d_k_cache || !d_v_cache || !d_out || !d_fused ||
+        !d_scores || !d_partial) return false;
     if (cudaMemset(d_q, 0, q_heads * head_dim * sizeof(uint16_t)) != cudaSuccess ||
         cudaMemset(d_k_cache, 0, context_len * kv_heads * head_dim * sizeof(uint16_t)) != cudaSuccess ||
         cudaMemset(d_v_cache, 0, context_len * kv_heads * head_dim * sizeof(uint16_t)) != cudaSuccess ||
         !dsv4::qwen_gqa_decode_attention_f16_cuda(
             d_q, d_k_cache, d_v_cache, d_out, d_scores, q_heads, kv_heads,
             head_dim, context_len, context_len) ||
+        !dsv4::qwen_gqa_decode_attention_f16_fused_cuda(
+            d_q, d_k_cache, d_v_cache, d_fused, d_partial, q_heads, kv_heads,
+            head_dim, context_len, context_len) ||
         cudaDeviceSynchronize() != cudaSuccess) {
         fail("FP16 256K decode grid launch");
         return true;
     }
     std::vector<uint16_t> got(q_heads * head_dim);
+    std::vector<uint16_t> fused(q_heads * head_dim);
     cudaMemcpy(got.data(), d_out, got.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    cudaMemcpy(fused.data(), d_fused, fused.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
     for (uint16_t value : got) {
         if (value != 0) {
             fail("FP16 256K decode zero output");
             break;
         }
     }
-    std::printf("  FP16 decode context=%d grid=flattened PASS\n", context_len);
+    bool finite = true;
+    const double worst = max_half_difference(got, fused, &finite);
+    if (!finite || worst > 4.0e-3) fail("FP16 256K fused decode numerical check");
+    std::printf("  FP16 decode context=%d grid=flattened fused worst=%.3e\n",
+                context_len, worst);
     return true;
 }
 
@@ -269,6 +408,15 @@ int main() {
     check_fp16_cache(1);
     check_fp16_cache(17);
     check_fp16_cache(333);
+    check_prefill_tiled(1, 64, 0);
+    check_prefill_tiled(2, 256, 0);
+    check_prefill_tiled(7, 64, 3);
+    check_prefill_tiled(17, 256, 5);
+    check_prefill_tiled(128, 64, 7);
+    check_prefill_tiled(333, 256, 11);
+    check_decode_fused(4096, 64);
+    check_decode_fused(8192, 256);
+    check_decode_fused(32768, 64);
     check_decode_grid_256k();
     check_fp8_cache();
     if (failures != 0) {

--- a/cpp_engine/tests/test_qwen_half_ops.cpp
+++ b/cpp_engine/tests/test_qwen_half_ops.cpp
@@ -158,13 +158,14 @@ bool check_prefill_tiled(int seq_len, int head_dim, int position_offset) {
     for (uint16_t& item : k) item = to_half(dist(rng));
     for (uint16_t& item : v) item = to_half(dist(rng));
 
-    DeviceBuffer dq, dk, dv, dold, dnew;
+    DeviceBuffer dq, dk, dv, dold, dnew, dsparse;
     uint16_t* d_q = dq.allocate<uint16_t>(q.size());
     uint16_t* d_k = dk.allocate<uint16_t>(k.size());
     uint16_t* d_v = dv.allocate<uint16_t>(v.size());
     uint16_t* d_old = dold.allocate<uint16_t>(q.size());
     uint16_t* d_new = dnew.allocate<uint16_t>(q.size());
-    if (!d_q || !d_k || !d_v || !d_old || !d_new) return false;
+    uint16_t* d_sparse = dsparse.allocate<uint16_t>(q.size());
+    if (!d_q || !d_k || !d_v || !d_old || !d_new || !d_sparse) return false;
     if (cudaMemcpy(d_q, q.data(), q.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
         cudaMemcpy(d_k, k.data(), k.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
         cudaMemcpy(d_v, v.data(), v.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
@@ -174,24 +175,31 @@ bool check_prefill_tiled(int seq_len, int head_dim, int position_offset) {
         !dsv4::qwen_gqa_prefill_attention_f16_tiled_cuda(
             d_q, d_k, d_v, d_new, seq_len, q_heads, kv_heads, head_dim,
             position_offset, max_context) ||
+        !dsv4::qwen_gqa_prefill_attention_f16_tiled_cuda(
+            d_q, d_k, d_v, d_sparse, seq_len, q_heads, kv_heads, head_dim,
+            position_offset, max_context, seq_len + position_offset + 8, 0) ||
         cudaDeviceSynchronize() != cudaSuccess) {
         fail("FP16 tiled prefill launch");
         return true;
     }
     std::vector<uint16_t> old_output(q.size());
     std::vector<uint16_t> new_output(q.size());
+    std::vector<uint16_t> sparse_output(q.size());
     if (cudaMemcpy(old_output.data(), d_old, old_output.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess ||
-        cudaMemcpy(new_output.data(), d_new, new_output.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess) {
+        cudaMemcpy(new_output.data(), d_new, new_output.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(sparse_output.data(), d_sparse, sparse_output.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess) {
         fail("FP16 tiled prefill copy");
         return true;
     }
     bool finite = true;
     const double worst = max_half_difference(old_output, new_output, &finite);
-    if (!finite || worst > 4.0e-3) {
+    bool sparse_finite = true;
+    const double sparse_worst = max_half_difference(old_output, sparse_output, &sparse_finite);
+    if (!finite || worst > 4.0e-3 || !sparse_finite || sparse_worst > 4.0e-3) {
         fail("FP16 tiled prefill numerical check");
     } else {
-        std::printf("  FP16 tiled prefill seq=%d dim=%d offset=%d worst=%.3e\n",
-                    seq_len, head_dim, position_offset, worst);
+        std::printf("  FP16 tiled prefill seq=%d dim=%d offset=%d worst=%.3e sparse_exact=%.3e\n",
+                    seq_len, head_dim, position_offset, worst, sparse_worst);
     }
     return true;
 }
@@ -208,17 +216,19 @@ bool check_decode_fused(int context_len, int head_dim) {
     for (uint16_t& item : k) item = to_half(dist(rng));
     for (uint16_t& item : v) item = to_half(dist(rng));
 
-    DeviceBuffer dq, dk, dv, dold, dnew, dscores, dpartial;
+    DeviceBuffer dq, dk, dv, dold, dnew, dscores, dpartial, dsparse;
     uint16_t* d_q = dq.allocate<uint16_t>(q.size());
     uint16_t* d_k = dk.allocate<uint16_t>(k.size());
-    uint16_t* d_v = dv.allocate<uint16_t>(v.size());
+    uint16_t* d_v = dv.allocate<uint16_t>(k.size());
     uint16_t* d_old = dold.allocate<uint16_t>(q.size());
     uint16_t* d_new = dnew.allocate<uint16_t>(q.size());
+    uint16_t* d_sparse = dsparse.allocate<uint16_t>(q.size());
     float* d_scores = dscores.allocate<float>(static_cast<size_t>(q_heads) * context_len);
     const int splits = std::min(64, (context_len + 2048 - 1) / 2048);
     float* d_partial = dpartial.allocate<float>(
         static_cast<size_t>(q_heads) * splits * (head_dim + 2));
-    if (!d_q || !d_k || !d_v || !d_old || !d_new || !d_scores || !d_partial) return false;
+    if (!d_q || !d_k || !d_v || !d_old || !d_new || !d_sparse ||
+        !d_scores || !d_partial) return false;
     if (cudaMemcpy(d_q, q.data(), q.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
         cudaMemcpy(d_k, k.data(), k.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
         cudaMemcpy(d_v, v.data(), v.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
@@ -228,26 +238,33 @@ bool check_decode_fused(int context_len, int head_dim) {
         !dsv4::qwen_gqa_decode_attention_f16_fused_cuda(
             d_q, d_k, d_v, d_new, d_partial, q_heads, kv_heads, head_dim,
             context_len, context_len) ||
+        !dsv4::qwen_gqa_decode_attention_f16_fused_cuda(
+            d_q, d_k, d_v, d_sparse, d_partial, q_heads, kv_heads, head_dim,
+            context_len, context_len, context_len + 8, 0) ||
         cudaDeviceSynchronize() != cudaSuccess) {
         fail("FP16 fused decode launch");
         return true;
     }
     std::vector<uint16_t> old_output(q.size());
     std::vector<uint16_t> new_output(q.size());
+    std::vector<uint16_t> sparse_output(q.size());
     if (cudaMemcpy(old_output.data(), d_old, old_output.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess ||
-        cudaMemcpy(new_output.data(), d_new, new_output.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess) {
+        cudaMemcpy(new_output.data(), d_new, new_output.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(sparse_output.data(), d_sparse, sparse_output.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess) {
         fail("FP16 fused decode copy");
         return true;
     }
     bool finite = true;
     const double worst = max_half_difference(old_output, new_output, &finite);
-    if (!finite || worst > 4.0e-3) {
+    bool sparse_finite = true;
+    const double sparse_worst = max_half_difference(old_output, sparse_output, &sparse_finite);
+    if (!finite || worst > 4.0e-3 || !sparse_finite || sparse_worst > 4.0e-3) {
         std::printf("  FP16 fused decode context=%d dim=%d worst=%.3e finite=%d\n",
                     context_len, head_dim, worst, finite ? 1 : 0);
         fail("FP16 fused decode numerical check");
     } else {
-        std::printf("  FP16 fused decode context=%d dim=%d worst=%.3e\n",
-                    context_len, head_dim, worst);
+        std::printf("  FP16 fused decode context=%d dim=%d worst=%.3e sparse_exact=%.3e\n",
+                    context_len, head_dim, worst, sparse_worst);
     }
     return true;
 }

--- a/docs/models/qwen3.8-27b-fp8.md
+++ b/docs/models/qwen3.8-27b-fp8.md
@@ -74,6 +74,7 @@ The same executable was then run serially over longer prompts with four generate
 | 4,096 | 386.16 tok/s | 29.82 tok/s | 61.00 MiB | 64.1 MiB | 8.02 GiB | PASS |
 | 8,192 | 293.60 tok/s | 24.58 tok/s | 61.00 MiB | 128.1 MiB | 8.09 GiB | PASS |
 | 32,768 | 113.92 tok/s | 11.05 tok/s | 61.00 MiB | 512.1 MiB | 8.47 GiB | PASS |
+| 65,536 | 65.21 tok/s | 6.60 tok/s | 61.00 MiB | 1,024.1 MiB | 8.97 GiB | PASS |
 
 The direct FP16-activation FP8 projection gate covers aligned and padded strides, masked rows, tail K tiles, vectorized-versus-scalar decode dispatch, and the wide prefill tile. It reports decode max absolute error `1.459e-2` against the FP32 host reference, with vectorized-versus-scalar output difference `0`; the 4-row experimental path differs by at most `3.906e-3`. The focused FP8 online operator suite and full TP4 rank parity checks also pass.
 

--- a/docs/models/qwen3.8-27b-fp8.md
+++ b/docs/models/qwen3.8-27b-fp8.md
@@ -75,6 +75,7 @@ The same executable was then run serially over longer prompts with four generate
 | 8,192 | 293.60 tok/s | 24.58 tok/s | 61.00 MiB | 128.1 MiB | 8.09 GiB | PASS |
 | 32,768 | 113.92 tok/s | 11.05 tok/s | 61.00 MiB | 512.1 MiB | 8.47 GiB | PASS |
 | 65,536 | 65.21 tok/s | 6.60 tok/s | 61.00 MiB | 1,024.1 MiB | 8.97 GiB | PASS |
+| 131,072 | 35.19 tok/s | 3.65 tok/s | 62.50 MiB | 2,048.1 MiB | 9.97 GiB | PASS |
 
 The direct FP16-activation FP8 projection gate covers aligned and padded strides, masked rows, tail K tiles, vectorized-versus-scalar decode dispatch, and the wide prefill tile. It reports decode max absolute error `1.459e-2` against the FP32 host reference, with vectorized-versus-scalar output difference `0`; the 4-row experimental path differs by at most `3.906e-3`. The focused FP8 online operator suite and full TP4 rank parity checks also pass.
 

--- a/docs/models/qwen3.8-27b-fp8.md
+++ b/docs/models/qwen3.8-27b-fp8.md
@@ -61,6 +61,22 @@ Hardware: 4×RTX 2080 Ti 22 GiB, TP4, single request, real Qwen3.8-27B-FP8 check
 
 Additional repeat runs on the 512-token fixture measured approximately 411.8–416.4 tok/s prefill and 35.66–35.85 tok/s decode.
 
+### Current memory-safe FP16-activation kernels
+
+The current reference runtime now uses FP16-input, FP32-accumulation FP8 projection kernels without expanding prompt activations or weights. The prefill path uses a 128-token x 64-output N64 tile when alignment and batch size permit; decode uses vectorized single-row FP8 matvec, while the original scalar kernel remains the fallback. Two-row and four-row decode variants remain explicit experiments because their register pressure reduced end-to-end decode throughput. These kernels preserve the default exact full-attention semantics and FP16 KV cache.
+
+A clean serial TP4 run on the same real checkpoint and 512-token fixture measured `453.08 tok/s` prefill and `36.95 tok/s` decode with 24 generated tokens. A prior repeat measured `456.78 / 37.12 tok/s`; both runs produced identical rank-local greedy sequences and `rank_token_parity=PASS`. The resident weight and scale bytes remained `7,367,270,656` and `742,400` per rank, and peak GPU memory was `8,497,528,832` bytes on the highest rank.
+
+The same executable was then run serially over longer prompts with four generated tokens, complete 64-layer execution, 512-token chunks, and FP16 KV cache:
+
+| Prompt | Prefill | Decode | Activation workspace | KV data | Highest rank memory | Rank parity |
+| ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 4,096 | 386.16 tok/s | 29.82 tok/s | 61.00 MiB | 64.1 MiB | 8.02 GiB | PASS |
+| 8,192 | 293.60 tok/s | 24.58 tok/s | 61.00 MiB | 128.1 MiB | 8.09 GiB | PASS |
+| 32,768 | 113.92 tok/s | 11.05 tok/s | 61.00 MiB | 512.1 MiB | 8.47 GiB | PASS |
+
+The direct FP16-activation FP8 projection gate covers aligned and padded strides, masked rows, tail K tiles, vectorized-versus-scalar decode dispatch, and the wide prefill tile. It reports decode max absolute error `1.459e-2` against the FP32 host reference, with vectorized-versus-scalar output difference `0`; the 4-row experimental path differs by at most `3.906e-3`. The focused FP8 online operator suite and full TP4 rank parity checks also pass.
+
 ### Long-context TP4 baseline
 
 The following recent serial runs use the real checkpoint, deterministic natural-language tokenizer IDs, four generated tokens, complete 64-layer execution, 512-token prefill chunks, and greedy-token parity across all four ranks. Decode TPS excludes the first generated token, which is produced by prefill. The activation workspace is the peak capacity of the reusable chunk workspace, not a prompt-length buffer.

--- a/docs/models/qwen3.8-27b-fp8.md
+++ b/docs/models/qwen3.8-27b-fp8.md
@@ -155,7 +155,17 @@ python scripts/bench_qwen_long_context.py \
 
 The harness persists one log per rank, records rank-local timing and memory fields, checks greedy-token parity across TP ranks, and writes `results.json` after every successful context length. FP16-versus-FP8 cache parity is a separate comparison of the generated sequences from two serial runs.
 
-For the exact optimized FP16 GQA path, set `DSV4_QWEN_GQA_OPTIMIZED=1` around the engine command or benchmark process. It keeps full attention, uses a tiled prefill kernel, and uses compact split-context fused decode partials only from context 4,096 onward. The direct CUDA gate covers causal offsets through 333 tokens, head dimensions 64/256, contexts 4,096/8,192/32,768, and a 262,144-token compact-partial boundary check. The optimized path preserves the default token sequence in the validated TP4 smoke runs.
+For the exact optimized FP16 GQA path, set `DSV4_QWEN_GQA_OPTIMIZED=1` around the engine command or benchmark process. It keeps full attention and uses a tiled prefill kernel. The engine uses compact split-context fused decode partials from context 16,384 onward on SM75; shorter contexts retain the reference score/value decode path because it is faster there. A clean TP4 run with 24 generated tokens measured the following opt-in results, with token parity at every length:
+
+| Prompt | Reference prefill / decode | Optimized prefill / decode |
+| ---: | ---: | ---: |
+| 512 | 295.46 / 31.06 tok/s | 294.84 / 30.98 tok/s |
+| 4,096 | 259.69 / 25.96 tok/s | 282.47 / 25.72 tok/s |
+| 8,192 | 211.02 / 21.19 tok/s | 253.70 / 21.01 tok/s |
+| 16,384 | 154.58 / 15.58 tok/s | 208.24 / 17.57 tok/s |
+| 32,768 | 97.75 / 10.66 tok/s | 159.52 / 17.36 tok/s |
+
+The 4,096 and 8,192 optimized rows use the tiled prefill but reference decode dispatch; the 16,384 row is the fused-decode crossover validation, and the 32,768 row shows the long-context gain. The direct CUDA gate covers causal offsets through 333 tokens, head dimensions 64/256, contexts 4,096/8,192/32,768, and a 262,144-token compact-partial boundary check. The optimized path preserves the default token sequence in the clean TP4 runs.
 
 Sparse experiments require an explicit `--qwen-attention-window N` and may add `--qwen-attention-sink-tokens N`; `N=0` is exact full attention. The sparse kernel attends to the leading sink prefix plus the newest window positions without changing KV-cache storage. This is an experimental semantic change, not an exact full-attention optimization claim. Window values that cover the complete context are directly checked against exact output; long-context quality and throughput are not reported here until measured on clean GPUs.
 

--- a/docs/models/qwen3.8-27b-fp8.md
+++ b/docs/models/qwen3.8-27b-fp8.md
@@ -46,6 +46,8 @@ The root config also contains a vision tower, but PocketLLM deliberately dispatc
 - Chunked prefill (default 512 tokens) that retains only recurrent state, convolution tails, and full-attention KV cache between chunks.
 - FP16 KV cache by default, plus explicit opt-in FP8 E4M3 cache with per-token/KV-head FP16 scales over 64-channel blocks.
 - Decode-only fused FP8 gate/up projection plus SwiGLU.
+- Opt-in exact FP16 GQA kernels: tiled prefill and split-context fused decode with compact online-softmax partials. Enable with `DSV4_QWEN_GQA_OPTIMIZED=1`; the default remains the reference full-attention path.
+- Opt-in FP16 sink-plus-sliding-window attention through `--qwen-attention-window N` and optional `--qwen-attention-sink-tokens N`. This changes full-attention semantics and is not part of exact parity or default performance claims; FP8 cache is intentionally rejected for this mode.
 - TP4 NCCL reductions and global greedy top-1 selection.
 
 ## Validated performance
@@ -152,6 +154,10 @@ python scripts/bench_qwen_long_context.py \
 
 The harness persists one log per rank, records rank-local timing and memory fields, checks greedy-token parity across TP ranks, and writes `results.json` after every successful context length. FP16-versus-FP8 cache parity is a separate comparison of the generated sequences from two serial runs.
 
+For the exact optimized FP16 GQA path, set `DSV4_QWEN_GQA_OPTIMIZED=1` around the engine command or benchmark process. It keeps full attention, uses a tiled prefill kernel, and uses compact split-context fused decode partials only from context 4,096 onward. The direct CUDA gate covers causal offsets through 333 tokens, head dimensions 64/256, contexts 4,096/8,192/32,768, and a 262,144-token compact-partial boundary check. The optimized path preserves the default token sequence in the validated TP4 smoke runs.
+
+Sparse experiments require an explicit `--qwen-attention-window N` and may add `--qwen-attention-sink-tokens N`; `N=0` is exact full attention. The sparse kernel attends to the leading sink prefix plus the newest window positions without changing KV-cache storage. This is an experimental semantic change, not an exact full-attention optimization claim. Window values that cover the complete context are directly checked against exact output; long-context quality and throughput are not reported here until measured on clean GPUs.
+
 Audit only the rank-local weight mapping:
 
 ```bash
@@ -169,6 +175,7 @@ build/cpp_engine/dsv4_cpp_engine \
 - The model limit is 262,144 positions; with four generated tokens, the longest valid benchmark prompt is 262,140 tokens. This boundary is validated with the default FP16 KV cache; the separate FP8 boundary validation is reported only when complete.
 - The executable and internal C++ namespace retain DSV4 compatibility names.
 - CUDA Graph, a decode megakernel, and DSpark integration remain future work; none is included in the reported TPS.
+- The exact optimized GQA kernels and sparse attention mode are opt-in. The optimized kernels have direct numerical gates, but clean full-network TP4 A/B timing is still required before making either path the default or updating the long-context TPS table.
 
 ## Evidence and related notes
 

--- a/docs/models/qwen3.8-27b-fp8.md
+++ b/docs/models/qwen3.8-27b-fp8.md
@@ -74,10 +74,11 @@ The following recent serial runs use the real checkpoint, deterministic natural-
 | FP16 | 131,072 | 33.80 tok/s | 3.58 tok/s | 62.50 MB | 2,048.0 / 0 MB | 9.97 GiB | PASS |
 | FP8 | 131,072 | 26.03 tok/s | 1.25 tok/s | 62.50 MB | 1,024.0 / 32.00 MB | 9.01 GiB | PASS |
 | FP16 | 262,140 | 17.88 tok/s | 1.92 tok/s | 65.50 MB | 4,096.0 / 0 MB | 11.91 GiB | PASS |
+| FP8 | 262,140 | 13.29 tok/s | 0.64 tok/s | 65.50 MB | 2,048.0 / 64.0 MB | 9.97 GiB | PASS |
 
-The 32K, 64K, and 128K FP16/FP8 runs produced identical four-token sequences for each cache-dtype pair. The FP16 262,140-token boundary run generated `[321, 5979, 13914, 13]` with `max_context=262144`, completed without OOM, and preserved TP-rank token parity. FP8 cache is retained as an explicit memory-saving option, not the default: on this RTX 2080 Ti setup, online cache dequantization materially reduces prefill and decode throughput. FP16 KV cache remains the precision/performance baseline.
+The 32K, 64K, and 128K FP16/FP8 runs produced identical four-token sequences for each cache-dtype pair. The FP16 and FP8 262,140-token boundary runs both generated `[321, 5979, 13914, 13]` with `max_context=262144`, completed without OOM, and preserved TP-rank token parity. FP8 cache is retained as an explicit memory-saving option, not the default: on this RTX 2080 Ti setup, online cache dequantization materially reduces prefill and decode throughput. At the 262K boundary it halves KV data from 4,096 MiB to 2,048 MiB and reduces the highest observed rank memory from 11.91 GiB to 9.97 GiB, while prefill falls from 17.88 to 13.29 tok/s and decode from 1.92 to 0.64 tok/s. FP16 KV cache remains the precision/performance baseline.
 
-These measurements establish that chunked prefill removes the previous prompt-length FP32 activation allocation and that a 262,140-token prompt plus four generated positions completes within the 22 GiB/rank budget using the FP16 cache. The FP8 262,140-token boundary run is still being evaluated separately.
+These measurements establish that chunked prefill removes the previous prompt-length FP32 activation allocation and that a 262,140-token prompt plus four generated positions completes within the 22 GiB/rank budget with either FP16 or FP8 KV cache. The FP8 boundary run took approximately 19,729.6 seconds wall time with the complete 64-layer runtime.
 
 ### Decode Context Parallelism feasibility on four GPUs
 
@@ -172,7 +173,7 @@ build/cpp_engine/dsv4_cpp_engine \
 - Text-only: no image/video preprocessing or vision-tower execution.
 - CLI/smoke integration only: Qwen is explicitly rejected by the current DSV4 OpenAI server path.
 - Greedy generation only in the current Qwen engine API.
-- The model limit is 262,144 positions; with four generated tokens, the longest valid benchmark prompt is 262,140 tokens. This boundary is validated with the default FP16 KV cache; the separate FP8 boundary validation is reported only when complete.
+- The model limit is 262,144 positions; with four generated tokens, the longest valid benchmark prompt is 262,140 tokens. This boundary is validated with both the default FP16 KV cache and the explicit FP8 cache mode; FP8 uses less memory but is slower on this RTX 2080 Ti setup.
 - The executable and internal C++ namespace retain DSV4 compatibility names.
 - CUDA Graph, a decode megakernel, and DSpark integration remain future work; none is included in the reported TPS.
 - The exact optimized GQA kernels and sparse attention mode are opt-in. The optimized kernels have direct numerical gates, but clean full-network TP4 A/B timing is still required before making either path the default or updating the long-context TPS table.


### PR DESCRIPTION
## Summary

恢复 Qwen3.8-27B-FP8 memory-safe runtime 短序列性能，同时保持 256K context、FP16 activation、512-token chunked prefill 和 FP16/FP8 KV cache。

## Changes

### 1. FP16 activation FP8 prefill kernel
- 新增 `fp8_matmul_f16_wide_n64_kernel`：128x64x16 tile，FP16 input + FP32 accumulation + FP16 output
- 默认 `batch>=96` 使用 wide N64，保留 64x64 fallback
- `uint2` 4-element FP16 input staging + `uchar4` FP8 weight staging
- 512-token prefill 从约 295 提升到约 453 tok/s

### 2. FP16 activation FP8 decode matvec vectorization
- 新增 `fp8_matvec_f16_multirow_kernel<kWarps,1>`：单行/warp，向量化 FP16 input 和 FP8 weight 加载
- `uint2` + `uchar4` 替代原标量路径
- 默认 `weight_stride % 4 == 0` 使用向量化单行
- 512-token decode 从约 31.1 提升到约 37.1 tok/s

### 3. Multi-row decode 实验路径
- 实现 2/4 rows-per-warp，但真实端到端回归：2-row 降至 25.67、4-row 降至 24.34 tok/s
- 保留为显式 opt-in `QWEN_FP8_F16_MULTIROW=1 QWEN_FP8_F16_MULTIROW_ROWS=2|4`

### 4. Direct numerical gate
- `test_qwen_half_ops.cpp` 新增 `check_fp8_f16_projection()`
- Decode 4352x512 覆盖 occupancy threshold
- Prefill 128x130x300 覆盖 wide N64 tile、padded cols、masked rows
- Vectorized vs scalar dispatch A/B
- Max absolute error gate：decode `2.0e-2`、prefill `3.0e-2`

## Validation

### Short-context baseline (FP16 KV cache, 512 chunk, 64 layers, TP4)
| Prompt | Prefill | Decode | GPU/rank | Parity |
| ---: | ---: | ---: | ---: | --- |
| 512 | 453.08 tok/s | 36.95 tok/s | 7.91 GiB | PASS |
| 4,096 | 386.16 tok/s | 29.82 tok/s | 8.02 GiB | PASS |
| 8,192 | 293.60 tok/s | 24.58 tok/s | 8.08 GiB | PASS |
| 32,768 | 113.92 tok/s | 11.05 tok/s | 8.47 GiB | PASS |
| 65,536 | 65.21 tok/s | 6.60 tok/s | 8.97 GiB | PASS |
| 131,072 | 35.19 tok/s | 3.65 tok/s | 9.97 GiB | PASS |

### Correctness
- `test_qwen_half_ops` PASS：decode error `1.459e-2`、prefill error `1.547e-2`、dispatch diff `3.906e-3`
- `test_qwen_fp8_online` 完整回归 PASS
- FP8 KV cache 512-token parity PASS：159.51 / 13.24 tok/s
- 4/8/32/64/128K complete TP4 runs all report `rank_token_parity=PASS`
- The existing 262,140-token FP16/FP8 boundary validation remains documented from the prior complete runtime run; this PR does not claim a new 262K rerun.

## Performance delta
- 短序列 prefill：约 295 -> 约 453 tok/s (+53%)
- 短序列 decode：约 31.1 -> 约 37.1 tok/s (+19%)
- 达到用户目标：prefill 400+ / decode 35+ tok/s
- 长上下文退化趋势与旧 256K boundary 基线一致

## Memory safety preserved
- FP16 activation storage：无 prompt-length FP32 buffer
- 512-token chunked prefill：workspace 61-62.5 MiB 可跨层复用
- FP16 KV cache 默认：FP8 opt-in 保留
- 256K context 语义：exact full-attention 默认、sparse opt-in
- TP4 resident weight：7.04 GiB/rank

🤖 Generated with [Claude Code](https://claude.com/claude-code)