### PR TITLE
Add native Qwen MTP speculative decoding

### DIFF
--- a/cpp_engine/cuda/cuda_ops.cu
+++ b/cpp_engine/cuda/cuda_ops.cu
@@ -4,6 +4,7 @@
 #include <sm_61_intrinsics.h>
 
 #include <algorithm>
+#include <climits>
 #include <cmath>
 
 namespace dsv4 {
@@ -74,6 +75,51 @@ __global__ void argmax_fp32_kernel(
     if (tid == 0) {
         *out_token = token_offset + s_idx[0];
         *out_logit = s_val[0];
+    }
+}
+
+__global__ void argmax_fp32_rows_kernel(
+    const float* __restrict__ logits,
+    int* __restrict__ out_tokens,
+    float* __restrict__ out_logits,
+    int rows,
+    int count,
+    int token_offset) {
+    const int row = blockIdx.x;
+    if (row >= rows) return;
+    const int tid = threadIdx.x;
+    const int threads = blockDim.x;
+    extern __shared__ char smem_raw[];
+    float* s_val = reinterpret_cast<float*>(smem_raw);
+    int* s_idx = reinterpret_cast<int*>(s_val + threads);
+    float best = -INFINITY;
+    int best_idx = 0;
+    const float* row_logits = logits + static_cast<size_t>(row) * count;
+    for (int i = tid; i < count; i += threads) {
+        const float value = row_logits[i];
+        if (value > best || (value == best && i < best_idx)) {
+            best = value;
+            best_idx = i;
+        }
+    }
+    s_val[tid] = best;
+    s_idx[tid] = best_idx;
+    __syncthreads();
+    for (int stride = threads >> 1; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            const float other_value = s_val[tid + stride];
+            const int other_idx = s_idx[tid + stride];
+            if (other_value > s_val[tid] ||
+                (other_value == s_val[tid] && other_idx < s_idx[tid])) {
+                s_val[tid] = other_value;
+                s_idx[tid] = other_idx;
+            }
+        }
+        __syncthreads();
+    }
+    if (tid == 0) {
+        out_tokens[row] = token_offset + s_idx[0];
+        out_logits[row] = s_val[0];
     }
 }
 
@@ -2078,6 +2124,24 @@ bool argmax_fp32_cuda(
     const size_t shared_bytes = threads * (sizeof(float) + sizeof(int));
     argmax_fp32_kernel<<<1, threads, shared_bytes, cuda_stream>>>(
         d_logits, d_token, d_logit, count, token_offset);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool argmax_fp32_rows_cuda(
+    const float* d_logits,
+    int* d_tokens,
+    float* d_logits_out,
+    int rows,
+    int count,
+    int token_offset,
+    void* stream) {
+    if (d_logits == nullptr || d_tokens == nullptr || d_logits_out == nullptr ||
+        rows <= 0 || count <= 0) return false;
+    auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
+    constexpr int threads = 256;
+    const size_t shared_bytes = threads * (sizeof(float) + sizeof(int));
+    argmax_fp32_rows_kernel<<<rows, threads, shared_bytes, cuda_stream>>>(
+        d_logits, d_tokens, d_logits_out, rows, count, token_offset);
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/cuda/qwen_gqa_optimized.cu
+++ b/cpp_engine/cuda/qwen_gqa_optimized.cu
@@ -19,6 +19,7 @@ constexpr int kPrefillCombos = kHeadsPerGroup * kQueryRows;
 constexpr int kDecodeMaxSplits = 64;
 constexpr int kDecodeTargetPositions = 2048;
 constexpr int kDecodeMinContext = 4096;
+constexpr int kVerifyMaxRows = 8;
 
 // A window of 0 keeps exact full attention. Otherwise every query attends to
 // the leading sink prefix plus the most recent window positions, expressed as
@@ -374,6 +375,346 @@ __global__ void gqa_decode_split_f16_kernel(
     }
 }
 
+// Speculative verification scans one context split per CTA. A CTA owns one
+// KV head, one group of three Q heads, and every query row, so each K/V element
+// is loaded once for up to rows * 3 outputs. Splitting the history restores
+// enough parallelism for the 4-32K context regime where a single CTA per group
+// leaves SM75 mostly idle.
+template <int kRows>
+__global__ void gqa_verify_split_f16_kernel(
+    const uint16_t* __restrict__ q_rows,
+    const uint16_t* __restrict__ k_cache,
+    const uint16_t* __restrict__ v_cache,
+    float* __restrict__ partial_output,
+    int rows,
+    int q_heads,
+    int kv_heads,
+    int head_dim,
+    int position_offset,
+    int splits,
+    int positions_per_split) {
+    constexpr int kCombos = kRows * kHeadsPerGroup;
+    const int q_per_kv = q_heads / kv_heads;
+    const int groups_per_kv =
+        (q_per_kv + kHeadsPerGroup - 1) / kHeadsPerGroup;
+    const int grouped = static_cast<int>(blockIdx.x) / splits;
+    const int split = static_cast<int>(blockIdx.x) % splits;
+    const int kv_head = grouped / groups_per_kv;
+    const int group = grouped % groups_per_kv;
+    const int first_head = kv_head * q_per_kv + group * kHeadsPerGroup;
+    const int split_start = split * positions_per_split;
+    const int split_end = min(
+        position_offset + rows, split_start + positions_per_split);
+    if (kv_head >= kv_heads || split_start >= split_end) return;
+
+    __shared__ float warp_sums[kCombos][kWarps];
+    __shared__ float scores[kCombos];
+    __shared__ float running_max[kCombos];
+    __shared__ float running_sum[kCombos];
+    __shared__ float rescale[kCombos];
+    __shared__ float probability[kCombos];
+
+    const int tid = static_cast<int>(threadIdx.x);
+    float query[kCombos][kValuesPerThread];
+    float accumulator[kCombos][kValuesPerThread];
+    bool active[kCombos];
+    int context_limit[kCombos];
+#pragma unroll
+    for (int combo = 0; combo < kCombos; ++combo) {
+        const int row = combo / kHeadsPerGroup;
+        const int head_in_group = combo % kHeadsPerGroup;
+        const int head = first_head + head_in_group;
+        active[combo] = row < rows &&
+            head < (kv_head + 1) * q_per_kv && head < q_heads;
+        context_limit[combo] = position_offset + row + 1;
+#pragma unroll
+        for (int i = 0; i < kValuesPerThread; ++i) {
+            const int d = tid + i * kThreads;
+            query[combo][i] = active[combo] && d < head_dim
+                ? half_to_float(q_rows[
+                      (static_cast<size_t>(row) * q_heads + head) * head_dim + d])
+                : 0.0f;
+            accumulator[combo][i] = 0.0f;
+        }
+        if (tid == combo) {
+            running_max[combo] = -INFINITY;
+            running_sum[combo] = 0.0f;
+        }
+    }
+    __syncthreads();
+
+    const float attention_scale = rsqrtf(static_cast<float>(head_dim));
+    const size_t kv_stride = static_cast<size_t>(kv_heads) * head_dim;
+    for (int position = split_start; position < split_end; ++position) {
+        const size_t kv_base = static_cast<size_t>(position) * kv_stride +
+            static_cast<size_t>(kv_head) * head_dim;
+        float key[kValuesPerThread];
+        float value[kValuesPerThread];
+#pragma unroll
+        for (int i = 0; i < kValuesPerThread; ++i) {
+            const int d = tid + i * kThreads;
+            key[i] = d < head_dim ? half_to_float(k_cache[kv_base + d]) : 0.0f;
+            value[i] = d < head_dim ? half_to_float(v_cache[kv_base + d]) : 0.0f;
+        }
+        float dot[kCombos] = {};
+#pragma unroll
+        for (int combo = 0; combo < kCombos; ++combo) {
+            if (active[combo] && position < context_limit[combo]) {
+#pragma unroll
+                for (int i = 0; i < kValuesPerThread; ++i) {
+                    dot[combo] += query[combo][i] * key[i];
+                }
+            }
+        }
+        reduce_dot_products(dot, warp_sums, scores, attention_scale);
+        if (tid < kCombos) {
+            if (active[tid] && position < context_limit[tid]) {
+                const float old_max = running_max[tid];
+                const float new_max = fmaxf(old_max, scores[tid]);
+                const float old_scale = old_max == -INFINITY
+                    ? 0.0f : expf(old_max - new_max);
+                const float weight = expf(scores[tid] - new_max);
+                running_max[tid] = new_max;
+                running_sum[tid] = running_sum[tid] * old_scale + weight;
+                rescale[tid] = old_scale;
+                probability[tid] = weight;
+            } else {
+                rescale[tid] = 1.0f;
+                probability[tid] = 0.0f;
+            }
+        }
+        __syncthreads();
+#pragma unroll
+        for (int combo = 0; combo < kCombos; ++combo) {
+#pragma unroll
+            for (int i = 0; i < kValuesPerThread; ++i) {
+                accumulator[combo][i] = accumulator[combo][i] * rescale[combo] +
+                    probability[combo] * value[i];
+            }
+        }
+        __syncthreads();
+    }
+
+    const int partial_stride = head_dim + 2;
+#pragma unroll
+    for (int combo = 0; combo < kCombos; ++combo) {
+        if (!active[combo]) continue;
+        const int row = combo / kHeadsPerGroup;
+        const int head_in_group = combo % kHeadsPerGroup;
+        const int head = first_head + head_in_group;
+        float* destination = partial_output +
+            ((static_cast<size_t>(row) * q_heads + head) * splits + split) *
+                partial_stride;
+        if (tid == 0) {
+            destination[0] = running_max[combo];
+            destination[1] = running_sum[combo];
+        }
+#pragma unroll
+        for (int i = 0; i < kValuesPerThread; ++i) {
+            const int d = tid + i * kThreads;
+            if (d < head_dim) destination[2 + d] = accumulator[combo][i];
+        }
+    }
+}
+
+__global__ void gqa_verify_merge_f16_kernel(
+    const float* __restrict__ partial_output,
+    uint16_t* __restrict__ output,
+    int rows,
+    int q_heads,
+    int head_dim,
+    int splits) {
+    const int row = static_cast<int>(blockIdx.y);
+    const int head = static_cast<int>(blockIdx.x);
+    if (row >= rows || head >= q_heads) return;
+    __shared__ float weights[kDecodeMaxSplits];
+    if (threadIdx.x == 0) {
+        const int stride = head_dim + 2;
+        const size_t base =
+            (static_cast<size_t>(row) * q_heads + head) * splits * stride;
+        float maximum = -INFINITY;
+        for (int split = 0; split < splits; ++split) {
+            maximum = fmaxf(maximum,
+                partial_output[base + static_cast<size_t>(split) * stride]);
+        }
+        float denominator = 0.0f;
+        for (int split = 0; split < splits; ++split) {
+            const float* source = partial_output + base +
+                static_cast<size_t>(split) * stride;
+            weights[split] = expf(source[0] - maximum);
+            denominator += weights[split] * source[1];
+        }
+        const float inverse = denominator > 0.0f ? 1.0f / denominator : 0.0f;
+        for (int split = 0; split < splits; ++split) weights[split] *= inverse;
+    }
+    __syncthreads();
+    const int stride = head_dim + 2;
+    const size_t base =
+        (static_cast<size_t>(row) * q_heads + head) * splits * stride;
+    for (int d = static_cast<int>(threadIdx.x); d < head_dim; d += kThreads) {
+        float value = 0.0f;
+        for (int split = 0; split < splits; ++split) {
+            const float* source = partial_output + base +
+                static_cast<size_t>(split) * stride;
+            value += weights[split] * source[2 + d];
+        }
+        output[(static_cast<size_t>(row) * q_heads + head) * head_dim + d] =
+            float_to_half(value);
+    }
+}
+
+template <int kRows>
+__global__ void gqa_verify_scores_exact_f16_kernel(
+    const uint16_t* __restrict__ q_rows,
+    const uint16_t* __restrict__ k_cache,
+    float* __restrict__ scores,
+    int rows,
+    int q_heads,
+    int kv_heads,
+    int head_dim,
+    int position_offset,
+    int context_len) {
+    constexpr int kCombos = kRows * kHeadsPerGroup;
+    const int q_per_kv = q_heads / kv_heads;
+    const int groups_per_kv =
+        (q_per_kv + kHeadsPerGroup - 1) / kHeadsPerGroup;
+    const int grouped = static_cast<int>(blockIdx.x) / context_len;
+    const int position = static_cast<int>(blockIdx.x) % context_len;
+    const int kv_head = grouped / groups_per_kv;
+    const int group = grouped % groups_per_kv;
+    const int first_head = kv_head * q_per_kv + group * kHeadsPerGroup;
+    if (kv_head >= kv_heads) return;
+
+    __shared__ float warp_sums[kCombos][kWarps];
+    __shared__ float reduced[kCombos];
+    const int tid = static_cast<int>(threadIdx.x);
+    const size_t kv_base =
+        (static_cast<size_t>(position) * kv_heads + kv_head) * head_dim;
+    float key[kValuesPerThread];
+#pragma unroll
+    for (int i = 0; i < kValuesPerThread; ++i) {
+        const int d = tid + i * kThreads;
+        key[i] = d < head_dim ? half_to_float(k_cache[kv_base + d]) : 0.0f;
+    }
+    float partial[kCombos] = {};
+#pragma unroll
+    for (int combo = 0; combo < kCombos; ++combo) {
+        const int row = combo / kHeadsPerGroup;
+        const int head = first_head + combo % kHeadsPerGroup;
+        if (row >= rows || head >= (kv_head + 1) * q_per_kv ||
+            head >= q_heads || position >= position_offset + row + 1) continue;
+        const uint16_t* query = q_rows +
+            (static_cast<size_t>(row) * q_heads + head) * head_dim;
+#pragma unroll
+        for (int i = 0; i < kValuesPerThread; ++i) {
+            const int d = tid + i * kThreads;
+            if (d < head_dim) partial[combo] += half_to_float(query[d]) * key[i];
+        }
+    }
+    reduce_dot_products(partial, warp_sums, reduced,
+                        rsqrtf(static_cast<float>(head_dim)));
+    if (tid < kCombos) {
+        const int row = tid / kHeadsPerGroup;
+        const int head = first_head + tid % kHeadsPerGroup;
+        if (row < rows && head < (kv_head + 1) * q_per_kv && head < q_heads) {
+            scores[(static_cast<size_t>(row) * q_heads + head) * context_len +
+                   position] = position < position_offset + row + 1
+                ? reduced[tid] : -INFINITY;
+        }
+    }
+}
+
+__global__ void gqa_verify_softmax_exact_f16_kernel(
+    float* __restrict__ scores, int rows, int q_heads, int context_len) {
+    const int row = static_cast<int>(blockIdx.y);
+    const int head = static_cast<int>(blockIdx.x);
+    if (row >= rows || head >= q_heads) return;
+    float* line = scores +
+        (static_cast<size_t>(row) * q_heads + head) * context_len;
+    __shared__ float reduce[kThreads];
+    float local_max = -INFINITY;
+    for (int position = static_cast<int>(threadIdx.x); position < context_len;
+         position += kThreads) {
+        local_max = fmaxf(local_max, line[position]);
+    }
+    reduce[threadIdx.x] = local_max;
+    __syncthreads();
+    for (int stride = kThreads / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            reduce[threadIdx.x] =
+                fmaxf(reduce[threadIdx.x], reduce[threadIdx.x + stride]);
+        }
+        __syncthreads();
+    }
+    const float maximum = reduce[0];
+    float sum = 0.0f;
+    for (int position = static_cast<int>(threadIdx.x); position < context_len;
+         position += kThreads) {
+        line[position] = expf(line[position] - maximum);
+        sum += line[position];
+    }
+    reduce[threadIdx.x] = sum;
+    __syncthreads();
+    for (int stride = kThreads / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) reduce[threadIdx.x] += reduce[threadIdx.x + stride];
+        __syncthreads();
+    }
+    const float inverse = reduce[0] > 0.0f ? 1.0f / reduce[0] : 0.0f;
+    for (int position = static_cast<int>(threadIdx.x); position < context_len;
+         position += kThreads) {
+        line[position] *= inverse;
+    }
+}
+
+// A warp owns one candidate row, three Q heads sharing a KV head, and a
+// contiguous 32-channel value tile. Splitting rows and channels into separate
+// CTAs preserves each output element's left-to-right FP32 accumulation order,
+// while exposing enough independent work to occupy all SMs. The previous kernel
+// kept every candidate row in one CTA; for Qwen TP4 that launched only four
+// long-running CTAs per layer at head_dim=256.
+__global__ void gqa_verify_values_exact_f16_kernel(
+    const float* __restrict__ probabilities,
+    const uint16_t* __restrict__ v_cache,
+    uint16_t* __restrict__ output,
+    int rows,
+    int q_heads,
+    int kv_heads,
+    int head_dim,
+    int context_len) {
+    const int q_per_kv = q_heads / kv_heads;
+    const int groups_per_kv =
+        (q_per_kv + kHeadsPerGroup - 1) / kHeadsPerGroup;
+    const int kv_head = static_cast<int>(blockIdx.x) / groups_per_kv;
+    const int group = static_cast<int>(blockIdx.x) % groups_per_kv;
+    const int row = static_cast<int>(blockIdx.y);
+    const int first_head = kv_head * q_per_kv + group * kHeadsPerGroup;
+    const int d = static_cast<int>(blockIdx.z) * 32 + threadIdx.x;
+    if (kv_head >= kv_heads || row >= rows || d >= head_dim) return;
+
+    float accumulators[kHeadsPerGroup] = {};
+    for (int position = 0; position < context_len; ++position) {
+        const float value = half_to_float(v_cache[
+            (static_cast<size_t>(position) * kv_heads + kv_head) * head_dim + d]);
+#pragma unroll
+        for (int i = 0; i < kHeadsPerGroup; ++i) {
+            const int head = first_head + i;
+            if (head < (kv_head + 1) * q_per_kv && head < q_heads) {
+                accumulators[i] += probabilities[
+                    (static_cast<size_t>(row) * q_heads + head) * context_len +
+                    position] * value;
+            }
+        }
+    }
+#pragma unroll
+    for (int i = 0; i < kHeadsPerGroup; ++i) {
+        const int head = first_head + i;
+        if (head < (kv_head + 1) * q_per_kv && head < q_heads) {
+            output[(static_cast<size_t>(row) * q_heads + head) * head_dim + d] =
+                float_to_half(accumulators[i]);
+        }
+    }
+}
+
 __global__ void gqa_decode_merge_f16_kernel(
     const float* __restrict__ partial_output,
     uint16_t* __restrict__ output,
@@ -437,6 +778,92 @@ bool qwen_gqa_prefill_attention_f16_tiled_cuda(
         static_cast<cudaStream_t>(stream)>>>(q, k_cache, v_cache, output,
         seq_len, q_heads, kv_heads, head_dim, position_offset,
         attention_window, sink_tokens);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gqa_verify_attention_f16_exact_cuda(
+    const uint16_t* q, const uint16_t* k_cache,
+    const uint16_t* v_cache, uint16_t* output, float* score_scratch,
+    int rows, int q_heads, int kv_heads, int head_dim,
+    int position_offset, int max_context, void* stream) {
+    if (!q || !k_cache || !v_cache || !output || !score_scratch ||
+        rows < 2 || rows > kVerifyMaxRows || position_offset < 0 ||
+        position_offset + rows > max_context ||
+        !valid_shape(q_heads, kv_heads, head_dim)) return false;
+    const int context_len = position_offset + rows;
+    const int groups_per_kv =
+        (q_heads / kv_heads + kHeadsPerGroup - 1) / kHeadsPerGroup;
+    const uint64_t score_blocks =
+        static_cast<uint64_t>(kv_heads) * groups_per_kv * context_len;
+    if (score_blocks > static_cast<uint64_t>(UINT32_MAX)) return false;
+    const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
+#define DSV4_LAUNCH_EXACT_SCORES(ROWS) \
+    gqa_verify_scores_exact_f16_kernel<ROWS> \
+        <<<static_cast<unsigned>(score_blocks), kThreads, 0, cuda_stream>>>( \
+            q, k_cache, score_scratch, rows, q_heads, kv_heads, head_dim, \
+            position_offset, context_len)
+    switch (rows) {
+        case 2: DSV4_LAUNCH_EXACT_SCORES(2); break;
+        case 3: DSV4_LAUNCH_EXACT_SCORES(3); break;
+        case 4: DSV4_LAUNCH_EXACT_SCORES(4); break;
+        case 5: DSV4_LAUNCH_EXACT_SCORES(5); break;
+        case 6: DSV4_LAUNCH_EXACT_SCORES(6); break;
+        case 7: DSV4_LAUNCH_EXACT_SCORES(7); break;
+        case 8: DSV4_LAUNCH_EXACT_SCORES(8); break;
+        default: return false;
+    }
+#undef DSV4_LAUNCH_EXACT_SCORES
+    if (cudaGetLastError() != cudaSuccess) return false;
+    const dim3 softmax_grid(static_cast<unsigned>(q_heads),
+                            static_cast<unsigned>(rows), 1);
+    gqa_verify_softmax_exact_f16_kernel<<<softmax_grid, kThreads, 0, cuda_stream>>>(
+        score_scratch, rows, q_heads, context_len);
+    if (cudaGetLastError() != cudaSuccess) return false;
+    const dim3 value_grid(static_cast<unsigned>(kv_heads * groups_per_kv),
+                          static_cast<unsigned>(rows),
+                          static_cast<unsigned>((head_dim + 31) / 32));
+    gqa_verify_values_exact_f16_kernel<<<value_grid, 32, 0, cuda_stream>>>(
+        score_scratch, v_cache, output, rows, q_heads, kv_heads, head_dim,
+        context_len);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gqa_verify_attention_f16_cuda(
+    const uint16_t* q, const uint16_t* k_cache,
+    const uint16_t* v_cache, uint16_t* output, float* partial_scratch,
+    int rows, int q_heads, int kv_heads, int head_dim,
+    int position_offset, int max_context, int splits, void* stream) {
+    if (!q || !k_cache || !v_cache || !output || !partial_scratch ||
+        rows < 2 || rows > kVerifyMaxRows || position_offset < 0 ||
+        position_offset + rows > max_context || splits <= 0 ||
+        splits > kDecodeMaxSplits ||
+        !valid_shape(q_heads, kv_heads, head_dim)) return false;
+    const int context_len = position_offset + rows;
+    const int positions_per_split = (context_len + splits - 1) / splits;
+    const int groups_per_kv =
+        (q_heads / kv_heads + kHeadsPerGroup - 1) / kHeadsPerGroup;
+    const int blocks = kv_heads * groups_per_kv * splits;
+    const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
+#define DSV4_LAUNCH_VERIFY(ROWS) \
+    gqa_verify_split_f16_kernel<ROWS><<<blocks, kThreads, 0, cuda_stream>>>( \
+        q, k_cache, v_cache, partial_scratch, rows, q_heads, kv_heads, \
+        head_dim, position_offset, splits, positions_per_split)
+    switch (rows) {
+        case 2: DSV4_LAUNCH_VERIFY(2); break;
+        case 3: DSV4_LAUNCH_VERIFY(3); break;
+        case 4: DSV4_LAUNCH_VERIFY(4); break;
+        case 5: DSV4_LAUNCH_VERIFY(5); break;
+        case 6: DSV4_LAUNCH_VERIFY(6); break;
+        case 7: DSV4_LAUNCH_VERIFY(7); break;
+        case 8: DSV4_LAUNCH_VERIFY(8); break;
+        default: return false;
+    }
+#undef DSV4_LAUNCH_VERIFY
+    if (cudaGetLastError() != cudaSuccess) return false;
+    const dim3 merge_grid(static_cast<unsigned>(q_heads),
+                          static_cast<unsigned>(rows), 1);
+    gqa_verify_merge_f16_kernel<<<merge_grid, kThreads, 0, cuda_stream>>>(
+        partial_scratch, output, rows, q_heads, head_dim, splits);
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/cuda/qwen_half_ops.cu
+++ b/cpp_engine/cuda/qwen_half_ops.cu
@@ -179,6 +179,155 @@ __global__ void fp8_matvec_f16_multirow_kernel(
     }
 }
 
+// Small speculative batches are weight-bandwidth bound. One warp owns one
+// output channel and evaluates all token rows while each FP8 weight code is in
+// registers, so a K+1 verify block reads every projection weight only once.
+template <int kWarps, int kBatchCapacity>
+__global__ void fp8_matmul_f16_small_batch_kernel(
+    const uint16_t* __restrict__ x, const uint8_t* __restrict__ weight,
+    const uint16_t* __restrict__ scale, uint16_t* __restrict__ y,
+    int batch, int rows, int cols, int x_stride, int y_stride,
+    int weight_stride, int scale_stride) {
+    __shared__ float lut[256];
+    for (int i = static_cast<int>(threadIdx.x); i < 256; i += blockDim.x) {
+        lut[i] = fp8_e4m3_to_float(static_cast<uint8_t>(i));
+    }
+    __syncthreads();
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int lane = static_cast<int>(threadIdx.x) & 31;
+    const int row = static_cast<int>(blockIdx.x) * kWarps + warp;
+    if (row >= rows) return;
+    const uint8_t* w = weight + static_cast<size_t>(row) * weight_stride;
+    const uint16_t* s = scale + static_cast<size_t>(row / kFp8WeightBlock) * scale_stride;
+    float sums[kBatchCapacity] = {};
+    const int vec_cols = cols & ~3;
+    for (int col = lane * 4; col < vec_cols; col += 128) {
+        const uchar4 codes = *reinterpret_cast<const uchar4*>(w + col);
+        const float weight_scale = half_to_float(s[col / kFp8WeightBlock]);
+        const float w0 = lut[codes.x] * weight_scale;
+        const float w1 = lut[codes.y] * weight_scale;
+        const float w2 = lut[codes.z] * weight_scale;
+        const float w3 = lut[codes.w] * weight_scale;
+#pragma unroll
+        for (int sample = 0; sample < kBatchCapacity; ++sample) {
+            if (sample >= batch) break;
+            const uint2 packed = *reinterpret_cast<const uint2*>(
+                x + static_cast<size_t>(sample) * x_stride + col);
+            sums[sample] +=
+                half_to_float(static_cast<uint16_t>(packed.x)) * w0 +
+                half_to_float(static_cast<uint16_t>(packed.x >> 16)) * w1 +
+                half_to_float(static_cast<uint16_t>(packed.y)) * w2 +
+                half_to_float(static_cast<uint16_t>(packed.y >> 16)) * w3;
+        }
+    }
+    for (int col = vec_cols + lane; col < cols; col += 32) {
+        const float weight_value = lut[w[col]] *
+            half_to_float(s[col / kFp8WeightBlock]);
+#pragma unroll
+        for (int sample = 0; sample < kBatchCapacity; ++sample) {
+            if (sample >= batch) break;
+            sums[sample] += half_to_float(
+                x[static_cast<size_t>(sample) * x_stride + col]) * weight_value;
+        }
+    }
+#pragma unroll
+    for (int sample = 0; sample < kBatchCapacity; ++sample) {
+        if (sample >= batch) break;
+        float sum = sums[sample];
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            sum += __shfl_xor_sync(0xffffffffu, sum, offset);
+        }
+        if (lane == 0) {
+            y[static_cast<size_t>(sample) * y_stride + row] = float_to_half(sum);
+        }
+    }
+}
+
+template <int kWarps, int kBatchCapacity>
+__global__ void fp8_swiglu_small_batch_f16_kernel(
+    const uint16_t* __restrict__ x,
+    const uint8_t* __restrict__ gate_weight,
+    const uint16_t* __restrict__ gate_scale,
+    const uint8_t* __restrict__ up_weight,
+    const uint16_t* __restrict__ up_scale,
+    uint16_t* __restrict__ y, int batch, int rows, int cols,
+    int x_stride, int y_stride, int weight_stride, int scale_stride) {
+    __shared__ float lut[256];
+    for (int i = static_cast<int>(threadIdx.x); i < 256; i += blockDim.x) {
+        lut[i] = fp8_e4m3_to_float(static_cast<uint8_t>(i));
+    }
+    __syncthreads();
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int lane = static_cast<int>(threadIdx.x) & 31;
+    const int row = static_cast<int>(blockIdx.x) * kWarps + warp;
+    if (row >= rows) return;
+    const uint8_t* gate_row = gate_weight +
+        static_cast<size_t>(row) * weight_stride;
+    const uint8_t* up_row = up_weight +
+        static_cast<size_t>(row) * weight_stride;
+    const uint16_t* gate_scale_row = gate_scale +
+        static_cast<size_t>(row / kFp8WeightBlock) * scale_stride;
+    const uint16_t* up_scale_row = up_scale +
+        static_cast<size_t>(row / kFp8WeightBlock) * scale_stride;
+    float gate_sums[kBatchCapacity] = {};
+    float up_sums[kBatchCapacity] = {};
+    const int vec_cols = cols & ~3;
+    for (int col = lane * 4; col < vec_cols; col += 128) {
+        const uchar4 gate_codes = *reinterpret_cast<const uchar4*>(gate_row + col);
+        const uchar4 up_codes = *reinterpret_cast<const uchar4*>(up_row + col);
+        const float gate_s = half_to_float(gate_scale_row[col / kFp8WeightBlock]);
+        const float up_s = half_to_float(up_scale_row[col / kFp8WeightBlock]);
+        const float gw0 = lut[gate_codes.x] * gate_s;
+        const float gw1 = lut[gate_codes.y] * gate_s;
+        const float gw2 = lut[gate_codes.z] * gate_s;
+        const float gw3 = lut[gate_codes.w] * gate_s;
+        const float uw0 = lut[up_codes.x] * up_s;
+        const float uw1 = lut[up_codes.y] * up_s;
+        const float uw2 = lut[up_codes.z] * up_s;
+        const float uw3 = lut[up_codes.w] * up_s;
+#pragma unroll
+        for (int sample = 0; sample < kBatchCapacity; ++sample) {
+            if (sample >= batch) break;
+            const uint2 packed = *reinterpret_cast<const uint2*>(
+                x + static_cast<size_t>(sample) * x_stride + col);
+            const float x0 = half_to_float(static_cast<uint16_t>(packed.x));
+            const float x1 = half_to_float(static_cast<uint16_t>(packed.x >> 16));
+            const float x2 = half_to_float(static_cast<uint16_t>(packed.y));
+            const float x3 = half_to_float(static_cast<uint16_t>(packed.y >> 16));
+            gate_sums[sample] += x0 * gw0 + x1 * gw1 + x2 * gw2 + x3 * gw3;
+            up_sums[sample] += x0 * uw0 + x1 * uw1 + x2 * uw2 + x3 * uw3;
+        }
+    }
+    for (int col = vec_cols + lane; col < cols; col += 32) {
+        const float gate_value = lut[gate_row[col]] *
+            half_to_float(gate_scale_row[col / kFp8WeightBlock]);
+        const float up_value = lut[up_row[col]] *
+            half_to_float(up_scale_row[col / kFp8WeightBlock]);
+#pragma unroll
+        for (int sample = 0; sample < kBatchCapacity; ++sample) {
+            if (sample >= batch) break;
+            const float xv = half_to_float(
+                x[static_cast<size_t>(sample) * x_stride + col]);
+            gate_sums[sample] += xv * gate_value;
+            up_sums[sample] += xv * up_value;
+        }
+    }
+#pragma unroll
+    for (int sample = 0; sample < kBatchCapacity; ++sample) {
+        if (sample >= batch) break;
+        float gate_sum = gate_sums[sample];
+        float up_sum = up_sums[sample];
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            gate_sum += __shfl_xor_sync(0xffffffffu, gate_sum, offset);
+            up_sum += __shfl_xor_sync(0xffffffffu, up_sum, offset);
+        }
+        if (lane == 0) {
+            y[static_cast<size_t>(sample) * y_stride + row] =
+                float_to_half(silu(gate_sum) * up_sum);
+        }
+    }
+}
+
 template <int kWarps, int kRowsPerWarp>
 __global__ void fp8_swiglu_matvec_f16_kernel(
     const uint16_t* __restrict__ x,
@@ -433,6 +582,63 @@ __global__ void fp8_matmul_f16_wide_n64_kernel(
     }
 }
 
+template <bool kFloatOutput, int kWarps, int kBatchCapacity>
+__global__ void fp16_matmul_f16_small_batch_kernel(
+    const uint16_t* __restrict__ x, const uint16_t* __restrict__ weight,
+    void* __restrict__ output, int batch, int rows, int cols,
+    int x_stride, int y_stride, int weight_stride) {
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int lane = static_cast<int>(threadIdx.x) & 31;
+    const int row = static_cast<int>(blockIdx.x) * kWarps + warp;
+    if (row >= rows) return;
+    const uint16_t* wr = weight + static_cast<size_t>(row) * weight_stride;
+    float sums[kBatchCapacity] = {};
+    const int vec_cols = cols & ~3;
+    for (int col = lane * 4; col < vec_cols; col += 128) {
+        const uint2 packed_w = *reinterpret_cast<const uint2*>(wr + col);
+        const float w0 = half_to_float(static_cast<uint16_t>(packed_w.x));
+        const float w1 = half_to_float(static_cast<uint16_t>(packed_w.x >> 16));
+        const float w2 = half_to_float(static_cast<uint16_t>(packed_w.y));
+        const float w3 = half_to_float(static_cast<uint16_t>(packed_w.y >> 16));
+#pragma unroll
+        for (int sample = 0; sample < kBatchCapacity; ++sample) {
+            if (sample >= batch) break;
+            const uint2 packed_x = *reinterpret_cast<const uint2*>(
+                x + static_cast<size_t>(sample) * x_stride + col);
+            sums[sample] +=
+                half_to_float(static_cast<uint16_t>(packed_x.x)) * w0 +
+                half_to_float(static_cast<uint16_t>(packed_x.x >> 16)) * w1 +
+                half_to_float(static_cast<uint16_t>(packed_x.y)) * w2 +
+                half_to_float(static_cast<uint16_t>(packed_x.y >> 16)) * w3;
+        }
+    }
+    for (int col = vec_cols + lane; col < cols; col += 32) {
+        const float weight_value = half_to_float(wr[col]);
+#pragma unroll
+        for (int sample = 0; sample < kBatchCapacity; ++sample) {
+            if (sample >= batch) break;
+            sums[sample] += half_to_float(
+                x[static_cast<size_t>(sample) * x_stride + col]) * weight_value;
+        }
+    }
+#pragma unroll
+    for (int sample = 0; sample < kBatchCapacity; ++sample) {
+        if (sample >= batch) break;
+        float sum = sums[sample];
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            sum += __shfl_xor_sync(0xffffffffu, sum, offset);
+        }
+        if (lane == 0) {
+            const size_t index = static_cast<size_t>(sample) * y_stride + row;
+            if constexpr (kFloatOutput) {
+                static_cast<float*>(output)[index] = sum;
+            } else {
+                static_cast<uint16_t*>(output)[index] = float_to_half(sum);
+            }
+        }
+    }
+}
+
 template <bool kFloatOutput>
 __global__ void fp16_matmul_f16_kernel(
     const uint16_t* __restrict__ x, const uint16_t* __restrict__ weight,
@@ -469,6 +675,19 @@ __global__ void embedding_f16_kernel(const uint16_t* table, const int* tokens,
     }
     const uint16_t* src = table + static_cast<size_t>(token - row_start) * cols;
     for (int col = threadIdx.x; col < cols; col += blockDim.x) dst[col] = src[col];
+}
+
+__global__ void concat_rows_f16_kernel(const uint16_t* left, const uint16_t* right,
+                                       uint16_t* output, int rows, int cols) {
+    const int row = static_cast<int>(blockIdx.x);
+    if (row >= rows) return;
+    const uint16_t* left_row = left + static_cast<size_t>(row) * cols;
+    const uint16_t* right_row = right + static_cast<size_t>(row) * cols;
+    uint16_t* output_row = output + static_cast<size_t>(row) * 2 * cols;
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+        output_row[col] = left_row[col];
+        output_row[cols + col] = right_row[col];
+    }
 }
 
 __global__ void rmsnorm_f16_kernel(const uint16_t* x, const uint16_t* gamma,
@@ -1138,6 +1357,51 @@ bool qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
     return cudaGetLastError() == cudaSuccess;
 }
 
+bool qwen_fp8_e4m3_fp16scale_swiglu_small_batch_f16_cuda(
+    const uint16_t* x, const uint8_t* gate_weight,
+    const uint16_t* gate_scale, const uint8_t* up_weight,
+    const uint16_t* up_scale, uint16_t* y, int batch, int rows, int cols,
+    int x_stride, int y_stride, int weight_stride, int scale_stride,
+    void* stream) {
+    if (!x || !gate_weight || !gate_scale || !up_weight || !up_scale || !y ||
+        batch <= 1 || batch > 8 || rows <= 0 || cols <= 0 ||
+        x_stride < cols || y_stride < rows || weight_stride < cols ||
+        x_stride % 4 != 0 || weight_stride % 4 != 0 ||
+        scale_stride < (cols + kFp8WeightBlock - 1) / kFp8WeightBlock) {
+        return false;
+    }
+    constexpr int kWarps = 8;
+    const int blocks = (rows + kWarps - 1) / kWarps;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    if (batch <= 2) {
+        fp8_swiglu_small_batch_f16_kernel<kWarps, 2>
+            <<<blocks, kWarps * 32, 0, s>>>(
+                x, gate_weight, gate_scale, up_weight, up_scale, y, batch,
+                rows, cols, x_stride, y_stride, weight_stride, scale_stride);
+    } else if (batch == 3) {
+        fp8_swiglu_small_batch_f16_kernel<kWarps, 3>
+            <<<blocks, kWarps * 32, 0, s>>>(
+                x, gate_weight, gate_scale, up_weight, up_scale, y, batch,
+                rows, cols, x_stride, y_stride, weight_stride, scale_stride);
+    } else if (batch == 4) {
+        fp8_swiglu_small_batch_f16_kernel<kWarps, 4>
+            <<<blocks, kWarps * 32, 0, s>>>(
+                x, gate_weight, gate_scale, up_weight, up_scale, y, batch,
+                rows, cols, x_stride, y_stride, weight_stride, scale_stride);
+    } else if (batch == 5) {
+        fp8_swiglu_small_batch_f16_kernel<kWarps, 5>
+            <<<blocks, kWarps * 32, 0, s>>>(
+                x, gate_weight, gate_scale, up_weight, up_scale, y, batch,
+                rows, cols, x_stride, y_stride, weight_stride, scale_stride);
+    } else {
+        fp8_swiglu_small_batch_f16_kernel<kWarps, 8>
+            <<<blocks, kWarps * 32, 0, s>>>(
+                x, gate_weight, gate_scale, up_weight, up_scale, y, batch,
+                rows, cols, x_stride, y_stride, weight_stride, scale_stride);
+    }
+    return cudaGetLastError() == cudaSuccess;
+}
+
 bool qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
     const uint16_t* x, const uint8_t* weight, const uint16_t* scale,
     uint16_t* y, int batch, int rows, int cols, int x_stride,
@@ -1146,20 +1410,92 @@ bool qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
         x_stride < cols || y_stride < rows || weight_stride < cols ||
         scale_stride < (cols + kFp8WeightBlock - 1) / kFp8WeightBlock) return false;
     const cudaStream_t s = static_cast<cudaStream_t>(stream);
-    const char* wide = std::getenv("QWEN_FP8_F16_PREFILL_WIDE_N64");
-    const bool use_wide = wide == nullptr || std::strcmp(wide, "0") != 0;
-    if (use_wide && batch >= 96 && x_stride % 4 == 0 && weight_stride % 4 == 0) {
-        dim3 grid(static_cast<unsigned>((rows + 63) / 64),
-                  static_cast<unsigned>((batch + 127) / 128), 1);
-        fp8_matmul_f16_wide_n64_kernel<<<grid, 256, 0, s>>>(
-            x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
-            weight_stride, scale_stride);
+    const char* small_batch_env = std::getenv("QWEN_FP8_F16_SMALL_BATCH");
+    const bool use_small_batch = small_batch_env == nullptr ||
+        std::strcmp(small_batch_env, "0") != 0;
+    constexpr int kSmallBatchWarps = 8;
+    if (use_small_batch && batch <= 8 && x_stride % 4 == 0 &&
+        weight_stride % 4 == 0) {
+        const int blocks = (rows + kSmallBatchWarps - 1) / kSmallBatchWarps;
+        if (batch <= 2) {
+            fp8_matmul_f16_small_batch_kernel<kSmallBatchWarps, 2>
+                <<<blocks, kSmallBatchWarps * 32, 0, s>>>(
+                    x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+                    weight_stride, scale_stride);
+        } else if (batch == 3) {
+            fp8_matmul_f16_small_batch_kernel<kSmallBatchWarps, 3>
+                <<<blocks, kSmallBatchWarps * 32, 0, s>>>(
+                    x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+                    weight_stride, scale_stride);
+        } else if (batch == 4) {
+            fp8_matmul_f16_small_batch_kernel<kSmallBatchWarps, 4>
+                <<<blocks, kSmallBatchWarps * 32, 0, s>>>(
+                    x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+                    weight_stride, scale_stride);
+        } else if (batch == 5) {
+            fp8_matmul_f16_small_batch_kernel<kSmallBatchWarps, 5>
+                <<<blocks, kSmallBatchWarps * 32, 0, s>>>(
+                    x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+                    weight_stride, scale_stride);
+        } else {
+            fp8_matmul_f16_small_batch_kernel<kSmallBatchWarps, 8>
+                <<<blocks, kSmallBatchWarps * 32, 0, s>>>(
+                    x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+                    weight_stride, scale_stride);
+        }
     } else {
-        dim3 grid(static_cast<unsigned>((rows + 63) / 64),
-                  static_cast<unsigned>((batch + 63) / 64), 1);
-        fp8_matmul_f16_tiled_kernel<32><<<grid, 256, 0, s>>>(
-            x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
-            weight_stride, scale_stride);
+        const char* wide = std::getenv("QWEN_FP8_F16_PREFILL_WIDE_N64");
+        const bool use_wide = wide == nullptr || std::strcmp(wide, "0") != 0;
+        if (use_wide && batch >= 96 && x_stride % 4 == 0 &&
+            weight_stride % 4 == 0) {
+            dim3 grid(static_cast<unsigned>((rows + 63) / 64),
+                      static_cast<unsigned>((batch + 127) / 128), 1);
+            fp8_matmul_f16_wide_n64_kernel<<<grid, 256, 0, s>>>(
+                x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+                weight_stride, scale_stride);
+        } else {
+            dim3 grid(static_cast<unsigned>((rows + 63) / 64),
+                      static_cast<unsigned>((batch + 63) / 64), 1);
+            fp8_matmul_f16_tiled_kernel<32><<<grid, 256, 0, s>>>(
+                x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+                weight_stride, scale_stride);
+        }
+    }
+    return cudaGetLastError() == cudaSuccess;
+}
+
+template <bool kFloatOutput>
+bool launch_fp16_matmul_rows_f16(
+    const uint16_t* x, const uint16_t* weight, void* y,
+    int batch, int rows, int cols, int x_stride, int y_stride,
+    int weight_stride, bool allow_small_batch, void* stream) {
+    if (!x || !weight || !y || batch <= 0 || rows <= 0 || cols <= 0 ||
+        x_stride < cols || y_stride < rows || weight_stride < cols) return false;
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    const char* small_batch_env = std::getenv("QWEN_FP16_SMALL_BATCH");
+    const bool use_small_batch = small_batch_env == nullptr ||
+        std::strcmp(small_batch_env, "0") != 0;
+    constexpr int kWarps = 8;
+    if (allow_small_batch && use_small_batch && batch > 1 && batch <= 8 &&
+        x_stride % 4 == 0 &&
+        weight_stride % 4 == 0) {
+        const int blocks = (rows + kWarps - 1) / kWarps;
+#define LAUNCH_FP16_SMALL(CAPACITY) \
+        fp16_matmul_f16_small_batch_kernel<kFloatOutput, kWarps, CAPACITY> \
+            <<<blocks, kWarps * 32, 0, s>>>( \
+                x, weight, y, batch, rows, cols, x_stride, y_stride, weight_stride)
+        if (batch <= 2) { LAUNCH_FP16_SMALL(2); }
+        else if (batch == 3) { LAUNCH_FP16_SMALL(3); }
+        else if (batch == 4) { LAUNCH_FP16_SMALL(4); }
+        else if (batch == 5) { LAUNCH_FP16_SMALL(5); }
+        else { LAUNCH_FP16_SMALL(8); }
+#undef LAUNCH_FP16_SMALL
+    } else {
+        dim3 grid(static_cast<unsigned>(rows), static_cast<unsigned>(batch), 1);
+        fp16_matmul_f16_kernel<kFloatOutput>
+            <<<grid, kThreads, kThreads * sizeof(float), s>>>(
+                x, weight, y, batch, rows, cols, x_stride, y_stride,
+                weight_stride);
     }
     return cudaGetLastError() == cudaSuccess;
 }
@@ -1168,26 +1504,21 @@ bool qwen_fp16_matmul_rows_f16_cuda(
     const uint16_t* x, const uint16_t* weight, uint16_t* y,
     int batch, int rows, int cols, int x_stride, int y_stride,
     int weight_stride, void* stream) {
-    if (!x || !weight || !y || batch <= 0 || rows <= 0 || cols <= 0 ||
-        x_stride < cols || y_stride < rows || weight_stride < cols) return false;
-    dim3 grid(static_cast<unsigned>(rows), static_cast<unsigned>(batch), 1);
-    fp16_matmul_f16_kernel<false><<<grid, kThreads, kThreads * sizeof(float),
-        static_cast<cudaStream_t>(stream)>>>(x, weight, y, batch, rows, cols,
-        x_stride, y_stride, weight_stride);
-    return cudaGetLastError() == cudaSuccess;
+    return launch_fp16_matmul_rows_f16<false>(
+        x, weight, y, batch, rows, cols, x_stride, y_stride, weight_stride,
+        true, stream);
 }
 
 bool qwen_fp16_matmul_rows_f16_f32_cuda(
     const uint16_t* x, const uint16_t* weight, float* y,
     int batch, int rows, int cols, int x_stride, int y_stride,
     int weight_stride, void* stream) {
-    if (!x || !weight || !y || batch <= 0 || rows <= 0 || cols <= 0 ||
-        x_stride < cols || y_stride < rows || weight_stride < cols) return false;
-    dim3 grid(static_cast<unsigned>(rows), static_cast<unsigned>(batch), 1);
-    fp16_matmul_f16_kernel<true><<<grid, kThreads, kThreads * sizeof(float),
-        static_cast<cudaStream_t>(stream)>>>(x, weight, y, batch, rows, cols,
-        x_stride, y_stride, weight_stride);
-    return cudaGetLastError() == cudaSuccess;
+    // Keep FP32 logits on the established reduction order. Greedy argmax can be
+    // sensitive to near ties even when the small-batch dot product is numerically
+    // close; FP16 activation outputs may still use the weight-reuse kernel.
+    return launch_fp16_matmul_rows_f16<true>(
+        x, weight, y, batch, rows, cols, x_stride, y_stride, weight_stride,
+        false, stream);
 }
 
 bool qwen_embedding_fp16_gather_f16_cuda(
@@ -1197,6 +1528,15 @@ bool qwen_embedding_fp16_gather_f16_cuda(
         row_start < 0 || row_count <= 0) return false;
     embedding_f16_kernel<<<count, kThreads, 0, static_cast<cudaStream_t>(stream)>>>(
         table, tokens, output, count, cols, row_start, row_count);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_concat_rows_f16_cuda(const uint16_t* left, const uint16_t* right,
+                               uint16_t* output, int rows, int cols,
+                               void* stream) {
+    if (!left || !right || !output || rows <= 0 || cols <= 0) return false;
+    concat_rows_f16_kernel<<<rows, kThreads, 0, static_cast<cudaStream_t>(stream)>>>(
+        left, right, output, rows, cols);
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/include/cuda_ops.hpp
+++ b/cpp_engine/include/cuda_ops.hpp
@@ -725,6 +725,17 @@ bool argmax_fp32_cuda(
     int token_offset,
     void* stream = nullptr);
 
+// Row-wise greedy top-1 over a contiguous [rows, count] logits matrix.
+// Each output token includes token_offset and ties prefer the lower token id.
+bool argmax_fp32_rows_cuda(
+    const float* d_logits,
+    int* d_tokens,
+    float* d_logits_out,
+    int rows,
+    int count,
+    int token_offset,
+    void* stream = nullptr);
+
 bool vector_add_cuda(
     const float* d_a,
     const float* d_b,

--- a/cpp_engine/include/qwen_config.hpp
+++ b/cpp_engine/include/qwen_config.hpp
@@ -46,6 +46,10 @@ struct QwenConfig {
     uint64_t hidden_size = 0;
     uint64_t num_hidden_layers = 0;
     uint64_t max_position_embeddings = 0;
+    // Native Qwen next-token predictor layers. Zero means the checkpoint has
+    // no native MTP branch and the plain runtime remains the only path.
+    uint64_t mtp_num_hidden_layers = 0;
+    bool mtp_use_dedicated_embeddings = false;
     double rms_norm_eps = 1.0e-6;
     double rope_theta = 10000000.0;
     double partial_rotary_factor = 1.0;

--- a/cpp_engine/include/qwen_cuda_ops.hpp
+++ b/cpp_engine/include/qwen_cuda_ops.hpp
@@ -76,6 +76,22 @@ bool qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
     int scale_stride,
     void* stream = nullptr);
 
+bool qwen_fp8_e4m3_fp16scale_swiglu_small_batch_f16_cuda(
+    const uint16_t* d_x_fp16,
+    const uint8_t* d_gate_weight,
+    const uint16_t* d_gate_scale_fp16,
+    const uint8_t* d_up_weight,
+    const uint16_t* d_up_scale_fp16,
+    uint16_t* d_y_fp16,
+    int batch,
+    int rows,
+    int cols,
+    int x_stride,
+    int y_stride,
+    int weight_stride,
+    int scale_stride,
+    void* stream = nullptr);
+
 bool qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
     const uint16_t* d_x_fp16,
     const uint8_t* d_weight,
@@ -276,6 +292,9 @@ bool qwen_embedding_fp16_gather_f16_cuda(const uint16_t* d_table_fp16,
                                          uint16_t* d_out_fp16, int count,
                                          int cols, int row_start, int row_count,
                                          void* stream = nullptr);
+bool qwen_concat_rows_f16_cuda(const uint16_t* d_left, const uint16_t* d_right,
+                               uint16_t* d_out, int rows, int cols,
+                               void* stream = nullptr);
 bool qwen_rmsnorm_fp16_gamma_rows_f16_cuda(const uint16_t* d_x_fp16,
                                            const uint16_t* d_gamma_fp16,
                                            uint16_t* d_y_fp16, int rows,
@@ -373,6 +392,25 @@ bool qwen_gqa_prefill_attention_f16_tiled_cuda(
     int seq_len, int q_heads, int kv_heads, int head_dim,
     int position_offset, int max_context, int attention_window = 0,
     int sink_tokens = 0, void* stream = nullptr);
+// Batched verifier preserving the reference decode reduction order. Each K row
+// is shared across all candidate rows and the Q heads belonging to one KV head;
+// scratch contains rows * q_heads * (position_offset + rows) FP32 scores.
+bool qwen_gqa_verify_attention_f16_exact_cuda(
+    const uint16_t* d_q_rows_fp16, const uint16_t* d_k_cache_fp16,
+    const uint16_t* d_v_cache_fp16, uint16_t* d_out_rows_fp16,
+    float* d_score_scratch, int rows, int q_heads, int kv_heads,
+    int head_dim, int position_offset, int max_context,
+    void* stream = nullptr);
+// Experimental exact-full-attention path for speculative target verification.
+// Context splits run in parallel while every K/V load serves every verify row
+// in the CTA. Its online-softmax order may change near-tie downstream logits.
+// Scratch contains rows * q_heads * splits * (head_dim + 2) FP32 elements.
+bool qwen_gqa_verify_attention_f16_cuda(
+    const uint16_t* d_q_rows_fp16, const uint16_t* d_k_cache_fp16,
+    const uint16_t* d_v_cache_fp16, uint16_t* d_out_rows_fp16,
+    float* d_partial_scratch, int rows, int q_heads, int kv_heads,
+    int head_dim, int position_offset, int max_context, int splits,
+    void* stream = nullptr);
 bool qwen_gqa_decode_attention_fp8_cuda(
     const uint16_t* d_q_fp16, const uint8_t* d_k_cache_fp8,
     const uint8_t* d_v_cache_fp8, const uint16_t* d_k_scale_fp16,

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -39,6 +39,14 @@ struct QwenEngineOptions {
     // through the 262,144-token limit, and a few request-boundary snapshots.
     // This uses about 3.0 GiB/rank for 48-layer Qwen3.8 recurrent snapshots.
     int max_state_snapshots = 82;
+    // Native Qwen MTP is opt-in until real TP4 parity/performance validation
+    // proves that speculative verification is a win on the target GPU.
+    bool mtp = false;
+    int mtp_speculative_tokens = 1;
+    // When enabled, start with one draft token, double K after full acceptance,
+    // and back off after rejection. This protects low-acceptance prompts while
+    // quickly reaching the configured maximum on predictable continuations.
+    bool mtp_adaptive = false;
     std::string nccl_id_path;
 };
 
@@ -48,12 +56,37 @@ struct QwenForwardResult {
     int dim = 0;
     int logits = 0;
     int top_token = 0;
+    // Filled by native MTP speculative steps; plain forwards leave these zero.
+    int correct_drafts = 0;
+    int bonus_token = 0;
+    std::vector<int> accept_tokens;
+    std::vector<float> accept_logits;
+    std::vector<float> accept_checksums;
     float top_logit = 0.0f;
     float checksum = 0.0f;
     int position = 0;
 };
 
-// Accounting for one prefill call under exact prefix reuse.
+// Accounting for one native-MTP generate call.
+struct QwenMtpStats {
+    uint64_t verify_count = 0;
+    uint64_t proposed_drafts = 0;
+    uint64_t correct_drafts = 0;
+    uint64_t rollback_count = 0;
+    uint64_t replay_tokens = 0;
+    double prefill_seconds = 0.0;
+    double draft_seconds = 0.0;
+    double verify_seconds = 0.0;
+    double replay_seconds = 0.0;
+
+    double accept_rate() const {
+        return proposed_drafts == 0
+            ? 0.0
+            : static_cast<double>(correct_drafts) /
+                  static_cast<double>(proposed_drafts);
+    }
+};
+
 struct QwenPrefixCacheStats {
     // Tokens whose KV cache and recurrent state were reused unchanged.
     int reused_tokens = 0;
@@ -97,6 +130,7 @@ public:
     const QwenPrefixCacheStats& prefix_cache_stats() const {
         return prefix_stats_;
     }
+    const QwenMtpStats& mtp_stats() const { return mtp_stats_; }
 
     void reset();
     // Drops every cached prefix so the next prefill recomputes from zero.
@@ -121,6 +155,7 @@ private:
     uint64_t resident_weight_bytes_ = 0;
     uint64_t resident_scale_bytes_ = 0;
     QwenPrefixCacheStats prefix_stats_;
+    QwenMtpStats mtp_stats_;
     QwenForwardResult cached_result_;
     bool has_cached_result_ = false;
     Impl* impl_ = nullptr;

--- a/cpp_engine/include/qwen_weights.hpp
+++ b/cpp_engine/include/qwen_weights.hpp
@@ -112,6 +112,15 @@ struct QwenLayerWeights {
     QwenMlpWeights mlp;
 };
 
+struct QwenMtpWeights {
+    QwenTensorRef pre_fc_norm_embedding;
+    QwenTensorRef pre_fc_norm_hidden;
+    QwenLinearRef fc;
+    QwenLayerWeights layer;
+    QwenTensorRef norm;
+    bool found = false;
+};
+
 class QwenWeightMap {
 public:
     QwenWeightMap(const SafeTensorsIndex& index, const QwenConfig& config,
@@ -121,6 +130,7 @@ public:
     const QwenTensorRef& final_norm() const { return final_norm_; }
     const QwenTensorRef& lm_head() const { return lm_head_; }
     const std::vector<QwenLayerWeights>& layers() const { return layers_; }
+    const QwenMtpWeights& mtp() const { return mtp_; }
     const QwenConfig& config() const { return config_; }
     int tp_world() const { return tp_world_; }
     int tp_rank() const { return tp_rank_; }
@@ -150,6 +160,7 @@ private:
     QwenTensorRef final_norm_;
     QwenTensorRef lm_head_;
     std::vector<QwenLayerWeights> layers_;
+    QwenMtpWeights mtp_;
     uint64_t local_weight_bytes_ = 0;
     uint64_t local_scale_bytes_ = 0;
     size_t tensor_count_ = 0;

--- a/cpp_engine/include/tp_comm.hpp
+++ b/cpp_engine/include/tp_comm.hpp
@@ -14,6 +14,10 @@ bool nccl_available();
 #ifdef DSV4_HAVE_NCCL
 void run_nccl_float_sum_smoke(int world, int rank, int device, const char* id_path, float value);
 TpTopResult nccl_global_top1(int world, int rank, int device, const char* id_path, int local_token, float local_logit);
+void nccl_global_top1_rows(int world, int rank, int device, const char* id_path,
+                           const int* d_local_tokens,
+                           const float* d_local_logits, int rows,
+                           int* global_tokens, float* global_logits);
 void nccl_all_reduce_sum_float_inplace(int world, int rank, int device, const char* id_path, float* d_values, int count);
 void nccl_all_reduce_sum_f16_inplace(int world, int rank, int device, const char* id_path, uint16_t* d_values, int count);
 void nccl_all_reduce_sum_bf16_inplace(int world, int rank, int device, const char* id_path, uint16_t* d_values, int count);

--- a/cpp_engine/src/main.cpp
+++ b/cpp_engine/src/main.cpp
@@ -14,6 +14,7 @@
 #include <cuda_runtime.h>
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -55,6 +56,9 @@ struct Args {
     bool qwen_prefix_cache = true;
     int qwen_snapshot_interval = 4096;
     int qwen_max_snapshots = 82;
+    bool qwen_mtp = false;
+    int qwen_mtp_tokens = 1;
+    bool qwen_mtp_adaptive = false;
     bool serve = false;
     int port = 8000;
     std::string host = "0.0.0.0";
@@ -148,6 +152,14 @@ Args parse_args(int argc, char** argv) {
             args.qwen_snapshot_interval = std::stoi(argv[++i]);
         } else if (arg == "--qwen-max-snapshots" && i + 1 < argc) {
             args.qwen_max_snapshots = std::stoi(argv[++i]);
+        } else if (arg == "--qwen-mtp") {
+            args.qwen_mtp = true;
+        } else if (arg == "--qwen-mtp-tokens" && i + 1 < argc) {
+            args.qwen_mtp = true;
+            args.qwen_mtp_tokens = std::stoi(argv[++i]);
+        } else if (arg == "--qwen-mtp-adaptive") {
+            args.qwen_mtp = true;
+            args.qwen_mtp_adaptive = true;
         } else if (arg == "--serve") {
             args.serve = true;
         } else if (arg == "--port" && i + 1 < argc) {
@@ -171,6 +183,9 @@ Args parse_args(int argc, char** argv) {
     if (args.prefill_chunk_tokens <= 0) throw std::runtime_error("--prefill-chunk-tokens must be positive");
     if (args.qwen_snapshot_interval < 0 || args.qwen_max_snapshots < 0) {
         throw std::runtime_error("Qwen snapshot settings must not be negative");
+    }
+    if (args.qwen_mtp_tokens <= 0) {
+        throw std::runtime_error("--qwen-mtp-tokens must be positive");
     }
     if (args.kv_cache_dtype != "fp16" && args.kv_cache_dtype != "fp8") {
         throw std::runtime_error("--kv-cache-dtype must be fp16 or fp8");
@@ -221,6 +236,7 @@ enum class QwenPersistentCommand : int32_t {
     Decode = 1,
     Reset = 2,
     Shutdown = 3,
+    Generate = 4,
 };
 
 void qwen_send_command(dsv4::CmdChannel& channel, QwenPersistentCommand command,
@@ -258,6 +274,8 @@ void run_qwen_persistent_worker(dsv4::QwenEngine& qwen,
             (void)qwen.prefill(payload);
         } else if (command == QwenPersistentCommand::Decode) {
             (void)qwen.decode_step(header[1]);
+        } else if (command == QwenPersistentCommand::Generate) {
+            (void)qwen.generate(payload, header[1]);
         } else {
             throw std::runtime_error("unknown Qwen persistent worker command");
         }
@@ -393,6 +411,9 @@ int main(int argc, char** argv) {
                         args.qwen_persistent_stdin;
                     qwen_opts.state_snapshot_interval_tokens = args.qwen_snapshot_interval;
                     qwen_opts.max_state_snapshots = args.qwen_max_snapshots;
+                    qwen_opts.mtp = args.qwen_mtp;
+                    qwen_opts.mtp_speculative_tokens = args.qwen_mtp_tokens;
+                    qwen_opts.mtp_adaptive = args.qwen_mtp_adaptive;
                     qwen_opts.nccl_id_path = args.nccl_id_path;
                     const int qwen_context = args.max_context > 0
                         ? args.max_context
@@ -411,6 +432,9 @@ int main(int argc, char** argv) {
                               << " attention_window=" << qwen_opts.attention_window
                               << " attention_sink_tokens=" << qwen_opts.attention_sink_tokens
                               << " prefix_cache=" << (qwen_opts.prefix_cache ? 1 : 0)
+                              << " mtp=" << (qwen_opts.mtp ? 1 : 0)
+                              << " mtp_tokens=" << qwen_opts.mtp_speculative_tokens
+                              << " mtp_adaptive=" << (qwen_opts.mtp_adaptive ? 1 : 0)
                               << " snapshot_interval=" << qwen_opts.state_snapshot_interval_tokens
                               << " max_snapshots=" << qwen_opts.max_state_snapshots
                               << " prompt_tokens=" << prompt_ids.size()
@@ -461,24 +485,44 @@ int main(int argc, char** argv) {
                                     throw std::runtime_error(
                                         "persistent Qwen prompt is empty or exceeds max_context");
                                 }
-                                qwen_send_command(*channel, QwenPersistentCommand::Prefill,
-                                                  0, 0, &ids);
                                 const auto t0 = std::chrono::steady_clock::now();
-                                dsv4::QwenForwardResult next = qwen.prefill(ids);
-                                const auto t1 = std::chrono::steady_clock::now();
+                                double plain_prefill_seconds = 0.0;
                                 std::vector<int> generated;
                                 generated.reserve(static_cast<size_t>(max_new_tokens));
-                                generated.push_back(next.top_token);
-                                for (int step = 1; step < max_new_tokens; ++step) {
-                                    qwen_send_command(*channel, QwenPersistentCommand::Decode,
-                                                      next.top_token,
-                                                      static_cast<int>(ids.size()) + step - 1);
-                                    next = qwen.decode_step(next.top_token);
+                                if (qwen.options().mtp) {
+                                    qwen_send_command(*channel, QwenPersistentCommand::Generate,
+                                                      max_new_tokens, 0, &ids);
+                                    const std::vector<dsv4::QwenForwardResult> outputs =
+                                        qwen.generate(ids, max_new_tokens);
+                                    for (const dsv4::QwenForwardResult& output : outputs) {
+                                        generated.push_back(output.top_token);
+                                    }
+                                } else {
+                                    qwen_send_command(*channel, QwenPersistentCommand::Prefill,
+                                                      0, 0, &ids);
+                                    const auto prefill_started =
+                                        std::chrono::steady_clock::now();
+                                    dsv4::QwenForwardResult next = qwen.prefill(ids);
+                                    plain_prefill_seconds = std::chrono::duration<double>(
+                                        std::chrono::steady_clock::now() - prefill_started).count();
                                     generated.push_back(next.top_token);
+                                    for (int step = 1; step < max_new_tokens; ++step) {
+                                        qwen_send_command(*channel, QwenPersistentCommand::Decode,
+                                                          next.top_token,
+                                                          static_cast<int>(ids.size()) + step - 1);
+                                        next = qwen.decode_step(next.top_token);
+                                        generated.push_back(next.top_token);
+                                    }
                                 }
+                                const auto t1 = std::chrono::steady_clock::now();
                                 const auto stats = qwen.prefix_cache_stats();
-                                const double prefill_seconds =
+                                const double wall_seconds =
                                     std::chrono::duration<double>(t1 - t0).count();
+                                const double prefill_seconds = qwen.options().mtp
+                                    ? qwen.mtp_stats().prefill_seconds
+                                    : plain_prefill_seconds;
+                                const double decode_seconds = std::max(
+                                    0.0, wall_seconds - prefill_seconds);
                                 std::cout << "qwen_persistent_result=1 prompt_tokens="
                                           << ids.size() << " generated_tokens="
                                           << generated.size() << " tokens=";
@@ -486,7 +530,13 @@ int main(int argc, char** argv) {
                                     if (i) std::cout << ',';
                                     std::cout << generated[i];
                                 }
-                                std::cout << " prefill_seconds=" << prefill_seconds
+                                std::cout << " wall=" << wall_seconds
+                                          << " prefill_seconds=" << prefill_seconds
+                                          << " decode_seconds=" << decode_seconds
+                                          << " decode_tokens_per_s="
+                                          << (decode_seconds > 0.0 && generated.size() > 1
+                                                  ? (generated.size() - 1) / decode_seconds
+                                                  : 0.0)
                                           << " prefill_tokens_per_s="
                                           << (prefill_seconds > 0.0 ? ids.size() / prefill_seconds : 0.0)
                                           << " prefill_computed_tokens_per_s="
@@ -498,7 +548,20 @@ int main(int argc, char** argv) {
                                           << " prefix_matched_tokens=" << stats.matched_tokens
                                           << " prefix_resume_source=" << stats.resume_source
                                           << " prefix_snapshots=" << stats.snapshots
-                                          << " prefix_snapshot_bytes=" << stats.snapshot_bytes << "\n";
+                                          << " prefix_snapshot_bytes=" << stats.snapshot_bytes
+                                          << " mtp=" << (qwen.options().mtp ? 1 : 0)
+                                          << " mtp_tokens=" << qwen.options().mtp_speculative_tokens
+                                          << " mtp_adaptive=" << (qwen.options().mtp_adaptive ? 1 : 0)
+                                          << " mtp_accept_rate=" << qwen.mtp_stats().accept_rate()
+                                          << " mtp_verify_count=" << qwen.mtp_stats().verify_count
+                                          << " mtp_proposed_drafts=" << qwen.mtp_stats().proposed_drafts
+                                          << " mtp_correct_drafts=" << qwen.mtp_stats().correct_drafts
+                                          << " mtp_rollback_count=" << qwen.mtp_stats().rollback_count
+                                          << " mtp_replay_tokens=" << qwen.mtp_stats().replay_tokens
+                                          << " mtp_prefill_seconds=" << qwen.mtp_stats().prefill_seconds
+                                          << " mtp_draft_seconds=" << qwen.mtp_stats().draft_seconds
+                                          << " mtp_verify_seconds=" << qwen.mtp_stats().verify_seconds
+                                          << " mtp_replay_seconds=" << qwen.mtp_stats().replay_seconds << "\n";
                                 std::cout.flush();
                             }
                         } catch (...) {
@@ -515,15 +578,25 @@ int main(int argc, char** argv) {
                         const auto t_prefill0 = Clock::now();
                         std::vector<dsv4::QwenForwardResult> generated;
                         generated.reserve(static_cast<size_t>(args.max_new_tokens));
-                        dsv4::QwenForwardResult next = qwen.prefill(prompt_ids);
-                        const dsv4::QwenPrefixCacheStats prefix_stats =
-                            qwen.prefix_cache_stats();
-                        const auto t_prefill1 = Clock::now();
-                        generated.push_back(next);
-                        const auto t_decode0 = Clock::now();
-                        for (int step = 1; step < args.max_new_tokens; ++step) {
-                            next = qwen.decode_step(next.top_token);
+                        dsv4::QwenPrefixCacheStats prefix_stats;
+                        Clock::time_point t_prefill1;
+                        Clock::time_point t_decode0;
+                        if (qwen.options().mtp) {
+                            generated = qwen.generate(prompt_ids, args.max_new_tokens);
+                            prefix_stats = qwen.prefix_cache_stats();
+                            t_prefill1 = t_prefill0 + std::chrono::duration_cast<Clock::duration>(
+                                std::chrono::duration<double>(qwen.mtp_stats().prefill_seconds));
+                            t_decode0 = t_prefill1;
+                        } else {
+                            dsv4::QwenForwardResult next = qwen.prefill(prompt_ids);
+                            prefix_stats = qwen.prefix_cache_stats();
+                            t_prefill1 = Clock::now();
+                            t_decode0 = t_prefill1;
                             generated.push_back(next);
+                            for (int step = 1; step < args.max_new_tokens; ++step) {
+                                next = qwen.decode_step(next.top_token);
+                                generated.push_back(next);
+                            }
                         }
                         const auto t_decode1 = Clock::now();
                         for (size_t step = 0; step < generated.size(); ++step) {
@@ -565,7 +638,20 @@ int main(int argc, char** argv) {
                                   << " prefix_snapshots=" << prefix_stats.snapshots
                                   << " prefix_snapshot_bytes=" << prefix_stats.snapshot_bytes
                                   << " prefix_hits=" << prefix_stats.hits
-                                  << " prefix_misses=" << prefix_stats.misses;
+                                  << " prefix_misses=" << prefix_stats.misses
+                                  << " mtp=" << (qwen.options().mtp ? 1 : 0)
+                                  << " mtp_tokens=" << qwen.options().mtp_speculative_tokens
+                                  << " mtp_adaptive=" << (qwen.options().mtp_adaptive ? 1 : 0)
+                                  << " mtp_accept_rate=" << qwen.mtp_stats().accept_rate()
+                                  << " mtp_verify_count=" << qwen.mtp_stats().verify_count
+                                  << " mtp_proposed_drafts=" << qwen.mtp_stats().proposed_drafts
+                                  << " mtp_correct_drafts=" << qwen.mtp_stats().correct_drafts
+                                  << " mtp_rollback_count=" << qwen.mtp_stats().rollback_count
+                                  << " mtp_replay_tokens=" << qwen.mtp_stats().replay_tokens
+                                  << " mtp_prefill_seconds=" << qwen.mtp_stats().prefill_seconds
+                                  << " mtp_draft_seconds=" << qwen.mtp_stats().draft_seconds
+                                  << " mtp_verify_seconds=" << qwen.mtp_stats().verify_seconds
+                                  << " mtp_replay_seconds=" << qwen.mtp_stats().replay_seconds;
                         if (args.resident_bench) {
                             const auto seconds = [](auto begin, auto end) {
                                 return std::chrono::duration<double>(end - begin).count();

--- a/cpp_engine/src/qwen_config.cpp
+++ b/cpp_engine/src/qwen_config.cpp
@@ -68,6 +68,13 @@ bool required_bool(const JsonObject& obj, const std::string& key) {
     return value->boolean();
 }
 
+bool optional_bool(const JsonObject& obj, const std::string& key, bool fallback) {
+    const JsonValue* value = object_get(obj, key);
+    if (value == nullptr || value->is_null()) return fallback;
+    if (!value->is_bool()) throw std::runtime_error("Qwen config boolean has wrong type: " + key);
+    return value->boolean();
+}
+
 std::string optional_string(const JsonObject& obj, const std::string& key, const std::string& fallback) {
     const JsonValue* value = object_get(obj, key);
     if (value == nullptr || value->is_null()) return fallback;
@@ -100,6 +107,9 @@ QwenConfig QwenConfig::from_hf_config(const std::string& ckpt_dir) {
     cfg.hidden_size = required_u64(text, "hidden_size");
     cfg.num_hidden_layers = required_u64(text, "num_hidden_layers");
     cfg.max_position_embeddings = required_u64(text, "max_position_embeddings");
+    cfg.mtp_num_hidden_layers = optional_u64(text, "mtp_num_hidden_layers", 0);
+    cfg.mtp_use_dedicated_embeddings = optional_bool(
+        text, "mtp_use_dedicated_embeddings", false);
     cfg.rms_norm_eps = optional_f64(text, "rms_norm_eps", 1.0e-6);
     cfg.partial_rotary_factor = optional_f64(text, "partial_rotary_factor", 1.0);
     cfg.fp8_block_size = 128;
@@ -216,6 +226,8 @@ std::string QwenConfig::to_string() const {
         << "hidden_size=" << hidden_size << '\n'
         << "num_hidden_layers=" << num_hidden_layers << '\n'
         << "max_position_embeddings=" << max_position_embeddings << '\n'
+        << "mtp_num_hidden_layers=" << mtp_num_hidden_layers << '\n'
+        << "mtp_use_dedicated_embeddings=" << (mtp_use_dedicated_embeddings ? 1 : 0) << '\n'
         << "rms_norm_eps=" << rms_norm_eps << '\n'
         << "rope_theta=" << rope_theta << '\n'
         << "partial_rotary_factor=" << partial_rotary_factor << '\n'

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <chrono>
 #include <stdexcept>
 #include <utility>
 
@@ -37,6 +38,17 @@ bool qwen_env_enabled(const char* name) {
            std::strcmp(value, "FALSE") != 0 &&
            std::strcmp(value, "off") != 0 &&
            std::strcmp(value, "OFF") != 0;
+}
+
+int qwen_env_int(const char* name, int fallback) {
+    const char* value = std::getenv(name);
+    if (value == nullptr || *value == '\0') return fallback;
+    char* end = nullptr;
+    const long parsed = std::strtol(value, &end, 10);
+    if (end == value || *end != '\0' || parsed <= 0 || parsed > 1'000'000) {
+        return fallback;
+    }
+    return static_cast<int>(parsed);
 }
 
 struct DeviceLinear {
@@ -151,6 +163,7 @@ struct QwenRecurrentSnapshot {
     // of small allocations. The tensors are local to one TP rank.
     QwenDeviceTensor state;
     QwenDeviceTensor conv_tail;
+    QwenDeviceTensor target_hidden;
     bool periodic = false;
     // A request-boundary snapshot can answer an exact shorter-prefix prefill
     // without re-running its final token.
@@ -158,8 +171,15 @@ struct QwenRecurrentSnapshot {
     bool has_result = false;
 
     uint64_t bytes() const {
-        return state.capacity + conv_tail.capacity;
+        return state.capacity + conv_tail.capacity + target_hidden.capacity;
     }
+};
+
+struct QwenVerifyBatch {
+    std::vector<int> top_tokens;
+    std::vector<float> top_logits;
+    std::vector<float> local_logits;
+    int position_after = 0;
 };
 
 struct QwenWorkspace {
@@ -217,9 +237,35 @@ struct QwenEngine::Impl {
     QwenEngineOptions options;
     int max_context = 0;
     std::vector<DeviceLayer> layers;
+    std::vector<QwenDeviceTensor> transaction_states;
+    std::vector<QwenDeviceTensor> transaction_conv_tails;
+    QwenDeviceTensor transaction_target_hidden;
     QwenDeviceTensor embed;
     QwenDeviceTensor final_norm;
     QwenDeviceTensor lm_head;
+    bool mtp_enabled = false;
+    DeviceLinear mtp_fc;
+    QwenDeviceTensor mtp_pre_fc_norm_embedding;
+    QwenDeviceTensor mtp_pre_fc_norm_hidden;
+    QwenDeviceTensor mtp_norm;
+    DeviceLayer mtp_layer;
+    QwenDeviceTensor target_hidden_rows;
+    QwenDeviceTensor target_last_hidden;
+    QwenDeviceTensor mtp_seed_hidden;
+    QwenDeviceTensor mtp_embedding;
+    QwenDeviceTensor mtp_normalized_embedding;
+    QwenDeviceTensor mtp_normalized_hidden;
+    QwenDeviceTensor mtp_concat;
+    QwenDeviceTensor mtp_fused;
+    QwenDeviceTensor mtp_next_hidden;
+    QwenDeviceTensor mtp_normalized_output;
+    int mtp_position = 0;
+    int mtp_seed_input_token = 0;
+    int mtp_next_token = 0;
+    float mtp_next_logit = 0.0f;
+    float mtp_next_checksum = 0.0f;
+    bool has_target_last_hidden = false;
+    bool mtp_seed_ready = false;
     std::vector<int> local_tokens;
     QwenDeviceTensor d_tokens;
     QwenDeviceTensor hidden_a;
@@ -386,6 +432,89 @@ struct QwenEngine::Impl {
             }
             layers.push_back(std::move(destination));
         }
+
+        if (options.mtp) {
+            if (!map.mtp().found) {
+                throw std::runtime_error(
+                    "Qwen MTP requested but checkpoint has no native MTP weights");
+            }
+            if (config.mtp_num_hidden_layers != 1) {
+                throw std::runtime_error(
+                    "Qwen runtime currently supports exactly one native MTP layer");
+            }
+            mtp_enabled = true;
+            const QwenMtpWeights& source = map.mtp();
+            mtp_pre_fc_norm_embedding = upload(index, source.pre_fc_norm_embedding);
+            mtp_pre_fc_norm_hidden = upload(index, source.pre_fc_norm_hidden);
+            mtp_norm = upload(index, source.norm);
+            mtp_fc = upload_linear(index, source.fc);
+            const QwenLayerWeights& mtp_source = source.layer;
+            mtp_layer.input_norm = upload(index, mtp_source.input_layernorm);
+            mtp_layer.post_norm = upload(index, mtp_source.post_attention_layernorm);
+            mtp_layer.gate = upload_linear(index, mtp_source.mlp.gate_proj);
+            mtp_layer.up = upload_linear(index, mtp_source.mlp.up_proj);
+            mtp_layer.down = upload_linear(index, mtp_source.mlp.down_proj);
+            mtp_layer.full.q = upload_linear(index, mtp_source.full_attention.q_proj);
+            mtp_layer.full.k = upload_linear(index, mtp_source.full_attention.k_proj);
+            mtp_layer.full.v = upload_linear(index, mtp_source.full_attention.v_proj);
+            mtp_layer.full.out = upload_linear(index, mtp_source.full_attention.o_proj);
+            mtp_layer.full.q_norm = upload(index, mtp_source.full_attention.q_norm);
+            mtp_layer.full.k_norm = upload(index, mtp_source.full_attention.k_norm);
+            uploaded_weight_bytes += source.pre_fc_norm_embedding.device_nbytes +
+                source.pre_fc_norm_hidden.device_nbytes + source.norm.device_nbytes +
+                mtp_source.input_layernorm.device_nbytes +
+                mtp_source.post_attention_layernorm.device_nbytes +
+                mtp_source.full_attention.q_norm.device_nbytes +
+                mtp_source.full_attention.k_norm.device_nbytes;
+            const auto count_mtp_linear = [this](const QwenLinearRef& linear) {
+                uploaded_weight_bytes += linear.weight.device_nbytes;
+                if (linear.has_scale) {
+                    uploaded_scale_bytes += linear.scale.device_nbytes;
+                }
+            };
+            count_mtp_linear(source.fc);
+            for (const QwenLinearRef* linear : {
+                     &mtp_source.full_attention.q_proj,
+                     &mtp_source.full_attention.k_proj,
+                     &mtp_source.full_attention.v_proj,
+                     &mtp_source.full_attention.o_proj,
+                     &mtp_source.mlp.gate_proj,
+                     &mtp_source.mlp.up_proj,
+                     &mtp_source.mlp.down_proj}) {
+                count_mtp_linear(*linear);
+            }
+            const size_t mtp_cache_elements = static_cast<size_t>(max_context) *
+                local_kv_heads * head_dim;
+            const std::vector<uint64_t> mtp_cache_shape = {
+                static_cast<uint64_t>(max_context),
+                static_cast<uint64_t>(local_kv_heads),
+                static_cast<uint64_t>(head_dim)};
+            if (options.kv_cache_dtype == QwenKvCacheDType::Fp16) {
+                allocate_half(mtp_layer.full.k_cache, mtp_cache_elements,
+                              mtp_cache_shape);
+                allocate_half(mtp_layer.full.v_cache, mtp_cache_elements,
+                              mtp_cache_shape);
+                cache_data_bytes += mtp_layer.full.k_cache.nbytes +
+                                    mtp_layer.full.v_cache.nbytes;
+            } else {
+                allocate_elements(mtp_layer.full.k_cache, mtp_cache_elements,
+                                  mtp_cache_shape, SafeDType::F8_E4M3);
+                allocate_elements(mtp_layer.full.v_cache, mtp_cache_elements,
+                                  mtp_cache_shape, SafeDType::F8_E4M3);
+                const size_t scale_elements = static_cast<size_t>(max_context) *
+                    local_kv_heads * (head_dim / kKvScaleBlock);
+                const std::vector<uint64_t> scale_shape = {
+                    static_cast<uint64_t>(max_context),
+                    static_cast<uint64_t>(local_kv_heads),
+                    static_cast<uint64_t>(head_dim / kKvScaleBlock)};
+                allocate_half(mtp_layer.full.k_scale, scale_elements, scale_shape);
+                allocate_half(mtp_layer.full.v_scale, scale_elements, scale_shape);
+                cache_data_bytes += mtp_layer.full.k_cache.nbytes +
+                                    mtp_layer.full.v_cache.nbytes;
+                cache_scale_bytes += mtp_layer.full.k_scale.nbytes +
+                                     mtp_layer.full.v_scale.nbytes;
+            }
+        }
     }
 
     bool has_recurrent_state() const {
@@ -401,11 +530,69 @@ struct QwenEngine::Impl {
             zero_tensor(layer.linear.state);
             zero_tensor(layer.linear.conv_tail);
         }
+        has_target_last_hidden = false;
+        mtp_seed_ready = false;
+        mtp_position = 0;
+        mtp_seed_input_token = 0;
+        mtp_next_token = 0;
+        mtp_next_logit = 0.0f;
+        mtp_next_checksum = 0.0f;
     }
 
     // Copies the recurrent half of the network to device-resident snapshots.
     // Only the 48 DeltaNet layers carry order-dependent state; full attention
     // is skipped because its KV cache is addressed by absolute position.
+    void prepare_transaction_state() {
+        if (transaction_states.size() == layers.size()) return;
+        transaction_states.clear();
+        transaction_conv_tails.clear();
+        transaction_states.resize(layers.size());
+        transaction_conv_tails.resize(layers.size());
+        for (size_t index = 0; index < layers.size(); ++index) {
+            const DeviceLayer& layer = layers[index];
+            if (layer.linear.state.data == nullptr) continue;
+            allocate_float(transaction_states[index],
+                           layer.linear.state.nbytes / sizeof(float),
+                           layer.linear.state.shape);
+            allocate_half(transaction_conv_tails[index],
+                          layer.linear.conv_tail.nbytes / sizeof(uint16_t),
+                          layer.linear.conv_tail.shape);
+        }
+        if (mtp_enabled) {
+            allocate_half(transaction_target_hidden, config.hidden_size,
+                          {config.hidden_size});
+        }
+    }
+
+    void restore_transaction_state(int position) {
+        if (transaction_states.size() != layers.size()) {
+            throw std::runtime_error("Qwen transaction state is unavailable");
+        }
+        for (size_t index = 0; index < layers.size(); ++index) {
+            DeviceLayer& layer = layers[index];
+            if (layer.linear.state.data == nullptr) continue;
+            check_cuda(cudaMemcpy(layer.linear.state.data,
+                                  transaction_states[index].data,
+                                  layer.linear.state.nbytes,
+                                  cudaMemcpyDeviceToDevice),
+                       "Qwen transaction state restore");
+            check_cuda(cudaMemcpy(layer.linear.conv_tail.data,
+                                  transaction_conv_tails[index].data,
+                                  layer.linear.conv_tail.nbytes,
+                                  cudaMemcpyDeviceToDevice),
+                       "Qwen transaction convolution restore");
+        }
+        check_cuda(cudaMemcpy(target_last_hidden.data,
+                              transaction_target_hidden.data,
+                              static_cast<size_t>(config.hidden_size) *
+                                  sizeof(uint16_t),
+                              cudaMemcpyDeviceToDevice),
+                   "Qwen transaction hidden restore");
+        has_target_last_hidden = true;
+        mtp_seed_ready = false;
+        mtp_position = position;
+    }
+
     QwenRecurrentSnapshot capture_recurrent_state(
         int position, const QwenForwardResult* result = nullptr,
         bool periodic = false) {
@@ -431,6 +618,20 @@ struct QwenEngine::Impl {
             allocate(snapshot.conv_tail, tail_bytes,
                      {tail_bytes / sizeof(uint16_t)}, SafeDType::F16);
         }
+        if (mtp_enabled && position > 0) {
+            if (!has_target_last_hidden || target_last_hidden.data == nullptr) {
+                throw std::runtime_error(
+                    "Qwen MTP snapshot requires the committed target hidden");
+            }
+            const size_t hidden_elements = static_cast<size_t>(config.hidden_size);
+            allocate_half(snapshot.target_hidden, hidden_elements,
+                          {config.hidden_size});
+            check_cuda(cudaMemcpy(snapshot.target_hidden.data,
+                                  target_last_hidden.data,
+                                  hidden_elements * sizeof(uint16_t),
+                                  cudaMemcpyDeviceToDevice),
+                       "Qwen target hidden snapshot copy");
+        }
         size_t state_offset = 0;
         size_t tail_offset = 0;
         for (const DeviceLayer& layer : layers) {
@@ -454,7 +655,8 @@ struct QwenEngine::Impl {
         return snapshot;
     }
 
-    void restore_recurrent_state(const QwenRecurrentSnapshot& snapshot) {
+    void restore_recurrent_state(const QwenRecurrentSnapshot& snapshot,
+                                 bool restore_target_hidden = true) {
         size_t expected_state_bytes = 0;
         size_t expected_tail_bytes = 0;
         for (const DeviceLayer& layer : layers) {
@@ -465,6 +667,27 @@ struct QwenEngine::Impl {
         if (snapshot.state.nbytes != expected_state_bytes ||
             snapshot.conv_tail.nbytes != expected_tail_bytes) {
             throw std::runtime_error("Qwen recurrent snapshot extent mismatch");
+        }
+        if (restore_target_hidden && mtp_enabled && snapshot.position > 0) {
+            const size_t hidden_bytes = static_cast<size_t>(config.hidden_size) *
+                sizeof(uint16_t);
+            if (snapshot.target_hidden.nbytes != hidden_bytes) {
+                throw std::runtime_error(
+                    "Qwen MTP snapshot target hidden extent mismatch");
+            }
+            allocate_half(target_last_hidden, config.hidden_size,
+                          {config.hidden_size});
+            check_cuda(cudaMemcpy(target_last_hidden.data,
+                                  snapshot.target_hidden.data, hidden_bytes,
+                                  cudaMemcpyDeviceToDevice),
+                       "Qwen target hidden snapshot restore");
+            has_target_last_hidden = true;
+            mtp_seed_ready = false;
+            mtp_position = snapshot.position;
+        } else if (snapshot.position == 0) {
+            has_target_last_hidden = false;
+            mtp_seed_ready = false;
+            mtp_position = 0;
         }
         size_t state_offset = 0;
         size_t tail_offset = 0;
@@ -497,7 +720,7 @@ struct QwenEngine::Impl {
             options.max_state_snapshots <= 0 || position <= 0) {
             return;
         }
-        if (!has_recurrent_state()) return;
+        if (!has_recurrent_state() && !mtp_enabled) return;
         for (QwenRecurrentSnapshot& entry : snapshots) {
             if (entry.position != position) continue;
             entry.periodic = entry.periodic || periodic;
@@ -870,6 +1093,44 @@ struct QwenEngine::Impl {
                 layer.full.v_scale.f16_data(), attention.f16_data(), rows,
                 q_heads, kv_heads, head_dim, kKvScaleBlock, position_offset,
                 max_context), "prefill FP8-cache GQA");
+        } else if (rows <= 8 && attention_window == 0) {
+            const int context_length = position_offset + rows;
+            if (qwen_env_enabled("QWEN_GQA_VERIFY_SPLIT")) {
+                const int verify_target_positions =
+                    qwen_env_int("QWEN_GQA_VERIFY_TILE", 64);
+                const int verify_splits = std::max(1, std::min(
+                    64, (context_length + verify_target_positions - 1) /
+                            verify_target_positions));
+                const size_t partial_elements =
+                    static_cast<size_t>(rows) * q_heads * verify_splits *
+                    static_cast<size_t>(head_dim + 2);
+                QwenDeviceTensor& partials = workspace_float(
+                    partial_elements,
+                    {static_cast<uint64_t>(rows),
+                     static_cast<uint64_t>(q_heads),
+                     static_cast<uint64_t>(verify_splits),
+                     static_cast<uint64_t>(head_dim + 2)});
+                require_launch(qwen_gqa_verify_attention_f16_cuda(
+                    q_norm.f16_data(), layer.full.k_cache.f16_data(),
+                    layer.full.v_cache.f16_data(), attention.f16_data(),
+                    partials.f32_data(), rows, q_heads, kv_heads, head_dim,
+                    position_offset, max_context, verify_splits),
+                    "verify split FP16-cache GQA");
+            } else {
+                const size_t score_elements =
+                    static_cast<size_t>(rows) * q_heads * context_length;
+                QwenDeviceTensor& scores = workspace_float(
+                    score_elements,
+                    {static_cast<uint64_t>(rows),
+                     static_cast<uint64_t>(q_heads),
+                     static_cast<uint64_t>(context_length)});
+                require_launch(qwen_gqa_verify_attention_f16_exact_cuda(
+                    q_norm.f16_data(), layer.full.k_cache.f16_data(),
+                    layer.full.v_cache.f16_data(), attention.f16_data(),
+                    scores.f32_data(), rows, q_heads, kv_heads, head_dim,
+                    position_offset, max_context),
+                    "verify exact FP16-cache GQA");
+            }
         } else if (qwen_env_enabled("DSV4_QWEN_GQA_OPTIMIZED") ||
                    attention_window > 0) {
             require_launch(qwen_gqa_prefill_attention_f16_tiled_cuda(
@@ -904,12 +1165,15 @@ struct QwenEngine::Impl {
                               static_cast<uint64_t>(hidden_size)});
         QwenDeviceTensor& attention = workspace_half(hidden_elements, normalized.shape);
         QwenDeviceTensor& post = workspace_half(hidden_elements, normalized.shape);
-        const bool fused_swiglu = rows == 1 && layer.gate.fp8 && layer.up.fp8 &&
+        const bool compatible_swiglu = layer.gate.fp8 && layer.up.fp8 &&
             layer.gate.weight.shape == layer.up.weight.shape &&
             layer.gate.scale.shape == layer.up.scale.shape;
+        const bool fused_decode_swiglu = rows == 1 && compatible_swiglu;
+        const bool fused_small_batch_swiglu = rows > 1 && rows <= 8 &&
+            compatible_swiglu && hidden_size % 4 == 0;
         QwenDeviceTensor* gate = nullptr;
         QwenDeviceTensor* up = nullptr;
-        if (!fused_swiglu) {
+        if (!fused_decode_swiglu && !fused_small_batch_swiglu) {
             gate = &workspace_half(intermediate_elements,
                 {static_cast<uint64_t>(rows), layer.gate.weight.shape[0]});
             up = &workspace_half(intermediate_elements, gate->shape);
@@ -932,7 +1196,7 @@ struct QwenEngine::Impl {
             "Qwen FP16 residual copy");
         add(output, attention.f16_data(), rows * hidden_size);
         norm(layer.post_norm, output, post.f16_data(), rows, hidden_size);
-        if (fused_swiglu) {
+        if (fused_decode_swiglu) {
             require_launch(qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
                 post.f16_data(), layer.gate.weight.fp8_data(),
                 layer.gate.scale.f16_data(), layer.up.weight.fp8_data(),
@@ -940,6 +1204,16 @@ struct QwenEngine::Impl {
                 static_cast<int>(layer.gate.weight.shape[0]), hidden_size,
                 hidden_size, static_cast<int>(layer.gate.scale.shape[1])),
                 "FP16 fused decode SwiGLU");
+        } else if (fused_small_batch_swiglu) {
+            require_launch(
+                qwen_fp8_e4m3_fp16scale_swiglu_small_batch_f16_cuda(
+                    post.f16_data(), layer.gate.weight.fp8_data(),
+                    layer.gate.scale.f16_data(), layer.up.weight.fp8_data(),
+                    layer.up.scale.f16_data(), intermediate.f16_data(), rows,
+                    static_cast<int>(layer.gate.weight.shape[0]), hidden_size,
+                    hidden_size, static_cast<int>(layer.gate.weight.shape[0]),
+                    hidden_size, static_cast<int>(layer.gate.scale.shape[1])),
+                "FP16 fused small-batch SwiGLU");
         } else {
             projection(layer.gate, post.f16_data(), gate->f16_data(), rows);
             projection(layer.up, post.f16_data(), up->f16_data(), rows);
@@ -952,63 +1226,355 @@ struct QwenEngine::Impl {
         add(output, mlp.f16_data(), rows * hidden_size);
     }
 
-    QwenForwardResult logits_for(const uint16_t* hidden, int last_row,
-                                 int position_after, int active_layers) {
+    QwenVerifyBatch top_tokens_for(const uint16_t* hidden, int rows,
+                                   const QwenDeviceTensor* output_norm,
+                                   int position_after) {
+        if (rows <= 0) {
+            throw std::runtime_error("Qwen logits require at least one row");
+        }
         const int hidden_size = static_cast<int>(config.hidden_size);
         const int local_vocab = static_cast<int>(lm_head.shape[0]);
         begin_workspace();
         QwenDeviceTensor& normalized = workspace_half(
-            hidden_size, {static_cast<uint64_t>(hidden_size)});
-        norm(final_norm, hidden + static_cast<size_t>(last_row) * hidden_size,
-             normalized.f16_data(), 1, hidden_size);
+            static_cast<size_t>(rows) * hidden_size,
+            {static_cast<uint64_t>(rows), static_cast<uint64_t>(hidden_size)});
+        if (output_norm != nullptr) {
+            norm(*output_norm, hidden, normalized.f16_data(), rows, hidden_size);
+        } else {
+            check_cuda(cudaMemcpy(normalized.data, hidden,
+                                  static_cast<size_t>(rows) * hidden_size *
+                                      sizeof(uint16_t),
+                                  cudaMemcpyDeviceToDevice),
+                       "Qwen normalized hidden copy");
+        }
         QwenDeviceTensor& local_logits = workspace_float(
-            local_vocab, {static_cast<uint64_t>(local_vocab)});
+            static_cast<size_t>(rows) * local_vocab,
+            {static_cast<uint64_t>(rows), static_cast<uint64_t>(local_vocab)});
         require_launch(qwen_fp16_matmul_rows_f16_f32_cuda(
             normalized.f16_data(), lm_head.f16_data(), local_logits.f32_data(),
-            1, local_vocab, hidden_size, hidden_size, local_vocab, hidden_size),
-            "Qwen final FP32 logits");
-        allocate(argmax_token, sizeof(int), {1}, SafeDType::I64);
-        allocate_float(argmax_logit, 1, {1});
+            rows, local_vocab, hidden_size, hidden_size, local_vocab,
+            hidden_size), "Qwen batched FP32 logits");
+        allocate(argmax_token, static_cast<size_t>(rows) * sizeof(int),
+                 {static_cast<uint64_t>(rows)}, SafeDType::I64);
+        allocate_float(argmax_logit, static_cast<size_t>(rows),
+                       {static_cast<uint64_t>(rows)});
         const int vocab_start = static_cast<int>(weights_vocab_start());
-        require_launch(argmax_fp32_cuda(
+        require_launch(argmax_fp32_rows_cuda(
             local_logits.f32_data(), static_cast<int*>(argmax_token.data),
-            argmax_logit.f32_data(), local_vocab, vocab_start),
-            "Qwen local argmax");
-        check_cuda(cudaDeviceSynchronize(), "Qwen logits synchronization");
-        int local_token = 0;
-        float local_logit = 0.0f;
-        check_cuda(cudaMemcpy(&local_token, argmax_token.data, sizeof(local_token),
-                              cudaMemcpyDeviceToHost),
-                   "Qwen argmax token copy");
-        check_cuda(cudaMemcpy(&local_logit, argmax_logit.data, sizeof(local_logit),
-                              cudaMemcpyDeviceToHost),
-                   "Qwen argmax logit copy");
-        int top_token = local_token;
-        float top_logit = local_logit;
+            argmax_logit.f32_data(), rows, local_vocab, vocab_start),
+            "Qwen batched local argmax");
+
+        QwenVerifyBatch result;
+        result.top_tokens.resize(static_cast<size_t>(rows));
+        result.top_logits.resize(static_cast<size_t>(rows));
+        result.local_logits.resize(static_cast<size_t>(rows));
+        result.position_after = position_after;
 #ifdef DSV4_HAVE_NCCL
         if (options.tp_world > 1) {
             if (options.nccl_id_path.empty()) {
                 throw std::runtime_error("Qwen TP requires --nccl-id-path");
             }
-            const TpTopResult global = nccl_global_top1(
+            nccl_global_top1_rows(
                 options.tp_world, options.tp_rank, options.device,
-                options.nccl_id_path.c_str(), local_token, local_logit);
-            top_token = global.token;
-            top_logit = global.logit;
-        }
-#else
-        if (options.tp_world > 1) {
-            throw std::runtime_error("Qwen TP requires an NCCL-enabled build");
-        }
+                options.nccl_id_path.c_str(),
+                static_cast<const int*>(argmax_token.data),
+                argmax_logit.f32_data(), rows, result.top_tokens.data(),
+                result.top_logits.data());
+            check_cuda(cudaMemcpy(result.local_logits.data(), argmax_logit.data,
+                                  static_cast<size_t>(rows) * sizeof(float),
+                                  cudaMemcpyDeviceToHost),
+                       "Qwen batched local logit copy");
+        } else
 #endif
+        {
+#ifndef DSV4_HAVE_NCCL
+            if (options.tp_world > 1) {
+                throw std::runtime_error(
+                    "Qwen TP requires an NCCL-enabled build");
+            }
+#endif
+            check_cuda(cudaMemcpy(result.top_tokens.data(), argmax_token.data,
+                                  static_cast<size_t>(rows) * sizeof(int),
+                                  cudaMemcpyDeviceToHost),
+                       "Qwen batched argmax token copy");
+            check_cuda(cudaMemcpy(result.top_logits.data(), argmax_logit.data,
+                                  static_cast<size_t>(rows) * sizeof(float),
+                                  cudaMemcpyDeviceToHost),
+                       "Qwen batched argmax logit copy");
+            result.local_logits = result.top_logits;
+        }
+        return result;
+    }
+
+    QwenForwardResult logits_for(const uint16_t* hidden, int last_row,
+                                 int position_after, int active_layers) {
+        const int hidden_size = static_cast<int>(config.hidden_size);
+        QwenVerifyBatch batch = top_tokens_for(
+            hidden + static_cast<size_t>(last_row) * hidden_size, 1,
+            &final_norm, position_after);
         QwenForwardResult result;
         result.layers = active_layers;
         result.dim = hidden_size;
         result.logits = static_cast<int>(config.vocab_size);
-        result.top_token = top_token;
-        result.top_logit = top_logit;
-        result.checksum = local_logit;
+        result.top_token = batch.top_tokens[0];
+        result.top_logit = batch.top_logits[0];
+        result.checksum = batch.local_logits[0];
         result.position = position_after;
+        return result;
+    }
+
+    QwenVerifyBatch target_logits_for(const uint16_t* hidden, int rows,
+                                      int position_after) {
+        return top_tokens_for(hidden, rows, &final_norm, position_after);
+    }
+
+    QwenForwardResult mtp_logits_for(const uint16_t* normalized_hidden,
+                                     int position_after) {
+        const int hidden_size = static_cast<int>(config.hidden_size);
+        QwenVerifyBatch batch = top_tokens_for(normalized_hidden, 1, nullptr,
+                                               position_after);
+        QwenForwardResult result;
+        result.layers = 1;
+        result.dim = hidden_size;
+        result.logits = static_cast<int>(config.vocab_size);
+        result.top_token = batch.top_tokens[0];
+        result.top_logit = batch.top_logits[0];
+        result.checksum = batch.local_logits[0];
+        result.position = position_after;
+        return result;
+    }
+
+    QwenForwardResult mtp_forward_rows(const std::vector<int>& tokens,
+                                       const uint16_t* hidden, int position) {
+        if (!mtp_enabled) {
+            throw std::runtime_error("Qwen MTP rows requested while disabled");
+        }
+        const int rows = static_cast<int>(tokens.size());
+        if (hidden == nullptr || rows <= 0 || position < 0 ||
+            position + rows > max_context) {
+            throw std::runtime_error("invalid Qwen MTP row extent");
+        }
+        const int hidden_size = static_cast<int>(config.hidden_size);
+        const size_t hidden_elements = static_cast<size_t>(rows) * hidden_size;
+        const std::vector<uint64_t> hidden_shape = {
+            static_cast<uint64_t>(rows), config.hidden_size};
+        allocate(d_tokens, tokens.size() * sizeof(int),
+                 {static_cast<uint64_t>(rows)}, SafeDType::I64);
+        check_cuda(cudaMemcpy(d_tokens.data, tokens.data(),
+                              tokens.size() * sizeof(int), cudaMemcpyHostToDevice),
+                   "Qwen MTP token upload");
+        allocate_half(mtp_embedding, hidden_elements, hidden_shape);
+        require_launch(qwen_embedding_fp16_gather_f16_cuda(
+            embed.f16_data(), static_cast<int*>(d_tokens.data),
+            mtp_embedding.f16_data(), rows, hidden_size,
+            static_cast<int>(weights_vocab_start()),
+            static_cast<int>(embed.shape[0])), "Qwen MTP embedding lookup");
+        all_reduce_half(mtp_embedding.f16_data(), rows * hidden_size);
+
+        allocate_half(mtp_normalized_embedding, hidden_elements, hidden_shape);
+        allocate_half(mtp_normalized_hidden, hidden_elements, hidden_shape);
+        norm(mtp_pre_fc_norm_embedding, mtp_embedding.f16_data(),
+             mtp_normalized_embedding.f16_data(), rows, hidden_size);
+        norm(mtp_pre_fc_norm_hidden, hidden,
+             mtp_normalized_hidden.f16_data(), rows, hidden_size);
+        allocate_half(mtp_concat, hidden_elements * 2,
+                      {static_cast<uint64_t>(rows),
+                       static_cast<uint64_t>(2 * hidden_size)});
+        require_launch(qwen_concat_rows_f16_cuda(
+            mtp_normalized_embedding.f16_data(),
+            mtp_normalized_hidden.f16_data(), mtp_concat.f16_data(), rows,
+            hidden_size), "Qwen MTP fusion concat");
+        allocate_half(mtp_fused, hidden_elements, hidden_shape);
+        projection(mtp_fc, mtp_concat.f16_data(), mtp_fused.f16_data(), rows);
+        allocate_half(mtp_next_hidden, hidden_elements, hidden_shape);
+        layer_forward(mtp_layer, mtp_fused.f16_data(),
+                      mtp_next_hidden.f16_data(), rows, position);
+        allocate_half(mtp_normalized_output, hidden_elements, hidden_shape);
+        norm(mtp_norm, mtp_next_hidden.f16_data(),
+             mtp_normalized_output.f16_data(), rows, hidden_size);
+        const uint16_t* last_hidden = mtp_normalized_output.f16_data() +
+            static_cast<size_t>(rows - 1) * hidden_size;
+        QwenForwardResult result = mtp_logits_for(last_hidden, position + rows);
+        allocate_half(mtp_seed_hidden, hidden_size, {config.hidden_size});
+        // Recursive Qwen3.5 MTP consumes the prior predictor's returned hidden,
+        // and that return is after mtp.norm in both vLLM and SGLang.
+        check_cuda(cudaMemcpy(mtp_seed_hidden.data, last_hidden,
+                              static_cast<size_t>(hidden_size) *
+                                  sizeof(uint16_t),
+                              cudaMemcpyDeviceToDevice),
+                   "Qwen MTP seed hidden copy");
+        mtp_position = position + rows;
+        mtp_seed_input_token = tokens.back();
+        mtp_next_token = result.top_token;
+        mtp_next_logit = result.top_logit;
+        mtp_next_checksum = result.checksum;
+        mtp_seed_ready = true;
+        return result;
+    }
+
+    QwenForwardResult mtp_forward_row(int token, const uint16_t* hidden,
+                                      int position) {
+        return mtp_forward_rows({token}, hidden, position);
+    }
+
+    QwenForwardResult prime_target_mtp(const std::vector<int>& shifted_tokens,
+                                       int position) {
+        const int rows = static_cast<int>(shifted_tokens.size());
+        const int hidden_size = static_cast<int>(config.hidden_size);
+        if (rows <= 0 || target_hidden_rows.data == nullptr ||
+            target_hidden_rows.nbytes < static_cast<uint64_t>(rows) * hidden_size *
+                sizeof(uint16_t)) {
+            throw std::runtime_error(
+                "Qwen MTP target prime requires matching target hidden rows");
+        }
+        return mtp_forward_rows(shifted_tokens, target_hidden_rows.f16_data(),
+                                position);
+    }
+
+    QwenForwardResult seed_mtp(int input_token) {
+        if (!has_target_last_hidden) {
+            throw std::runtime_error(
+                "Qwen MTP seed requires a committed target hidden");
+        }
+        return mtp_forward_row(input_token, target_last_hidden.f16_data(),
+                               mtp_position - 1);
+    }
+
+    void rewrite_mtp_boundary(int input_token, int position) {
+        if (!has_target_last_hidden || position < 0 || position >= max_context) {
+            throw std::runtime_error(
+                "Qwen MTP boundary rewrite requires a committed target hidden");
+        }
+        (void)mtp_forward_row(input_token, target_last_hidden.f16_data(), position);
+    }
+
+    std::vector<int> draft_tokens(int count, int input_token,
+                                  QwenMtpStats* stats) {
+        if (count <= 0) return {};
+        const auto started = std::chrono::steady_clock::now();
+        QwenForwardResult next;
+        if (mtp_seed_ready && mtp_seed_input_token == input_token) {
+            next.top_token = mtp_next_token;
+            next.top_logit = mtp_next_logit;
+            next.checksum = mtp_next_checksum;
+        } else {
+            next = seed_mtp(input_token);
+        }
+        std::vector<int> drafts;
+        drafts.reserve(static_cast<size_t>(count));
+        drafts.push_back(next.top_token);
+        while (static_cast<int>(drafts.size()) < count) {
+            next = mtp_forward_row(
+                drafts.back(), mtp_seed_hidden.f16_data(), mtp_position);
+            drafts.push_back(next.top_token);
+        }
+        if (stats != nullptr) {
+            stats->draft_seconds += std::chrono::duration<double>(
+                std::chrono::steady_clock::now() - started).count();
+            stats->proposed_drafts += static_cast<uint64_t>(drafts.size());
+        }
+        return drafts;
+    }
+
+    QwenForwardResult speculative_step(int input_token, int draft_count,
+                                       QwenMtpStats* stats) {
+        if (!mtp_enabled || draft_count <= 0) {
+            return run_chunk({input_token}, mtp_position,
+                             static_cast<int>(layers.size()), true);
+        }
+        const int committed_position = mtp_position;
+        prepare_transaction_state();
+        check_cuda(cudaMemcpy(transaction_target_hidden.data,
+                              target_last_hidden.data,
+                              static_cast<size_t>(config.hidden_size) *
+                                  sizeof(uint16_t),
+                              cudaMemcpyDeviceToDevice),
+                   "Qwen transaction hidden copy");
+        for (size_t index = 0; index < layers.size(); ++index) {
+            const DeviceLayer& layer = layers[index];
+            if (layer.linear.state.data == nullptr) continue;
+            check_cuda(cudaMemcpy(transaction_states[index].data,
+                                  layer.linear.state.data,
+                                  layer.linear.state.nbytes,
+                                  cudaMemcpyDeviceToDevice),
+                       "Qwen transaction state copy");
+            check_cuda(cudaMemcpy(transaction_conv_tails[index].data,
+                                  layer.linear.conv_tail.data,
+                                  layer.linear.conv_tail.nbytes,
+                                  cudaMemcpyDeviceToDevice),
+                       "Qwen transaction convolution copy");
+        }
+        const std::vector<int> drafts = draft_tokens(draft_count, input_token, stats);
+        std::vector<int> verify_inputs;
+        verify_inputs.reserve(drafts.size() + 1);
+        verify_inputs.push_back(input_token);
+        verify_inputs.insert(verify_inputs.end(), drafts.begin(), drafts.end());
+        QwenVerifyBatch verify;
+        const auto verify_started = std::chrono::steady_clock::now();
+        (void)run_chunk(verify_inputs, committed_position,
+                        static_cast<int>(layers.size()), false, &verify);
+        if (stats != nullptr) {
+            stats->verify_seconds += std::chrono::duration<double>(
+                std::chrono::steady_clock::now() - verify_started).count();
+        }
+        int correct = 0;
+        while (correct < draft_count &&
+               verify.top_tokens[static_cast<size_t>(correct)] ==
+                   drafts[static_cast<size_t>(correct)]) {
+            ++correct;
+        }
+        if (stats != nullptr) {
+            ++stats->verify_count;
+            stats->correct_drafts += static_cast<uint64_t>(correct);
+        }
+        const size_t bonus_row = static_cast<size_t>(correct);
+        const int bonus = verify.top_tokens[bonus_row];
+        const float bonus_logit = verify.top_logits[bonus_row];
+        const float bonus_checksum = verify.local_logits[bonus_row];
+        const bool full_accept = correct == draft_count;
+        if (!full_accept) {
+            if (stats != nullptr) {
+                ++stats->rollback_count;
+                stats->replay_tokens += static_cast<uint64_t>(correct + 1);
+            }
+            const auto replay_started = std::chrono::steady_clock::now();
+            restore_transaction_state(committed_position);
+            std::vector<int> replay(verify_inputs.begin(),
+                                    verify_inputs.begin() + correct + 1);
+            (void)run_chunk(replay, committed_position,
+                            static_cast<int>(layers.size()), false);
+            if (stats != nullptr) {
+                stats->replay_seconds += std::chrono::duration<double>(
+                    std::chrono::steady_clock::now() - replay_started).count();
+            }
+        }
+        // Rebind the last committed MTP row to the target bonus. On full accept
+        // this fills the one row beyond the recursively proposed drafts; on
+        // rejection it overwrites the stale speculative suffix after replay.
+        const auto seed_started = std::chrono::steady_clock::now();
+        rewrite_mtp_boundary(bonus, committed_position + correct);
+        if (stats != nullptr) {
+            stats->draft_seconds += std::chrono::duration<double>(
+                std::chrono::steady_clock::now() - seed_started).count();
+        }
+        // The target state now ends after the accepted input sequence. The
+        // bonus is the next input and must not be consumed by target yet. The
+        // MTP boundary row is already primed with that bonus for the next round.
+        QwenForwardResult result;
+        result.top_token = bonus;
+        result.bonus_token = bonus;
+        result.correct_drafts = correct;
+        result.accept_tokens.assign(drafts.begin(), drafts.begin() + correct);
+        result.accept_logits.assign(verify.top_logits.begin(),
+                                    verify.top_logits.begin() + correct);
+        result.accept_checksums.assign(verify.local_logits.begin(),
+                                       verify.local_logits.begin() + correct);
+        result.layers = static_cast<int>(layers.size());
+        result.dim = static_cast<int>(config.hidden_size);
+        result.logits = static_cast<int>(config.vocab_size);
+        result.top_logit = bonus_logit;
+        result.checksum = bonus_checksum;
+        result.position = mtp_position;
         return result;
     }
 
@@ -1019,7 +1585,9 @@ struct QwenEngine::Impl {
 
     QwenForwardResult run_chunk(const std::vector<int>& token_ids,
                                 int position_offset, int active_layers,
-                                bool compute_logits) {
+                                bool compute_logits,
+                                QwenVerifyBatch* verify_batch = nullptr,
+                                const std::vector<int>* mtp_shifted_tokens = nullptr) {
         if (token_ids.empty()) {
             throw std::runtime_error("Qwen forward requires at least one token");
         }
@@ -1053,9 +1621,50 @@ struct QwenEngine::Impl {
                           output, rows, position_offset);
             std::swap(hidden, output);
         }
+        if (mtp_enabled) {
+            allocate_half(target_hidden_rows, hidden_elements, hidden_shape);
+            // Qwen3.5 MTP consumes the target model's returned hidden states,
+            // which are after the target final RMSNorm (matching vLLM/SGLang).
+            norm(final_norm, hidden, target_hidden_rows.f16_data(), rows,
+                 hidden_size);
+            allocate_half(target_last_hidden, hidden_size,
+                          {config.hidden_size});
+            check_cuda(cudaMemcpy(
+                           target_last_hidden.data,
+                           target_hidden_rows.f16_data() +
+                               static_cast<size_t>(rows - 1) * hidden_size,
+                           static_cast<size_t>(hidden_size) * sizeof(uint16_t),
+                           cudaMemcpyDeviceToDevice),
+                       "Qwen target last hidden copy");
+            has_target_last_hidden = true;
+            mtp_seed_ready = false;
+            mtp_position = position_offset + rows;
+            if (mtp_shifted_tokens != nullptr) {
+                if (mtp_shifted_tokens->size() != token_ids.size()) {
+                    throw std::runtime_error(
+                        "Qwen MTP shifted-token extent does not match target rows");
+                }
+                (void)prime_target_mtp(*mtp_shifted_tokens, position_offset);
+            }
+        }
+        if (verify_batch != nullptr) {
+            *verify_batch = target_logits_for(
+                hidden, rows, position_offset + rows);
+        }
         if (compute_logits) {
-            return logits_for(hidden, rows - 1, position_offset + rows,
-                              active_layers);
+            if (verify_batch != nullptr) {
+                QwenForwardResult result;
+                result.layers = active_layers;
+                result.dim = hidden_size;
+                result.logits = static_cast<int>(config.vocab_size);
+                result.top_token = verify_batch->top_tokens.back();
+                result.top_logit = verify_batch->top_logits.back();
+                result.checksum = verify_batch->local_logits.back();
+                result.position = position_offset + rows;
+                return result;
+            }
+            return logits_for(
+                hidden, rows - 1, position_offset + rows, active_layers);
         }
         QwenForwardResult result;
         result.layers = active_layers;
@@ -1068,7 +1677,12 @@ struct QwenEngine::Impl {
     uint64_t activation_capacity_bytes() const {
         return hidden_a.capacity + hidden_b.capacity + d_tokens.capacity +
                argmax_token.capacity + argmax_logit.capacity +
-               workspace.capacity_bytes();
+               target_hidden_rows.capacity + target_last_hidden.capacity +
+               mtp_seed_hidden.capacity + mtp_embedding.capacity +
+               mtp_normalized_embedding.capacity +
+               mtp_normalized_hidden.capacity + mtp_concat.capacity +
+               mtp_fused.capacity + mtp_next_hidden.capacity +
+               mtp_normalized_output.capacity + workspace.capacity_bytes();
     }
 };
 
@@ -1079,6 +1693,12 @@ QwenEngine::QwenEngine(const std::string& ckpt_dir,
       config_(QwenConfig::from_hf_config(ckpt_dir)), index_(ckpt_dir),
       weights_(index_, config_, options.tp_world, options.tp_rank) {
     if (options_.device < 0) options_.device = options_.tp_rank;
+    if (options_.mtp && layer_count > 0 &&
+        layer_count != static_cast<int>(config_.num_hidden_layers)) {
+        throw std::runtime_error(
+            "Qwen MTP requires the complete target model; partial --smoke-layers "
+            "would verify drafts against a different model");
+    }
     if (options_.prefill_chunk_tokens <= 0) {
         throw std::runtime_error("Qwen prefill chunk size must be positive");
     }
@@ -1253,6 +1873,15 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids) {
     }
 
     const int target_position = static_cast<int>(token_ids.size());
+    if (options_.mtp && start_position > 0 && start_position < target_position) {
+        // The cached MTP row at S-1 was paired with the prior request's token
+        // x[S]. An append may reuse that token, while a branch or compression
+        // may replace it. Rebind the shifted-token boundary before priming the
+        // new suffix so every predictor row observes target h[S-1] + new x[S].
+        impl_->rewrite_mtp_boundary(
+            token_ids[static_cast<size_t>(start_position)],
+            start_position - 1);
+    }
     QwenForwardResult result;
     const int chunk_size = std::max(1, options_.prefill_chunk_tokens);
     for (int offset = start_position; offset < target_position;) {
@@ -1269,8 +1898,29 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids) {
         std::vector<int> chunk(
             token_ids.begin() + static_cast<ptrdiff_t>(offset),
             token_ids.begin() + static_cast<ptrdiff_t>(end));
-        result = impl_->run_chunk(chunk, offset, active_layers_,
-                                  end == target_position);
+        if (options_.mtp) {
+            std::vector<int> shifted;
+            shifted.reserve(chunk.size());
+            for (int position = offset; position < end; ++position) {
+                shifted.push_back(
+                    position + 1 < target_position
+                        ? token_ids[static_cast<size_t>(position + 1)]
+                        : -1);
+            }
+            if (shifted.back() < 0) {
+                // The last shifted input is the target token predicted by this
+                // final prompt row, so obtain its logits before priming MTP.
+                result = impl_->run_chunk(chunk, offset, active_layers_, true);
+                shifted.back() = result.top_token;
+                (void)impl_->prime_target_mtp(shifted, offset);
+            } else {
+                result = impl_->run_chunk(chunk, offset, active_layers_, false,
+                                          nullptr, &shifted);
+            }
+        } else {
+            result = impl_->run_chunk(chunk, offset, active_layers_,
+                                      end == target_position);
+        }
         const bool periodic_snapshot =
             impl_->is_periodic_snapshot_position(end);
         if (periodic_snapshot || end == target_position) {
@@ -1324,12 +1974,86 @@ QwenForwardResult QwenEngine::decode_step(int token_id) {
 std::vector<QwenForwardResult> QwenEngine::generate(
     const std::vector<int>& prompt_ids, int max_new_tokens) {
     if (max_new_tokens <= 0) return {};
+    if (prompt_ids.empty()) {
+        throw std::runtime_error("Qwen generation requires a non-empty prompt");
+    }
+    if (prompt_ids.size() + static_cast<size_t>(max_new_tokens) >
+        static_cast<size_t>(max_context_)) {
+        throw std::runtime_error("Qwen prompt plus generation exceeds context");
+    }
+    mtp_stats_ = QwenMtpStats{};
+    const auto prefill_started = std::chrono::steady_clock::now();
     QwenForwardResult next = prefill(prompt_ids);
+    mtp_stats_.prefill_seconds = std::chrono::duration<double>(
+        std::chrono::steady_clock::now() - prefill_started).count();
     std::vector<QwenForwardResult> results;
     results.reserve(static_cast<size_t>(max_new_tokens));
-    for (int index = 0; index < max_new_tokens; ++index) {
-        results.push_back(next);
-        if (index + 1 < max_new_tokens) next = decode_step(next.top_token);
+    if (!options_.mtp) {
+        for (int index = 0; index < max_new_tokens; ++index) {
+            results.push_back(next);
+            if (index + 1 < max_new_tokens) next = decode_step(next.top_token);
+        }
+        return results;
+    }
+
+    // `prefill()` predicts the first output token without consuming it, just as
+    // the plain path does. A speculative transaction consumes that token and
+    // any correct drafts, then returns a bonus token which remains unconsumed
+    // until the next transaction.
+    results.push_back(next);
+    int current_token = next.top_token;
+    const int max_draft_tokens = std::max(1, options_.mtp_speculative_tokens);
+    int adaptive_draft_tokens = options_.mtp_adaptive ? 1 : max_draft_tokens;
+    int full_accept_streak = 0;
+    while (static_cast<int>(results.size()) < max_new_tokens) {
+        const int remaining = max_new_tokens - static_cast<int>(results.size());
+        if (remaining == 1) {
+            next = decode_step(current_token);
+            results.push_back(next);
+            break;
+        }
+        const int proposed = std::min(adaptive_draft_tokens, remaining - 1);
+        next = impl_->speculative_step(current_token, proposed, &mtp_stats_);
+        const int correct = next.correct_drafts;
+        if (options_.mtp_adaptive) {
+            if (correct == proposed) {
+                ++full_accept_streak;
+                if (full_accept_streak >= 1 &&
+                    adaptive_draft_tokens < max_draft_tokens) {
+                    adaptive_draft_tokens = std::min(
+                        max_draft_tokens, adaptive_draft_tokens * 2);
+                    full_accept_streak = 0;
+                }
+            } else {
+                adaptive_draft_tokens = std::max(
+                    1, std::min(adaptive_draft_tokens / 2, correct + 1));
+                full_accept_streak = 0;
+            }
+        }
+        const int consumed = 1 + correct;
+        position_ += consumed;
+        if (options_.prefix_cache) {
+            impl_->cached_prompt.push_back(current_token);
+            impl_->cached_prompt.insert(impl_->cached_prompt.end(),
+                                        next.accept_tokens.begin(),
+                                        next.accept_tokens.end());
+            cached_result_ = next;
+            has_cached_result_ = true;
+        }
+
+        for (size_t index = 0; index < next.accept_tokens.size(); ++index) {
+            if (static_cast<int>(results.size()) == max_new_tokens) break;
+            QwenForwardResult token_result = next;
+            token_result.top_token = next.accept_tokens[index];
+            token_result.top_logit = next.accept_logits[index];
+            token_result.checksum = next.accept_checksums[index];
+            token_result.position = position_ - correct + static_cast<int>(index);
+            results.push_back(std::move(token_result));
+        }
+        if (static_cast<int>(results.size()) < max_new_tokens) {
+            results.push_back(next);
+        }
+        current_token = next.bonus_token;
     }
     return results;
 }

--- a/cpp_engine/src/qwen_weights.cpp
+++ b/cpp_engine/src/qwen_weights.cpp
@@ -400,17 +400,84 @@ QwenWeightMap::QwenWeightMap(const SafeTensorsIndex& index, const QwenConfig& co
             QwenShardRule::RowParallel, 1);
         layers_.push_back(std::move(layer));
     }
+
+    if (config_.mtp_num_hidden_layers != 0) {
+        if (config_.mtp_num_hidden_layers != 1) {
+            throw std::runtime_error(
+                "Qwen native MTP currently supports exactly one MTP layer");
+        }
+        if (config_.mtp_use_dedicated_embeddings) {
+            throw std::runtime_error(
+                "Qwen native MTP dedicated embeddings are not supported");
+        }
+        mtp_.found = true;
+        mtp_.pre_fc_norm_embedding = require_tensor(
+            "mtp.pre_fc_norm_embedding.weight", SafeDType::BF16,
+            {config_.hidden_size});
+        mtp_.pre_fc_norm_hidden = require_tensor(
+            "mtp.pre_fc_norm_hidden.weight", SafeDType::BF16,
+            {config_.hidden_size});
+        mtp_.norm = require_tensor(
+            "mtp.norm.weight", SafeDType::BF16, {config_.hidden_size});
+        mtp_.fc = require_linear(
+            "mtp.fc.weight", {config_.hidden_size, 2 * config_.hidden_size},
+            QwenShardRule::Replicated, -1, SafeDType::BF16);
+
+        const std::string prefix = "mtp.layers.0.";
+        mtp_.layer.input_layernorm = require_tensor(
+            prefix + "input_layernorm.weight", SafeDType::BF16,
+            {config_.hidden_size});
+        mtp_.layer.post_attention_layernorm = require_tensor(
+            prefix + "post_attention_layernorm.weight", SafeDType::BF16,
+            {config_.hidden_size});
+        const auto& full = config_.full_attention;
+        const uint64_t attention_dim = full.num_heads * full.head_dim;
+        const uint64_t q_dim = attention_dim * 2;
+        const uint64_t kv_dim = full.num_key_value_heads * full.head_dim;
+        mtp_.layer.full_attention.q_proj = require_linear(
+            prefix + "self_attn.q_proj.weight", {q_dim, config_.hidden_size},
+            QwenShardRule::ColumnParallel, 0);
+        mtp_.layer.full_attention.k_proj = require_linear(
+            prefix + "self_attn.k_proj.weight", {kv_dim, config_.hidden_size},
+            QwenShardRule::ColumnParallel, 0);
+        mtp_.layer.full_attention.v_proj = require_linear(
+            prefix + "self_attn.v_proj.weight", {kv_dim, config_.hidden_size},
+            QwenShardRule::ColumnParallel, 0);
+        mtp_.layer.full_attention.o_proj = require_linear(
+            prefix + "self_attn.o_proj.weight", {config_.hidden_size, attention_dim},
+            QwenShardRule::RowParallel, 1);
+        mtp_.layer.full_attention.q_norm = require_tensor(
+            prefix + "self_attn.q_norm.weight", SafeDType::BF16,
+            {full.head_dim});
+        mtp_.layer.full_attention.k_norm = require_tensor(
+            prefix + "self_attn.k_norm.weight", SafeDType::BF16,
+            {full.head_dim});
+        const std::string mlp_prefix = prefix + "mlp.";
+        mtp_.layer.mlp.gate_proj = require_linear(
+            mlp_prefix + "gate_proj.weight",
+            {config_.mlp.intermediate_size, config_.hidden_size},
+            QwenShardRule::ColumnParallel, 0);
+        mtp_.layer.mlp.up_proj = require_linear(
+            mlp_prefix + "up_proj.weight",
+            {config_.mlp.intermediate_size, config_.hidden_size},
+            QwenShardRule::ColumnParallel, 0);
+        mtp_.layer.mlp.down_proj = require_linear(
+            mlp_prefix + "down_proj.weight",
+            {config_.hidden_size, config_.mlp.intermediate_size},
+            QwenShardRule::RowParallel, 1);
+    }
+
     auto count_ref = [this](const QwenTensorRef& ref, bool scale) { record(ref, scale); };
+    const auto count_linear = [&count_ref](const QwenLinearRef& linear) {
+        if (linear.weight.found) count_ref(linear.weight, false);
+        if (linear.has_scale) count_ref(linear.scale, true);
+    };
     count_ref(embed_tokens_, false);
     count_ref(final_norm_, false);
     count_ref(lm_head_, false);
     for (const auto& layer : layers_) {
         count_ref(layer.input_layernorm, false);
         count_ref(layer.post_attention_layernorm, false);
-        const auto count_linear = [&count_ref](const QwenLinearRef& linear) {
-            if (linear.weight.found) count_ref(linear.weight, false);
-            if (linear.has_scale) count_ref(linear.scale, true);
-        };
         if (layer.linear_attention.in_proj_qkv.weight.found) {
             count_linear(layer.linear_attention.in_proj_qkv);
             count_linear(layer.linear_attention.in_proj_z);
@@ -429,6 +496,24 @@ QwenWeightMap::QwenWeightMap(const SafeTensorsIndex& index, const QwenConfig& co
             count_ref(layer.full_attention.q_norm, false);
             count_ref(layer.full_attention.k_norm, false);
         }
+        count_linear(layer.mlp.gate_proj);
+        count_linear(layer.mlp.up_proj);
+        count_linear(layer.mlp.down_proj);
+    }
+    if (mtp_.found) {
+        count_ref(mtp_.pre_fc_norm_embedding, false);
+        count_ref(mtp_.pre_fc_norm_hidden, false);
+        count_linear(mtp_.fc);
+        count_ref(mtp_.norm, false);
+        const QwenLayerWeights& layer = mtp_.layer;
+        count_ref(layer.input_layernorm, false);
+        count_ref(layer.post_attention_layernorm, false);
+        count_linear(layer.full_attention.q_proj);
+        count_linear(layer.full_attention.k_proj);
+        count_linear(layer.full_attention.v_proj);
+        count_linear(layer.full_attention.o_proj);
+        count_ref(layer.full_attention.q_norm, false);
+        count_ref(layer.full_attention.k_norm, false);
         count_linear(layer.mlp.gate_proj);
         count_linear(layer.mlp.up_proj);
         count_linear(layer.mlp.down_proj);

--- a/cpp_engine/src/tp_comm.cpp
+++ b/cpp_engine/src/tp_comm.cpp
@@ -76,6 +76,33 @@ struct CachedComm {
     ncclComm_t comm = nullptr;
 };
 
+struct Top1RowsWorkspace {
+    int* d_tokens = nullptr;
+    float* d_logits = nullptr;
+    size_t capacity = 0;
+};
+
+Top1RowsWorkspace& top1_rows_workspace(int device, size_t count) {
+    static std::unordered_map<int, Top1RowsWorkspace> workspaces;
+    Top1RowsWorkspace& workspace = workspaces[device];
+    if (workspace.capacity >= count) return workspace;
+    check_cuda(cudaSetDevice(device), "cudaSetDevice top1 workspace");
+    if (workspace.d_tokens != nullptr) {
+        check_cuda(cudaFree(workspace.d_tokens), "cudaFree gathered top tokens");
+        workspace.d_tokens = nullptr;
+    }
+    if (workspace.d_logits != nullptr) {
+        check_cuda(cudaFree(workspace.d_logits), "cudaFree gathered top logits");
+        workspace.d_logits = nullptr;
+    }
+    check_cuda(cudaMalloc(&workspace.d_tokens, count * sizeof(int)),
+               "cudaMalloc gathered batched top tokens");
+    check_cuda(cudaMalloc(&workspace.d_logits, count * sizeof(float)),
+               "cudaMalloc gathered batched top logits");
+    workspace.capacity = count;
+    return workspace;
+}
+
 ncclComm_t cached_comm(int world, int rank, int device, const char* id_path) {
     static std::unordered_map<std::string, CachedComm> comms;
     const std::string key = std::to_string(world) + ":" + std::to_string(rank) + ":" + std::to_string(device) + ":" + id_path;
@@ -110,6 +137,52 @@ void run_nccl_float_sum_smoke(int world, int rank, int device, const char* id_pa
     cudaFree(d_value);
     cudaFree(d_sum);
     ncclCommDestroy(comm);
+}
+
+void nccl_global_top1_rows(int world, int rank, int device, const char* id_path,
+                           const int* d_local_tokens,
+                           const float* d_local_logits, int rows,
+                           int* global_tokens, float* global_logits) {
+    if (world <= 0 || rank < 0 || rank >= world || rows <= 0 ||
+        d_local_tokens == nullptr || d_local_logits == nullptr ||
+        global_tokens == nullptr || global_logits == nullptr) {
+        throw std::runtime_error("invalid NCCL batched top args");
+    }
+    ncclComm_t comm = cached_comm(world, rank, device, id_path);
+    const size_t gathered_count = static_cast<size_t>(world) * rows;
+    Top1RowsWorkspace& workspace = top1_rows_workspace(device, gathered_count);
+    check_nccl(ncclGroupStart(), "ncclGroupStart batched top");
+    check_nccl(ncclAllGather(d_local_tokens, workspace.d_tokens, rows, ncclInt32,
+                             comm, nullptr),
+               "ncclAllGather batched top tokens");
+    check_nccl(ncclAllGather(d_local_logits, workspace.d_logits, rows, ncclFloat,
+                             comm, nullptr),
+               "ncclAllGather batched top logits");
+    check_nccl(ncclGroupEnd(), "ncclGroupEnd batched top");
+    std::vector<int> all_tokens(gathered_count);
+    std::vector<float> all_logits(gathered_count);
+    check_cuda(cudaMemcpy(all_tokens.data(), workspace.d_tokens,
+                          gathered_count * sizeof(int), cudaMemcpyDeviceToHost),
+               "copy gathered batched top tokens");
+    check_cuda(cudaMemcpy(all_logits.data(), workspace.d_logits,
+                          gathered_count * sizeof(float), cudaMemcpyDeviceToHost),
+               "copy gathered batched top logits");
+    for (int row = 0; row < rows; ++row) {
+        float best_logit = -INFINITY;
+        int best_token = 0;
+        for (int r = 0; r < world; ++r) {
+            const size_t at = static_cast<size_t>(r) * rows + row;
+            const float logit = all_logits[at];
+            const int token = all_tokens[at];
+            if (logit > best_logit ||
+                (logit == best_logit && token < best_token)) {
+                best_logit = logit;
+                best_token = token;
+            }
+        }
+        global_tokens[row] = best_token;
+        global_logits[row] = best_logit;
+    }
 }
 
 void nccl_all_reduce_sum_float_inplace(int world, int rank, int device, const char* id_path, float* d_values, int count) {

--- a/cpp_engine/tests/test_qwen_config.cpp
+++ b/cpp_engine/tests/test_qwen_config.cpp
@@ -54,6 +54,8 @@ std::string qwen38_config_json() {
         << "    \"hidden_size\": 5120,\n"
         << "    \"intermediate_size\": 17408,\n"
         << "    \"num_hidden_layers\": 64,\n"
+        << "    \"mtp_num_hidden_layers\": 1,\n"
+        << "    \"mtp_use_dedicated_embeddings\": false,\n"
         << "    \"num_attention_heads\": 24,\n"
         << "    \"num_key_value_heads\": 4,\n"
         << "    \"head_dim\": 256,\n"
@@ -113,6 +115,9 @@ int main() {
     check_eq(cfg.hidden_size, 5120u, "hidden_size");
     check_eq(cfg.vocab_size, 248320u, "vocab_size");
     check_eq(cfg.num_hidden_layers, 64u, "num_hidden_layers");
+    check_eq(cfg.mtp_num_hidden_layers, 1u, "mtp_num_hidden_layers");
+    check(!cfg.mtp_use_dedicated_embeddings,
+          "MTP shares the main embedding table");
     check_eq(cfg.mlp.intermediate_size, 17408u, "dense MLP intermediate_size");
     check_eq(cfg.max_position_embeddings, 262144u, "max_position_embeddings");
     check_eq(cfg.full_attention.num_heads, 24u, "num_attention_heads");

--- a/cpp_engine/tests/test_qwen_engine.cpp
+++ b/cpp_engine/tests/test_qwen_engine.cpp
@@ -80,7 +80,9 @@ std::string config_json() {
     "rms_norm_eps": 1e-6,
     "partial_rotary_factor": 0.25,
     "rope_parameters": {"rope_type": "default", "rope_theta": 10000000},
-    "layer_types": ["linear_attention", "full_attention"]
+    "layer_types": ["linear_attention", "full_attention"],
+    "mtp_num_hidden_layers": 1,
+    "mtp_use_dedicated_embeddings": false
   }
 })JSON";
 }
@@ -146,6 +148,32 @@ std::vector<TensorSpec> specs() {
         {full + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale},
         {full + "mlp.down_proj.weight", "F8_E4M3", mlp},
         {full + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale},
+    });
+    const std::string mtp = "mtp.";
+    const std::string mtp_layer = "mtp.layers.0.";
+    out.insert(out.end(), {
+        {mtp + "pre_fc_norm_embedding.weight", "BF16", hidden},
+        {mtp + "pre_fc_norm_hidden.weight", "BF16", hidden},
+        {mtp + "norm.weight", "BF16", hidden},
+        {mtp + "fc.weight", "BF16", {128, 256}},
+        {mtp_layer + "input_layernorm.weight", "BF16", hidden},
+        {mtp_layer + "post_attention_layernorm.weight", "BF16", hidden},
+        {mtp_layer + "self_attn.q_proj.weight", "F8_E4M3", q_proj},
+        {mtp_layer + "self_attn.q_proj.weight_scale_inv", "BF16", q_proj_scale},
+        {mtp_layer + "self_attn.k_proj.weight", "F8_E4M3", value_proj},
+        {mtp_layer + "self_attn.k_proj.weight_scale_inv", "BF16", value_scale},
+        {mtp_layer + "self_attn.v_proj.weight", "F8_E4M3", value_proj},
+        {mtp_layer + "self_attn.v_proj.weight_scale_inv", "BF16", value_scale},
+        {mtp_layer + "self_attn.o_proj.weight", "F8_E4M3", out_proj},
+        {mtp_layer + "self_attn.o_proj.weight_scale_inv", "BF16", out_scale},
+        {mtp_layer + "self_attn.q_norm.weight", "BF16", hidden},
+        {mtp_layer + "self_attn.k_norm.weight", "BF16", hidden},
+        {mtp_layer + "mlp.gate_proj.weight", "F8_E4M3", mlp},
+        {mtp_layer + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale},
+        {mtp_layer + "mlp.up_proj.weight", "F8_E4M3", mlp},
+        {mtp_layer + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale},
+        {mtp_layer + "mlp.down_proj.weight", "F8_E4M3", mlp},
+        {mtp_layer + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale},
     });
     return out;
 }
@@ -225,6 +253,54 @@ void require(bool condition, const std::string& message) {
     if (!condition) throw std::runtime_error(message);
 }
 
+void require_same_generation(
+    const std::vector<dsv4::QwenForwardResult>& actual,
+    const std::vector<dsv4::QwenForwardResult>& expected,
+    const std::string& label) {
+    require(actual.size() == expected.size(), label + " output count");
+    for (size_t index = 0; index < actual.size(); ++index) {
+        require(actual[index].top_token == expected[index].top_token,
+                label + " greedy token parity at " + std::to_string(index) +
+                    ": got " + std::to_string(actual[index].top_token) +
+                    ", expected " + std::to_string(expected[index].top_token));
+    }
+}
+
+void require_same_mtp_decisions(const dsv4::QwenMtpStats& actual,
+                                const dsv4::QwenMtpStats& expected,
+                                const std::string& label) {
+    require(actual.verify_count == expected.verify_count &&
+                actual.proposed_drafts == expected.proposed_drafts &&
+                actual.correct_drafts == expected.correct_drafts &&
+                actual.rollback_count == expected.rollback_count &&
+                actual.replay_tokens == expected.replay_tokens,
+            label + " MTP decision parity");
+}
+
+std::vector<dsv4::QwenForwardResult> require_cached_mtp_matches_cold(
+    const std::string& dir, dsv4::QwenEngine& cached,
+    const dsv4::QwenEngineOptions& cached_options,
+    const std::vector<int>& prompt, int max_new_tokens,
+    const std::string& resume_source, int reused_tokens, int computed_tokens,
+    const std::string& label) {
+    const auto actual = cached.generate(prompt, max_new_tokens);
+    const dsv4::QwenMtpStats actual_stats = cached.mtp_stats();
+    const dsv4::QwenPrefixCacheStats prefix = cached.prefix_cache_stats();
+    require(prefix.resume_source == resume_source &&
+                prefix.reused_tokens == reused_tokens &&
+                prefix.computed_tokens == computed_tokens,
+            label + " prefix accounting");
+
+    dsv4::QwenEngineOptions cold_options = cached_options;
+    cold_options.prefix_cache = false;
+    dsv4::QwenEngine cold(dir, cold_options, 2, 32);
+    const auto expected = cold.generate(prompt, max_new_tokens);
+    require_same_generation(actual, expected, label);
+    require_same_mtp_decisions(actual_stats, cold.mtp_stats(), label);
+    require(cached.position() == cold.position(), label + " committed position");
+    return actual;
+}
+
 void exercise_prefix_cache(const std::string& dir,
                            dsv4::QwenKvCacheDType cache_dtype) {
     dsv4::QwenEngineOptions options;
@@ -286,6 +362,108 @@ void exercise_prefix_cache(const std::string& dir,
     require(reset.reused_tokens == 0 && reset.computed_tokens == 3 &&
                 reset.resume_source == "empty",
             "reset must invalidate prefix cache");
+}
+
+void exercise_mtp(const std::string& dir,
+                  dsv4::QwenKvCacheDType cache_dtype) {
+    dsv4::QwenEngineOptions plain_options;
+    plain_options.tp_world = 1;
+    plain_options.tp_rank = 0;
+    plain_options.device = 0;
+    plain_options.prefill_chunk_tokens = 2;
+    plain_options.kv_cache_dtype = cache_dtype;
+    plain_options.prefix_cache = false;
+
+    dsv4::QwenEngineOptions mtp_options = plain_options;
+    mtp_options.mtp = true;
+    mtp_options.mtp_speculative_tokens = 4;
+    dsv4::QwenEngine plain(dir, plain_options, 2, 16);
+    dsv4::QwenEngine mtp(dir, mtp_options, 2, 16);
+    const auto plain_outputs = plain.generate({1, 2, 3}, 8);
+    const auto mtp_outputs = mtp.generate({1, 2, 3}, 8);
+    require_same_generation(mtp_outputs, plain_outputs, "MTP");
+    dsv4::QwenEngineOptions adaptive_options = mtp_options;
+    adaptive_options.mtp_adaptive = true;
+    dsv4::QwenEngine adaptive(dir, adaptive_options, 2, 16);
+    const auto adaptive_outputs = adaptive.generate({1, 2, 3}, 8);
+    require_same_generation(adaptive_outputs, plain_outputs, "adaptive MTP");
+
+    require(mtp.mtp_stats().verify_count > 0 &&
+                mtp.mtp_stats().proposed_drafts > 0 &&
+                mtp.mtp_stats().prefill_seconds > 0.0,
+            "MTP runtime statistics");
+    require(mtp.position() <= mtp.max_context(), "MTP committed position");
+
+    bool partial_depth_rejected = false;
+    try {
+        dsv4::QwenEngine invalid(dir, mtp_options, 1, 16);
+    } catch (const std::runtime_error&) {
+        partial_depth_rejected = true;
+    }
+    require(partial_depth_rejected, "MTP must reject a partial target model");
+}
+
+void exercise_mtp_prefix_cache(const std::string& dir,
+                               dsv4::QwenKvCacheDType cache_dtype) {
+    dsv4::QwenEngineOptions options;
+    options.tp_world = 1;
+    options.tp_rank = 0;
+    options.device = 0;
+    options.prefill_chunk_tokens = 2;
+    options.kv_cache_dtype = cache_dtype;
+    options.mtp = true;
+    options.mtp_speculative_tokens = 2;
+    options.state_snapshot_interval_tokens = 2;
+    options.max_state_snapshots = 16;
+
+    dsv4::QwenEngine cached(dir, options, 2, 32);
+    const std::vector<int> base = {1, 2, 3};
+    const auto base_outputs = cached.generate(base, 4);
+    const dsv4::QwenPrefixCacheStats initial = cached.prefix_cache_stats();
+    require(initial.resume_source == "empty" && initial.reused_tokens == 0 &&
+                initial.computed_tokens == 3,
+            "MTP initial chunk-boundary prompt prefix accounting");
+
+    // A generated request leaves committed output tokens in cached_prompt. An
+    // exact repeat of the original prompt therefore restores its request-boundary
+    // snapshot rather than reusing the later live generation state.
+    const auto repeated = cached.generate(base, 4);
+    const dsv4::QwenPrefixCacheStats repeated_prefix = cached.prefix_cache_stats();
+    require(repeated_prefix.resume_source == "snapshot" &&
+                repeated_prefix.reused_tokens == 3 &&
+                repeated_prefix.computed_tokens == 0,
+            "MTP exact repeat prefix accounting");
+    require_same_generation(repeated, base_outputs, "MTP exact repeat");
+
+    std::vector<int> committed_after_repeat = base;
+    committed_after_repeat.reserve(base.size() + repeated.size() - 1);
+    for (size_t index = 0; index + 1 < repeated.size(); ++index) {
+        committed_after_repeat.push_back(repeated[index].top_token);
+    }
+    std::vector<int> appended = committed_after_repeat;
+    appended.push_back(repeated.back().top_token);
+    require_cached_mtp_matches_cold(
+        dir, cached, options, appended, 4, "live",
+        static_cast<int>(committed_after_repeat.size()), 1,
+        "MTP live continuation");
+    require_cached_mtp_matches_cold(
+        dir, cached, options, base, 4, "snapshot", 3, 0,
+        "MTP shorter request-boundary snapshot");
+    require_cached_mtp_matches_cold(
+        dir, cached, options, {1, 2, 9, 10}, 4, "snapshot", 2, 2,
+        "MTP interior branch");
+
+    // Compression is a branch whose replacement suffix starts at an interior
+    // snapshot. It specifically checks that predictor row S-1 is rebound from
+    // the old token x[S] to the compressed request's new token.
+    require_cached_mtp_matches_cold(
+        dir, cached, options, {1, 2, 11}, 4, "snapshot", 2, 1,
+        "MTP compressed suffix");
+
+    cached.reset();
+    require_cached_mtp_matches_cold(
+        dir, cached, options, {7, 8, 9, 10, 11}, 4, "empty", 0, 5,
+        "MTP reset after prefix reuse");
 }
 
 void exercise_cache_lifecycle(const std::string& dir,
@@ -352,7 +530,11 @@ int main() {
         exercise_cache_lifecycle(dir, dsv4::QwenKvCacheDType::Fp8);
         exercise_prefix_cache(dir, dsv4::QwenKvCacheDType::Fp16);
         exercise_prefix_cache(dir, dsv4::QwenKvCacheDType::Fp8);
-        std::cout << "[PASS] test_qwen_engine layers=2\n";
+        exercise_mtp(dir, dsv4::QwenKvCacheDType::Fp16);
+        exercise_mtp(dir, dsv4::QwenKvCacheDType::Fp8);
+        exercise_mtp_prefix_cache(dir, dsv4::QwenKvCacheDType::Fp16);
+        exercise_mtp_prefix_cache(dir, dsv4::QwenKvCacheDType::Fp8);
+        std::cout << "[PASS] test_qwen_engine layers=2 mtp=1\n";
         return 0;
     } catch (const std::exception& ex) {
         std::cout << "[FAIL] test_qwen_engine " << ex.what() << "\n";

--- a/cpp_engine/tests/test_qwen_half_ops.cpp
+++ b/cpp_engine/tests/test_qwen_half_ops.cpp
@@ -205,6 +205,73 @@ bool check_prefill_tiled(int seq_len, int head_dim, int position_offset) {
     return true;
 }
 
+bool check_verify_split(int seq_len, int head_dim, int position_offset) {
+    constexpr int q_heads = 6;
+    constexpr int kv_heads = 1;
+    const int max_context = position_offset + seq_len + 3;
+    const int splits = std::min(64, (position_offset + seq_len + 255) / 256);
+    std::mt19937 rng(11000 + seq_len * 17 + head_dim + position_offset);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<uint16_t> q(static_cast<size_t>(seq_len) * q_heads * head_dim);
+    std::vector<uint16_t> k(static_cast<size_t>(max_context) * kv_heads * head_dim);
+    std::vector<uint16_t> v(k.size());
+    for (uint16_t& item : q) item = to_half(dist(rng));
+    for (uint16_t& item : k) item = to_half(dist(rng));
+    for (uint16_t& item : v) item = to_half(dist(rng));
+
+    DeviceBuffer dq, dk, dv, dref, dexact, dverify, dscores, dpartial;
+    uint16_t* d_q = dq.allocate<uint16_t>(q.size());
+    uint16_t* d_k = dk.allocate<uint16_t>(k.size());
+    uint16_t* d_v = dv.allocate<uint16_t>(v.size());
+    uint16_t* d_ref = dref.allocate<uint16_t>(q.size());
+    uint16_t* d_exact = dexact.allocate<uint16_t>(q.size());
+    uint16_t* d_verify = dverify.allocate<uint16_t>(q.size());
+    float* d_scores = dscores.allocate<float>(
+        static_cast<size_t>(seq_len) * q_heads * (position_offset + seq_len));
+    float* d_partial = dpartial.allocate<float>(
+        static_cast<size_t>(seq_len) * q_heads * splits * (head_dim + 2));
+    if (!d_q || !d_k || !d_v || !d_ref || !d_exact || !d_verify ||
+        !d_scores || !d_partial) return false;
+    if (cudaMemcpy(d_q, q.data(), q.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_k, k.data(), k.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_v, v.data(), v.size() * sizeof(uint16_t), cudaMemcpyHostToDevice) != cudaSuccess ||
+        !dsv4::qwen_gqa_prefill_attention_f16_cuda(
+            d_q, d_k, d_v, d_ref, seq_len, q_heads, kv_heads, head_dim,
+            position_offset, max_context) ||
+        !dsv4::qwen_gqa_verify_attention_f16_exact_cuda(
+            d_q, d_k, d_v, d_exact, d_scores, seq_len, q_heads, kv_heads,
+            head_dim, position_offset, max_context) ||
+        !dsv4::qwen_gqa_verify_attention_f16_cuda(
+            d_q, d_k, d_v, d_verify, d_partial, seq_len, q_heads, kv_heads,
+            head_dim, position_offset, max_context, splits) ||
+        cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP16 split verify launch");
+        return true;
+    }
+    std::vector<uint16_t> reference(q.size());
+    std::vector<uint16_t> exact(q.size());
+    std::vector<uint16_t> verify(q.size());
+    if (cudaMemcpy(reference.data(), d_ref, reference.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(exact.data(), d_exact, exact.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(verify.data(), d_verify, verify.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost) != cudaSuccess) {
+        fail("FP16 split verify copy");
+        return true;
+    }
+    bool exact_finite = true;
+    const double exact_worst = max_half_difference(reference, exact, &exact_finite);
+    bool finite = true;
+    const double worst = max_half_difference(reference, verify, &finite);
+    if (!exact_finite || exact_worst > 4.0e-3) {
+        fail("FP16 exact verify numerical check");
+    } else if (!finite || worst > 4.0e-3) {
+        fail("FP16 split verify numerical check");
+    } else {
+        std::printf("  FP16 verify seq=%d dim=%d offset=%d splits=%d exact=%.3e split=%.3e\n",
+                    seq_len, head_dim, position_offset, splits, exact_worst, worst);
+    }
+    return true;
+}
+
 bool check_decode_fused(int context_len, int head_dim) {
     constexpr int q_heads = 6;
     constexpr int kv_heads = 1;
@@ -511,6 +578,85 @@ bool check_fp8_f16_projection() {
                     decode_vector_dispatch_error, decode_multi_dispatch_error);
     }
 
+    // Small speculative batches reuse each FP8 weight across all input rows.
+    constexpr int small_batch = 5;
+    constexpr int small_rows = 130;
+    constexpr int small_cols = 300;
+    constexpr int small_x_stride = 304;
+    constexpr int small_y_stride = 136;
+    constexpr int small_weight_stride = 304;
+    constexpr int small_scale_stride = 3;
+    std::vector<uint16_t> small_x(
+        static_cast<size_t>(small_batch) * small_x_stride);
+    std::vector<uint8_t> small_weight(
+        static_cast<size_t>(small_rows) * small_weight_stride);
+    std::vector<uint16_t> small_scale(
+        static_cast<size_t>((small_rows + 127) / 128) * small_scale_stride);
+    for (uint16_t& value : small_x) value = to_half(x_dist(rng));
+    for (uint8_t& value : small_weight) value = random_code();
+    for (uint16_t& value : small_scale) value = to_half(scale_dist(rng));
+    DeviceBuffer d_small_x, d_small_weight, d_small_scale, d_small_reuse,
+        d_small_tiled;
+    uint16_t* sx = d_small_x.allocate<uint16_t>(small_x.size());
+    uint8_t* sw = d_small_weight.allocate<uint8_t>(small_weight.size());
+    uint16_t* ss = d_small_scale.allocate<uint16_t>(small_scale.size());
+    uint16_t* sy_reuse = d_small_reuse.allocate<uint16_t>(
+        static_cast<size_t>(small_batch) * small_y_stride);
+    uint16_t* sy_tiled = d_small_tiled.allocate<uint16_t>(
+        static_cast<size_t>(small_batch) * small_y_stride);
+    if (!sx || !sw || !ss || !sy_reuse || !sy_tiled ||
+        cudaMemcpy(sx, small_x.data(), small_x.size() * sizeof(uint16_t),
+                   cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(sw, small_weight.data(), small_weight.size(),
+                   cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(ss, small_scale.data(), small_scale.size() * sizeof(uint16_t),
+                   cudaMemcpyHostToDevice) != cudaSuccess) {
+        fail("FP16 FP8 small-batch allocation/copy");
+        return false;
+    }
+    setenv("QWEN_FP8_F16_SMALL_BATCH", "1", 1);
+    if (!dsv4::qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
+            sx, sw, ss, sy_reuse, small_batch, small_rows, small_cols,
+            small_x_stride, small_y_stride, small_weight_stride,
+            small_scale_stride) || cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP16 FP8 small-batch reuse launch");
+        return false;
+    }
+    setenv("QWEN_FP8_F16_SMALL_BATCH", "0", 1);
+    if (!dsv4::qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
+            sx, sw, ss, sy_tiled, small_batch, small_rows, small_cols,
+            small_x_stride, small_y_stride, small_weight_stride,
+            small_scale_stride) || cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP16 FP8 small-batch tiled launch");
+        return false;
+    }
+    std::vector<uint16_t> small_reuse(
+        static_cast<size_t>(small_batch) * small_y_stride);
+    std::vector<uint16_t> small_tiled(small_reuse.size());
+    cudaMemcpy(small_reuse.data(), sy_reuse,
+               small_reuse.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    cudaMemcpy(small_tiled.data(), sy_tiled,
+               small_tiled.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    double small_dispatch_error = 0.0;
+    for (int sample = 0; sample < small_batch; ++sample) {
+        for (int row = 0; row < small_rows; ++row) {
+            const size_t at = static_cast<size_t>(sample) * small_y_stride + row;
+            small_dispatch_error = std::max(
+                small_dispatch_error,
+                std::fabs(static_cast<double>(from_half(small_reuse[at])) -
+                          from_half(small_tiled[at])));
+        }
+    }
+    unsetenv("QWEN_FP8_F16_SMALL_BATCH");
+    if (small_dispatch_error > 3.0e-2) {
+        fail("FP16 FP8 small-batch numerical check");
+    } else {
+        std::printf("  FP16 FP8 small batch=%d rows=%d cols=%d "
+                    "reuse_vs_tiled=%.3e\n",
+                    small_batch, small_rows, small_cols,
+                    small_dispatch_error);
+    }
+
     // Prefill shape triggers the 128-token x 64-row N64 tile and has padded
     // strides so both aligned vector loads and output indexing are exercised.
     constexpr int batch = 128;
@@ -586,6 +732,54 @@ bool check_fp8_f16_projection() {
     } else {
         std::printf("  FP16 FP8 prefill batch=%d rows=%d cols=%d error=%.3e dispatch=%.3e\n",
                     batch, rows, cols, prefill_error, prefill_dispatch_error);
+    }
+    return true;
+}
+
+bool check_batched_argmax() {
+    constexpr int rows = 5;
+    constexpr int count = 263;
+    constexpr int token_offset = 1000;
+    std::vector<float> logits(static_cast<size_t>(rows) * count, -10.0f);
+    logits[7] = 3.0f;
+    logits[2] = 2.5f;
+    logits[static_cast<size_t>(count) + 5] = 4.0f;
+    logits[static_cast<size_t>(count) + 9] = 4.0f;
+    logits[static_cast<size_t>(2) * count + 262] = 9.0f;
+    logits[static_cast<size_t>(2) * count + 3] = 8.0f;
+    logits[static_cast<size_t>(3) * count] = -1.0f;
+    logits[static_cast<size_t>(3) * count + 11] = -2.0f;
+    logits[static_cast<size_t>(4) * count + 129] = 0.5f;
+    logits[static_cast<size_t>(4) * count + 130] = 0.25f;
+    DeviceBuffer d_logits, d_tokens, d_values;
+    float* device_logits = d_logits.allocate<float>(logits.size());
+    int* device_tokens = d_tokens.allocate<int>(rows);
+    float* device_values = d_values.allocate<float>(rows);
+    if (!device_logits || !device_tokens || !device_values ||
+        cudaMemcpy(device_logits, logits.data(), logits.size() * sizeof(float),
+                   cudaMemcpyHostToDevice) != cudaSuccess ||
+        !dsv4::argmax_fp32_rows_cuda(device_logits, device_tokens, device_values,
+                                     rows, count, token_offset) ||
+        cudaDeviceSynchronize() != cudaSuccess) {
+        fail("batched argmax launch");
+        return false;
+    }
+    std::vector<int> tokens(rows);
+    std::vector<float> values(rows);
+    if (cudaMemcpy(tokens.data(), device_tokens, rows * sizeof(int),
+                   cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(values.data(), device_values, rows * sizeof(float),
+                   cudaMemcpyDeviceToHost) != cudaSuccess) {
+        fail("batched argmax copy");
+        return false;
+    }
+    const std::vector<int> expected_tokens = {1007, 1005, 1262, 1000, 1129};
+    const std::vector<float> expected_values = {3.0f, 4.0f, 9.0f, -1.0f, 0.5f};
+    if (tokens != expected_tokens || values != expected_values) {
+        fail("batched argmax numerical/tie check");
+    } else {
+        std::printf("  batched argmax rows=%d count=%d tie=lower-token\n",
+                    rows, count);
     }
     return true;
 }
@@ -704,12 +898,17 @@ int main() {
     check_prefill_tiled(17, 256, 5);
     check_prefill_tiled(128, 64, 7);
     check_prefill_tiled(333, 256, 11);
+    check_verify_split(2, 64, 0);
+    check_verify_split(3, 256, 37);
+    check_verify_split(5, 64, 4093);
+    check_verify_split(8, 256, 8191);
     check_decode_fused(4096, 64);
     check_decode_fused(8192, 256);
     check_decode_fused(32768, 64);
     check_decode_window_reference();
     check_decode_grid_256k();
     check_fp8_f16_projection();
+    check_batched_argmax();
     check_fp8_cache();
     if (failures != 0) {
         std::printf("test_qwen_half_ops failures=%d\n", failures);

--- a/cpp_engine/tests/test_qwen_weights.cpp
+++ b/cpp_engine/tests/test_qwen_weights.cpp
@@ -68,6 +68,8 @@ std::string config_json() {
     "hidden_size": 128,
     "intermediate_size": 512,
     "num_hidden_layers": 2,
+    "mtp_num_hidden_layers": 1,
+    "mtp_use_dedicated_embeddings": false,
     "num_attention_heads": 4,
     "num_key_value_heads": 4,
     "head_dim": 128,
@@ -153,6 +155,25 @@ std::vector<TensorSpec> tensor_specs() {
     };
     add_mlp(linear_prefix);
     add_mlp(full_prefix);
+
+    add("mtp.pre_fc_norm_embedding.weight", "BF16", hidden);
+    add("mtp.pre_fc_norm_hidden.weight", "BF16", hidden);
+    add("mtp.norm.weight", "BF16", hidden);
+    add("mtp.fc.weight", "BF16", {128, 256});
+    const std::string mtp_prefix = "mtp.layers.0.";
+    add(mtp_prefix + "input_layernorm.weight", "BF16", hidden);
+    add(mtp_prefix + "post_attention_layernorm.weight", "BF16", hidden);
+    add(mtp_prefix + "self_attn.q_proj.weight", "F8_E4M3", q_proj);
+    add(mtp_prefix + "self_attn.q_proj.weight_scale_inv", "BF16", q_proj_scale);
+    add(mtp_prefix + "self_attn.k_proj.weight", "F8_E4M3", value_proj);
+    add(mtp_prefix + "self_attn.k_proj.weight_scale_inv", "BF16", value_proj_scale);
+    add(mtp_prefix + "self_attn.v_proj.weight", "F8_E4M3", value_proj);
+    add(mtp_prefix + "self_attn.v_proj.weight_scale_inv", "BF16", value_proj_scale);
+    add(mtp_prefix + "self_attn.o_proj.weight", "F8_E4M3", out_proj);
+    add(mtp_prefix + "self_attn.o_proj.weight_scale_inv", "BF16", out_proj_scale);
+    add(mtp_prefix + "self_attn.q_norm.weight", "BF16", {128});
+    add(mtp_prefix + "self_attn.k_norm.weight", "BF16", {128});
+    add_mlp(mtp_prefix);
     return out;
 }
 
@@ -298,6 +319,32 @@ void check_rank(const dsv4::SafeTensorsIndex& index, const dsv4::QwenConfig& con
             "head local shape");
     require(map.lm_head().device_dtype == dsv4::SafeDType::F16,
             "head must upload as FP16");
+
+    const dsv4::QwenMtpWeights& mtp = map.mtp();
+    require(mtp.found, "native MTP tensors must be mapped");
+    require(mtp.fc.weight.dtype == dsv4::SafeDType::BF16 &&
+                mtp.fc.weight.device_dtype == dsv4::SafeDType::F16 &&
+                !mtp.fc.has_scale,
+            "MTP fusion projection must stay dense FP16 on Turing");
+    require(mtp.fc.weight.rule == dsv4::QwenShardRule::Replicated &&
+                mtp.fc.weight.local_shape == std::vector<uint64_t>({128, 256}),
+            "MTP fusion projection must be replicated");
+    require(mtp.pre_fc_norm_embedding.device_dtype == dsv4::SafeDType::F16 &&
+                mtp.pre_fc_norm_hidden.device_dtype == dsv4::SafeDType::F16 &&
+                mtp.norm.device_dtype == dsv4::SafeDType::F16,
+            "MTP norms must materialize as FP16");
+    const auto& mtp_full = mtp.layer.full_attention;
+    require(mtp_full.q_proj.weight.local_shape ==
+                std::vector<uint64_t>({256, 128}),
+            "MTP Q projection local shape");
+    require(mtp_full.k_proj.weight.local_shape ==
+                std::vector<uint64_t>({128, 128}) &&
+                mtp_full.v_proj.weight.local_shape ==
+                    std::vector<uint64_t>({128, 128}),
+            "MTP KV projection local shapes");
+    require(mtp_full.o_proj.weight.local_shape ==
+                std::vector<uint64_t>({128, 128}),
+            "MTP output projection local shape");
 
     const dsv4::QwenHostTensor qkv_host =
         dsv4::qwen_materialize_host_tensor(index, linear.in_proj_qkv.weight);

--- a/docs/models/qwen3.8-27b-fp8.md
+++ b/docs/models/qwen3.8-27b-fp8.md
@@ -50,6 +50,7 @@ The root config also contains a vision tower, but PocketLLM deliberately dispatc
 - Opt-in exact FP16 GQA kernels: tiled prefill and split-context fused decode with compact online-softmax partials. Enable with `DSV4_QWEN_GQA_OPTIMIZED=1`; the default remains the reference full-attention path.
 - Opt-in FP16 sink-plus-sliding-window attention through `--qwen-attention-window N` and optional `--qwen-attention-sink-tokens N`. This changes full-attention semantics and is not part of exact parity or default performance claims; FP8 cache is intentionally rejected for this mode.
 - TP4 NCCL reductions and global greedy top-1 selection.
+- Opt-in native one-layer MTP loading and greedy speculative generation through `--qwen-mtp-tokens K`. The MTP layer reuses the target embedding/LM head, recursively proposes drafts, and verifies `[current_token, draft_1, ..., draft_K]` in one multi-row target forward. Partial rejection restores DeltaNet state/convolution tails and replays only the committed input prefix. MTP remains disabled by default.
 
 ## Validated performance
 
@@ -80,6 +81,69 @@ The same executable was then run serially over longer prompts with four generate
 
 The direct FP16-activation FP8 projection gate covers aligned and padded strides, masked rows, tail K tiles, vectorized-versus-scalar decode dispatch, and the wide prefill tile. It reports decode max absolute error `1.459e-2` against the FP32 host reference, with vectorized-versus-scalar output difference `0`; the 4-row experimental path differs by at most `3.906e-3`. The focused FP8 online operator suite and full TP4 rank parity checks also pass.
 
+### Native MTP speculative decoding
+
+The checkpoint declares `mtp_num_hidden_layers=1` and ships the predictor in `mtp.safetensors`. PocketLLM maps this full-attention layer under TP4, uses the required `[normalized_embedding, normalized_hidden]` fusion order, consumes the target's final-normalized hidden state, and uses the MTP layer's normalized output as the recursive hidden. Target verification computes all candidate-row logits together and performs one batched TP global top-1 collective.
+
+Enable it explicitly with:
+
+```bash
+--qwen-mtp-tokens 4
+```
+
+`--qwen-mtp` is equivalent to enabling the default `K=1`. MTP requires all 64 target layers; combining it with a nonzero partial `--smoke-layers` value is rejected. It is also context-safe: the prompt plus requested output count must fit in `max_context`; each speculative block is capped by the remaining output count, so its temporary verify suffix stays within that bound. The runtime reports `mtp_accept_rate`, proposed/correct draft counts, rollback/replay counts, and separate prefill/draft/verify/replay seconds.
+
+This MTP implementation follows the standard Qwen3.5 shifted-hidden predictor path used by vLLM: prompt target rows are paired with their next-token inputs to prime an independent absolute-position MTP KV cache, after which the predictor advances recursively. SGLang's newer `frozen_kv_mtp` worker is a separate Gemma-oriented optimization that requires a model-specific mapping from assistant layers to target KV-owner layers; Qwen3.5 does not expose such a mapping, so target and MTP KV are not aliased.
+
+The optimized target verifier reuses each FP8 weight row across all 2–8 candidate rows, fuses small-batch gate/up/SwiGLU, reuses transaction buffers, and batches exact GQA while retaining the reference score/softmax/value reduction order. An even faster split online-softmax verifier is available through `QWEN_GQA_VERIFY_SPLIT=1`, but stays experimental: its small numerical drift can change greedy output at near-tie logits even though direct attention error is below `8e-6`.
+
+Real TP4, full 64-layer, 64-token generation results below cover several tokenizer-real 512-token prompts. Every TP rank agreed and each MTP sequence matched its serial plain run. The final adaptive policy starts at `K=1`, doubles K after full acceptance, and backs off after rejection:
+
+| Prompt | Acceptance | Plain TPS | Adaptive K<=4 TPS | Decode speedup | Wall speedup |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Repeated natural language | 100.0% | 37.19 | 79.39 | **2.135x** | **1.331x** |
+| Config/model text | 94.0% | 36.75 | 69.61 | **1.894x** | **1.273x** |
+| Source code | 70.0% | 36.91 | 50.66 | 1.372x | 1.106x |
+| README prose | 70.9% | 36.83 | 48.10 | 1.306x | 1.079x |
+| Model documentation | 64.8% | 36.93 | 43.53 | 1.179x | 1.026x |
+
+The optimized path therefore clears 1.5x only when draft acceptance is high (94% or better in the measured cases); it cannot honestly guarantee 1.5x for arbitrary prompts. Starting adaptive mode at K=1 protects mixed prompts better than starting at K=4, but 65–71% acceptance still yields only 1.18–1.37x decode speedup. A target top1-top2 logit-margin gate was also tested and rejected: thresholds 0.5 and 1.0 reduced performance on the difficult prompts, so no margin-gating code or CLI option is retained. The one-shot wall result includes independent-MTP prompt priming; persistent single-concurrency requests with exact prefix reuse remain the intended workload.
+
+The parity-safe exact-GQA verifier now uses a warp-tiled value pass: one warp owns one candidate row, three query heads, and 32 value channels while preserving each output element's left-to-right FP32 accumulation order. Fresh 100%-acceptance measurements show the long-context gain increasing as plain decode becomes attention-bound:
+
+| Prompt | Plain TPS | MTP K=4 TPS | Decode speedup | One-shot wall speedup | Parity |
+| ---: | ---: | ---: | ---: | ---: | --- |
+| 4,096 | 30.10 | 50.17 | **1.667x** | not reported | PASS |
+| 8,192 | 24.78 | 61.29 | **2.474x** | 0.961x | PASS |
+| 32,768 | 11.30 | 36.26 | **3.208x** | 0.929x | PASS |
+
+The 8K/32K one-shot wall numbers remain below 1x because each separately launched MTP process primes an additional full-prompt predictor KV cache; this is not repeated for an exact-prefix hit in the long-lived workload. An opt-in split-GQA experiment measured 2.38–4.57x at 512/4K/8K/32K, but it is not included in the parity-safe claim because a separate near-tie prompt exposed sequence drift.
+
+Reproduce serial plain/K=1/K=2/K=4 A/B cases with real tokenizer IDs and automatic TP-rank/plain parity checks:
+
+```bash
+python scripts/bench_qwen_mtp.py \
+  --ckpt /path/to/Qwen3.8-27B-FP8 \
+  --tp-world 4 --devices 0,1,2,3 \
+  --lengths 512,32768 \
+  --mtp-tokens 1,2,4 \
+  --max-new-tokens 32 \
+  --layers 0 \
+  --tokenizer-python /path/to/deepseek/bin/python
+```
+
+For the recommended adaptive policy, pass one maximum K and `--adaptive`:
+
+```bash
+python scripts/bench_qwen_mtp.py \
+  --ckpt /path/to/Qwen3.8-27B-FP8 \
+  --tp-world 4 --devices 0,1,2,3 \
+  --lengths 512,8192,32768 \
+  --mtp-tokens 4 --adaptive \
+  --max-new-tokens 64 --layers 0 \
+  --tokenizer-python /path/to/deepseek/bin/python
+```
+
 ### Exact prefix reuse
 
 `QwenEngineOptions::prefix_cache` is enabled by default for a long-lived engine. The full-attention KV cache is already indexed by absolute position, while the 48 DeltaNet layers carry a small recurrent state (`state` plus convolution tail). The engine retains both across sequential prefill requests and reports `prefix_reused_tokens`, `prefix_computed_tokens`, `prefix_matched_tokens`, and `prefix_resume_source` in the persistent stdin result.
@@ -98,6 +162,17 @@ A real TP4 continuous-request test on the Qwen3.8-27B-FP8 checkpoint produced:
 | 4 | 768 (256 common prefix + compressed suffix) | 256 | 512 | snapshot | 627.5 |
 
 The cache-on and cold A/B runs generated identical tokens on all four TP ranks. In the cold run, requests 2/3/4 computed 1,028/1,544/768 tokens respectively, and every cold request reported `prefix_snapshots=0` with `prefix_snapshot_bytes=0`. Prefix reuse is exact: it does not claim that newly compressed content is cached; only the unchanged token prefix is reused.
+
+Native MTP was also exercised through this same long-lived protocol with adaptive `K<=4`, 64 generated tokens, two appends, and an interior compression branch. A separate serial plain run used the identical four requests. All generated sequences matched, every request had TP-rank parity, and both modes reported identical prefix accounting:
+
+| Request | Prompt | Reused | Computed | Resume | MTP acceptance | Plain decode TPS | MTP decode TPS | Decode speedup | Plain wall | MTP wall | Wall speedup |
+| ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 512 | 0 | 512 | empty | 100.0% | 37.13 | 79.67 | **2.146x** | 2.959 s | 2.219 s | **1.334x** |
+| 2 | 1,088 | 575 | 513 | live | 77.8% | 35.75 | 50.42 | 1.410x | 3.426 s | 3.120 s | 1.098x |
+| 3 | 1,664 | 1,151 | 513 | live | 70.2% | 34.55 | 48.65 | 1.408x | 3.484 s | 3.169 s | 1.099x |
+| 4 | 768 (256 common prefix + compressed suffix) | 256 | 512 | snapshot | 63.2% | 36.30 | 42.45 | 1.169x | 2.955 s | 2.897 s | 1.020x |
+
+This validates the intended single-concurrency cache behavior and shows a wall win on all four requests, but it also confirms that the 1.5x requirement remains acceptance-dependent: only the 100%-acceptance request clears 1.5x decode and wall throughput. Appends reuse the target recurrent/KV state and the MTP shifted boundary; compression restores a target-hidden snapshot and rewrites the MTP boundary before priming the new suffix. The persistent harness reports wall, prefill, and decode timing separately; prefill includes MTP predictor priming when enabled.
 
 The same harness was then run from a 32,768-token cold prompt with 512-token appends and a 4,096-token compression boundary:
 
@@ -235,7 +310,8 @@ build/cpp_engine/dsv4_cpp_engine \
 - The model limit is 262,144 positions; with four generated tokens, the longest valid benchmark prompt is 262,140 tokens. This boundary is validated with both the default FP16 KV cache and the explicit FP8 cache mode; FP8 uses less memory but is slower on this RTX 2080 Ti setup.
 - The executable and internal C++ namespace retain DSV4 compatibility names.
 - CUDA Graph, a decode megakernel, and DSpark integration remain future work; none is included in the reported TPS.
-- The exact optimized GQA kernels and sparse attention mode are opt-in. The optimized kernels have direct numerical gates, but clean full-network TP4 A/B timing is still required before making either path the default or updating the long-context TPS table.
+- Native MTP is opt-in. Parity-safe high-acceptance cases accelerate decode by 1.67x at 4K, 2.47x at 8K, and 3.21x at 32K; 65–71% acceptance gives only 1.18–1.37x on 512-token varied prompts. Persistent exact-prefix workloads are the intended use case; `--qwen-mtp-adaptive` starts at K=1 and limits but does not eliminate low-acceptance overhead.
+- Split exact-GQA verification is experimental and enabled only with `QWEN_GQA_VERIFY_SPLIT=1`; direct numerical checks pass, but near-tie greedy output can drift. General long-prefill/decode optimized GQA and sparse attention remain separate opt-in paths; sparse attention changes model semantics.
 
 ## Evidence and related notes
 
@@ -251,4 +327,6 @@ build/cpp_engine/dsv4_cpp_engine \
 - `cpp_engine/tests/test_qwen_gqa_attention.cpp`
 - `cpp_engine/tests/test_qwen_half_ops.cpp`
 - `cpp_engine/tests/test_qwen_weights.cpp`
+- `cpp_engine/tests/test_qwen_engine.cpp`
+- `scripts/bench_qwen_mtp.py`
 - [Benchmark reporting rules](../benchmarking.md)

--- a/scripts/bench_qwen_mtp.py
+++ b/scripts/bench_qwen_mtp.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Run serial plain-versus-native-MTP Qwen TP benchmarks.
+
+Each case launches every TP rank, checks rank-local greedy parity, then compares
+MTP K=1/2/4 with the plain sequence for the same real-token prompt. Cases run
+serially so resident-weight and attention timings do not contend across modes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+FIXTURE_TEXT = (
+    "Multi-token prediction proposes several future tokens and verifies them with "
+    "one target-model forward pass. End-to-end speedup depends on acceptance, "
+    "batched verification cost, recurrent-state rollback, and context length. "
+    "This benchmark uses deterministic natural-language tokens and checks exact "
+    "greedy parity between plain decoding and native Qwen MTP. "
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt", required=True)
+    parser.add_argument("--binary", default="build/cpp_engine/dsv4_cpp_engine")
+    parser.add_argument("--lengths", default="512,32768")
+    parser.add_argument("--mtp-tokens", default="1,2,4")
+    parser.add_argument(
+        "--adaptive", action="store_true",
+        help="enable acceptance-adaptive K for every MTP case",
+    )
+    parser.add_argument("--max-new-tokens", type=int, default=32)
+    parser.add_argument("--prefill-chunk-tokens", type=int, default=512)
+    parser.add_argument("--kv-cache-dtype", choices=("fp16", "fp8"), default="fp16")
+    parser.add_argument("--tp-world", type=int, default=4)
+    parser.add_argument("--devices", default="0,1,2,3")
+    parser.add_argument("--layers", type=int, default=0)
+    parser.add_argument("--work-dir", default=".tmp/qwen_mtp")
+    parser.add_argument(
+        "--tokenizer-python",
+        default="/home/lvyufeng/miniconda3/envs/deepseek/bin/python",
+        help="interpreter with transformers for real-token fixtures",
+    )
+    return parser.parse_args()
+
+
+def make_token_fixture(
+    ckpt: Path, path: Path, length: int, tokenizer_python: str
+) -> list[int]:
+    if path.exists():
+        tokens = [int(item) for item in path.read_text(encoding="ascii").split(",") if item]
+        if len(tokens) >= length:
+            return tokens[:length]
+    code = f"""
+from transformers import AutoTokenizer
+import json, sys
+ckpt, target = sys.argv[1], int(sys.argv[2])
+text = {FIXTURE_TEXT!r} * max(4000, target // 20 + 1)
+tok = AutoTokenizer.from_pretrained(ckpt, local_files_only=True)
+ids = tok.encode(text, add_special_tokens=False)
+if len(ids) < target:
+    raise RuntimeError(f"fixture produced {{len(ids)}} tokens, need {{target}}")
+print(json.dumps(ids[:target]))
+"""
+    completed = subprocess.run(
+        [tokenizer_python, "-c", code, str(ckpt), str(length)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    tokens = json.loads(completed.stdout)
+    if not isinstance(tokens, list) or len(tokens) != length:
+        raise RuntimeError(f"invalid fixture for length {length}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(",".join(str(int(token)) for token in tokens), encoding="ascii")
+    return [int(token) for token in tokens]
+
+
+def parse_runtime(line: str) -> dict[str, Any] | None:
+    if not line.startswith("qwen_runtime=1 "):
+        return None
+    result: dict[str, Any] = {}
+    for key, value in re.findall(r"(\w+)=([^\s]+)", line):
+        try:
+            result[key] = int(value)
+        except ValueError:
+            try:
+                result[key] = float(value)
+            except ValueError:
+                result[key] = value
+    return result
+
+
+def parse_log(path: Path) -> tuple[dict[str, Any], list[int]]:
+    runtime: dict[str, Any] | None = None
+    tokens: list[int] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        parsed = parse_runtime(line)
+        if parsed is not None:
+            runtime = parsed
+        match = re.match(r"generate_step=(\d+) token=(-?\d+)", line)
+        if match:
+            tokens.append(int(match.group(2)))
+    if runtime is None or not tokens:
+        raise RuntimeError(f"incomplete Qwen log: {path}")
+    return runtime, tokens
+
+
+def run_case(
+    *,
+    binary: Path,
+    ckpt: Path,
+    work_dir: Path,
+    token_path: Path,
+    length: int,
+    max_new_tokens: int,
+    layers: int,
+    tp_world: int,
+    devices: list[int],
+    prefill_chunk_tokens: int,
+    kv_cache_dtype: str,
+    mtp_tokens: int | None,
+    adaptive: bool,
+) -> dict[str, Any]:
+    mode = "plain" if mtp_tokens is None else (
+        f"mtp_adaptive_k{mtp_tokens}" if adaptive else f"mtp_k{mtp_tokens}"
+    )
+    case_dir = work_dir / f"length_{length}" / mode
+    case_dir.mkdir(parents=True, exist_ok=True)
+    id_path = case_dir / "nccl.id"
+    try:
+        id_path.unlink()
+    except FileNotFoundError:
+        pass
+    for path in case_dir.glob("rank*.log"):
+        path.unlink()
+
+    processes: list[tuple[int, subprocess.Popen[bytes]]] = []
+    log_handles = []
+    started = time.monotonic()
+    statuses: dict[int, int] = {}
+    try:
+        for rank in range(tp_world):
+            command = [
+                str(binary),
+                "--ckpt", str(ckpt),
+                "--tp-world", str(tp_world),
+                "--tp-rank", str(rank),
+                "--device", "0",
+                "--nccl-id-path", str(id_path),
+                "--token-ids-file", str(token_path),
+                "--generate-token", "123",
+                "--max-new-tokens", str(max_new_tokens),
+                "--max-context", str(length + max_new_tokens),
+                "--prefill-chunk-tokens", str(prefill_chunk_tokens),
+                "--kv-cache-dtype", kv_cache_dtype,
+                "--smoke-layers", str(layers),
+                "--resident-bench",
+            ]
+            if mtp_tokens is not None:
+                command += ["--qwen-mtp-tokens", str(mtp_tokens)]
+                if adaptive:
+                    command.append("--qwen-mtp-adaptive")
+            env = os.environ.copy()
+            env["CUDA_VISIBLE_DEVICES"] = str(devices[rank])
+            log = (case_dir / f"rank{rank}.log").open("wb")
+            log_handles.append(log)
+            processes.append(
+                (rank, subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, env=env))
+            )
+        while len(statuses) < len(processes):
+            for rank, process in processes:
+                if rank in statuses:
+                    continue
+                status = process.poll()
+                if status is None:
+                    continue
+                statuses[rank] = status
+                if status != 0:
+                    for other_rank, other in processes:
+                        if other_rank not in statuses and other.poll() is None:
+                            other.terminate()
+                    break
+            if any(status != 0 for status in statuses.values()):
+                break
+            time.sleep(0.1)
+    finally:
+        for rank, process in processes:
+            if process.poll() is None:
+                process.terminate()
+            try:
+                statuses[rank] = process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                statuses[rank] = process.wait(timeout=30)
+        for log in log_handles:
+            log.close()
+
+    if any(statuses.get(rank, -1) != 0 for rank in range(tp_world)):
+        raise RuntimeError(f"{mode} TP case failed: {statuses}")
+    parsed = [parse_log(case_dir / f"rank{rank}.log") for rank in range(tp_world)]
+    rank_runtime = [item[0] for item in parsed]
+    rank_tokens = [item[1] for item in parsed]
+    if any(rank_tokens[0] != tokens for tokens in rank_tokens[1:]):
+        raise RuntimeError(f"{mode} TP-rank token parity failed at length {length}")
+    runtime = rank_runtime[0]
+    if layers == 0 and runtime.get("layers") != 64:
+        raise RuntimeError(f"{mode} did not run all 64 layers: {runtime}")
+    memory = [item.get("gpu_memory_used_bytes") for item in rank_runtime]
+    return {
+        "mode": mode,
+        "prompt_tokens": length,
+        "tokens": rank_tokens[0],
+        "runtime": runtime,
+        "rank_runtime": rank_runtime,
+        "rank_token_parity": True,
+        "elapsed_process_wall_seconds": time.monotonic() - started,
+        "max_gpu_memory_used_bytes": max(value for value in memory if value is not None),
+        "log_dir": str(case_dir),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    binary = Path(args.binary).resolve()
+    ckpt = Path(args.ckpt).resolve()
+    work_dir = Path(args.work_dir).resolve()
+    lengths = [int(item) for item in args.lengths.split(",") if item.strip()]
+    mtp_values = [int(item) for item in args.mtp_tokens.split(",") if item.strip()]
+    devices = [int(item) for item in args.devices.split(",") if item.strip()]
+    if not binary.is_file() or not ckpt.is_dir():
+        raise SystemExit("binary or checkpoint is missing")
+    if not lengths or any(length <= 0 for length in lengths):
+        raise SystemExit("--lengths must contain positive integers")
+    if not mtp_values or any(value <= 0 for value in mtp_values):
+        raise SystemExit("--mtp-tokens must contain positive integers")
+    if len(devices) != args.tp_world or len(set(devices)) != len(devices):
+        raise SystemExit("--devices must contain one distinct device per TP rank")
+    if args.layers != 0:
+        raise SystemExit("native MTP validation requires --layers 0 (complete target)")
+    if args.max_new_tokens < 2:
+        raise SystemExit("--max-new-tokens must be at least 2")
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    output: dict[str, Any] = {
+        "mode": "qwen_native_mtp_ab",
+        "checkpoint": str(ckpt),
+        "binary": str(binary),
+        "tp_world": args.tp_world,
+        "devices": devices,
+        "layers": args.layers,
+        "max_new_tokens": args.max_new_tokens,
+        "prefill_chunk_tokens": args.prefill_chunk_tokens,
+        "kv_cache_dtype": args.kv_cache_dtype,
+        "results": [],
+    }
+    result_path = work_dir / "results.json"
+    for length in lengths:
+        token_path = work_dir / f"tokens_{length}.txt"
+        make_token_fixture(ckpt, token_path, length, args.tokenizer_python)
+        plain = run_case(
+            binary=binary,
+            ckpt=ckpt,
+            work_dir=work_dir,
+            token_path=token_path,
+            length=length,
+            max_new_tokens=args.max_new_tokens,
+            layers=args.layers,
+            tp_world=args.tp_world,
+            devices=devices,
+            prefill_chunk_tokens=args.prefill_chunk_tokens,
+            kv_cache_dtype=args.kv_cache_dtype,
+            mtp_tokens=None,
+            adaptive=False,
+        )
+        length_results = [plain]
+        print(
+            f"length={length} mode=plain wall={plain['runtime'].get('wall')} "
+            f"decode_tps={plain['runtime'].get('decode_tokens_per_s')} rank_parity=PASS"
+        )
+        for mtp_tokens in mtp_values:
+            result = run_case(
+                binary=binary,
+                ckpt=ckpt,
+                work_dir=work_dir,
+                token_path=token_path,
+                length=length,
+                max_new_tokens=args.max_new_tokens,
+                layers=args.layers,
+                tp_world=args.tp_world,
+                devices=devices,
+                prefill_chunk_tokens=args.prefill_chunk_tokens,
+                kv_cache_dtype=args.kv_cache_dtype,
+                mtp_tokens=mtp_tokens,
+                adaptive=args.adaptive,
+            )
+            if result["tokens"] != plain["tokens"]:
+                raise RuntimeError(
+                    f"MTP K={mtp_tokens} differs from plain greedy tokens at length {length}"
+                )
+            plain_wall = float(plain["runtime"]["wall"])
+            mtp_wall = float(result["runtime"]["wall"])
+            result["plain_token_parity"] = True
+            result["speedup_vs_plain_wall"] = plain_wall / mtp_wall
+            plain_decode_tps = float(plain["runtime"]["decode_tokens_per_s"])
+            mtp_decode_tps = float(result["runtime"]["decode_tokens_per_s"])
+            result["speedup_vs_plain_decode"] = mtp_decode_tps / plain_decode_tps
+            length_results.append(result)
+            runtime = result["runtime"]
+            print(
+                f"length={length} mode={result['mode']} "
+                f"wall={mtp_wall} wall_speedup={result['speedup_vs_plain_wall']:.4f} "
+                f"decode_tps={mtp_decode_tps:.4f} "
+                f"decode_speedup={result['speedup_vs_plain_decode']:.4f} "
+                f"accept_rate={runtime.get('mtp_accept_rate')} "
+                f"draft_s={runtime.get('mtp_draft_seconds')} "
+                f"verify_s={runtime.get('mtp_verify_seconds')} "
+                f"replay_s={runtime.get('mtp_replay_seconds')} parity=PASS"
+            )
+        output["results"].append({"prompt_tokens": length, "cases": length_results})
+        result_path.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+    print(f"results={result_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr or exc.stdout or str(exc), file=sys.stderr)
+        raise

--- a/scripts/bench_qwen_prefix_cache.py
+++ b/scripts/bench_qwen_prefix_cache.py
@@ -30,6 +30,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--layers", type=int, default=0)
     parser.add_argument("--prefill-chunk-tokens", type=int, default=512)
     parser.add_argument("--kv-cache-dtype", choices=("fp16", "fp8"), default="fp16")
+    parser.add_argument(
+        "--qwen-mtp-tokens", type=int, default=0,
+        help="enable native Qwen MTP with this many speculative draft tokens",
+    )
+    parser.add_argument(
+        "--qwen-mtp-adaptive", action="store_true",
+        help="start at K=1 and adapt up to --qwen-mtp-tokens",
+    )
     parser.add_argument("--nccl-id-path", default=".tmp/qwen_prefix_cache/nccl.id")
     parser.add_argument("--log-dir", default=".tmp/qwen_prefix_cache/logs")
     parser.add_argument("--suffix-tokens", type=int, default=512)
@@ -98,6 +106,10 @@ def main() -> int:
         raise SystemExit("--devices count must match --tp-world")
     if args.max_new_tokens <= 0 or args.suffix_tokens <= 0:
         raise SystemExit("max-new-tokens and suffix-tokens must be positive")
+    if args.qwen_mtp_tokens < 0:
+        raise SystemExit("--qwen-mtp-tokens must be non-negative")
+    if args.qwen_mtp_tokens > 0 and args.layers != 0:
+        raise SystemExit("native MTP validation requires --layers 0")
 
     id_path = Path(args.nccl_id_path).resolve()
     id_path.parent.mkdir(parents=True, exist_ok=True)
@@ -130,6 +142,10 @@ def main() -> int:
             ])
             if args.disable_prefix_cache:
                 commands[-1].append("--qwen-no-prefix-cache")
+            if args.qwen_mtp_tokens > 0:
+                commands[-1] += ["--qwen-mtp-tokens", str(args.qwen_mtp_tokens)]
+                if args.qwen_mtp_adaptive:
+                    commands[-1].append("--qwen-mtp-adaptive")
         for rank in range(1, args.tp_world):
             log_path = log_dir / f"rank{rank}.log"
             log = log_path.open("wb")
@@ -167,7 +183,9 @@ def main() -> int:
             result = wait_result(root)
             print(
                 f"request={request_index} prompt_tokens={result.get('prompt_tokens')} "
-                f"request_tps={result.get('prefill_tokens_per_s')} "
+                f"wall={result.get('wall')} "
+                f"prefill_tps={result.get('prefill_tokens_per_s')} "
+                f"decode_tps={result.get('decode_tokens_per_s')} "
                 f"computed_tps={result.get('prefill_computed_tokens_per_s')} "
                 f"reused={result.get('prefix_reused_tokens')} "
                 f"computed={result.get('prefix_computed_tokens')} "
@@ -175,6 +193,7 @@ def main() -> int:
                 f"source={result.get('prefix_resume_source')} "
                 f"snapshots={result.get('prefix_snapshots')} "
                 f"snapshot_bytes={result.get('prefix_snapshot_bytes')} "
+                f"mtp_accept_rate={result.get('mtp_accept_rate')} "
                 f"tokens={result.get('tokens')}"
             )
             generated = result.get("tokens")


### PR DESCRIPTION
## Summary

- load and execute the checkpoint-native Qwen3.8 one-layer MTP predictor under TP4
- recursively draft tokens and verify `[current, draft_1, ..., draft_K]` in one multi-row target forward with batched LM-head argmax/NCCL selection
- restore and replay DeltaNet recurrent state on partial rejection, and integrate MTP boundaries with exact prefix append, branch, and compression snapshots
- add adaptive draft depth (`K=1 -> 2 -> 4`) and parity-safe warp-tiled exact-GQA verification for long contexts
- add real TP4 benchmark harnesses, focused CUDA/engine tests, runtime statistics, and documentation

## Validation

- `cmake --build build/cpp_engine`
- `build/cpp_engine/tests/test_qwen_config`
- `build/cpp_engine/tests/test_qwen_weights`
- `build/cpp_engine/tests/test_qwen_half_ops`
- `build/cpp_engine/tests/test_qwen_engine`
- Python benchmark `py_compile`
- `git diff --check`
- real full-64-layer TP4 plain-vs-MTP greedy parity on 512/4K/8K/32K prompts
- persistent exact-prefix append and compression parity

## Performance

4x RTX 2080 Ti 22 GiB, TP4, FP16 KV, real Qwen3.8-27B-FP8 checkpoint:

- 512-token, 100% acceptance: 37.19 -> 79.39 tok/s (**2.135x**)
- 4K, 100% acceptance: 30.10 -> 50.17 tok/s (**1.667x**)
- 8K, 100% acceptance: 24.78 -> 61.29 tok/s (**2.474x**)
- 32K, 100% acceptance: 11.30 -> 36.26 tok/s (**3.208x**)

Mixed prompts with 65-71% draft acceptance measured 1.18-1.37x decode speedup, so MTP remains opt-in and the docs do not claim a universal 1.5x guarantee. The recommended configuration is `--qwen-mtp-tokens 4 --qwen-mtp-adaptive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)