### PR TITLE
Add external Qwen DSpark speculative decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ wait
 
 For a normal run, use the same command-line options as the Qwen smoke entrypoint and let rank 0 report `prefill_tokens_per_s`, `decode_tokens_per_s`, resident weight bytes, and GPU memory. The Qwen OpenAI server adapter is not implemented yet.
 
+External Qwen DSpark is available as an opt-in with `--qwen-dspark /path/to/Qwen3.8-27B-DSpark`; it cannot be combined with native MTP. The real five-layer drafter proposes seven tokens and verifies eight target rows at once. It remains default-off because measured gains are acceptance-dependent. See the [Qwen model page](docs/models/qwen3.8-27b-fp8.md#external-dspark-speculative-decoding) for real 512/8K/32K results and the prefix/cold-parity command.
+
 For a single-concurrency client whose next request extends or compresses the previous one, keep one TP4 process group alive with the persistent token-ID worker. Rank 0 reads `<max_new_tokens> token0 token1 ...` lines and reports exact prefix accounting; the worker reuses live state for appends and device snapshots for branches:
 
 ```bash
@@ -194,7 +196,7 @@ The benchmark starts ranks 1–3 as command workers and keeps rank 0 alive for a
 
 - Performance is highly sensitive to GPU model, PCIe topology, NUMA placement, driver/runtime versions, and checkpoint variant.
 - GGUF expert staging can dominate decode on PCIe-only systems; a high prefill number does not imply high decode TPS.
-- DSpark's current C++ verify path is sequential and should not be presented as a speedup claim; multi-token verification has a separate numerical-drift policy.
+- DeepSeek-V4 DSpark's current C++ verify path is sequential and should not be presented as a speedup claim. Qwen DSpark is a separate external drafter with one eight-row target verification and model-specific parity/performance data.
 - The Qwen runtime currently supports the text checkpoint path only. Vision inputs and OpenAI-compatible Qwen serving are not wired in.
 - Some experimental optimizations are intentionally opt-in or disabled after real end-to-end regressions. See the model pages and historical notes for details.
 

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(dsv4_cpp_core STATIC
     src/model_config.cpp
     src/qwen_config.cpp
     src/qwen_weights.cpp
+    src/qwen_dspark.cpp
     src/qwen_engine.cpp
     src/tokenizer.cpp
     src/tensor.cpp
@@ -59,6 +60,7 @@ add_library(dsv4_cpp_core STATIC
     cuda/qwen_attention_ops.cu
     cuda/qwen_half_ops.cu
     cuda/qwen_gqa_optimized.cu
+    cuda/qwen_dspark_ops.cu
     cuda/q2_ops.cu
     cuda/iq1_ops.cu
     cuda/rmsnorm_rope.cu
@@ -296,6 +298,14 @@ set_target_properties(test_nccl_smoke PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAK
 add_executable(test_qwen_config tests/test_qwen_config.cpp)
 target_link_libraries(test_qwen_config PRIVATE dsv4_cpp_core)
 set_target_properties(test_qwen_config PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_dspark tests/test_qwen_dspark.cpp)
+target_link_libraries(test_qwen_dspark PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_dspark PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_dspark_ops tests/test_qwen_dspark_ops.cpp)
+target_link_libraries(test_qwen_dspark_ops PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_dspark_ops PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(test_qwen_fp8_online tests/test_qwen_fp8_online.cpp)
 target_link_libraries(test_qwen_fp8_online PRIVATE dsv4_cpp_core)

--- a/cpp_engine/cuda/qwen_dspark_ops.cu
+++ b/cpp_engine/cuda/qwen_dspark_ops.cu
@@ -1,0 +1,430 @@
+#include "qwen_cuda_ops.hpp"
+
+#include <cublas_v2.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+
+namespace dsv4 {
+namespace {
+
+constexpr int kThreads = 256;
+constexpr int kAttentionThreads = 128;
+constexpr int kMaxHeadDim = 128;
+constexpr int kAttentionWarps = kAttentionThreads / 32;
+
+__device__ __forceinline__ float half_to_float(uint16_t bits) {
+    return __half2float(__ushort_as_half(bits));
+}
+
+__device__ __forceinline__ uint16_t float_to_half(float value) {
+    return __half_as_ushort(__float2half_rn(value));
+}
+
+__device__ __forceinline__ float warp_sum(float value) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        value += __shfl_down_sync(0xffffffffu, value, offset);
+    }
+    return value;
+}
+
+__global__ void standard_rmsnorm_f16_kernel(
+    const uint16_t* __restrict__ x,
+    const uint16_t* __restrict__ gamma,
+    uint16_t* __restrict__ y,
+    int cols,
+    float eps) {
+    const int row = static_cast<int>(blockIdx.x);
+    float sum = 0.0f;
+    for (int col = static_cast<int>(threadIdx.x); col < cols; col += blockDim.x) {
+        const float value = half_to_float(x[static_cast<size_t>(row) * cols + col]);
+        sum += value * value;
+    }
+    __shared__ float scratch[kThreads];
+    scratch[threadIdx.x] = sum;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            scratch[threadIdx.x] += scratch[threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+    const float inverse = rsqrtf(scratch[0] / static_cast<float>(cols) + eps);
+    for (int col = static_cast<int>(threadIdx.x); col < cols; col += blockDim.x) {
+        const size_t index = static_cast<size_t>(row) * cols + col;
+        y[index] = float_to_half(
+            half_to_float(x[index]) * inverse * half_to_float(gamma[col]));
+    }
+}
+
+__global__ void yarn_rope_f16_kernel(
+    uint16_t* __restrict__ x,
+    const float* __restrict__ inverse_frequencies,
+    int heads,
+    int head_dim,
+    int start_position,
+    float attention_factor) {
+    const int row = static_cast<int>(blockIdx.y);
+    const int head = static_cast<int>(blockIdx.x);
+    const int half_dim = head_dim / 2;
+    const size_t base =
+        (static_cast<size_t>(row) * heads + head) * head_dim;
+    for (int pair = static_cast<int>(threadIdx.x); pair < half_dim;
+         pair += blockDim.x) {
+        const float angle = static_cast<float>(start_position + row) *
+            inverse_frequencies[pair];
+        float sine = 0.0f;
+        float cosine = 0.0f;
+        sincosf(angle, &sine, &cosine);
+        sine *= attention_factor;
+        cosine *= attention_factor;
+        const float left = half_to_float(x[base + pair]);
+        const float right = half_to_float(x[base + half_dim + pair]);
+        x[base + pair] = float_to_half(left * cosine - right * sine);
+        x[base + half_dim + pair] =
+            float_to_half(right * cosine + left * sine);
+    }
+}
+
+__global__ void dual_source_gqa_f16_kernel(
+    const uint16_t* __restrict__ q,
+    const uint16_t* __restrict__ context_k,
+    const uint16_t* __restrict__ context_v,
+    const uint16_t* __restrict__ block_k,
+    const uint16_t* __restrict__ block_v,
+    uint16_t* __restrict__ output,
+    int block_rows,
+    int q_heads,
+    int kv_heads,
+    int head_dim,
+    int context_len,
+    int max_context) {
+    const int q_head = static_cast<int>(blockIdx.x);
+    const int query_row = static_cast<int>(blockIdx.y);
+    if (q_head >= q_heads || query_row >= block_rows) return;
+    const int kv_head = q_head / (q_heads / kv_heads);
+    const int tid = static_cast<int>(threadIdx.x);
+    const int lane = tid & 31;
+    const int warp = tid >> 5;
+    const size_t q_base =
+        (static_cast<size_t>(query_row) * q_heads + q_head) * head_dim;
+    float query_value = tid < head_dim ? half_to_float(q[q_base + tid]) : 0.0f;
+    float accumulator = 0.0f;
+
+    __shared__ float warp_partials[kAttentionWarps];
+    __shared__ float score;
+    __shared__ float running_max;
+    __shared__ float running_sum;
+    __shared__ float previous_scale;
+    __shared__ float probability;
+    if (tid == 0) {
+        running_max = -INFINITY;
+        running_sum = 0.0f;
+    }
+    __syncthreads();
+
+    const int total_keys = context_len + block_rows;
+    const float attention_scale = rsqrtf(static_cast<float>(head_dim));
+    for (int key_index = 0; key_index < total_keys; ++key_index) {
+        const bool from_context = key_index < context_len;
+        const int position = from_context ? key_index : key_index - context_len;
+        const size_t base = from_context
+            ? (static_cast<size_t>(position) * kv_heads + kv_head) * head_dim
+            : (static_cast<size_t>(position) * kv_heads + kv_head) * head_dim;
+        const uint16_t* key = from_context ? context_k : block_k;
+        const uint16_t* value = from_context ? context_v : block_v;
+        float partial = tid < head_dim
+            ? query_value * half_to_float(key[base + tid]) : 0.0f;
+        partial = warp_sum(partial);
+        if (lane == 0) warp_partials[warp] = partial;
+        __syncthreads();
+        if (tid == 0) {
+            float dot = 0.0f;
+#pragma unroll
+            for (int index = 0; index < kAttentionWarps; ++index) {
+                dot += warp_partials[index];
+            }
+            score = dot * attention_scale;
+            const float next_max = fmaxf(running_max, score);
+            previous_scale = running_max == -INFINITY
+                ? 0.0f : expf(running_max - next_max);
+            probability = expf(score - next_max);
+            running_sum = running_sum * previous_scale + probability;
+            running_max = next_max;
+        }
+        __syncthreads();
+        if (tid < head_dim) {
+            accumulator = accumulator * previous_scale +
+                probability * half_to_float(value[base + tid]);
+        }
+        __syncthreads();
+    }
+    if (tid < head_dim) {
+        const float normalized = running_sum > 0.0f
+            ? accumulator / running_sum : 0.0f;
+        output[q_base + tid] = float_to_half(normalized);
+    }
+    (void)max_context;
+}
+
+__global__ void add_markov_bias_f32_kernel(
+    float* __restrict__ logits,
+    const uint16_t* __restrict__ embedding,
+    const uint16_t* __restrict__ weight,
+    int local_vocab,
+    int rank) {
+    const int output = static_cast<int>(blockIdx.x);
+    if (output >= local_vocab) return;
+    float partial = 0.0f;
+    const uint16_t* row = weight + static_cast<size_t>(output) * rank;
+    for (int index = static_cast<int>(threadIdx.x); index < rank;
+         index += blockDim.x) {
+        partial += half_to_float(embedding[index]) * half_to_float(row[index]);
+    }
+    __shared__ float scratch[kThreads];
+    scratch[threadIdx.x] = partial;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            scratch[threadIdx.x] += scratch[threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) logits[output] += scratch[0];
+}
+
+__global__ void replicated_embedding_gather_f16_kernel(
+    const uint16_t* __restrict__ table,
+    const int* __restrict__ tokens,
+    uint16_t* __restrict__ output,
+    int cols,
+    int table_rows) {
+    const int row = static_cast<int>(blockIdx.x);
+    const int token = tokens[row];
+    if (token < 0 || token >= table_rows) return;
+    for (int col = static_cast<int>(threadIdx.x); col < cols;
+         col += blockDim.x) {
+        output[static_cast<size_t>(row) * cols + col] =
+            table[static_cast<size_t>(token) * cols + col];
+    }
+}
+
+__global__ void confidence_f16_kernel(
+    const uint16_t* __restrict__ hidden,
+    const uint16_t* __restrict__ markov,
+    const uint16_t* __restrict__ weight,
+    const uint16_t* __restrict__ bias,
+    float* __restrict__ output,
+    int hidden_size,
+    int rank) {
+    const int row = static_cast<int>(blockIdx.x);
+    float partial = 0.0f;
+    for (int index = static_cast<int>(threadIdx.x); index < hidden_size;
+         index += blockDim.x) {
+        partial += half_to_float(hidden[static_cast<size_t>(row) * hidden_size + index]) *
+            half_to_float(weight[index]);
+    }
+    for (int index = static_cast<int>(threadIdx.x); index < rank;
+         index += blockDim.x) {
+        partial += half_to_float(markov[static_cast<size_t>(row) * rank + index]) *
+            half_to_float(weight[hidden_size + index]);
+    }
+    __shared__ float scratch[kThreads];
+    scratch[threadIdx.x] = partial;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            scratch[threadIdx.x] += scratch[threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) {
+        const float logit = scratch[0] + half_to_float(bias[0]);
+        output[row] = 1.0f / (1.0f + expf(-logit));
+    }
+}
+
+bool valid_positive_extent(int rows, int cols) {
+    return rows > 0 && cols > 0;
+}
+
+struct DSparkCublasHandle {
+    int device = -1;
+    cublasHandle_t handle = nullptr;
+
+    ~DSparkCublasHandle() {
+        if (handle != nullptr) cublasDestroy(handle);
+    }
+
+    bool get(cublasHandle_t* output) {
+        int current_device = 0;
+        if (cudaGetDevice(&current_device) != cudaSuccess) return false;
+        if (handle != nullptr && current_device != device) {
+            cublasDestroy(handle);
+            handle = nullptr;
+        }
+        if (handle == nullptr) {
+            if (cublasCreate(&handle) != CUBLAS_STATUS_SUCCESS) return false;
+            if (cublasSetMathMode(handle, CUBLAS_TENSOR_OP_MATH) !=
+                CUBLAS_STATUS_SUCCESS) {
+                return false;
+            }
+            device = current_device;
+        }
+        *output = handle;
+        return true;
+    }
+};
+
+DSparkCublasHandle& dspark_cublas_handle() {
+    static DSparkCublasHandle holder;
+    return holder;
+}
+
+}  // namespace
+
+bool qwen_dspark_fp16_gemm_rows_f16_cuda(
+    const uint16_t* d_x_fp16, const uint16_t* d_weight_fp16,
+    uint16_t* d_y_fp16, int batch, int output_rows, int columns,
+    void* stream) {
+    if (d_x_fp16 == nullptr || d_weight_fp16 == nullptr ||
+        d_y_fp16 == nullptr || batch <= 0 || output_rows <= 0 ||
+        columns <= 0) {
+        return false;
+    }
+    cublasHandle_t handle = nullptr;
+    if (!dspark_cublas_handle().get(&handle)) return false;
+    const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
+    if (cublasSetStream(handle, cuda_stream) != CUBLAS_STATUS_SUCCESS) {
+        return false;
+    }
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+    // cuBLAS column-major view: the row-major buffers are W^T [K,N],
+    // X^T [K,M], and Y^T [N,M]. Compute Y^T = W^T * X.
+    return cublasGemmEx(
+        handle, CUBLAS_OP_T, CUBLAS_OP_N,
+        output_rows, batch, columns,
+        &alpha,
+        reinterpret_cast<const __half*>(d_weight_fp16), CUDA_R_16F,
+        columns,
+        reinterpret_cast<const __half*>(d_x_fp16), CUDA_R_16F,
+        columns,
+        &beta,
+        reinterpret_cast<__half*>(d_y_fp16), CUDA_R_16F,
+        output_rows,
+        CUBLAS_COMPUTE_32F,
+        CUBLAS_GEMM_DEFAULT_TENSOR_OP) == CUBLAS_STATUS_SUCCESS;
+}
+
+bool qwen_dspark_rmsnorm_f16_cuda(
+    const uint16_t* d_x_fp16, const uint16_t* d_gamma_fp16,
+    uint16_t* d_y_fp16, int rows, int cols, float eps, void* stream) {
+    if (d_x_fp16 == nullptr || d_gamma_fp16 == nullptr || d_y_fp16 == nullptr ||
+        !valid_positive_extent(rows, cols) || eps < 0.0f) {
+        return false;
+    }
+    standard_rmsnorm_f16_kernel<<<rows, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(
+            d_x_fp16, d_gamma_fp16, d_y_fp16, cols, eps);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_dspark_yarn_rope_f16_cuda(
+    uint16_t* d_x_fp16, const float* d_inv_freqs, int rows,
+    int heads, int head_dim, int start_position, float attention_factor,
+    void* stream) {
+    if (d_x_fp16 == nullptr || d_inv_freqs == nullptr || rows <= 0 ||
+        heads <= 0 || head_dim <= 0 || head_dim % 2 != 0 ||
+        start_position < 0 || attention_factor <= 0.0f) {
+        return false;
+    }
+    const dim3 grid(static_cast<unsigned>(heads), static_cast<unsigned>(rows));
+    const int threads = head_dim / 2 < kThreads ? head_dim / 2 : kThreads;
+    yarn_rope_f16_kernel<<<grid, threads, 0,
+        static_cast<cudaStream_t>(stream)>>>(
+            d_x_fp16, d_inv_freqs, heads, head_dim, start_position,
+            attention_factor);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_dspark_dual_source_gqa_f16_cuda(
+    const uint16_t* d_q_fp16, const uint16_t* d_context_k_fp16,
+    const uint16_t* d_context_v_fp16, const uint16_t* d_block_k_fp16,
+    const uint16_t* d_block_v_fp16, uint16_t* d_output_fp16,
+    int block_rows, int q_heads, int kv_heads, int head_dim,
+    int context_len, int max_context, void* stream) {
+    if (d_q_fp16 == nullptr || d_block_k_fp16 == nullptr ||
+        d_block_v_fp16 == nullptr || d_output_fp16 == nullptr ||
+        block_rows <= 0 || q_heads <= 0 || kv_heads <= 0 ||
+        q_heads % kv_heads != 0 || head_dim <= 0 ||
+        head_dim > kMaxHeadDim || context_len < 0 ||
+        context_len > max_context ||
+        (context_len > 0 &&
+         (d_context_k_fp16 == nullptr || d_context_v_fp16 == nullptr))) {
+        return false;
+    }
+    const dim3 grid(static_cast<unsigned>(q_heads),
+                    static_cast<unsigned>(block_rows));
+    dual_source_gqa_f16_kernel<<<grid, kAttentionThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(
+            d_q_fp16, d_context_k_fp16, d_context_v_fp16,
+            d_block_k_fp16, d_block_v_fp16, d_output_fp16,
+            block_rows, q_heads, kv_heads, head_dim, context_len,
+            max_context);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_dspark_add_markov_bias_f32_cuda(
+    float* d_logits, const uint16_t* d_markov_embedding_fp16,
+    const uint16_t* d_markov_w2_fp16, int local_vocab, int markov_rank,
+    void* stream) {
+    if (d_logits == nullptr || d_markov_embedding_fp16 == nullptr ||
+        d_markov_w2_fp16 == nullptr || local_vocab <= 0 || markov_rank <= 0) {
+        return false;
+    }
+    add_markov_bias_f32_kernel<<<local_vocab, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(
+            d_logits, d_markov_embedding_fp16, d_markov_w2_fp16,
+            local_vocab, markov_rank);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_dspark_embedding_gather_f16_cuda(
+    const uint16_t* d_table_fp16, const int* d_tokens,
+    uint16_t* d_output_fp16, int count, int cols, int table_rows,
+    void* stream) {
+    if (d_table_fp16 == nullptr || d_tokens == nullptr ||
+        d_output_fp16 == nullptr || count <= 0 || cols <= 0 ||
+        table_rows <= 0) {
+        return false;
+    }
+    replicated_embedding_gather_f16_kernel<<<count, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(
+            d_table_fp16, d_tokens, d_output_fp16, cols, table_rows);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_dspark_confidence_f16_cuda(
+    const uint16_t* d_hidden_fp16,
+    const uint16_t* d_markov_embeddings_fp16,
+    const uint16_t* d_weight_fp16, const uint16_t* d_bias_fp16,
+    float* d_confidence, int rows, int hidden_size, int markov_rank,
+    void* stream) {
+    if (d_hidden_fp16 == nullptr || d_markov_embeddings_fp16 == nullptr ||
+        d_weight_fp16 == nullptr || d_bias_fp16 == nullptr ||
+        d_confidence == nullptr || rows <= 0 || hidden_size <= 0 ||
+        markov_rank <= 0) {
+        return false;
+    }
+    confidence_f16_kernel<<<rows, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(
+            d_hidden_fp16, d_markov_embeddings_fp16, d_weight_fp16,
+            d_bias_fp16, d_confidence, hidden_size, markov_rank);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+}  // namespace dsv4

--- a/cpp_engine/include/qwen_cuda_ops.hpp
+++ b/cpp_engine/include/qwen_cuda_ops.hpp
@@ -5,6 +5,53 @@
 
 namespace dsv4 {
 
+// Qwen DSpark uses standard Qwen3 RMSNorm affine weights (gamma directly),
+// unlike the Qwen3.5 target runtime's (1 + weight) convention.
+bool qwen_dspark_rmsnorm_f16_cuda(const uint16_t* d_x_fp16,
+                                  const uint16_t* d_gamma_fp16,
+                                  uint16_t* d_y_fp16, int rows, int cols,
+                                  float eps, void* stream = nullptr);
+
+// Apply full NeoX-style YaRN RoPE in-place to [rows, heads, head_dim]. The
+// inverse-frequency table has head_dim/2 FP32 elements; attention_factor scales
+// both cos and sin exactly like Transformers Qwen3RotaryEmbedding.
+bool qwen_dspark_yarn_rope_f16_cuda(uint16_t* d_x_fp16,
+                                    const float* d_inv_freqs, int rows,
+                                    int heads, int head_dim,
+                                    int start_position,
+                                    float attention_factor,
+                                    void* stream = nullptr);
+
+// Non-causal dual-source block attention used by the fixed-width DSpark
+// proposal: every query sees committed context [0, context_len) and all block
+// K/V rows [0, block_rows).
+bool qwen_dspark_dual_source_gqa_f16_cuda(
+    const uint16_t* d_q_fp16, const uint16_t* d_context_k_fp16,
+    const uint16_t* d_context_v_fp16, const uint16_t* d_block_k_fp16,
+    const uint16_t* d_block_v_fp16, uint16_t* d_output_fp16,
+    int block_rows, int q_heads, int kv_heads, int head_dim,
+    int context_len, int max_context, void* stream = nullptr);
+
+// In-place local-vocab Markov correction for one proposal row.
+bool qwen_dspark_add_markov_bias_f32_cuda(
+    float* d_logits, const uint16_t* d_markov_embedding_fp16,
+    const uint16_t* d_markov_w2_fp16, int local_vocab, int markov_rank,
+    void* stream = nullptr);
+
+// Gather rows from a replicated FP16 table; unlike target TP embedding gather,
+// every token must be locally present.
+bool qwen_dspark_embedding_gather_f16_cuda(
+    const uint16_t* d_table_fp16, const int* d_tokens,
+    uint16_t* d_output_fp16, int count, int cols, int table_rows,
+    void* stream = nullptr);
+
+bool qwen_dspark_confidence_f16_cuda(
+    const uint16_t* d_hidden_fp16,
+    const uint16_t* d_markov_embeddings_fp16,
+    const uint16_t* d_weight_fp16, const uint16_t* d_bias_fp16,
+    float* d_confidence, int rows, int hidden_size, int markov_rank,
+    void* stream = nullptr);
+
 // Qwen FP8 weights use E4M3 codes and 128x128 block scales. On Turing,
 // checkpoint BF16 scales are converted to IEEE FP16 before device upload.
 // These kernels decode each code at the point of use; no expanded copy of the
@@ -276,6 +323,13 @@ bool qwen_silu_mul_rows_cuda(const float* d_gate, const float* d_up, float* d_y,
                              int rows, int cols, void* stream = nullptr);
 
 // --- FP16 activation-storage runtime ----------------------------------------
+
+// cuBLAS-backed FP16 matrix product for large DSpark batches. Weight storage is
+// row-major [output_rows, columns]; output is row-major [batch, output_rows].
+bool qwen_dspark_fp16_gemm_rows_f16_cuda(
+    const uint16_t* d_x_fp16, const uint16_t* d_weight_fp16,
+    uint16_t* d_y_fp16, int batch, int output_rows, int columns,
+    void* stream = nullptr);
 
 bool qwen_fp16_matmul_rows_f16_cuda(const uint16_t* d_x_fp16,
                                     const uint16_t* d_w_fp16,

--- a/cpp_engine/include/qwen_dspark.hpp
+++ b/cpp_engine/include/qwen_dspark.hpp
@@ -1,0 +1,158 @@
+#pragma once
+
+#include "qwen_weights.hpp"
+#include "safetensors_reader.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace dsv4 {
+
+class QwenDSparkWeightMap;
+
+struct QwenDSparkRopeConfig {
+    double theta = 10000000.0;
+    double factor = 32.0;
+    double beta_fast = 32.0;
+    double beta_slow = 1.0;
+    int original_max_positions = 8192;
+    double attention_factor = 0.0;
+};
+
+struct QwenDSparkConfig {
+    int block_size = 0;
+    int mask_token_id = -1;
+    int hidden_size = 0;
+    int intermediate_size = 0;
+    int num_hidden_layers = 0;
+    int num_attention_heads = 0;
+    int num_key_value_heads = 0;
+    int head_dim = 0;
+    int vocab_size = 0;
+    int num_target_layers = 0;
+    int max_position_embeddings = 0;
+    int markov_rank = 0;
+    float rms_norm_eps = 1.0e-6f;
+    bool attention_bias = false;
+    bool confidence_head_with_markov = false;
+    bool enable_confidence_head = false;
+    std::string hidden_act;
+    std::string markov_head_type;
+    std::string attention_mode;
+    std::string projector_type;
+    std::vector<int> target_layer_ids;
+    std::vector<std::string> layer_types;
+    QwenDSparkRopeConfig rope;
+
+    static QwenDSparkConfig from_directory(const std::string& checkpoint_dir);
+    void validate_for_target(uint64_t target_hidden_size,
+                             uint64_t target_vocab_size,
+                             uint64_t target_layers) const;
+};
+
+struct QwenDSparkLayerWeights {
+    QwenTensorRef input_layernorm;
+    QwenTensorRef post_attention_layernorm;
+    QwenLinearRef q_proj;
+    QwenLinearRef k_proj;
+    QwenLinearRef v_proj;
+    QwenLinearRef o_proj;
+    QwenTensorRef q_norm;
+    QwenTensorRef k_norm;
+    QwenLinearRef gate_proj;
+    QwenLinearRef up_proj;
+    QwenLinearRef down_proj;
+};
+
+struct QwenDSparkProposal {
+    std::vector<int> tokens;
+    std::vector<float> confidences;
+    std::vector<float> top_logits;
+};
+
+// Device-resident replicated 5-layer DSpark drafter. Target feature taps are
+// appended as committed rows, then propose() generates the fixed seven-token
+// block without mutating the committed context.
+class QwenDSparkRuntime {
+public:
+    QwenDSparkRuntime(const std::string& checkpoint_dir,
+                      const QwenDSparkConfig& config,
+                      const QwenDSparkWeightMap& weights,
+                      const QwenDeviceTensor& target_embedding,
+                      const QwenDeviceTensor& target_lm_head,
+                      uint64_t target_vocab_start,
+                      int tp_world, int tp_rank, int device,
+                      std::string nccl_id_path, int max_context);
+    ~QwenDSparkRuntime();
+
+    QwenDSparkRuntime(const QwenDSparkRuntime&) = delete;
+    QwenDSparkRuntime& operator=(const QwenDSparkRuntime&) = delete;
+
+    void reset();
+    int committed_position() const;
+    uint64_t resident_weight_bytes() const;
+    uint64_t context_cache_bytes() const;
+    uint64_t activation_workspace_bytes() const;
+
+    // target_taps is [rows, target_layer_ids.size() * hidden_size], containing
+    // raw target post-layer hidden states in target_layer_ids order.
+    void append_target_taps(const uint16_t* target_taps, int rows,
+                            int position_offset);
+    void crop_context(int position);
+    QwenDSparkProposal propose(int anchor_token);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+class QwenDSparkWeightMap {
+public:
+    QwenDSparkWeightMap(const SafeTensorsIndex& index,
+                        const QwenDSparkConfig& config,
+                        int tp_world = 1, int tp_rank = 0);
+
+    const QwenTensorRef& projector() const { return projector_; }
+    const QwenTensorRef& hidden_norm() const { return hidden_norm_; }
+    const QwenTensorRef& final_norm() const { return final_norm_; }
+    const QwenTensorRef& markov_w1() const { return markov_w1_; }
+    const QwenTensorRef& markov_w2() const { return markov_w2_; }
+    const QwenTensorRef& confidence_weight() const { return confidence_weight_; }
+    const QwenTensorRef& confidence_bias() const { return confidence_bias_; }
+    const std::vector<QwenDSparkLayerWeights>& layers() const { return layers_; }
+    uint64_t local_device_bytes() const { return local_device_bytes_; }
+    size_t tensor_count() const { return tensor_count_; }
+
+private:
+    QwenTensorRef require_tensor(const std::string& name,
+                                 const std::vector<uint64_t>& shape,
+                                 QwenShardRule rule = QwenShardRule::Replicated,
+                                 int shard_dim = -1) const;
+    QwenLinearRef require_linear(const std::string& name,
+                                 const std::vector<uint64_t>& shape,
+                                 QwenShardRule rule = QwenShardRule::Replicated,
+                                 int shard_dim = -1) const;
+    void record(const QwenTensorRef& ref);
+
+    const SafeTensorsIndex& index_;
+    QwenDSparkConfig config_;
+    int tp_world_ = 1;
+    int tp_rank_ = 0;
+    QwenTensorRef projector_;
+    QwenTensorRef hidden_norm_;
+    QwenTensorRef final_norm_;
+    QwenTensorRef markov_w1_;
+    QwenTensorRef markov_w2_;
+    QwenTensorRef confidence_weight_;
+    QwenTensorRef confidence_bias_;
+    std::vector<QwenDSparkLayerWeights> layers_;
+    uint64_t local_device_bytes_ = 0;
+    size_t tensor_count_ = 0;
+};
+
+std::vector<float> qwen_dspark_yarn_inv_freqs(
+    const QwenDSparkConfig& config);
+
+}  // namespace dsv4

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -47,6 +47,10 @@ struct QwenEngineOptions {
     // and back off after rejection. This protects low-acceptance prompts while
     // quickly reaching the configured maximum on predictable continuations.
     bool mtp_adaptive = false;
+    // External Qwen DSpark drafter. Empty keeps the feature disabled. DSpark and
+    // native MTP are mutually exclusive because both own the speculative target
+    // transaction and hidden-state side channel.
+    std::string dspark_checkpoint;
     std::string nccl_id_path;
 };
 
@@ -67,23 +71,43 @@ struct QwenForwardResult {
     int position = 0;
 };
 
-// Accounting for one native-MTP generate call.
+// Accounting for one native-MTP or external-DSpark generate call.
 struct QwenMtpStats {
     uint64_t verify_count = 0;
     uint64_t proposed_drafts = 0;
     uint64_t correct_drafts = 0;
     uint64_t rollback_count = 0;
     uint64_t replay_tokens = 0;
+    uint64_t confidence_count = 0;
+    double confidence_sum = 0.0;
+    float confidence_min = 0.0f;
+    float confidence_max = 0.0f;
     double prefill_seconds = 0.0;
     double draft_seconds = 0.0;
     double verify_seconds = 0.0;
     double replay_seconds = 0.0;
 
+    // Mean committed tokens per speculative verification, including the target
+    // bonus token. This matches DSpark's published spec_accept_length metric.
+    double accept_length() const {
+        return verify_count == 0
+            ? 0.0
+            : static_cast<double>(correct_drafts + verify_count) /
+                  static_cast<double>(verify_count);
+    }
+
+    // Draft-token match ratio only. This excludes the target bonus and must not
+    // be compared directly with bonus-inclusive spec_accept_length results.
     double accept_rate() const {
         return proposed_drafts == 0
             ? 0.0
             : static_cast<double>(correct_drafts) /
                   static_cast<double>(proposed_drafts);
+    }
+
+    double mean_confidence() const {
+        return confidence_count == 0
+            ? 0.0 : confidence_sum / static_cast<double>(confidence_count);
     }
 };
 

--- a/cpp_engine/include/safetensors_reader.hpp
+++ b/cpp_engine/include/safetensors_reader.hpp
@@ -45,6 +45,12 @@ struct SafeFp4TensorPair {
 class SafeTensorsIndex {
 public:
     explicit SafeTensorsIndex(const std::string& ckpt_dir);
+    // Build an index for a checkpoint exported as one unsharded file. This is
+    // deliberately explicit so existing sharded-checkpoint error behavior stays
+    // unchanged for callers that require model.safetensors.index.json.
+    static SafeTensorsIndex from_single_file(const std::string& ckpt_dir,
+                                             const std::string& filename =
+                                                 "model.safetensors");
 
     const std::string& ckpt_dir() const { return ckpt_dir_; }
     uint64_t total_size() const { return total_size_; }
@@ -58,6 +64,8 @@ public:
     std::vector<std::string> grep_tensors(const std::string& needle, size_t limit = 50) const;
 
 private:
+    SafeTensorsIndex() = default;
+
     std::string ckpt_dir_;
     uint64_t total_size_ = 0;
     std::map<std::string, std::string> weight_map_;

--- a/cpp_engine/src/main.cpp
+++ b/cpp_engine/src/main.cpp
@@ -59,6 +59,7 @@ struct Args {
     bool qwen_mtp = false;
     int qwen_mtp_tokens = 1;
     bool qwen_mtp_adaptive = false;
+    std::string qwen_dspark_checkpoint;
     bool serve = false;
     int port = 8000;
     std::string host = "0.0.0.0";
@@ -160,6 +161,8 @@ Args parse_args(int argc, char** argv) {
         } else if (arg == "--qwen-mtp-adaptive") {
             args.qwen_mtp = true;
             args.qwen_mtp_adaptive = true;
+        } else if (arg == "--qwen-dspark" && i + 1 < argc) {
+            args.qwen_dspark_checkpoint = argv[++i];
         } else if (arg == "--serve") {
             args.serve = true;
         } else if (arg == "--port" && i + 1 < argc) {
@@ -186,6 +189,17 @@ Args parse_args(int argc, char** argv) {
     }
     if (args.qwen_mtp_tokens <= 0) {
         throw std::runtime_error("--qwen-mtp-tokens must be positive");
+    }
+    if (args.qwen_mtp && !args.qwen_dspark_checkpoint.empty()) {
+        throw std::runtime_error(
+            "--qwen-dspark cannot be combined with native Qwen MTP");
+    }
+    if (!args.qwen_dspark_checkpoint.empty() &&
+        (!is_dir(args.qwen_dspark_checkpoint) ||
+         !path_exists(args.qwen_dspark_checkpoint + "/config.json") ||
+         !path_exists(args.qwen_dspark_checkpoint + "/model.safetensors"))) {
+        throw std::runtime_error(
+            "--qwen-dspark must name a complete DSpark checkpoint directory");
     }
     if (args.kv_cache_dtype != "fp16" && args.kv_cache_dtype != "fp8") {
         throw std::runtime_error("--kv-cache-dtype must be fp16 or fp8");
@@ -275,7 +289,16 @@ void run_qwen_persistent_worker(dsv4::QwenEngine& qwen,
         } else if (command == QwenPersistentCommand::Decode) {
             (void)qwen.decode_step(header[1]);
         } else if (command == QwenPersistentCommand::Generate) {
-            (void)qwen.generate(payload, header[1]);
+            const std::vector<dsv4::QwenForwardResult> outputs =
+                qwen.generate(payload, header[1]);
+            std::cout << "qwen_persistent_worker_result=1 tp_rank="
+                      << qwen.options().tp_rank << " tokens=";
+            for (size_t index = 0; index < outputs.size(); ++index) {
+                if (index != 0) std::cout << ',';
+                std::cout << outputs[index].top_token;
+            }
+            std::cout << '\n';
+            std::cout.flush();
         } else {
             throw std::runtime_error("unknown Qwen persistent worker command");
         }
@@ -414,6 +437,7 @@ int main(int argc, char** argv) {
                     qwen_opts.mtp = args.qwen_mtp;
                     qwen_opts.mtp_speculative_tokens = args.qwen_mtp_tokens;
                     qwen_opts.mtp_adaptive = args.qwen_mtp_adaptive;
+                    qwen_opts.dspark_checkpoint = args.qwen_dspark_checkpoint;
                     qwen_opts.nccl_id_path = args.nccl_id_path;
                     const int qwen_context = args.max_context > 0
                         ? args.max_context
@@ -435,6 +459,9 @@ int main(int argc, char** argv) {
                               << " mtp=" << (qwen_opts.mtp ? 1 : 0)
                               << " mtp_tokens=" << qwen_opts.mtp_speculative_tokens
                               << " mtp_adaptive=" << (qwen_opts.mtp_adaptive ? 1 : 0)
+                              << " dspark=" << (!qwen_opts.dspark_checkpoint.empty() ? 1 : 0)
+                              << " dspark_checkpoint=" << (qwen_opts.dspark_checkpoint.empty()
+                                  ? "-" : qwen_opts.dspark_checkpoint)
                               << " snapshot_interval=" << qwen_opts.state_snapshot_interval_tokens
                               << " max_snapshots=" << qwen_opts.max_state_snapshots
                               << " prompt_tokens=" << prompt_ids.size()
@@ -489,7 +516,8 @@ int main(int argc, char** argv) {
                                 double plain_prefill_seconds = 0.0;
                                 std::vector<int> generated;
                                 generated.reserve(static_cast<size_t>(max_new_tokens));
-                                if (qwen.options().mtp) {
+                                if (qwen.options().mtp ||
+                                    !qwen.options().dspark_checkpoint.empty()) {
                                     qwen_send_command(*channel, QwenPersistentCommand::Generate,
                                                       max_new_tokens, 0, &ids);
                                     const std::vector<dsv4::QwenForwardResult> outputs =
@@ -518,7 +546,9 @@ int main(int argc, char** argv) {
                                 const auto stats = qwen.prefix_cache_stats();
                                 const double wall_seconds =
                                     std::chrono::duration<double>(t1 - t0).count();
-                                const double prefill_seconds = qwen.options().mtp
+                                const bool speculative = qwen.options().mtp ||
+                                    !qwen.options().dspark_checkpoint.empty();
+                                const double prefill_seconds = speculative
                                     ? qwen.mtp_stats().prefill_seconds
                                     : plain_prefill_seconds;
                                 const double decode_seconds = std::max(
@@ -550,14 +580,20 @@ int main(int argc, char** argv) {
                                           << " prefix_snapshots=" << stats.snapshots
                                           << " prefix_snapshot_bytes=" << stats.snapshot_bytes
                                           << " mtp=" << (qwen.options().mtp ? 1 : 0)
+                                          << " dspark=" << (!qwen.options().dspark_checkpoint.empty() ? 1 : 0)
                                           << " mtp_tokens=" << qwen.options().mtp_speculative_tokens
                                           << " mtp_adaptive=" << (qwen.options().mtp_adaptive ? 1 : 0)
                                           << " mtp_accept_rate=" << qwen.mtp_stats().accept_rate()
+                                          << " spec_accept_length=" << qwen.mtp_stats().accept_length()
                                           << " mtp_verify_count=" << qwen.mtp_stats().verify_count
                                           << " mtp_proposed_drafts=" << qwen.mtp_stats().proposed_drafts
                                           << " mtp_correct_drafts=" << qwen.mtp_stats().correct_drafts
                                           << " mtp_rollback_count=" << qwen.mtp_stats().rollback_count
                                           << " mtp_replay_tokens=" << qwen.mtp_stats().replay_tokens
+                                          << " dspark_confidence_count=" << qwen.mtp_stats().confidence_count
+                                          << " dspark_confidence_mean=" << qwen.mtp_stats().mean_confidence()
+                                          << " dspark_confidence_min=" << qwen.mtp_stats().confidence_min
+                                          << " dspark_confidence_max=" << qwen.mtp_stats().confidence_max
                                           << " mtp_prefill_seconds=" << qwen.mtp_stats().prefill_seconds
                                           << " mtp_draft_seconds=" << qwen.mtp_stats().draft_seconds
                                           << " mtp_verify_seconds=" << qwen.mtp_stats().verify_seconds
@@ -581,7 +617,8 @@ int main(int argc, char** argv) {
                         dsv4::QwenPrefixCacheStats prefix_stats;
                         Clock::time_point t_prefill1;
                         Clock::time_point t_decode0;
-                        if (qwen.options().mtp) {
+                        if (qwen.options().mtp ||
+                            !qwen.options().dspark_checkpoint.empty()) {
                             generated = qwen.generate(prompt_ids, args.max_new_tokens);
                             prefix_stats = qwen.prefix_cache_stats();
                             t_prefill1 = t_prefill0 + std::chrono::duration_cast<Clock::duration>(
@@ -640,14 +677,20 @@ int main(int argc, char** argv) {
                                   << " prefix_hits=" << prefix_stats.hits
                                   << " prefix_misses=" << prefix_stats.misses
                                   << " mtp=" << (qwen.options().mtp ? 1 : 0)
+                                  << " dspark=" << (!qwen.options().dspark_checkpoint.empty() ? 1 : 0)
                                   << " mtp_tokens=" << qwen.options().mtp_speculative_tokens
                                   << " mtp_adaptive=" << (qwen.options().mtp_adaptive ? 1 : 0)
                                   << " mtp_accept_rate=" << qwen.mtp_stats().accept_rate()
+                                  << " spec_accept_length=" << qwen.mtp_stats().accept_length()
                                   << " mtp_verify_count=" << qwen.mtp_stats().verify_count
                                   << " mtp_proposed_drafts=" << qwen.mtp_stats().proposed_drafts
                                   << " mtp_correct_drafts=" << qwen.mtp_stats().correct_drafts
                                   << " mtp_rollback_count=" << qwen.mtp_stats().rollback_count
                                   << " mtp_replay_tokens=" << qwen.mtp_stats().replay_tokens
+                                  << " dspark_confidence_count=" << qwen.mtp_stats().confidence_count
+                                  << " dspark_confidence_mean=" << qwen.mtp_stats().mean_confidence()
+                                  << " dspark_confidence_min=" << qwen.mtp_stats().confidence_min
+                                  << " dspark_confidence_max=" << qwen.mtp_stats().confidence_max
                                   << " mtp_prefill_seconds=" << qwen.mtp_stats().prefill_seconds
                                   << " mtp_draft_seconds=" << qwen.mtp_stats().draft_seconds
                                   << " mtp_verify_seconds=" << qwen.mtp_stats().verify_seconds

--- a/cpp_engine/src/qwen_dspark.cpp
+++ b/cpp_engine/src/qwen_dspark.cpp
@@ -1,0 +1,911 @@
+#include "qwen_dspark.hpp"
+
+#include "cuda_ops.hpp"
+#include "json_lite.hpp"
+#include "qwen_cuda_ops.hpp"
+#include "tp_comm.hpp"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+namespace dsv4 {
+namespace {
+
+const JsonValue& required(const JsonObject& object, const std::string& key) {
+    const JsonValue* value = object_get(object, key);
+    if (value == nullptr) {
+        throw std::runtime_error("Qwen DSpark config is missing " + key);
+    }
+    return *value;
+}
+
+int required_int(const JsonObject& object, const std::string& key) {
+    const JsonValue& value = required(object, key);
+    if (!value.is_number()) {
+        throw std::runtime_error("Qwen DSpark config field is not numeric: " + key);
+    }
+    return static_cast<int>(value.number());
+}
+
+double required_number(const JsonObject& object, const std::string& key) {
+    const JsonValue& value = required(object, key);
+    if (!value.is_number()) {
+        throw std::runtime_error("Qwen DSpark config field is not numeric: " + key);
+    }
+    return value.number();
+}
+
+bool required_bool(const JsonObject& object, const std::string& key) {
+    const JsonValue& value = required(object, key);
+    if (!value.is_bool()) {
+        throw std::runtime_error("Qwen DSpark config field is not boolean: " + key);
+    }
+    return value.boolean();
+}
+
+std::string required_string(const JsonObject& object, const std::string& key) {
+    return json_required_string(object, key);
+}
+
+std::vector<int> required_int_array(const JsonObject& object,
+                                    const std::string& key) {
+    const JsonValue& value = required(object, key);
+    if (!value.is_array()) {
+        throw std::runtime_error("Qwen DSpark config field is not an array: " + key);
+    }
+    std::vector<int> output;
+    output.reserve(value.array().size());
+    for (const JsonValue& item : value.array()) {
+        if (!item.is_number()) {
+            throw std::runtime_error("Qwen DSpark array is not numeric: " + key);
+        }
+        output.push_back(static_cast<int>(item.number()));
+    }
+    return output;
+}
+
+std::vector<std::string> required_string_array(const JsonObject& object,
+                                               const std::string& key) {
+    const JsonValue& value = required(object, key);
+    if (!value.is_array()) {
+        throw std::runtime_error("Qwen DSpark config field is not an array: " + key);
+    }
+    std::vector<std::string> output;
+    output.reserve(value.array().size());
+    for (const JsonValue& item : value.array()) {
+        if (!item.is_string()) {
+            throw std::runtime_error("Qwen DSpark array is not textual: " + key);
+        }
+        output.push_back(item.string());
+    }
+    return output;
+}
+
+std::string read_text(const std::string& path) {
+    std::ifstream input(path);
+    if (!input) throw std::runtime_error("cannot open Qwen DSpark config: " + path);
+    std::ostringstream output;
+    output << input.rdbuf();
+    return output.str();
+}
+
+std::string shape_string(const std::vector<uint64_t>& shape) {
+    std::ostringstream output;
+    output << '[';
+    for (size_t index = 0; index < shape.size(); ++index) {
+        if (index != 0) output << ',';
+        output << shape[index];
+    }
+    output << ']';
+    return output.str();
+}
+
+void shard_range(uint64_t total, int world, int rank,
+                 uint64_t* start, uint64_t* size) {
+    if (world <= 0 || rank < 0 || rank >= world ||
+        total % static_cast<uint64_t>(world) != 0) {
+        throw std::runtime_error("Qwen DSpark vocab cannot be evenly TP-sharded");
+    }
+    *size = total / static_cast<uint64_t>(world);
+    *start = *size * static_cast<uint64_t>(rank);
+}
+
+void check_cuda(cudaError_t status, const std::string& what) {
+    if (status != cudaSuccess) {
+        throw std::runtime_error(what + ": " + cudaGetErrorString(status));
+    }
+}
+
+void require_launch(bool ok, const std::string& what) {
+    if (!ok) throw std::runtime_error("Qwen DSpark CUDA launch failed: " + what);
+}
+
+void allocate_tensor(QwenDeviceTensor& tensor, size_t elements,
+                     const std::vector<uint64_t>& shape, SafeDType dtype) {
+    const uint64_t item_size = safe_dtype_size(dtype);
+    if (elements == 0 || item_size == 0 ||
+        elements > static_cast<size_t>(UINT64_MAX / item_size)) {
+        throw std::runtime_error("invalid Qwen DSpark device tensor extent");
+    }
+    const uint64_t bytes = elements * item_size;
+    if (tensor.data != nullptr && tensor.capacity >= bytes) {
+        tensor.device_dtype = dtype;
+        tensor.shape = shape;
+        tensor.nbytes = bytes;
+        return;
+    }
+    if (tensor.data != nullptr) {
+        check_cuda(cudaFree(tensor.data), "free Qwen DSpark device tensor");
+        tensor.data = nullptr;
+    }
+    check_cuda(cudaMalloc(&tensor.data, bytes),
+               "allocate Qwen DSpark device tensor");
+    tensor.device_dtype = dtype;
+    tensor.shape = shape;
+    tensor.nbytes = bytes;
+    tensor.capacity = bytes;
+}
+
+void allocate_half(QwenDeviceTensor& tensor, size_t elements,
+                   const std::vector<uint64_t>& shape) {
+    allocate_tensor(tensor, elements, shape, SafeDType::F16);
+}
+
+void allocate_float(QwenDeviceTensor& tensor, size_t elements,
+                    const std::vector<uint64_t>& shape) {
+    allocate_tensor(tensor, elements, shape, SafeDType::F32);
+}
+
+struct DSparkDeviceLinear {
+    QwenDeviceTensor weight;
+};
+
+struct DSparkDeviceLayer {
+    QwenDeviceTensor input_norm;
+    QwenDeviceTensor post_norm;
+    DSparkDeviceLinear q;
+    DSparkDeviceLinear k;
+    DSparkDeviceLinear v;
+    DSparkDeviceLinear out;
+    QwenDeviceTensor q_norm;
+    QwenDeviceTensor k_norm;
+    DSparkDeviceLinear gate;
+    DSparkDeviceLinear up;
+    DSparkDeviceLinear down;
+    QwenDeviceTensor context_k;
+    QwenDeviceTensor context_v;
+};
+
+DSparkDeviceLinear upload_linear(const SafeTensorsIndex& index,
+                                 const QwenLinearRef& ref) {
+    DSparkDeviceLinear output;
+    output.weight = qwen_upload_tensor_cuda(index, ref.weight);
+    return output;
+}
+
+}  // namespace
+
+QwenDSparkConfig QwenDSparkConfig::from_directory(
+    const std::string& checkpoint_dir) {
+    const JsonValue root = parse_json(read_text(checkpoint_dir + "/config.json"));
+    if (!root.is_object()) {
+        throw std::runtime_error("Qwen DSpark config root is not an object");
+    }
+    const JsonObject& object = root.object();
+    const JsonValue& dflash_value = required(object, "dflash_config");
+    const JsonValue& rope_value = required(object, "rope_parameters");
+    if (!dflash_value.is_object() || !rope_value.is_object()) {
+        throw std::runtime_error("Qwen DSpark nested config is malformed");
+    }
+    const JsonObject& dflash = dflash_value.object();
+    const JsonObject& rope = rope_value.object();
+
+    QwenDSparkConfig config;
+    config.block_size = required_int(object, "block_size");
+    config.hidden_size = required_int(object, "hidden_size");
+    config.intermediate_size = required_int(object, "intermediate_size");
+    config.num_hidden_layers = required_int(object, "num_hidden_layers");
+    config.num_attention_heads = required_int(object, "num_attention_heads");
+    config.num_key_value_heads = required_int(object, "num_key_value_heads");
+    config.head_dim = required_int(object, "head_dim");
+    config.vocab_size = required_int(object, "vocab_size");
+    config.num_target_layers = required_int(object, "num_target_layers");
+    config.max_position_embeddings = required_int(object, "max_position_embeddings");
+    config.markov_rank = required_int(object, "markov_rank");
+    config.mask_token_id = required_int(dflash, "mask_token_id");
+    config.rms_norm_eps = static_cast<float>(required_number(object, "rms_norm_eps"));
+    config.attention_bias = required_bool(object, "attention_bias");
+    config.confidence_head_with_markov =
+        required_bool(object, "confidence_head_with_markov");
+    config.enable_confidence_head = required_bool(object, "enable_confidence_head");
+    config.hidden_act = required_string(object, "hidden_act");
+    config.markov_head_type = required_string(object, "markov_head_type");
+    config.attention_mode = required_string(dflash, "attention_mode");
+    config.projector_type = required_string(dflash, "projector_type");
+    config.target_layer_ids = required_int_array(dflash, "target_layer_ids");
+    config.layer_types = required_string_array(object, "layer_types");
+    config.rope.theta = required_number(rope, "rope_theta");
+    config.rope.factor = required_number(rope, "factor");
+    config.rope.beta_fast = required_number(rope, "beta_fast");
+    config.rope.beta_slow = required_number(rope, "beta_slow");
+    config.rope.original_max_positions =
+        required_int(rope, "original_max_position_embeddings");
+    if (const JsonValue* value = object_get(rope, "attention_factor")) {
+        if (!value->is_number()) {
+            throw std::runtime_error("Qwen DSpark attention_factor is not numeric");
+        }
+        config.rope.attention_factor = value->number();
+    } else {
+        // Match Transformers' yarn_parameters default. Qwen3RotaryEmbedding
+        // multiplies both cosine and sine tables by this factor.
+        config.rope.attention_factor =
+            0.1 * std::log(config.rope.factor) + 1.0;
+    }
+
+    if (config.block_size != 7 || config.num_hidden_layers != 5 ||
+        config.hidden_size <= 0 || config.intermediate_size <= 0 ||
+        config.num_attention_heads <= 0 || config.num_key_value_heads <= 0 ||
+        config.num_attention_heads % config.num_key_value_heads != 0 ||
+        config.head_dim <= 0 || config.head_dim % 2 != 0 ||
+        config.markov_rank <= 0 || config.vocab_size <= 0 ||
+        config.rope.theta <= 0.0 || config.rope.factor <= 0.0 ||
+        config.rope.attention_factor <= 0.0 ||
+        config.mask_token_id < 0 ||
+        config.mask_token_id >= config.vocab_size ||
+        config.target_layer_ids.empty() ||
+        config.layer_types.size() != static_cast<size_t>(config.num_hidden_layers)) {
+        throw std::runtime_error("unsupported Qwen DSpark checkpoint architecture");
+    }
+    if (config.hidden_act != "silu" || config.markov_head_type != "vanilla" ||
+        config.attention_mode != "gqa" || config.projector_type != "dspark" ||
+        config.attention_bias || !config.enable_confidence_head ||
+        !config.confidence_head_with_markov) {
+        throw std::runtime_error("unsupported Qwen DSpark checkpoint semantics");
+    }
+    if (std::any_of(config.layer_types.begin(), config.layer_types.end(),
+                    [](const std::string& type) {
+                        return type != "full_attention";
+                    })) {
+        throw std::runtime_error("Qwen DSpark requires five full-attention layers");
+    }
+    return config;
+}
+
+void QwenDSparkConfig::validate_for_target(
+    uint64_t target_hidden_size, uint64_t target_vocab_size,
+    uint64_t target_layers) const {
+    if (static_cast<uint64_t>(hidden_size) != target_hidden_size ||
+        static_cast<uint64_t>(vocab_size) != target_vocab_size ||
+        static_cast<uint64_t>(num_target_layers) != target_layers) {
+        throw std::runtime_error("Qwen DSpark checkpoint does not match target model");
+    }
+    if (target_layer_ids != std::vector<int>({4, 16, 28, 40, 52})) {
+        throw std::runtime_error("Qwen DSpark target feature taps are unsupported");
+    }
+}
+
+QwenTensorRef QwenDSparkWeightMap::require_tensor(
+    const std::string& name, const std::vector<uint64_t>& shape,
+    QwenShardRule rule, int shard_dim) const {
+    const std::string* shard_name = index_.shard_for_tensor(name);
+    if (shard_name == nullptr) {
+        throw std::runtime_error("missing Qwen DSpark tensor: " + name);
+    }
+    SafeTensorsShard shard(index_.shard_path(*shard_name));
+    const SafeTensorInfo* info = shard.find_tensor(name);
+    if (info == nullptr || info->dtype != SafeDType::BF16 || info->shape != shape) {
+        throw std::runtime_error(
+            "invalid Qwen DSpark tensor " + name + ", expected BF16 " +
+            shape_string(shape));
+    }
+
+    QwenTensorRef ref;
+    ref.name = name;
+    ref.shard_name = *shard_name;
+    ref.dtype = SafeDType::BF16;
+    ref.device_dtype = SafeDType::F16;
+    ref.full_shape = shape;
+    ref.local_shape = shape;
+    ref.rule = rule;
+    ref.shard_dim = shard_dim;
+    ref.nbytes = info->nbytes;
+    ref.found = true;
+    if (rule == QwenShardRule::ParallelHead) {
+        uint64_t start = 0;
+        uint64_t size = 0;
+        shard_range(shape.at(static_cast<size_t>(shard_dim)), tp_world_, tp_rank_,
+                    &start, &size);
+        ref.shard_start = start;
+        ref.shard_size = size;
+        ref.local_shape[static_cast<size_t>(shard_dim)] = size;
+    }
+    ref.device_nbytes = safe_tensor_numel(ref.local_shape) * sizeof(uint16_t);
+    return ref;
+}
+
+QwenLinearRef QwenDSparkWeightMap::require_linear(
+    const std::string& name, const std::vector<uint64_t>& shape,
+    QwenShardRule rule, int shard_dim) const {
+    QwenLinearRef linear;
+    linear.weight = require_tensor(name, shape, rule, shard_dim);
+    return linear;
+}
+
+void QwenDSparkWeightMap::record(const QwenTensorRef& ref) {
+    if (!ref.found) return;
+    ++tensor_count_;
+    local_device_bytes_ += ref.device_nbytes;
+}
+
+QwenDSparkWeightMap::QwenDSparkWeightMap(
+    const SafeTensorsIndex& index, const QwenDSparkConfig& config,
+    int tp_world, int tp_rank)
+    : index_(index), config_(config), tp_world_(tp_world), tp_rank_(tp_rank) {
+    if (tp_world <= 0 || tp_rank < 0 || tp_rank >= tp_world) {
+        throw std::runtime_error("invalid Qwen DSpark TP rank");
+    }
+    const uint64_t hidden = static_cast<uint64_t>(config.hidden_size);
+    const uint64_t intermediate = static_cast<uint64_t>(config.intermediate_size);
+    const uint64_t q_dim = static_cast<uint64_t>(config.num_attention_heads) *
+                           config.head_dim;
+    const uint64_t kv_dim = static_cast<uint64_t>(config.num_key_value_heads) *
+                            config.head_dim;
+    const uint64_t vocab = static_cast<uint64_t>(config.vocab_size);
+    const uint64_t markov = static_cast<uint64_t>(config.markov_rank);
+
+    projector_ = require_tensor(
+        "fc.weight", {hidden, hidden * config.target_layer_ids.size()});
+    hidden_norm_ = require_tensor("hidden_norm.weight", {hidden});
+    final_norm_ = require_tensor("norm.weight", {hidden});
+    markov_w1_ = require_tensor("markov_head.markov_w1.weight", {vocab, markov});
+    markov_w2_ = require_tensor("markov_head.markov_w2.weight", {vocab, markov},
+                                QwenShardRule::ParallelHead, 0);
+    confidence_weight_ = require_tensor(
+        "confidence_head.proj.weight", {1, hidden + markov});
+    confidence_bias_ = require_tensor("confidence_head.proj.bias", {1});
+    for (const QwenTensorRef* ref : {&projector_, &hidden_norm_, &final_norm_,
+                                     &markov_w1_, &markov_w2_,
+                                     &confidence_weight_, &confidence_bias_}) {
+        record(*ref);
+    }
+
+    layers_.resize(static_cast<size_t>(config.num_hidden_layers));
+    for (int index = 0; index < config.num_hidden_layers; ++index) {
+        const std::string prefix = "layers." + std::to_string(index) + ".";
+        QwenDSparkLayerWeights& layer = layers_[static_cast<size_t>(index)];
+        layer.input_layernorm =
+            require_tensor(prefix + "input_layernorm.weight", {hidden});
+        layer.post_attention_layernorm =
+            require_tensor(prefix + "post_attention_layernorm.weight", {hidden});
+        layer.q_proj = require_linear(prefix + "self_attn.q_proj.weight",
+                                      {q_dim, hidden});
+        layer.k_proj = require_linear(prefix + "self_attn.k_proj.weight",
+                                      {kv_dim, hidden});
+        layer.v_proj = require_linear(prefix + "self_attn.v_proj.weight",
+                                      {kv_dim, hidden});
+        layer.o_proj = require_linear(prefix + "self_attn.o_proj.weight",
+                                      {hidden, q_dim});
+        layer.q_norm = require_tensor(prefix + "self_attn.q_norm.weight",
+                                      {static_cast<uint64_t>(config.head_dim)});
+        layer.k_norm = require_tensor(prefix + "self_attn.k_norm.weight",
+                                      {static_cast<uint64_t>(config.head_dim)});
+        layer.gate_proj = require_linear(prefix + "mlp.gate_proj.weight",
+                                         {intermediate, hidden});
+        layer.up_proj = require_linear(prefix + "mlp.up_proj.weight",
+                                       {intermediate, hidden});
+        layer.down_proj = require_linear(prefix + "mlp.down_proj.weight",
+                                         {hidden, intermediate});
+        for (const QwenTensorRef* ref : {
+                 &layer.input_layernorm, &layer.post_attention_layernorm,
+                 &layer.q_proj.weight, &layer.k_proj.weight, &layer.v_proj.weight,
+                 &layer.o_proj.weight, &layer.q_norm, &layer.k_norm,
+                 &layer.gate_proj.weight, &layer.up_proj.weight,
+                 &layer.down_proj.weight}) {
+            record(*ref);
+        }
+    }
+    if (tensor_count_ != 62 || tensor_count_ != index_.tensor_count()) {
+        throw std::runtime_error(
+            "Qwen DSpark checkpoint must contain exactly the 62 expected tensors");
+    }
+}
+
+struct QwenDSparkRuntime::Impl {
+    std::string checkpoint_dir;
+    QwenDSparkConfig config;
+    const QwenDSparkWeightMap& weight_map;
+    SafeTensorsIndex index;
+    const QwenDeviceTensor& target_embedding;
+    const QwenDeviceTensor& target_lm_head;
+    uint64_t target_vocab_start = 0;
+    int tp_world = 1;
+    int tp_rank = 0;
+    int device = 0;
+    std::string nccl_id_path;
+    int max_context = 0;
+    int committed = 0;
+    uint64_t weight_bytes = 0;
+    uint64_t cache_bytes = 0;
+
+    QwenDeviceTensor projector;
+    QwenDeviceTensor hidden_norm;
+    QwenDeviceTensor final_norm;
+    QwenDeviceTensor markov_w1;
+    QwenDeviceTensor markov_w2;
+    QwenDeviceTensor confidence_weight;
+    QwenDeviceTensor confidence_bias;
+    std::vector<DSparkDeviceLayer> layers;
+    QwenDeviceTensor inverse_frequencies;
+
+    QwenDeviceTensor projected_context;
+    QwenDeviceTensor normalized_context;
+    QwenDeviceTensor tokens;
+    QwenDeviceTensor hidden_a;
+    QwenDeviceTensor hidden_b;
+    QwenDeviceTensor normalized;
+    QwenDeviceTensor q;
+    QwenDeviceTensor block_k;
+    QwenDeviceTensor block_v;
+    QwenDeviceTensor attention;
+    QwenDeviceTensor gate;
+    QwenDeviceTensor up;
+    QwenDeviceTensor intermediate;
+    QwenDeviceTensor mlp;
+    QwenDeviceTensor logits;
+    QwenDeviceTensor markov_embeddings;
+    QwenDeviceTensor local_argmax_tokens;
+    QwenDeviceTensor local_argmax_logits;
+    QwenDeviceTensor confidence;
+
+    Impl(const std::string& checkpoint_dir_, const QwenDSparkConfig& config_,
+         const QwenDSparkWeightMap& weights_,
+         const QwenDeviceTensor& target_embedding_,
+         const QwenDeviceTensor& target_lm_head_,
+         uint64_t target_vocab_start_, int tp_world_, int tp_rank_, int device_,
+         std::string nccl_id_path_, int max_context_)
+        : checkpoint_dir(checkpoint_dir_), config(config_), weight_map(weights_),
+          index(SafeTensorsIndex::from_single_file(checkpoint_dir_)),
+          target_embedding(target_embedding_), target_lm_head(target_lm_head_),
+          target_vocab_start(target_vocab_start_), tp_world(tp_world_),
+          tp_rank(tp_rank_), device(device_),
+          nccl_id_path(std::move(nccl_id_path_)), max_context(max_context_) {
+        if (tp_world <= 0 || tp_rank < 0 || tp_rank >= tp_world ||
+            device < 0 || max_context <= 0 ||
+            target_embedding.device_dtype != SafeDType::F16 ||
+            target_lm_head.device_dtype != SafeDType::F16 ||
+            target_embedding.shape.size() != 2 ||
+            target_lm_head.shape.size() != 2 ||
+            target_embedding.shape[1] != static_cast<uint64_t>(config.hidden_size) ||
+            target_lm_head.shape[1] != static_cast<uint64_t>(config.hidden_size)) {
+            throw std::runtime_error("invalid Qwen DSpark runtime target tensors");
+        }
+        check_cuda(cudaSetDevice(device), "select Qwen DSpark CUDA device");
+        projector = qwen_upload_tensor_cuda(index, weight_map.projector());
+        hidden_norm = qwen_upload_tensor_cuda(index, weight_map.hidden_norm());
+        final_norm = qwen_upload_tensor_cuda(index, weight_map.final_norm());
+        markov_w1 = qwen_upload_tensor_cuda(index, weight_map.markov_w1());
+        markov_w2 = qwen_upload_tensor_cuda(index, weight_map.markov_w2());
+        confidence_weight =
+            qwen_upload_tensor_cuda(index, weight_map.confidence_weight());
+        confidence_bias =
+            qwen_upload_tensor_cuda(index, weight_map.confidence_bias());
+        weight_bytes = weight_map.projector().device_nbytes +
+            weight_map.hidden_norm().device_nbytes +
+            weight_map.final_norm().device_nbytes +
+            weight_map.markov_w1().device_nbytes +
+            weight_map.markov_w2().device_nbytes +
+            weight_map.confidence_weight().device_nbytes +
+            weight_map.confidence_bias().device_nbytes;
+
+        const int kv_heads = config.num_key_value_heads;
+        const int head_dim = config.head_dim;
+        const size_t context_elements = static_cast<size_t>(max_context) *
+            kv_heads * head_dim;
+        const std::vector<uint64_t> context_shape = {
+            static_cast<uint64_t>(max_context), static_cast<uint64_t>(kv_heads),
+            static_cast<uint64_t>(head_dim)};
+        layers.reserve(weight_map.layers().size());
+        for (const QwenDSparkLayerWeights& source : weight_map.layers()) {
+            DSparkDeviceLayer layer;
+            layer.input_norm = qwen_upload_tensor_cuda(index, source.input_layernorm);
+            layer.post_norm = qwen_upload_tensor_cuda(index, source.post_attention_layernorm);
+            layer.q = upload_linear(index, source.q_proj);
+            layer.k = upload_linear(index, source.k_proj);
+            layer.v = upload_linear(index, source.v_proj);
+            layer.out = upload_linear(index, source.o_proj);
+            layer.q_norm = qwen_upload_tensor_cuda(index, source.q_norm);
+            layer.k_norm = qwen_upload_tensor_cuda(index, source.k_norm);
+            layer.gate = upload_linear(index, source.gate_proj);
+            layer.up = upload_linear(index, source.up_proj);
+            layer.down = upload_linear(index, source.down_proj);
+            allocate_half(layer.context_k, context_elements, context_shape);
+            allocate_half(layer.context_v, context_elements, context_shape);
+            cache_bytes += layer.context_k.nbytes + layer.context_v.nbytes;
+            for (const QwenTensorRef* ref : {
+                     &source.input_layernorm, &source.post_attention_layernorm,
+                     &source.q_proj.weight, &source.k_proj.weight,
+                     &source.v_proj.weight, &source.o_proj.weight,
+                     &source.q_norm, &source.k_norm,
+                     &source.gate_proj.weight, &source.up_proj.weight,
+                     &source.down_proj.weight}) {
+                weight_bytes += ref->device_nbytes;
+            }
+            layers.push_back(std::move(layer));
+        }
+        const std::vector<float> host_frequencies =
+            qwen_dspark_yarn_inv_freqs(config);
+        allocate_float(inverse_frequencies, host_frequencies.size(),
+                       {static_cast<uint64_t>(host_frequencies.size())});
+        check_cuda(cudaMemcpy(inverse_frequencies.data, host_frequencies.data(),
+                              host_frequencies.size() * sizeof(float),
+                              cudaMemcpyHostToDevice),
+                   "upload Qwen DSpark YaRN frequencies");
+    }
+
+    void all_reduce_half(uint16_t* values, int count) {
+        if (tp_world == 1) return;
+#ifdef DSV4_HAVE_NCCL
+        if (nccl_id_path.empty()) {
+            throw std::runtime_error("Qwen DSpark TP requires NCCL ID path");
+        }
+        nccl_all_reduce_sum_f16_inplace(
+            tp_world, tp_rank, device, nccl_id_path.c_str(), values, count);
+#else
+        (void)values;
+        (void)count;
+        throw std::runtime_error("Qwen DSpark TP requires NCCL-enabled build");
+#endif
+    }
+
+    void projection(const DSparkDeviceLinear& linear, const uint16_t* input,
+                    uint16_t* output, int rows) {
+        const int output_rows = static_cast<int>(linear.weight.shape.at(0));
+        const int columns = static_cast<int>(linear.weight.shape.at(1));
+        require_launch(qwen_dspark_fp16_gemm_rows_f16_cuda(
+            input, linear.weight.f16_data(), output, rows, output_rows,
+            columns), "FP16 projection");
+    }
+
+    void standard_norm(const QwenDeviceTensor& gamma, const uint16_t* input,
+                       uint16_t* output, int rows, int columns) {
+        require_launch(qwen_dspark_rmsnorm_f16_cuda(
+            input, gamma.f16_data(), output, rows, columns,
+            config.rms_norm_eps), "standard RMSNorm");
+    }
+
+    void head_norm(const QwenDeviceTensor& gamma, const uint16_t* input,
+                   uint16_t* output, int rows, int heads) {
+        standard_norm(gamma, input, output, rows * heads, config.head_dim);
+    }
+
+    void apply_rope(uint16_t* values, int rows, int heads,
+                    int start_position) {
+        require_launch(qwen_dspark_yarn_rope_f16_cuda(
+            values, inverse_frequencies.f32_data(), rows, heads,
+            config.head_dim, start_position,
+            static_cast<float>(config.rope.attention_factor)),
+            "full YaRN RoPE");
+    }
+
+    void append_target_taps(const uint16_t* target_taps, int rows,
+                            int position_offset) {
+        if (target_taps == nullptr || rows <= 0 || position_offset < 0 ||
+            position_offset != committed || position_offset + rows > max_context) {
+            throw std::runtime_error("invalid Qwen DSpark target tap append");
+        }
+        const int hidden = config.hidden_size;
+        const int tap_columns = hidden * static_cast<int>(config.target_layer_ids.size());
+        const size_t hidden_elements = static_cast<size_t>(rows) * hidden;
+        allocate_half(projected_context, hidden_elements,
+                      {static_cast<uint64_t>(rows), static_cast<uint64_t>(hidden)});
+        allocate_half(normalized_context, hidden_elements, projected_context.shape);
+        require_launch(qwen_dspark_fp16_gemm_rows_f16_cuda(
+            target_taps, projector.f16_data(), projected_context.f16_data(),
+            rows, hidden, tap_columns), "target feature projector");
+        standard_norm(hidden_norm, projected_context.f16_data(),
+                      normalized_context.f16_data(), rows, hidden);
+
+        const int kv_heads = config.num_key_value_heads;
+        const int kv_dim = kv_heads * config.head_dim;
+        const size_t kv_elements = static_cast<size_t>(rows) * kv_dim;
+        allocate_half(block_k, kv_elements,
+                      {static_cast<uint64_t>(rows), static_cast<uint64_t>(kv_dim)});
+        allocate_half(block_v, kv_elements, block_k.shape);
+        allocate_half(normalized, kv_elements, block_k.shape);
+        for (DSparkDeviceLayer& layer : layers) {
+            projection(layer.k, normalized_context.f16_data(), block_k.f16_data(), rows);
+            projection(layer.v, normalized_context.f16_data(), block_v.f16_data(), rows);
+            head_norm(layer.k_norm, block_k.f16_data(), normalized.f16_data(),
+                      rows, kv_heads);
+            apply_rope(normalized.f16_data(), rows, kv_heads, position_offset);
+            const size_t offset = static_cast<size_t>(position_offset) * kv_dim;
+            check_cuda(cudaMemcpy(
+                layer.context_k.f16_data() + offset, normalized.f16_data(),
+                kv_elements * sizeof(uint16_t), cudaMemcpyDeviceToDevice),
+                "append Qwen DSpark context K");
+            check_cuda(cudaMemcpy(
+                layer.context_v.f16_data() + offset, block_v.f16_data(),
+                kv_elements * sizeof(uint16_t), cudaMemcpyDeviceToDevice),
+                "append Qwen DSpark context V");
+        }
+        committed += rows;
+    }
+
+    std::pair<int, float> global_top1(float* local_logits, int local_vocab) {
+        allocate_tensor(local_argmax_tokens, 1, {1}, SafeDType::I64);
+        allocate_float(local_argmax_logits, 1, {1});
+        require_launch(argmax_fp32_rows_cuda(
+            local_logits, static_cast<int*>(local_argmax_tokens.data),
+            local_argmax_logits.f32_data(), 1, local_vocab,
+            static_cast<int>(target_vocab_start)), "local Markov argmax");
+        int token = 0;
+        float value = 0.0f;
+#ifdef DSV4_HAVE_NCCL
+        if (tp_world > 1) {
+            if (nccl_id_path.empty()) {
+                throw std::runtime_error("Qwen DSpark TP requires NCCL ID path");
+            }
+            nccl_global_top1_rows(
+                tp_world, tp_rank, device, nccl_id_path.c_str(),
+                static_cast<const int*>(local_argmax_tokens.data),
+                local_argmax_logits.f32_data(), 1, &token, &value);
+            return {token, value};
+        }
+#else
+        if (tp_world > 1) {
+            throw std::runtime_error("Qwen DSpark TP requires NCCL-enabled build");
+        }
+#endif
+        check_cuda(cudaMemcpy(&token, local_argmax_tokens.data, sizeof(int),
+                              cudaMemcpyDeviceToHost),
+                   "download Qwen DSpark token");
+        check_cuda(cudaMemcpy(&value, local_argmax_logits.data, sizeof(float),
+                              cudaMemcpyDeviceToHost),
+                   "download Qwen DSpark logit");
+        return {token, value};
+    }
+
+    uint64_t activation_workspace_bytes() const {
+        return projected_context.capacity + normalized_context.capacity +
+            tokens.capacity + hidden_a.capacity + hidden_b.capacity +
+            normalized.capacity + q.capacity + block_k.capacity + block_v.capacity +
+            attention.capacity + gate.capacity + up.capacity + intermediate.capacity +
+            mlp.capacity + logits.capacity + markov_embeddings.capacity +
+            local_argmax_tokens.capacity + local_argmax_logits.capacity +
+            confidence.capacity;
+    }
+
+    QwenDSparkProposal propose(int anchor_token) {
+        if (anchor_token < 0 || anchor_token >= config.vocab_size ||
+            committed >= max_context) {
+            throw std::runtime_error("invalid Qwen DSpark proposal anchor");
+        }
+        const int rows = config.block_size;
+        const int hidden = config.hidden_size;
+        const int q_heads = config.num_attention_heads;
+        const int kv_heads = config.num_key_value_heads;
+        const int q_dim = q_heads * config.head_dim;
+        const int kv_dim = kv_heads * config.head_dim;
+        const int intermediate_size = config.intermediate_size;
+        const int local_vocab = static_cast<int>(target_lm_head.shape.at(0));
+        std::vector<int> host_tokens(static_cast<size_t>(rows),
+                                     config.mask_token_id);
+        host_tokens[0] = anchor_token;
+        allocate_tensor(tokens, rows, {static_cast<uint64_t>(rows)},
+                        SafeDType::I64);
+        check_cuda(cudaMemcpy(tokens.data, host_tokens.data(),
+                              host_tokens.size() * sizeof(int),
+                              cudaMemcpyHostToDevice),
+                   "upload Qwen DSpark noise tokens");
+        const size_t hidden_elements = static_cast<size_t>(rows) * hidden;
+        allocate_half(hidden_a, hidden_elements,
+                      {static_cast<uint64_t>(rows), static_cast<uint64_t>(hidden)});
+        allocate_half(hidden_b, hidden_elements, hidden_a.shape);
+        require_launch(qwen_embedding_fp16_gather_f16_cuda(
+            target_embedding.f16_data(), static_cast<const int*>(tokens.data),
+            hidden_a.f16_data(), rows, hidden,
+            static_cast<int>(target_vocab_start),
+            static_cast<int>(target_embedding.shape.at(0))),
+            "target embedding gather");
+        all_reduce_half(hidden_a.f16_data(), static_cast<int>(hidden_elements));
+
+        uint16_t* current = hidden_a.f16_data();
+        uint16_t* output = hidden_b.f16_data();
+        for (DSparkDeviceLayer& layer : layers) {
+            allocate_half(normalized, hidden_elements, hidden_a.shape);
+            standard_norm(layer.input_norm, current, normalized.f16_data(),
+                          rows, hidden);
+            allocate_half(q, static_cast<size_t>(rows) * q_dim,
+                          {static_cast<uint64_t>(rows), static_cast<uint64_t>(q_dim)});
+            allocate_half(block_k, static_cast<size_t>(rows) * kv_dim,
+                          {static_cast<uint64_t>(rows), static_cast<uint64_t>(kv_dim)});
+            allocate_half(block_v, static_cast<size_t>(rows) * kv_dim, block_k.shape);
+            projection(layer.q, normalized.f16_data(), q.f16_data(), rows);
+            projection(layer.k, normalized.f16_data(), block_k.f16_data(), rows);
+            projection(layer.v, normalized.f16_data(), block_v.f16_data(), rows);
+            allocate_half(attention, static_cast<size_t>(rows) * q_dim, q.shape);
+            head_norm(layer.q_norm, q.f16_data(), attention.f16_data(), rows, q_heads);
+            apply_rope(attention.f16_data(), rows, q_heads, committed);
+            head_norm(layer.k_norm, block_k.f16_data(), normalized.f16_data(),
+                      rows, kv_heads);
+            apply_rope(normalized.f16_data(), rows, kv_heads, committed);
+            require_launch(qwen_dspark_dual_source_gqa_f16_cuda(
+                attention.f16_data(), layer.context_k.f16_data(),
+                layer.context_v.f16_data(), normalized.f16_data(),
+                block_v.f16_data(), q.f16_data(), rows, q_heads, kv_heads,
+                config.head_dim, committed, max_context),
+                "dual-source GQA");
+            projection(layer.out, q.f16_data(), output, rows);
+            require_launch(qwen_add_inplace_f16_cuda(
+                output, current, static_cast<int>(hidden_elements)),
+                "attention residual");
+            standard_norm(layer.post_norm, output, normalized.f16_data(),
+                          rows, hidden);
+            allocate_half(gate, static_cast<size_t>(rows) * intermediate_size,
+                          {static_cast<uint64_t>(rows),
+                           static_cast<uint64_t>(intermediate_size)});
+            allocate_half(up, static_cast<size_t>(rows) * intermediate_size,
+                          gate.shape);
+            allocate_half(intermediate,
+                          static_cast<size_t>(rows) * intermediate_size,
+                          gate.shape);
+            projection(layer.gate, normalized.f16_data(), gate.f16_data(), rows);
+            projection(layer.up, normalized.f16_data(), up.f16_data(), rows);
+            require_launch(qwen_silu_mul_rows_f16_cuda(
+                gate.f16_data(), up.f16_data(), intermediate.f16_data(), rows,
+                intermediate_size), "dense SwiGLU");
+            allocate_half(mlp, hidden_elements, hidden_a.shape);
+            projection(layer.down, intermediate.f16_data(), mlp.f16_data(), rows);
+            require_launch(qwen_add_inplace_f16_cuda(
+                output, mlp.f16_data(), static_cast<int>(hidden_elements)),
+                "MLP residual");
+            current = output;
+            output = output == hidden_a.f16_data()
+                ? hidden_b.f16_data() : hidden_a.f16_data();
+        }
+        allocate_half(normalized, hidden_elements, hidden_a.shape);
+        standard_norm(final_norm, current, normalized.f16_data(), rows, hidden);
+        allocate_float(logits, static_cast<size_t>(rows) * local_vocab,
+                       {static_cast<uint64_t>(rows),
+                        static_cast<uint64_t>(local_vocab)});
+        require_launch(qwen_fp16_matmul_rows_f16_f32_cuda(
+            normalized.f16_data(), target_lm_head.f16_data(), logits.f32_data(),
+            rows, local_vocab, hidden, hidden, local_vocab, hidden),
+            "draft base logits");
+        allocate_half(markov_embeddings,
+                      static_cast<size_t>(rows) * config.markov_rank,
+                      {static_cast<uint64_t>(rows),
+                       static_cast<uint64_t>(config.markov_rank)});
+        allocate_float(confidence, rows, {static_cast<uint64_t>(rows)});
+
+        QwenDSparkProposal proposal;
+        proposal.tokens.reserve(static_cast<size_t>(rows));
+        proposal.top_logits.reserve(static_cast<size_t>(rows));
+        std::vector<int> previous_tokens(static_cast<size_t>(rows), anchor_token);
+        for (int row = 0; row < rows; ++row) {
+            const int previous = row == 0
+                ? anchor_token : proposal.tokens.back();
+            previous_tokens[static_cast<size_t>(row)] = previous;
+            check_cuda(cudaMemcpy(tokens.data, &previous, sizeof(int),
+                                  cudaMemcpyHostToDevice),
+                       "upload Qwen DSpark Markov token");
+            require_launch(qwen_dspark_embedding_gather_f16_cuda(
+                markov_w1.f16_data(), static_cast<const int*>(tokens.data),
+                markov_embeddings.f16_data() +
+                    static_cast<size_t>(row) * config.markov_rank,
+                1, config.markov_rank, config.vocab_size),
+                "Markov embedding gather");
+            float* row_logits = logits.f32_data() +
+                static_cast<size_t>(row) * local_vocab;
+            require_launch(qwen_dspark_add_markov_bias_f32_cuda(
+                row_logits,
+                markov_embeddings.f16_data() +
+                    static_cast<size_t>(row) * config.markov_rank,
+                markov_w2.f16_data(), local_vocab, config.markov_rank),
+                "Markov logit correction");
+            const auto [token, value] = global_top1(row_logits, local_vocab);
+            proposal.tokens.push_back(token);
+            proposal.top_logits.push_back(value);
+        }
+        require_launch(qwen_dspark_confidence_f16_cuda(
+            normalized.f16_data(), markov_embeddings.f16_data(),
+            confidence_weight.f16_data(), confidence_bias.f16_data(),
+            confidence.f32_data(), rows, hidden, config.markov_rank),
+            "confidence predictor");
+        proposal.confidences.resize(static_cast<size_t>(rows));
+        check_cuda(cudaMemcpy(proposal.confidences.data(), confidence.data,
+                              proposal.confidences.size() * sizeof(float),
+                              cudaMemcpyDeviceToHost),
+                   "download Qwen DSpark confidence");
+        return proposal;
+    }
+};
+
+QwenDSparkRuntime::QwenDSparkRuntime(
+    const std::string& checkpoint_dir, const QwenDSparkConfig& config,
+    const QwenDSparkWeightMap& weights,
+    const QwenDeviceTensor& target_embedding,
+    const QwenDeviceTensor& target_lm_head, uint64_t target_vocab_start,
+    int tp_world, int tp_rank, int device, std::string nccl_id_path,
+    int max_context)
+    : impl_(std::make_unique<Impl>(
+          checkpoint_dir, config, weights, target_embedding, target_lm_head,
+          target_vocab_start, tp_world, tp_rank, device,
+          std::move(nccl_id_path), max_context)) {}
+
+QwenDSparkRuntime::~QwenDSparkRuntime() = default;
+
+void QwenDSparkRuntime::reset() { impl_->committed = 0; }
+
+int QwenDSparkRuntime::committed_position() const { return impl_->committed; }
+
+uint64_t QwenDSparkRuntime::resident_weight_bytes() const {
+    return impl_->weight_bytes;
+}
+
+uint64_t QwenDSparkRuntime::context_cache_bytes() const {
+    return impl_->cache_bytes;
+}
+
+uint64_t QwenDSparkRuntime::activation_workspace_bytes() const {
+    return impl_->activation_workspace_bytes();
+}
+
+void QwenDSparkRuntime::append_target_taps(
+    const uint16_t* target_taps, int rows, int position_offset) {
+    impl_->append_target_taps(target_taps, rows, position_offset);
+}
+
+void QwenDSparkRuntime::crop_context(int position) {
+    if (position < 0 || position > impl_->committed) {
+        throw std::runtime_error("invalid Qwen DSpark context crop");
+    }
+    impl_->committed = position;
+}
+
+QwenDSparkProposal QwenDSparkRuntime::propose(int anchor_token) {
+    return impl_->propose(anchor_token);
+}
+
+std::vector<float> qwen_dspark_yarn_inv_freqs(
+    const QwenDSparkConfig& config) {
+    const int dim = config.head_dim;
+    if (dim <= 0 || dim % 2 != 0 || config.rope.theta <= 0.0 ||
+        config.rope.factor <= 0.0 || config.rope.original_max_positions <= 0) {
+        throw std::runtime_error("invalid Qwen DSpark YaRN parameters");
+    }
+    const auto correction_dim = [&](double rotations) {
+        return dim * std::log(config.rope.original_max_positions /
+                              (rotations * 2.0 * M_PI)) /
+               (2.0 * std::log(config.rope.theta));
+    };
+    const double low = std::max(0.0, std::floor(correction_dim(config.rope.beta_fast)));
+    const double high = std::min(
+        static_cast<double>(dim - 1),
+        std::ceil(correction_dim(config.rope.beta_slow)));
+    const double denominator = low == high ? 0.001 : high - low;
+    std::vector<float> output(static_cast<size_t>(dim / 2));
+    for (int pair = 0; pair < dim / 2; ++pair) {
+        const double base = std::pow(config.rope.theta,
+                                     2.0 * pair / static_cast<double>(dim));
+        const double ramp = std::clamp((pair - low) / denominator, 0.0, 1.0);
+        const double extrapolation_factor = 1.0 - ramp;
+        const double inverse_extrapolation = 1.0 / base;
+        const double inverse_interpolation =
+            inverse_extrapolation / config.rope.factor;
+        output[static_cast<size_t>(pair)] = static_cast<float>(
+            inverse_interpolation * (1.0 - extrapolation_factor) +
+            inverse_extrapolation * extrapolation_factor);
+    }
+    return output;
+}
+
+}  // namespace dsv4

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -2,6 +2,7 @@
 
 #include "cuda_ops.hpp"
 #include "qwen_cuda_ops.hpp"
+#include "qwen_dspark.hpp"
 #include "tp_comm.hpp"
 
 #include <cuda_runtime.h>
@@ -244,6 +245,12 @@ struct QwenEngine::Impl {
     QwenDeviceTensor final_norm;
     QwenDeviceTensor lm_head;
     bool mtp_enabled = false;
+    bool dspark_enabled = false;
+    std::unique_ptr<QwenDSparkConfig> dspark_config;
+    std::unique_ptr<SafeTensorsIndex> dspark_index;
+    std::unique_ptr<QwenDSparkWeightMap> dspark_weights;
+    std::unique_ptr<QwenDSparkRuntime> dspark;
+    QwenDeviceTensor dspark_target_taps;
     DeviceLinear mtp_fc;
     QwenDeviceTensor mtp_pre_fc_norm_embedding;
     QwenDeviceTensor mtp_pre_fc_norm_hidden;
@@ -433,6 +440,38 @@ struct QwenEngine::Impl {
             layers.push_back(std::move(destination));
         }
 
+        if (options.mtp && !options.dspark_checkpoint.empty()) {
+            throw std::runtime_error(
+                "Qwen native MTP and external DSpark are mutually exclusive");
+        }
+        if (!options.dspark_checkpoint.empty()) {
+            if (active_layers > 0 &&
+                active_layers != static_cast<int>(config.num_hidden_layers)) {
+                throw std::runtime_error(
+                    "Qwen DSpark requires the complete target layer stack");
+            }
+            dspark_config = std::make_unique<QwenDSparkConfig>(
+                QwenDSparkConfig::from_directory(options.dspark_checkpoint));
+            dspark_config->validate_for_target(
+                config.hidden_size, config.vocab_size, config.num_hidden_layers);
+            dspark_index = std::make_unique<SafeTensorsIndex>(
+                SafeTensorsIndex::from_single_file(options.dspark_checkpoint));
+            dspark_weights = std::make_unique<QwenDSparkWeightMap>(
+                *dspark_index, *dspark_config, options.tp_world, options.tp_rank);
+            // The target embedding is vocab-sharded. QwenDSparkRuntime gathers
+            // local rows then performs the same TP all-reduce as target prefill.
+            dspark = std::make_unique<QwenDSparkRuntime>(
+                options.dspark_checkpoint, *dspark_config, *dspark_weights,
+                embed, lm_head,
+                static_cast<uint64_t>(options.tp_rank) * config.vocab_size /
+                    options.tp_world,
+                options.tp_world, options.tp_rank, options.device,
+                options.nccl_id_path, max_context);
+            dspark_enabled = true;
+            uploaded_weight_bytes += dspark->resident_weight_bytes();
+            cache_data_bytes += dspark->context_cache_bytes();
+        }
+
         if (options.mtp) {
             if (!map.mtp().found) {
                 throw std::runtime_error(
@@ -530,6 +569,7 @@ struct QwenEngine::Impl {
             zero_tensor(layer.linear.state);
             zero_tensor(layer.linear.conv_tail);
         }
+        if (dspark_enabled) dspark->reset();
         has_target_last_hidden = false;
         mtp_seed_ready = false;
         mtp_position = 0;
@@ -543,24 +583,47 @@ struct QwenEngine::Impl {
     // Only the 48 DeltaNet layers carry order-dependent state; full attention
     // is skipped because its KV cache is addressed by absolute position.
     void prepare_transaction_state() {
-        if (transaction_states.size() == layers.size()) return;
-        transaction_states.clear();
-        transaction_conv_tails.clear();
-        transaction_states.resize(layers.size());
-        transaction_conv_tails.resize(layers.size());
-        for (size_t index = 0; index < layers.size(); ++index) {
-            const DeviceLayer& layer = layers[index];
-            if (layer.linear.state.data == nullptr) continue;
-            allocate_float(transaction_states[index],
-                           layer.linear.state.nbytes / sizeof(float),
-                           layer.linear.state.shape);
-            allocate_half(transaction_conv_tails[index],
-                          layer.linear.conv_tail.nbytes / sizeof(uint16_t),
-                          layer.linear.conv_tail.shape);
+        if (transaction_states.size() != layers.size()) {
+            transaction_states.clear();
+            transaction_conv_tails.clear();
+            transaction_states.resize(layers.size());
+            transaction_conv_tails.resize(layers.size());
+            for (size_t index = 0; index < layers.size(); ++index) {
+                const DeviceLayer& layer = layers[index];
+                if (layer.linear.state.data == nullptr) continue;
+                allocate_float(transaction_states[index],
+                               layer.linear.state.nbytes / sizeof(float),
+                               layer.linear.state.shape);
+                allocate_half(transaction_conv_tails[index],
+                              layer.linear.conv_tail.nbytes / sizeof(uint16_t),
+                              layer.linear.conv_tail.shape);
+            }
         }
         if (mtp_enabled) {
             allocate_half(transaction_target_hidden, config.hidden_size,
                           {config.hidden_size});
+        }
+        for (size_t index = 0; index < layers.size(); ++index) {
+            const DeviceLayer& layer = layers[index];
+            if (layer.linear.state.data == nullptr) continue;
+            check_cuda(cudaMemcpy(transaction_states[index].data,
+                                  layer.linear.state.data,
+                                  layer.linear.state.nbytes,
+                                  cudaMemcpyDeviceToDevice),
+                       "Qwen transaction state copy");
+            check_cuda(cudaMemcpy(transaction_conv_tails[index].data,
+                                  layer.linear.conv_tail.data,
+                                  layer.linear.conv_tail.nbytes,
+                                  cudaMemcpyDeviceToDevice),
+                       "Qwen transaction convolution copy");
+        }
+        if (mtp_enabled) {
+            check_cuda(cudaMemcpy(transaction_target_hidden.data,
+                                  target_last_hidden.data,
+                                  static_cast<size_t>(config.hidden_size) *
+                                      sizeof(uint16_t),
+                                  cudaMemcpyDeviceToDevice),
+                       "Qwen transaction hidden copy");
         }
     }
 
@@ -582,15 +645,18 @@ struct QwenEngine::Impl {
                                   cudaMemcpyDeviceToDevice),
                        "Qwen transaction convolution restore");
         }
-        check_cuda(cudaMemcpy(target_last_hidden.data,
-                              transaction_target_hidden.data,
-                              static_cast<size_t>(config.hidden_size) *
-                                  sizeof(uint16_t),
-                              cudaMemcpyDeviceToDevice),
-                   "Qwen transaction hidden restore");
-        has_target_last_hidden = true;
-        mtp_seed_ready = false;
-        mtp_position = position;
+        if (mtp_enabled) {
+            check_cuda(cudaMemcpy(target_last_hidden.data,
+                                  transaction_target_hidden.data,
+                                  static_cast<size_t>(config.hidden_size) *
+                                      sizeof(uint16_t),
+                                  cudaMemcpyDeviceToDevice),
+                       "Qwen transaction hidden restore");
+            has_target_last_hidden = true;
+            mtp_seed_ready = false;
+            mtp_position = position;
+        }
+        if (dspark_enabled) dspark->crop_context(position);
     }
 
     QwenRecurrentSnapshot capture_recurrent_state(
@@ -689,6 +755,16 @@ struct QwenEngine::Impl {
             mtp_seed_ready = false;
             mtp_position = 0;
         }
+        if (dspark_enabled) {
+            // DSpark K/V is position-indexed like target GQA. Cropping only moves
+            // the logical committed boundary; replay overwrites the suffix.
+            if (snapshot.position <= dspark->committed_position()) {
+                dspark->crop_context(snapshot.position);
+            } else {
+                throw std::runtime_error(
+                    "Qwen DSpark snapshot exceeds committed context");
+            }
+        }
         size_t state_offset = 0;
         size_t tail_offset = 0;
         for (DeviceLayer& layer : layers) {
@@ -720,7 +796,7 @@ struct QwenEngine::Impl {
             options.max_state_snapshots <= 0 || position <= 0) {
             return;
         }
-        if (!has_recurrent_state() && !mtp_enabled) return;
+        if (!has_recurrent_state() && !mtp_enabled && !dspark_enabled) return;
         for (QwenRecurrentSnapshot& entry : snapshots) {
             if (entry.position != position) continue;
             entry.periodic = entry.periodic || periodic;
@@ -1476,6 +1552,97 @@ struct QwenEngine::Impl {
         return drafts;
     }
 
+    QwenForwardResult dspark_speculative_step(int input_token,
+                                              QwenMtpStats* stats) {
+        if (!dspark_enabled) {
+            throw std::runtime_error("Qwen DSpark speculative step is disabled");
+        }
+        const int committed_position = dspark->committed_position();
+        prepare_transaction_state();
+        const auto draft_started = std::chrono::steady_clock::now();
+        const QwenDSparkProposal proposal = dspark->propose(input_token);
+        if (stats != nullptr) {
+            stats->draft_seconds += std::chrono::duration<double>(
+                std::chrono::steady_clock::now() - draft_started).count();
+            stats->proposed_drafts += proposal.tokens.size();
+            for (float confidence : proposal.confidences) {
+                if (!std::isfinite(confidence)) {
+                    throw std::runtime_error(
+                        "Qwen DSpark confidence is not finite");
+                }
+                if (stats->confidence_count == 0) {
+                    stats->confidence_min = confidence;
+                    stats->confidence_max = confidence;
+                } else {
+                    stats->confidence_min = std::min(
+                        stats->confidence_min, confidence);
+                    stats->confidence_max = std::max(
+                        stats->confidence_max, confidence);
+                }
+                stats->confidence_sum += confidence;
+                ++stats->confidence_count;
+            }
+        }
+        std::vector<int> verify_inputs;
+        verify_inputs.reserve(proposal.tokens.size() + 1);
+        verify_inputs.push_back(input_token);
+        verify_inputs.insert(verify_inputs.end(), proposal.tokens.begin(),
+                             proposal.tokens.end());
+        QwenVerifyBatch verify;
+        const auto verify_started = std::chrono::steady_clock::now();
+        (void)run_chunk(verify_inputs, committed_position,
+                        static_cast<int>(layers.size()), false, &verify);
+        if (stats != nullptr) {
+            stats->verify_seconds += std::chrono::duration<double>(
+                std::chrono::steady_clock::now() - verify_started).count();
+            ++stats->verify_count;
+        }
+        int correct = 0;
+        while (correct < static_cast<int>(proposal.tokens.size()) &&
+               verify.top_tokens[static_cast<size_t>(correct)] ==
+                   proposal.tokens[static_cast<size_t>(correct)]) {
+            ++correct;
+        }
+        if (stats != nullptr) stats->correct_drafts += correct;
+        const size_t bonus_row = static_cast<size_t>(correct);
+        const int bonus = verify.top_tokens[bonus_row];
+        const float bonus_logit = verify.top_logits[bonus_row];
+        const float bonus_checksum = verify.local_logits[bonus_row];
+        if (correct != static_cast<int>(proposal.tokens.size())) {
+            if (stats != nullptr) {
+                ++stats->rollback_count;
+                stats->replay_tokens += static_cast<uint64_t>(correct + 1);
+            }
+            const auto replay_started = std::chrono::steady_clock::now();
+            restore_transaction_state(committed_position);
+            std::vector<int> replay(verify_inputs.begin(),
+                                    verify_inputs.begin() + correct + 1);
+            (void)run_chunk(replay, committed_position,
+                            static_cast<int>(layers.size()), false);
+            if (stats != nullptr) {
+                stats->replay_seconds += std::chrono::duration<double>(
+                    std::chrono::steady_clock::now() - replay_started).count();
+            }
+        }
+        QwenForwardResult result;
+        result.top_token = bonus;
+        result.bonus_token = bonus;
+        result.correct_drafts = correct;
+        result.accept_tokens.assign(proposal.tokens.begin(),
+                                    proposal.tokens.begin() + correct);
+        result.accept_logits.assign(verify.top_logits.begin(),
+                                    verify.top_logits.begin() + correct);
+        result.accept_checksums.assign(verify.local_logits.begin(),
+                                       verify.local_logits.begin() + correct);
+        result.layers = static_cast<int>(layers.size());
+        result.dim = static_cast<int>(config.hidden_size);
+        result.logits = static_cast<int>(config.vocab_size);
+        result.top_logit = bonus_logit;
+        result.checksum = bonus_checksum;
+        result.position = dspark->committed_position();
+        return result;
+    }
+
     QwenForwardResult speculative_step(int input_token, int draft_count,
                                        QwenMtpStats* stats) {
         if (!mtp_enabled || draft_count <= 0) {
@@ -1484,26 +1651,6 @@ struct QwenEngine::Impl {
         }
         const int committed_position = mtp_position;
         prepare_transaction_state();
-        check_cuda(cudaMemcpy(transaction_target_hidden.data,
-                              target_last_hidden.data,
-                              static_cast<size_t>(config.hidden_size) *
-                                  sizeof(uint16_t),
-                              cudaMemcpyDeviceToDevice),
-                   "Qwen transaction hidden copy");
-        for (size_t index = 0; index < layers.size(); ++index) {
-            const DeviceLayer& layer = layers[index];
-            if (layer.linear.state.data == nullptr) continue;
-            check_cuda(cudaMemcpy(transaction_states[index].data,
-                                  layer.linear.state.data,
-                                  layer.linear.state.nbytes,
-                                  cudaMemcpyDeviceToDevice),
-                       "Qwen transaction state copy");
-            check_cuda(cudaMemcpy(transaction_conv_tails[index].data,
-                                  layer.linear.conv_tail.data,
-                                  layer.linear.conv_tail.nbytes,
-                                  cudaMemcpyDeviceToDevice),
-                       "Qwen transaction convolution copy");
-        }
         const std::vector<int> drafts = draft_tokens(draft_count, input_token, stats);
         std::vector<int> verify_inputs;
         verify_inputs.reserve(drafts.size() + 1);
@@ -1616,10 +1763,53 @@ struct QwenEngine::Impl {
         all_reduce_half(hidden_a.f16_data(), rows * hidden_size);
         uint16_t* hidden = hidden_a.f16_data();
         uint16_t* output = hidden_b.f16_data();
+        const int dspark_tap_count = dspark_enabled
+            ? static_cast<int>(dspark_config->target_layer_ids.size()) : 0;
+        if (dspark_enabled) {
+            allocate_half(
+                dspark_target_taps,
+                static_cast<size_t>(rows) * hidden_size * dspark_tap_count,
+                {static_cast<uint64_t>(rows),
+                 static_cast<uint64_t>(hidden_size * dspark_tap_count)});
+        }
+        int dspark_tap_index = 0;
         for (int layer_index = 0; layer_index < active_layers; ++layer_index) {
             layer_forward(layers[static_cast<size_t>(layer_index)], hidden,
                           output, rows, position_offset);
             std::swap(hidden, output);
+            if (dspark_enabled && dspark_tap_index < dspark_tap_count &&
+                layer_index == dspark_config->target_layer_ids[
+                    static_cast<size_t>(dspark_tap_index)]) {
+                // Store [row, tap, hidden] as the row-major concat expected by
+                // fc.weight [hidden, tap_count * hidden].
+                for (int row = 0; row < rows; ++row) {
+                    uint16_t* destination = dspark_target_taps.f16_data() +
+                        (static_cast<size_t>(row) * dspark_tap_count +
+                         dspark_tap_index) * hidden_size;
+                    check_cuda(cudaMemcpy(
+                        destination,
+                        hidden + static_cast<size_t>(row) * hidden_size,
+                        static_cast<size_t>(hidden_size) * sizeof(uint16_t),
+                        cudaMemcpyDeviceToDevice),
+                        "Qwen DSpark target tap copy");
+                }
+                ++dspark_tap_index;
+            }
+        }
+        if (dspark_enabled) {
+            if (dspark_tap_index != dspark_tap_count) {
+                throw std::runtime_error("Qwen DSpark target taps were not captured");
+            }
+            if (dspark->committed_position() != position_offset) {
+                if (position_offset <= dspark->committed_position()) {
+                    dspark->crop_context(position_offset);
+                } else {
+                    throw std::runtime_error(
+                        "Qwen DSpark target context has a position gap");
+                }
+            }
+            dspark->append_target_taps(dspark_target_taps.f16_data(), rows,
+                                       position_offset);
         }
         if (mtp_enabled) {
             allocate_half(target_hidden_rows, hidden_elements, hidden_shape);
@@ -1682,7 +1872,9 @@ struct QwenEngine::Impl {
                mtp_normalized_embedding.capacity +
                mtp_normalized_hidden.capacity + mtp_concat.capacity +
                mtp_fused.capacity + mtp_next_hidden.capacity +
-               mtp_normalized_output.capacity + workspace.capacity_bytes();
+               mtp_normalized_output.capacity + dspark_target_taps.capacity +
+               workspace.capacity_bytes() +
+               (dspark != nullptr ? dspark->activation_workspace_bytes() : 0);
     }
 };
 
@@ -1693,11 +1885,15 @@ QwenEngine::QwenEngine(const std::string& ckpt_dir,
       config_(QwenConfig::from_hf_config(ckpt_dir)), index_(ckpt_dir),
       weights_(index_, config_, options.tp_world, options.tp_rank) {
     if (options_.device < 0) options_.device = options_.tp_rank;
-    if (options_.mtp && layer_count > 0 &&
+    if (options_.mtp && !options_.dspark_checkpoint.empty()) {
+        throw std::runtime_error(
+            "Qwen native MTP and external DSpark are mutually exclusive");
+    }
+    if ((options_.mtp || !options_.dspark_checkpoint.empty()) && layer_count > 0 &&
         layer_count != static_cast<int>(config_.num_hidden_layers)) {
         throw std::runtime_error(
-            "Qwen MTP requires the complete target model; partial --smoke-layers "
-            "would verify drafts against a different model");
+            "Qwen speculative decoding requires the complete target model; partial "
+            "--smoke-layers would verify drafts against a different model");
     }
     if (options_.prefill_chunk_tokens <= 0) {
         throw std::runtime_error("Qwen prefill chunk size must be positive");
@@ -1790,7 +1986,6 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids) {
 
     prefix_stats_ = QwenPrefixCacheStats{};
     prefix_stats_.prompt_tokens = static_cast<int>(token_ids.size());
-
     const bool can_reuse = options_.prefix_cache &&
         !impl_->cached_prompt.empty() && position_ ==
             static_cast<int>(impl_->cached_prompt.size());
@@ -1988,7 +2183,7 @@ std::vector<QwenForwardResult> QwenEngine::generate(
         std::chrono::steady_clock::now() - prefill_started).count();
     std::vector<QwenForwardResult> results;
     results.reserve(static_cast<size_t>(max_new_tokens));
-    if (!options_.mtp) {
+    if (!options_.mtp && options_.dspark_checkpoint.empty()) {
         for (int index = 0; index < max_new_tokens; ++index) {
             results.push_back(next);
             if (index + 1 < max_new_tokens) next = decode_step(next.top_token);
@@ -2002,8 +2197,11 @@ std::vector<QwenForwardResult> QwenEngine::generate(
     // until the next transaction.
     results.push_back(next);
     int current_token = next.top_token;
-    const int max_draft_tokens = std::max(1, options_.mtp_speculative_tokens);
-    int adaptive_draft_tokens = options_.mtp_adaptive ? 1 : max_draft_tokens;
+    const bool use_dspark = !options_.dspark_checkpoint.empty();
+    const int max_draft_tokens = use_dspark
+        ? 7 : std::max(1, options_.mtp_speculative_tokens);
+    int adaptive_draft_tokens = use_dspark
+        ? 7 : (options_.mtp_adaptive ? 1 : max_draft_tokens);
     int full_accept_streak = 0;
     while (static_cast<int>(results.size()) < max_new_tokens) {
         const int remaining = max_new_tokens - static_cast<int>(results.size());
@@ -2012,10 +2210,23 @@ std::vector<QwenForwardResult> QwenEngine::generate(
             results.push_back(next);
             break;
         }
+        if (use_dspark && remaining < 8) {
+            // The published checkpoint is trained for a fixed seven-row block;
+            // use exact plain decode for a short output tail rather than changing
+            // its attention semantics or returning unnecessary tokens.
+            while (static_cast<int>(results.size()) < max_new_tokens) {
+                next = decode_step(current_token);
+                results.push_back(next);
+                current_token = next.top_token;
+            }
+            break;
+        }
         const int proposed = std::min(adaptive_draft_tokens, remaining - 1);
-        next = impl_->speculative_step(current_token, proposed, &mtp_stats_);
+        next = use_dspark
+            ? impl_->dspark_speculative_step(current_token, &mtp_stats_)
+            : impl_->speculative_step(current_token, proposed, &mtp_stats_);
         const int correct = next.correct_drafts;
-        if (options_.mtp_adaptive) {
+        if (!use_dspark && options_.mtp_adaptive) {
             if (correct == proposed) {
                 ++full_accept_streak;
                 if (full_accept_streak >= 1 &&

--- a/cpp_engine/src/safetensors_reader.cpp
+++ b/cpp_engine/src/safetensors_reader.cpp
@@ -49,6 +49,22 @@ SafeTensorsIndex::SafeTensorsIndex(const std::string& ckpt_dir) : ckpt_dir_(ckpt
     }
 }
 
+SafeTensorsIndex SafeTensorsIndex::from_single_file(
+    const std::string& ckpt_dir, const std::string& filename) {
+    if (filename.empty()) {
+        throw std::runtime_error("safetensors filename must not be empty");
+    }
+    SafeTensorsIndex index;
+    index.ckpt_dir_ = ckpt_dir;
+    SafeTensorsShard shard(ckpt_dir + "/" + filename);
+    index.total_size_ = shard.file_size();
+    index.shards_.insert(filename);
+    for (const auto& [name, _info] : shard.tensors()) {
+        index.weight_map_[name] = filename;
+    }
+    return index;
+}
+
 const std::string* SafeTensorsIndex::shard_for_tensor(const std::string& tensor) const {
     auto it = weight_map_.find(tensor);
     return it == weight_map_.end() ? nullptr : &it->second;

--- a/cpp_engine/tests/test_qwen_dspark.cpp
+++ b/cpp_engine/tests/test_qwen_dspark.cpp
@@ -1,0 +1,66 @@
+#include "qwen_dspark.hpp"
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const std::string& message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        std::cerr << "usage: test_qwen_dspark <draft_checkpoint>\n";
+        return 2;
+    }
+    try {
+        const std::string checkpoint = argv[1];
+        const dsv4::QwenDSparkConfig config =
+            dsv4::QwenDSparkConfig::from_directory(checkpoint);
+        config.validate_for_target(5120, 248320, 64);
+        require(config.block_size == 7, "unexpected DSpark block size");
+        require(config.target_layer_ids ==
+                    std::vector<int>({4, 16, 28, 40, 52}),
+                "unexpected target taps");
+
+        const dsv4::SafeTensorsIndex index =
+            dsv4::SafeTensorsIndex::from_single_file(checkpoint);
+        require(index.tensor_count() == 62, "unexpected DSpark tensor count");
+        const dsv4::QwenDSparkWeightMap rank0(index, config, 4, 0);
+        const dsv4::QwenDSparkWeightMap rank3(index, config, 4, 3);
+        require(rank0.tensor_count() == 62, "weight map missed tensors");
+        require(rank0.markov_w2().local_shape ==
+                    std::vector<uint64_t>({62080, 256}),
+                "bad rank-local Markov head shape");
+        require(rank3.markov_w2().shard_start == 186240,
+                "bad Markov rank offset");
+        require(rank0.local_device_bytes() < 3ull * 1024 * 1024 * 1024,
+                "replicated draft exceeds expected device budget");
+
+        const std::vector<float> frequencies =
+            dsv4::qwen_dspark_yarn_inv_freqs(config);
+        require(frequencies.size() == 64, "bad YaRN frequency count");
+        require(std::abs(config.rope.attention_factor -
+                         (0.1 * std::log(32.0) + 1.0)) < 1.0e-9,
+                "bad default YaRN attention factor");
+        require(std::abs(frequencies.front() - 1.0f) < 1.0e-6f,
+                "bad leading YaRN frequency");
+        require(frequencies.back() > 0.0f &&
+                    frequencies.back() < frequencies.front(),
+                "bad trailing YaRN frequency");
+
+        std::cout << "[PASS] qwen_dspark tensors=" << index.tensor_count()
+                  << " local_device_bytes=" << rank0.local_device_bytes()
+                  << "\n";
+        return 0;
+    } catch (const std::exception& exception) {
+        std::cerr << "[FAIL] " << exception.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_qwen_dspark_ops.cpp
+++ b/cpp_engine/tests/test_qwen_dspark_ops.cpp
@@ -1,0 +1,334 @@
+#include "qwen_cuda_ops.hpp"
+#include "qwen_weights.hpp"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const std::string& message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+void check_cuda(cudaError_t status, const std::string& message) {
+    if (status != cudaSuccess) {
+        throw std::runtime_error(message + ": " + cudaGetErrorString(status));
+    }
+}
+
+uint16_t half_bits(float value) {
+    const uint32_t bits = *reinterpret_cast<const uint32_t*>(&value);
+    const uint16_t bf16 = static_cast<uint16_t>(bits >> 16);
+    return dsv4::qwen_bf16_to_fp16_bits(bf16);
+}
+
+float half_value(uint16_t value) {
+    uint16_t exponent = static_cast<uint16_t>((value >> 10) & 0x1f);
+    uint16_t mantissa = static_cast<uint16_t>(value & 0x03ff);
+    const float sign = (value & 0x8000) ? -1.0f : 1.0f;
+    if (exponent == 0) {
+        return sign * std::ldexp(static_cast<float>(mantissa), -24);
+    }
+    if (exponent == 31) return mantissa ? NAN : sign * INFINITY;
+    return sign * std::ldexp(1.0f + static_cast<float>(mantissa) / 1024.0f,
+                             static_cast<int>(exponent) - 15);
+}
+
+template <typename T>
+T* upload(const std::vector<T>& values) {
+    T* device = nullptr;
+    check_cuda(cudaMalloc(&device, values.size() * sizeof(T)), "cudaMalloc");
+    check_cuda(cudaMemcpy(device, values.data(), values.size() * sizeof(T),
+                          cudaMemcpyHostToDevice), "cudaMemcpy H2D");
+    return device;
+}
+
+template <typename T>
+std::vector<T> download(const T* device, size_t count) {
+    std::vector<T> output(count);
+    check_cuda(cudaMemcpy(output.data(), device, count * sizeof(T),
+                          cudaMemcpyDeviceToHost), "cudaMemcpy D2H");
+    return output;
+}
+
+void test_gemm() {
+    const int batch = 3;
+    const int rows = 5;
+    const int cols = 7;
+    std::vector<float> x_values(static_cast<size_t>(batch) * cols);
+    std::vector<float> weight_values(static_cast<size_t>(rows) * cols);
+    for (size_t index = 0; index < x_values.size(); ++index) {
+        x_values[index] = static_cast<float>(static_cast<int>(index % 9) - 4) / 8.0f;
+    }
+    for (size_t index = 0; index < weight_values.size(); ++index) {
+        weight_values[index] = static_cast<float>(static_cast<int>(index % 11) - 5) / 7.0f;
+    }
+    std::vector<uint16_t> x;
+    std::vector<uint16_t> weight;
+    for (float value : x_values) x.push_back(half_bits(value));
+    for (float value : weight_values) weight.push_back(half_bits(value));
+    uint16_t* d_x = upload(x);
+    uint16_t* d_weight = upload(weight);
+    uint16_t* d_output = nullptr;
+    check_cuda(cudaMalloc(&d_output,
+                          static_cast<size_t>(batch) * rows * sizeof(uint16_t)),
+               "GEMM output");
+    require(dsv4::qwen_dspark_fp16_gemm_rows_f16_cuda(
+                d_x, d_weight, d_output, batch, rows, cols),
+            "DSpark GEMM launch failed");
+    const auto output = download(d_output, static_cast<size_t>(batch) * rows);
+    for (int sample = 0; sample < batch; ++sample) {
+        for (int row = 0; row < rows; ++row) {
+            float expected = 0.0f;
+            for (int col = 0; col < cols; ++col) {
+                expected += x_values[static_cast<size_t>(sample) * cols + col] *
+                    weight_values[static_cast<size_t>(row) * cols + col];
+            }
+            const float actual = half_value(
+                output[static_cast<size_t>(sample) * rows + row]);
+            if (std::abs(actual - expected) >= 0.006f) {
+                throw std::runtime_error(
+                    "DSpark GEMM mismatch sample=" + std::to_string(sample) +
+                    " row=" + std::to_string(row) +
+                    " expected=" + std::to_string(expected) +
+                    " actual=" + std::to_string(actual));
+            }
+        }
+    }
+    cudaFree(d_x);
+    cudaFree(d_weight);
+    cudaFree(d_output);
+}
+
+void test_rmsnorm() {
+    const int rows = 2;
+    const int cols = 4;
+    const std::vector<float> x_values = {1, 2, 3, 4, -2, 1, 0.5f, -1};
+    const std::vector<float> gamma_values = {0.5f, 1.0f, 1.5f, 2.0f};
+    std::vector<uint16_t> x;
+    std::vector<uint16_t> gamma;
+    for (float value : x_values) x.push_back(half_bits(value));
+    for (float value : gamma_values) gamma.push_back(half_bits(value));
+    uint16_t* d_x = upload(x);
+    uint16_t* d_gamma = upload(gamma);
+    uint16_t* d_y = nullptr;
+    check_cuda(cudaMalloc(&d_y, x.size() * sizeof(uint16_t)), "rmsnorm output");
+    require(dsv4::qwen_dspark_rmsnorm_f16_cuda(
+                d_x, d_gamma, d_y, rows, cols, 1.0e-6f),
+            "RMSNorm launch failed");
+    const auto y = download(d_y, x.size());
+    for (int row = 0; row < rows; ++row) {
+        float mean_square = 0.0f;
+        for (int col = 0; col < cols; ++col) {
+            const float value = x_values[row * cols + col];
+            mean_square += value * value;
+        }
+        const float inverse = 1.0f / std::sqrt(mean_square / cols + 1.0e-6f);
+        for (int col = 0; col < cols; ++col) {
+            const float expected = x_values[row * cols + col] * inverse *
+                gamma_values[col];
+            require(std::abs(half_value(y[row * cols + col]) - expected) < 0.004f,
+                    "standard RMSNorm mismatch");
+        }
+    }
+    cudaFree(d_x);
+    cudaFree(d_gamma);
+    cudaFree(d_y);
+}
+
+void test_rope() {
+    const int rows = 2;
+    const int heads = 1;
+    const int dim = 4;
+    std::vector<uint16_t> x = {
+        half_bits(1), half_bits(2), half_bits(3), half_bits(4),
+        half_bits(2), half_bits(-1), half_bits(0.5f), half_bits(3)};
+    const std::vector<float> frequencies = {1.0f, 0.25f};
+    uint16_t* d_x = upload(x);
+    float* d_frequencies = upload(frequencies);
+    require(dsv4::qwen_dspark_yarn_rope_f16_cuda(
+                d_x, d_frequencies, rows, heads, dim, 3, 1.25f),
+            "YaRN RoPE launch failed");
+    const auto output = download(d_x, x.size());
+    for (int row = 0; row < rows; ++row) {
+        for (int pair = 0; pair < dim / 2; ++pair) {
+            const float angle = (3 + row) * frequencies[pair];
+            const float cosine = std::cos(angle) * 1.25f;
+            const float sine = std::sin(angle) * 1.25f;
+            const float left = half_value(x[row * dim + pair]);
+            const float right = half_value(x[row * dim + dim / 2 + pair]);
+            const float expected_left = left * cosine - right * sine;
+            const float expected_right = right * cosine + left * sine;
+            require(std::abs(half_value(output[row * dim + pair]) -
+                             expected_left) < 0.005f,
+                    "YaRN left mismatch");
+            require(std::abs(half_value(output[row * dim + dim / 2 + pair]) -
+                             expected_right) < 0.005f,
+                    "YaRN right mismatch");
+        }
+    }
+    cudaFree(d_x);
+    cudaFree(d_frequencies);
+}
+
+void test_attention() {
+    const int block_rows = 2;
+    const int q_heads = 2;
+    const int kv_heads = 1;
+    const int dim = 4;
+    const int context = 2;
+    const std::vector<float> q_values = {
+        1, 0, 0, 0, 0, 1, 0, 0,
+        0, 0, 1, 0, 0, 0, 0, 1};
+    const std::vector<float> context_k_values = {1, 0, 0, 0, 0, 1, 0, 0};
+    const std::vector<float> context_v_values = {1, 2, 3, 4, 2, 0, 1, -1};
+    const std::vector<float> block_k_values = {0, 0, 1, 0, 0, 0, 0, 1};
+    const std::vector<float> block_v_values = {-1, 1, 2, 0, 3, -2, 0, 1};
+    auto convert = [](const std::vector<float>& values) {
+        std::vector<uint16_t> output;
+        for (float value : values) output.push_back(half_bits(value));
+        return output;
+    };
+    const auto q = convert(q_values);
+    const auto context_k = convert(context_k_values);
+    const auto context_v = convert(context_v_values);
+    const auto block_k = convert(block_k_values);
+    const auto block_v = convert(block_v_values);
+    uint16_t* d_q = upload(q);
+    uint16_t* d_context_k = upload(context_k);
+    uint16_t* d_context_v = upload(context_v);
+    uint16_t* d_block_k = upload(block_k);
+    uint16_t* d_block_v = upload(block_v);
+    uint16_t* d_output = nullptr;
+    check_cuda(cudaMalloc(&d_output, q.size() * sizeof(uint16_t)),
+               "attention output");
+    require(dsv4::qwen_dspark_dual_source_gqa_f16_cuda(
+                d_q, d_context_k, d_context_v, d_block_k, d_block_v,
+                d_output, block_rows, q_heads, kv_heads, dim, context, 8),
+            "dual-source attention launch failed");
+    const auto output = download(d_output, q.size());
+    const float scale = 1.0f / std::sqrt(static_cast<float>(dim));
+    const std::vector<std::vector<float>> keys = {
+        {1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}};
+    const std::vector<std::vector<float>> values = {
+        {1, 2, 3, 4}, {2, 0, 1, -1}, {-1, 1, 2, 0}, {3, -2, 0, 1}};
+    for (int row = 0; row < block_rows; ++row) {
+        for (int head = 0; head < q_heads; ++head) {
+            const int q_base = (row * q_heads + head) * dim;
+            std::vector<float> scores(4);
+            float maximum = -INFINITY;
+            for (int key = 0; key < 4; ++key) {
+                float dot = 0.0f;
+                for (int col = 0; col < dim; ++col) {
+                    dot += q_values[q_base + col] * keys[key][col];
+                }
+                scores[key] = dot * scale;
+                maximum = std::max(maximum, scores[key]);
+            }
+            float denominator = 0.0f;
+            for (float& score : scores) {
+                score = std::exp(score - maximum);
+                denominator += score;
+            }
+            for (int col = 0; col < dim; ++col) {
+                float expected = 0.0f;
+                for (int key = 0; key < 4; ++key) {
+                    expected += scores[key] / denominator * values[key][col];
+                }
+                require(std::abs(half_value(output[q_base + col]) - expected) <
+                                0.004f,
+                        "dual-source attention mismatch");
+            }
+        }
+    }
+    cudaFree(d_q);
+    cudaFree(d_context_k);
+    cudaFree(d_context_v);
+    cudaFree(d_block_k);
+    cudaFree(d_block_v);
+    cudaFree(d_output);
+}
+
+void test_heads() {
+    const int local_vocab = 3;
+    const int rank = 2;
+    std::vector<float> logits = {0.25f, -1.0f, 2.0f};
+    std::vector<uint16_t> embedding = {half_bits(2), half_bits(-1)};
+    std::vector<uint16_t> weight = {
+        half_bits(1), half_bits(0.5f),
+        half_bits(-2), half_bits(1),
+        half_bits(0.25f), half_bits(-0.75f)};
+    float* d_logits = upload(logits);
+    uint16_t* d_embedding = upload(embedding);
+    uint16_t* d_weight = upload(weight);
+    require(dsv4::qwen_dspark_add_markov_bias_f32_cuda(
+                d_logits, d_embedding, d_weight, local_vocab, rank),
+            "Markov launch failed");
+    const auto corrected = download(d_logits, logits.size());
+    const std::vector<float> expected = {1.75f, -6.0f, 3.25f};
+    for (size_t index = 0; index < expected.size(); ++index) {
+        require(std::abs(corrected[index] - expected[index]) < 0.003f,
+                "Markov bias mismatch");
+    }
+
+    const int rows = 2;
+    const int hidden_size = 2;
+    const std::vector<uint16_t> hidden = {
+        half_bits(1), half_bits(2), half_bits(-1), half_bits(0.5f)};
+    const std::vector<uint16_t> markov = {
+        half_bits(0.25f), half_bits(-2), half_bits(1), half_bits(3)};
+    const std::vector<uint16_t> confidence_weight = {
+        half_bits(0.5f), half_bits(-1), half_bits(2), half_bits(0.25f)};
+    const std::vector<uint16_t> bias = {half_bits(-0.5f)};
+    uint16_t* d_hidden = upload(hidden);
+    uint16_t* d_markov = upload(markov);
+    uint16_t* d_confidence_weight = upload(confidence_weight);
+    uint16_t* d_bias = upload(bias);
+    float* d_confidence = nullptr;
+    check_cuda(cudaMalloc(&d_confidence, rows * sizeof(float)),
+               "confidence output");
+    require(dsv4::qwen_dspark_confidence_f16_cuda(
+                d_hidden, d_markov, d_confidence_weight, d_bias,
+                d_confidence, rows, hidden_size, rank),
+            "confidence launch failed");
+    const auto confidence = download(d_confidence, rows);
+    const std::vector<float> raw = {-2.0f, 1.25f};
+    for (int row = 0; row < rows; ++row) {
+        const float expected_confidence = 1.0f / (1.0f + std::exp(-raw[row]));
+        require(std::abs(confidence[row] - expected_confidence) < 0.003f,
+                "confidence mismatch");
+    }
+    cudaFree(d_logits);
+    cudaFree(d_embedding);
+    cudaFree(d_weight);
+    cudaFree(d_hidden);
+    cudaFree(d_markov);
+    cudaFree(d_confidence_weight);
+    cudaFree(d_bias);
+    cudaFree(d_confidence);
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_gemm();
+        test_rmsnorm();
+        test_rope();
+        test_attention();
+        test_heads();
+        check_cuda(cudaDeviceSynchronize(), "DSpark op synchronization");
+        std::cout << "[PASS] qwen_dspark_ops\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "[FAIL] " << error.what() << "\n";
+        return 1;
+    }
+}

--- a/docs/models/qwen3.8-27b-fp8.md
+++ b/docs/models/qwen3.8-27b-fp8.md
@@ -51,6 +51,7 @@ The root config also contains a vision tower, but PocketLLM deliberately dispatc
 - Opt-in FP16 sink-plus-sliding-window attention through `--qwen-attention-window N` and optional `--qwen-attention-sink-tokens N`. This changes full-attention semantics and is not part of exact parity or default performance claims; FP8 cache is intentionally rejected for this mode.
 - TP4 NCCL reductions and global greedy top-1 selection.
 - Opt-in native one-layer MTP loading and greedy speculative generation through `--qwen-mtp-tokens K`. The MTP layer reuses the target embedding/LM head, recursively proposes drafts, and verifies `[current_token, draft_1, ..., draft_K]` in one multi-row target forward. Partial rejection restores DeltaNet state/convolution tails and replays only the committed input prefix. MTP remains disabled by default.
+- Opt-in external Qwen DSpark loading through `--qwen-dspark PATH`. The real five-layer BF16 drafter is replicated on every TP rank, consumes target post-layer taps `4,16,28,40,52`, proposes the checkpoint's fixed seven-token block, and verifies `[anchor,draft_1,...,draft_7]` in one eight-row target forward. Its position-indexed context K/V follows the target prefix cache across append, shorter-prefix, branch, and compressed-context restores.
 
 ## Validated performance
 
@@ -142,6 +143,61 @@ python scripts/bench_qwen_mtp.py \
   --mtp-tokens 4 --adaptive \
   --max-new-tokens 64 --layers 0 \
   --tokenizer-python /path/to/deepseek/bin/python
+```
+
+### External DSpark speculative decoding
+
+The external checkpoint `RadixArk/Qwen3.8-27B-DSpark` (`epoch_2_step_4166`) is supported as an explicit opt-in:
+
+```bash
+--qwen-dspark /path/to/Qwen3.8-27B-DSpark
+```
+
+The directory must contain its `config.json` and single `model.safetensors`. The implementation validates all 62 expected BF16 tensors, materializes them as FP16 on SM75, and adds `2,623,214,594` resident weight bytes per rank. The five-layer draft backbone is replicated rather than tensor-parallel; only target embedding/head operations and the vocabulary-sharded Markov `w2` use TP collectives. Native MTP and external DSpark are mutually exclusive, and DSpark requires all 64 target layers.
+
+The checkpoint fixes `block_size=7`, so each transaction proposes seven drafts and target-verifies eight rows: `[anchor,draft_1,...,draft_7]`. The target post-layer taps are `4,16,28,40,52`. Partial rejection restores DeltaNet recurrent state and convolution tails, crops logical target/DSpark K/V to the committed position, then replays only `[anchor,accepted drafts]`. A remaining output tail shorter than eight tokens uses ordinary exact decode rather than changing the checkpoint's block semantics.
+
+The confidence head is evaluated for every draft and reported as `dspark_confidence_count/mean/min/max`, but it does not currently change the static width-8 schedule: neither the checkpoint nor its published static deployment supplies a validated confidence threshold. Speculative accounting retains the existing `mtp_*` field names for CLI compatibility (`mtp_accept_rate`, proposed/correct drafts, rollback/replay, and stage seconds).
+
+Real TP4, full-model, FP16-target-KV A/B results below use the same tokenizer-real deterministic language fixture, 64 generated tokens, plain then DSpark serial execution, and exact DSpark-versus-plain plus all-rank token checks. The table's `draft match rate` is `correct_drafts / proposed_drafts` and excludes the target bonus token; it is not the model-card `spec_accept_length`, whose numerator includes one bonus token per verification step.
+
+| Prompt | Draft match rate | Plain TPS | DSpark TPS | Decode speedup | Plain wall | DSpark wall | Wall speedup | Highest DSpark rank memory | Parity |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 512 | 94.64% | 37.20 | 60.02 | **1.614x** | 2.944 s | 2.385 s | **1.235x** | 11.19 GB | PASS |
+| 8,192 | 96.43% | 24.80 | 43.79 | **1.766x** | 31.505 s | 31.551 s | 0.999x | 11.61 GB | PASS |
+| 32,768 | 96.43% | 11.31 | 21.70 | **1.919x** | 295.812 s | 295.773 s | 1.000x | 12.52 GB | PASS |
+
+Long-context one-shot wall time is prefill-bound. DSpark's target-feature projector and five layers of context K/V projection make prefill slightly slower even though decode gets progressively faster. This is why the intended deployment remains a long-lived, single-request prefix-reusing engine rather than repeatedly paying cold prefill.
+
+Acceptance is workload-sensitive. The earlier 17% figure came from a deliberately bare 16-token prompt, not the DSpark model-card benchmark protocol: it omitted the Qwen chat template, used greedy decoding, and counted only draft matches. Re-running the same wording with the real chat template still produced a difficult greedy case (15.34% draft match without thinking, 23.81% with thinking), so it is a valid stress case but not evidence that the published DSpark acceptance is 17%. The model card instead reports `spec_accept_length` including the bonus token, with a request-weighted mean of 3.39 accepted tokens per verification step over 1,164 sampled requests (macro-average 3.35) at temperature 0.6, top-k 20, top-p 0.95, thinking enabled, and 2,048 generated tokens. Our native path is currently greedy and should not be compared to those stochastic benchmark numbers as if they were the same metric. DSpark remains default-off pending benchmark-protocol-matched measurements.
+
+For reference, the bare greedy stress prompt measured 31 correct drafts out of 182 proposals (`31/182 = 17.03%`), 17.42 tok/s DSpark decode, and exact plain-token parity. The chat-template, thinking-enabled rerun measured 35/147 (`23.81%`).
+
+Reproduce the protocol-sensitive chat-template fixture with `AutoTokenizer.apply_chat_template(..., add_generation_prompt=True, enable_thinking=True)` before passing token IDs to the C++ runtime; do not use the raw user sentence as the benchmark prompt.
+
+DSpark therefore remains default-off; enable it only after measuring representative traffic with the intended chat template, sampling policy, and generation length.
+
+Reproduce the short/long serial A/B with:
+
+```bash
+/path/to/deepseek/bin/python scripts/bench_qwen_dspark.py \
+  --ckpt /path/to/Qwen3.8-27B-FP8 \
+  --dspark /path/to/Qwen3.8-27B-DSpark \
+  --tp-world 4 --devices 0,1,2,3 \
+  --lengths 512,8192,32768 \
+  --max-new-tokens 64
+```
+
+The focused prefix/cold-parity suite covers exact repeat, monotonic append, shorter prefix, interior branch, and compressed context under both target KV dtypes. With the default early 256-token snapshot spacing, a shorter/branched prompt may reuse the deepest safe 256-token boundary and recompute the remainder rather than claiming the entire matched prefix:
+
+```bash
+for dtype in fp16 fp8; do
+  /path/to/deepseek/bin/python scripts/bench_qwen_dspark_prefix_cache.py \
+    --ckpt /path/to/Qwen3.8-27B-FP8 \
+    --dspark /path/to/Qwen3.8-27B-DSpark \
+    --kv-cache-dtype "$dtype" \
+    --max-context 1024 --max-new-tokens 16
+done
 ```
 
 ### Exact prefix reuse
@@ -309,8 +365,9 @@ build/cpp_engine/dsv4_cpp_engine \
 - Greedy generation only in the current Qwen engine API.
 - The model limit is 262,144 positions; with four generated tokens, the longest valid benchmark prompt is 262,140 tokens. This boundary is validated with both the default FP16 KV cache and the explicit FP8 cache mode; FP8 uses less memory but is slower on this RTX 2080 Ti setup.
 - The executable and internal C++ namespace retain DSV4 compatibility names.
-- CUDA Graph, a decode megakernel, and DSpark integration remain future work; none is included in the reported TPS.
+- CUDA Graph and a decode megakernel remain future work; neither is included in the reported TPS.
 - Native MTP is opt-in. Parity-safe high-acceptance cases accelerate decode by 1.67x at 4K, 2.47x at 8K, and 3.21x at 32K; 65–71% acceptance gives only 1.18–1.37x on 512-token varied prompts. Persistent exact-prefix workloads are the intended use case; `--qwen-mtp-adaptive` starts at K=1 and limits but does not eliminate low-acceptance overhead.
+- External Qwen DSpark is opt-in and always uses its fixed seven-draft/eight-row transaction. It accelerates high-draft-match decode by 1.61–1.92x in measured 512/8K/32K cases, while a bare greedy stress prompt achieved only 31/182 draft matches and regressed to about 17.4 tok/s. This draft-match ratio excludes bonus tokens and is not comparable to the model card's bonus-inclusive `spec_accept_length=3.39` sampled-workload mean. Confidence is telemetry only; no unvalidated threshold is used to gate transactions.
 - Split exact-GQA verification is experimental and enabled only with `QWEN_GQA_VERIFY_SPLIT=1`; direct numerical checks pass, but near-tie greedy output can drift. General long-prefill/decode optimized GQA and sparse attention remain separate opt-in paths; sparse attention changes model semantics.
 
 ## Evidence and related notes
@@ -328,5 +385,12 @@ build/cpp_engine/dsv4_cpp_engine \
 - `cpp_engine/tests/test_qwen_half_ops.cpp`
 - `cpp_engine/tests/test_qwen_weights.cpp`
 - `cpp_engine/tests/test_qwen_engine.cpp`
+- `cpp_engine/include/qwen_dspark.hpp`
+- `cpp_engine/src/qwen_dspark.cpp`
+- `cpp_engine/cuda/qwen_dspark_ops.cu`
+- `cpp_engine/tests/test_qwen_dspark.cpp`
+- `cpp_engine/tests/test_qwen_dspark_ops.cpp`
 - `scripts/bench_qwen_mtp.py`
+- `scripts/bench_qwen_dspark.py`
+- `scripts/bench_qwen_dspark_prefix_cache.py`
 - [Benchmark reporting rules](../benchmarking.md)

--- a/scripts/bench_qwen_dspark.py
+++ b/scripts/bench_qwen_dspark.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Run serial plain-versus-external-DSpark Qwen TP benchmarks.
+
+Each prompt length runs plain first and DSpark second on the real target/draft
+checkpoints. Every TP rank must return the same greedy tokens and DSpark must
+match plain token-for-token. Cases are strictly serial to avoid GPU contention.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+FIXTURE_TEXT = (
+    "Speculative decoding proposes future language-model tokens and verifies them "
+    "with one target forward. Exact greedy parity requires rollback of rejected "
+    "state and commit of only the accepted prefix. This natural-language fixture "
+    "exercises target auxiliary features, DSpark attention, and Markov correction. "
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt", required=True)
+    parser.add_argument("--dspark", required=True)
+    parser.add_argument("--binary", default="build/cpp_engine/dsv4_cpp_engine")
+    parser.add_argument("--lengths", default="512,8192,32768")
+    parser.add_argument("--max-new-tokens", type=int, default=64)
+    parser.add_argument("--prefill-chunk-tokens", type=int, default=512)
+    parser.add_argument("--kv-cache-dtype", choices=("fp16", "fp8"), default="fp16")
+    parser.add_argument("--tp-world", type=int, default=4)
+    parser.add_argument("--devices", default="0,1,2,3")
+    parser.add_argument("--work-dir", default=".tmp/qwen_dspark")
+    parser.add_argument(
+        "--tokenizer-python",
+        default="/home/lvyufeng/miniconda3/envs/deepseek/bin/python",
+    )
+    return parser.parse_args()
+
+
+def make_token_fixture(
+    ckpt: Path, path: Path, length: int, tokenizer_python: str
+) -> list[int]:
+    if path.exists():
+        tokens = [int(item) for item in path.read_text(encoding="ascii").split(",") if item]
+        if len(tokens) >= length:
+            return tokens[:length]
+    code = f"""
+from transformers import AutoTokenizer
+import json, sys
+ckpt, target = sys.argv[1], int(sys.argv[2])
+text = {FIXTURE_TEXT!r} * max(4000, target // 20 + 1)
+tok = AutoTokenizer.from_pretrained(ckpt, local_files_only=True)
+ids = tok.encode(text, add_special_tokens=False)
+if len(ids) < target:
+    raise RuntimeError(f"fixture produced {{len(ids)}} tokens, need {{target}}")
+print(json.dumps(ids[:target]))
+"""
+    completed = subprocess.run(
+        [tokenizer_python, "-c", code, str(ckpt), str(length)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    tokens = json.loads(completed.stdout)
+    if not isinstance(tokens, list) or len(tokens) != length:
+        raise RuntimeError(f"invalid fixture for length {length}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(",".join(str(int(token)) for token in tokens), encoding="ascii")
+    return [int(token) for token in tokens]
+
+
+def parse_runtime(line: str) -> dict[str, Any] | None:
+    if not line.startswith("qwen_runtime=1 "):
+        return None
+    result: dict[str, Any] = {}
+    for key, value in re.findall(r"(\w+)=([^\s]+)", line):
+        try:
+            result[key] = int(value)
+        except ValueError:
+            try:
+                result[key] = float(value)
+            except ValueError:
+                result[key] = value
+    return result
+
+
+def parse_log(path: Path) -> tuple[dict[str, Any], list[int]]:
+    runtime: dict[str, Any] | None = None
+    tokens: list[int] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        parsed = parse_runtime(line)
+        if parsed is not None:
+            runtime = parsed
+        match = re.match(r"generate_step=(\d+) token=(-?\d+)", line)
+        if match:
+            tokens.append(int(match.group(2)))
+    if runtime is None or not tokens:
+        raise RuntimeError(f"incomplete Qwen log: {path}")
+    return runtime, tokens
+
+
+def run_case(
+    *,
+    binary: Path,
+    ckpt: Path,
+    dspark: Path,
+    work_dir: Path,
+    token_path: Path,
+    length: int,
+    max_new_tokens: int,
+    tp_world: int,
+    devices: list[int],
+    prefill_chunk_tokens: int,
+    kv_cache_dtype: str,
+    enabled: bool,
+) -> dict[str, Any]:
+    mode = "dspark" if enabled else "plain"
+    case_dir = work_dir / f"length_{length}" / mode
+    case_dir.mkdir(parents=True, exist_ok=True)
+    id_path = case_dir / "nccl.id"
+    try:
+        id_path.unlink()
+    except FileNotFoundError:
+        pass
+    for path in case_dir.glob("rank*.log"):
+        path.unlink()
+
+    processes: list[tuple[int, subprocess.Popen[bytes]]] = []
+    logs = []
+    statuses: dict[int, int] = {}
+    started = time.monotonic()
+    try:
+        for rank in range(tp_world):
+            command = [
+                str(binary),
+                "--ckpt", str(ckpt),
+                "--tp-world", str(tp_world),
+                "--tp-rank", str(rank),
+                "--device", "0",
+                "--nccl-id-path", str(id_path),
+                "--token-ids-file", str(token_path),
+                "--generate-token", "123",
+                "--max-new-tokens", str(max_new_tokens),
+                "--max-context", str(length + max_new_tokens),
+                "--prefill-chunk-tokens", str(prefill_chunk_tokens),
+                "--kv-cache-dtype", kv_cache_dtype,
+                "--smoke-layers", "0",
+                "--resident-bench",
+            ]
+            if enabled:
+                command += ["--qwen-dspark", str(dspark)]
+            env = os.environ.copy()
+            env["CUDA_VISIBLE_DEVICES"] = str(devices[rank])
+            log = (case_dir / f"rank{rank}.log").open("wb")
+            logs.append(log)
+            processes.append(
+                (rank, subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, env=env))
+            )
+        while len(statuses) < len(processes):
+            for rank, process in processes:
+                if rank in statuses:
+                    continue
+                status = process.poll()
+                if status is None:
+                    continue
+                statuses[rank] = status
+                if status != 0:
+                    for other_rank, other in processes:
+                        if other_rank not in statuses and other.poll() is None:
+                            other.terminate()
+                    break
+            if any(status != 0 for status in statuses.values()):
+                break
+            time.sleep(0.1)
+    finally:
+        for rank, process in processes:
+            if process.poll() is None:
+                process.terminate()
+            try:
+                statuses[rank] = process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                statuses[rank] = process.wait(timeout=30)
+        for log in logs:
+            log.close()
+
+    if any(statuses.get(rank, -1) != 0 for rank in range(tp_world)):
+        raise RuntimeError(f"{mode} TP case failed: {statuses}")
+    parsed = [parse_log(case_dir / f"rank{rank}.log") for rank in range(tp_world)]
+    runtimes = [item[0] for item in parsed]
+    rank_tokens = [item[1] for item in parsed]
+    if any(rank_tokens[0] != tokens for tokens in rank_tokens[1:]):
+        raise RuntimeError(f"{mode} TP-rank parity failed at length {length}")
+    if runtimes[0].get("layers") != 64:
+        raise RuntimeError(f"{mode} did not execute all target layers")
+    memory = [runtime.get("gpu_memory_used_bytes") for runtime in runtimes]
+    return {
+        "mode": mode,
+        "prompt_tokens": length,
+        "tokens": rank_tokens[0],
+        "runtime": runtimes[0],
+        "rank_runtime": runtimes,
+        "rank_token_parity": True,
+        "elapsed_process_wall_seconds": time.monotonic() - started,
+        "max_gpu_memory_used_bytes": max(value for value in memory if value is not None),
+        "log_dir": str(case_dir),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    binary = Path(args.binary).resolve()
+    ckpt = Path(args.ckpt).resolve()
+    dspark = Path(args.dspark).resolve()
+    work_dir = Path(args.work_dir).resolve()
+    lengths = [int(item) for item in args.lengths.split(",") if item.strip()]
+    devices = [int(item) for item in args.devices.split(",") if item.strip()]
+    if not binary.is_file() or not ckpt.is_dir():
+        raise SystemExit("binary or target checkpoint is missing")
+    if not (dspark / "config.json").is_file() or not (dspark / "model.safetensors").is_file():
+        raise SystemExit("DSpark checkpoint is incomplete")
+    if not lengths or any(length <= 0 for length in lengths):
+        raise SystemExit("--lengths must contain positive integers")
+    if len(devices) != args.tp_world or len(set(devices)) != len(devices):
+        raise SystemExit("--devices must contain one distinct device per TP rank")
+    if args.max_new_tokens < 8:
+        raise SystemExit("--max-new-tokens must be at least 8 for a DSpark block")
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    output: dict[str, Any] = {
+        "mode": "qwen_dspark_ab",
+        "checkpoint": str(ckpt),
+        "dspark_checkpoint": str(dspark),
+        "binary": str(binary),
+        "tp_world": args.tp_world,
+        "devices": devices,
+        "max_new_tokens": args.max_new_tokens,
+        "prefill_chunk_tokens": args.prefill_chunk_tokens,
+        "kv_cache_dtype": args.kv_cache_dtype,
+        "results": [],
+    }
+    result_path = work_dir / "results.json"
+    for length in lengths:
+        token_path = work_dir / f"tokens_{length}.txt"
+        make_token_fixture(ckpt, token_path, length, args.tokenizer_python)
+        cases = []
+        for enabled in (False, True):
+            result = run_case(
+                binary=binary,
+                ckpt=ckpt,
+                dspark=dspark,
+                work_dir=work_dir,
+                token_path=token_path,
+                length=length,
+                max_new_tokens=args.max_new_tokens,
+                tp_world=args.tp_world,
+                devices=devices,
+                prefill_chunk_tokens=args.prefill_chunk_tokens,
+                kv_cache_dtype=args.kv_cache_dtype,
+                enabled=enabled,
+            )
+            cases.append(result)
+            runtime = result["runtime"]
+            print(
+                f"length={length} mode={result['mode']} wall={runtime.get('wall')} "
+                f"decode_tps={runtime.get('decode_tokens_per_s')} "
+                f"draft_match_rate={runtime.get('mtp_accept_rate')} "
+                f"accept_length={runtime.get('spec_accept_length')} "
+                f"confidence_mean={runtime.get('dspark_confidence_mean')} "
+                f"rank_parity=PASS"
+            )
+        plain, speculative = cases
+        if speculative["tokens"] != plain["tokens"]:
+            raise RuntimeError(f"DSpark differs from plain greedy tokens at length {length}")
+        speculative["plain_token_parity"] = True
+        speculative["speedup_vs_plain_wall"] = (
+            float(plain["runtime"]["wall"]) / float(speculative["runtime"]["wall"])
+        )
+        speculative["speedup_vs_plain_decode"] = (
+            float(speculative["runtime"]["decode_tokens_per_s"])
+            / float(plain["runtime"]["decode_tokens_per_s"])
+        )
+        output["results"].append({"prompt_tokens": length, "cases": cases})
+        result_path.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+        print(
+            f"length={length} DSpark parity=PASS "
+            f"wall_speedup={speculative['speedup_vs_plain_wall']:.4f} "
+            f"decode_speedup={speculative['speedup_vs_plain_decode']:.4f}"
+        )
+    print(f"results={result_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except subprocess.CalledProcessError as error:
+        print(error.stderr or error.stdout or str(error), file=sys.stderr)
+        raise

--- a/scripts/bench_qwen_dspark_prefix_cache.py
+++ b/scripts/bench_qwen_dspark_prefix_cache.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+"""Validate external Qwen DSpark prefix reuse against cold TP4 engines.
+
+The persistent sequence covers an exact repeat, monotonic append, shorter prefix,
+interior branch, and a compressed-context branch. Every cached result is compared
+with an independently launched cold DSpark run, and every TP rank must agree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, BinaryIO, TextIO
+
+
+FIXTURE_TEXT = (
+    "Speculative decoding proposes future language-model tokens and verifies them "
+    "with one target forward. Exact greedy parity requires rollback of rejected "
+    "state and commit of only the accepted prefix. This natural-language fixture "
+    "exercises target auxiliary features, DSpark attention, and Markov correction. "
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt", required=True)
+    parser.add_argument("--dspark", required=True)
+    parser.add_argument("--binary", default="build/cpp_engine/dsv4_cpp_engine")
+    parser.add_argument("--tp-world", type=int, default=4)
+    parser.add_argument("--devices", default="0,1,2,3")
+    parser.add_argument("--kv-cache-dtype", choices=("fp16", "fp8"), default="fp16")
+    parser.add_argument("--prefill-chunk-tokens", type=int, default=512)
+    parser.add_argument("--max-new-tokens", type=int, default=16)
+    parser.add_argument("--base-tokens", type=int, default=512)
+    parser.add_argument("--append-tokens", type=int, default=64)
+    parser.add_argument("--shorter-tokens", type=int, default=384)
+    parser.add_argument("--branch-prefix-tokens", type=int, default=320)
+    parser.add_argument("--branch-suffix-tokens", type=int, default=96)
+    parser.add_argument("--compression-prefix-tokens", type=int, default=256)
+    parser.add_argument("--compression-suffix-tokens", type=int, default=192)
+    parser.add_argument("--max-context", type=int, default=1024)
+    parser.add_argument("--work-dir", default=".tmp/qwen_dspark_prefix_cache")
+    parser.add_argument(
+        "--tokenizer-python",
+        default="/home/lvyufeng/miniconda3/envs/deepseek/bin/python",
+    )
+    return parser.parse_args()
+
+
+def make_token_fixture(
+    ckpt: Path, path: Path, length: int, tokenizer_python: str
+) -> list[int]:
+    if path.exists():
+        tokens = [int(item) for item in path.read_text(encoding="ascii").split(",") if item]
+        if len(tokens) >= length:
+            return tokens[:length]
+    code = f"""
+from transformers import AutoTokenizer
+import json, sys
+ckpt, target = sys.argv[1], int(sys.argv[2])
+text = {FIXTURE_TEXT!r} * max(4000, target // 20 + 1)
+tok = AutoTokenizer.from_pretrained(ckpt, local_files_only=True)
+ids = tok.encode(text, add_special_tokens=False)
+if len(ids) < target:
+    raise RuntimeError(f"fixture produced {{len(ids)}} tokens, need {{target}}")
+print(json.dumps(ids[:target]))
+"""
+    completed = subprocess.run(
+        [tokenizer_python, "-c", code, str(ckpt), str(length)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    tokens = json.loads(completed.stdout)
+    if not isinstance(tokens, list) or len(tokens) != length:
+        raise RuntimeError(f"invalid fixture for length {length}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(",".join(str(int(token)) for token in tokens), encoding="ascii")
+    return [int(token) for token in tokens]
+
+
+def parse_result(line: str) -> dict[str, Any] | None:
+    if not line.startswith("qwen_persistent_result=1 "):
+        return None
+    result: dict[str, Any] = {}
+    for key, value in re.findall(r"(\w+)=([^\s]+)", line):
+        if key == "tokens":
+            result[key] = [int(item) for item in value.split(",") if item]
+            continue
+        try:
+            result[key] = int(value)
+        except ValueError:
+            try:
+                result[key] = float(value)
+            except ValueError:
+                result[key] = value
+    return result
+
+
+def parse_worker_tokens(path: Path) -> list[list[int]]:
+    results: list[list[int]] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not line.startswith("qwen_persistent_worker_result=1 "):
+            continue
+        match = re.search(r"\btokens=([^\s]*)", line)
+        if match is None:
+            raise RuntimeError(f"worker result is missing tokens: {path}")
+        results.append([int(item) for item in match.group(1).split(",") if item])
+    return results
+
+
+def require_worker_parity(
+    log_dir: Path, tp_world: int, expected: list[list[int]], label: str
+) -> None:
+    for rank in range(1, tp_world):
+        actual = parse_worker_tokens(log_dir / f"rank{rank}.log")
+        if actual != expected:
+            raise RuntimeError(
+                f"{label} TP-rank token parity failed for rank {rank}"
+            )
+
+
+def wait_result(root: subprocess.Popen[str]) -> dict[str, Any]:
+    while True:
+        line = root.stdout.readline() if root.stdout is not None else ""
+        if not line:
+            raise RuntimeError("persistent Qwen root exited before returning a result")
+        parsed = parse_result(line.strip())
+        if parsed is not None:
+            return parsed
+
+
+def command_for_rank(
+    *,
+    binary: Path,
+    ckpt: Path,
+    dspark: Path,
+    rank: int,
+    tp_world: int,
+    id_path: Path,
+    max_context: int,
+    prefill_chunk_tokens: int,
+    kv_cache_dtype: str,
+    prefix_cache: bool,
+) -> list[str]:
+    command = [
+        str(binary),
+        "--ckpt", str(ckpt),
+        "--tp-world", str(tp_world),
+        "--tp-rank", str(rank),
+        "--device", "0",
+        "--nccl-id-path", str(id_path),
+        "--max-context", str(max_context),
+        "--prefill-chunk-tokens", str(prefill_chunk_tokens),
+        "--kv-cache-dtype", kv_cache_dtype,
+        "--smoke-layers", "0",
+        "--qwen-dspark", str(dspark),
+        "--qwen-persistent-stdin",
+    ]
+    if not prefix_cache:
+        command.append("--qwen-no-prefix-cache")
+    return command
+
+
+def cleanup_nccl_paths(id_path: Path) -> None:
+    id_path.parent.mkdir(parents=True, exist_ok=True)
+    for path in (id_path, Path(str(id_path) + ".qwen")):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def launch_group(
+    *,
+    binary: Path,
+    ckpt: Path,
+    dspark: Path,
+    tp_world: int,
+    devices: list[int],
+    id_path: Path,
+    log_dir: Path,
+    max_context: int,
+    prefill_chunk_tokens: int,
+    kv_cache_dtype: str,
+    prefix_cache: bool,
+) -> tuple[subprocess.Popen[str], list[subprocess.Popen[bytes]], list[BinaryIO]]:
+    cleanup_nccl_paths(id_path)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    commands = [
+        command_for_rank(
+            binary=binary,
+            ckpt=ckpt,
+            dspark=dspark,
+            rank=rank,
+            tp_world=tp_world,
+            id_path=id_path,
+            max_context=max_context,
+            prefill_chunk_tokens=prefill_chunk_tokens,
+            kv_cache_dtype=kv_cache_dtype,
+            prefix_cache=prefix_cache,
+        )
+        for rank in range(tp_world)
+    ]
+    logs: list[BinaryIO] = []
+    workers: list[subprocess.Popen[bytes]] = []
+    for rank in range(1, tp_world):
+        log = (log_dir / f"rank{rank}.log").open("wb")
+        logs.append(log)
+        env = os.environ.copy()
+        env["CUDA_VISIBLE_DEVICES"] = str(devices[rank])
+        workers.append(
+            subprocess.Popen(commands[rank], stdout=log, stderr=subprocess.STDOUT, env=env)
+        )
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = str(devices[0])
+    root = subprocess.Popen(
+        commands[0],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        env=env,
+    )
+    return root, workers, logs
+
+
+def stop_group(
+    root: subprocess.Popen[str] | None,
+    workers: list[subprocess.Popen[bytes]],
+    logs: list[BinaryIO],
+) -> None:
+    if root is not None:
+        if root.stdin is not None and not root.stdin.closed:
+            root.stdin.close()
+        if root.poll() is None:
+            root.terminate()
+    for worker in workers:
+        if worker.poll() is None:
+            worker.terminate()
+    if root is not None:
+        try:
+            root.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            root.kill()
+            root.wait(timeout=30)
+    for worker in workers:
+        try:
+            worker.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            worker.kill()
+            worker.wait(timeout=30)
+    for log in logs:
+        log.close()
+
+
+def request(root: subprocess.Popen[str], prompt: list[int], max_new_tokens: int) -> dict[str, Any]:
+    if root.stdin is None:
+        raise RuntimeError("persistent root stdin is unavailable")
+    root.stdin.write(
+        f"{max_new_tokens} " + " ".join(str(token) for token in prompt) + "\n"
+    )
+    root.stdin.flush()
+    return wait_result(root)
+
+
+def run_cold_case(
+    *,
+    args: argparse.Namespace,
+    binary: Path,
+    ckpt: Path,
+    dspark: Path,
+    devices: list[int],
+    work_dir: Path,
+    case_index: int,
+    prompt: list[int],
+) -> dict[str, Any]:
+    case_dir = work_dir / "cold" / f"case_{case_index}"
+    root: subprocess.Popen[str] | None = None
+    workers: list[subprocess.Popen[bytes]] = []
+    logs: list[BinaryIO] = []
+    try:
+        root, workers, logs = launch_group(
+            binary=binary,
+            ckpt=ckpt,
+            dspark=dspark,
+            tp_world=args.tp_world,
+            devices=devices,
+            id_path=case_dir / "nccl.id",
+            log_dir=case_dir,
+            max_context=args.max_context,
+            prefill_chunk_tokens=args.prefill_chunk_tokens,
+            kv_cache_dtype=args.kv_cache_dtype,
+            prefix_cache=False,
+        )
+        result = request(root, prompt, args.max_new_tokens)
+        if root.stdin is not None:
+            root.stdin.close()
+        root.wait(timeout=120)
+        for worker in workers:
+            worker.wait(timeout=120)
+        if root.returncode != 0 or any(worker.returncode != 0 for worker in workers):
+            raise RuntimeError(
+                f"cold case failed root={root.returncode} "
+                f"workers={[worker.returncode for worker in workers]}"
+            )
+        require_worker_parity(
+            case_dir, args.tp_world,
+            [[int(token) for token in result.get("tokens", [])]],
+            f"cold case {case_index}",
+        )
+        return result
+    finally:
+        stop_group(root, workers, logs)
+
+
+def validate_args(args: argparse.Namespace) -> tuple[Path, Path, Path, Path, list[int]]:
+    binary = Path(args.binary).resolve()
+    ckpt = Path(args.ckpt).resolve()
+    dspark = Path(args.dspark).resolve()
+    work_dir = Path(args.work_dir).resolve()
+    devices = [int(item) for item in args.devices.split(",") if item.strip()]
+    if not binary.is_file() or not ckpt.is_dir():
+        raise SystemExit("binary or target checkpoint is missing")
+    if not (dspark / "config.json").is_file() or not (dspark / "model.safetensors").is_file():
+        raise SystemExit("DSpark checkpoint is incomplete")
+    if len(devices) != args.tp_world or len(set(devices)) != len(devices):
+        raise SystemExit("--devices must contain one distinct device per TP rank")
+    if args.max_new_tokens < 8:
+        raise SystemExit("--max-new-tokens must be at least 8 for a DSpark block")
+    positive = [
+        args.base_tokens,
+        args.append_tokens,
+        args.shorter_tokens,
+        args.branch_prefix_tokens,
+        args.branch_suffix_tokens,
+        args.compression_prefix_tokens,
+        args.compression_suffix_tokens,
+        args.max_context,
+    ]
+    if any(value <= 0 for value in positive):
+        raise SystemExit("prefix fixture sizes and max-context must be positive")
+    if args.shorter_tokens >= args.base_tokens:
+        raise SystemExit("--shorter-tokens must be smaller than --base-tokens")
+    if args.branch_prefix_tokens >= args.shorter_tokens:
+        raise SystemExit(
+            "--branch-prefix-tokens must be smaller than --shorter-tokens"
+        )
+    if args.compression_prefix_tokens >= args.branch_prefix_tokens:
+        raise SystemExit(
+            "--compression-prefix-tokens must be smaller than --branch-prefix-tokens"
+        )
+    return binary, ckpt, dspark, work_dir, devices
+
+
+def main() -> int:
+    args = parse_args()
+    binary, ckpt, dspark, work_dir, devices = validate_args(args)
+    fixture_length = args.base_tokens + args.append_tokens
+    base = make_token_fixture(
+        ckpt, work_dir / f"tokens_{fixture_length}.txt", fixture_length,
+        args.tokenizer_python,
+    )
+    original = base[:args.base_tokens]
+    prompts = [
+        ("initial", original),
+        ("exact_repeat", list(original)),
+        ("monotonic_append", list(base)),
+        ("shorter_prefix", original[:args.shorter_tokens]),
+        (
+            "interior_branch",
+            original[:args.branch_prefix_tokens]
+            + [70000 + index for index in range(args.branch_suffix_tokens)],
+        ),
+        (
+            "compression",
+            original[:args.compression_prefix_tokens]
+            + [90000 + index for index in range(args.compression_suffix_tokens)],
+        ),
+    ]
+    if any(len(prompt) + args.max_new_tokens > args.max_context for _, prompt in prompts):
+        raise SystemExit("a fixture prompt plus generation exceeds --max-context")
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    root: subprocess.Popen[str] | None = None
+    workers: list[subprocess.Popen[bytes]] = []
+    logs: list[BinaryIO] = []
+    cached_results: list[dict[str, Any]] = []
+    cached_worker_tokens: list[list[int]] = []
+    started = time.monotonic()
+    try:
+        root, workers, logs = launch_group(
+            binary=binary,
+            ckpt=ckpt,
+            dspark=dspark,
+            tp_world=args.tp_world,
+            devices=devices,
+            id_path=work_dir / "cached" / "nccl.id",
+            log_dir=work_dir / "cached",
+            max_context=args.max_context,
+            prefill_chunk_tokens=args.prefill_chunk_tokens,
+            kv_cache_dtype=args.kv_cache_dtype,
+            prefix_cache=True,
+        )
+        for _, prompt in prompts:
+            cached_results.append(request(root, prompt, args.max_new_tokens))
+        if root.stdin is not None:
+            root.stdin.close()
+        root.wait(timeout=120)
+        for worker in workers:
+            worker.wait(timeout=120)
+        if root.returncode != 0 or any(worker.returncode != 0 for worker in workers):
+            raise RuntimeError(
+                f"cached group failed root={root.returncode} "
+                f"workers={[worker.returncode for worker in workers]}"
+            )
+        cached_worker_tokens = [
+            [int(token) for token in result.get("tokens", [])]
+            for result in cached_results
+        ]
+        require_worker_parity(
+            work_dir / "cached", args.tp_world, cached_worker_tokens, "cached"
+        )
+    finally:
+        stop_group(root, workers, logs)
+
+    results: list[dict[str, Any]] = []
+    for index, ((name, prompt), cached) in enumerate(zip(prompts, cached_results)):
+        cold = run_cold_case(
+            args=args,
+            binary=binary,
+            ckpt=ckpt,
+            dspark=dspark,
+            devices=devices,
+            work_dir=work_dir,
+            case_index=index,
+            prompt=prompt,
+        )
+        if cached.get("tokens") != cold.get("tokens"):
+            raise RuntimeError(f"cached/cold DSpark token parity failed for {name}")
+        expected_reuse = {
+            "initial": 0,
+            "exact_repeat": args.base_tokens,
+            "monotonic_append": args.base_tokens + args.max_new_tokens - 1,
+            "shorter_prefix": args.shorter_tokens // 256 * 256,
+            "interior_branch": args.branch_prefix_tokens // 256 * 256,
+            "compression": args.compression_prefix_tokens // 256 * 256,
+        }[name]
+        if int(cached.get("prefix_reused_tokens", -1)) != expected_reuse:
+            raise RuntimeError(
+                f"unexpected reused-token count for {name}: "
+                f"{cached.get('prefix_reused_tokens')} != {expected_reuse}"
+            )
+        if int(cold.get("prefix_reused_tokens", -1)) != 0:
+            raise RuntimeError(f"cold case unexpectedly reused prefix for {name}")
+        if int(cold.get("prefix_computed_tokens", -1)) != len(prompt):
+            raise RuntimeError(f"cold case did not recompute full prompt for {name}")
+        if int(cached.get("dspark_confidence_count", 0)) <= 0:
+            raise RuntimeError(f"missing DSpark confidence telemetry for {name}")
+        row = {
+            "name": name,
+            "prompt_tokens": len(prompt),
+            "cached": cached,
+            "cold": cold,
+            "token_parity": True,
+        }
+        results.append(row)
+        print(
+            f"case={name} prompt={len(prompt)} "
+            f"reused={cached.get('prefix_reused_tokens')} "
+            f"computed={cached.get('prefix_computed_tokens')} "
+            f"source={cached.get('prefix_resume_source')} "
+            f"cold_parity=PASS confidence_mean={cached.get('dspark_confidence_mean')}"
+        )
+
+    print("cached_cold_token_parity=PASS dspark_rank_token_parity=PASS")
+    output = {
+        "mode": "qwen_dspark_prefix_cache",
+        "checkpoint": str(ckpt),
+        "dspark_checkpoint": str(dspark),
+        "kv_cache_dtype": args.kv_cache_dtype,
+        "tp_world": args.tp_world,
+        "max_new_tokens": args.max_new_tokens,
+        "results": results,
+        "elapsed_wall_seconds": time.monotonic() - started,
+    }
+    result_path = work_dir / "results.json"
+    result_path.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+    print(f"results={result_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except subprocess.CalledProcessError as error:
+        print(error.stderr or error.stdout or str(error), file=sys.stderr)
+        raise
+    except subprocess.TimeoutExpired as error:
+        print(f"timeout: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/bench_qwen_prefix_cache.py
+++ b/scripts/bench_qwen_prefix_cache.py
@@ -38,6 +38,10 @@ def parse_args() -> argparse.Namespace:
         "--qwen-mtp-adaptive", action="store_true",
         help="start at K=1 and adapt up to --qwen-mtp-tokens",
     )
+    parser.add_argument(
+        "--qwen-dspark",
+        help="enable external Qwen DSpark from this checkpoint directory",
+    )
     parser.add_argument("--nccl-id-path", default=".tmp/qwen_prefix_cache/nccl.id")
     parser.add_argument("--log-dir", default=".tmp/qwen_prefix_cache/logs")
     parser.add_argument("--suffix-tokens", type=int, default=512)
@@ -81,6 +85,18 @@ def parse_result(line: str) -> dict[str, Any] | None:
     return result
 
 
+def parse_worker_tokens(path: Path) -> list[list[int]]:
+    results: list[list[int]] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not line.startswith("qwen_persistent_worker_result=1 "):
+            continue
+        match = re.search(r"\btokens=([^\s]*)", line)
+        if match is None:
+            raise RuntimeError(f"worker result is missing tokens: {path}")
+        results.append([int(item) for item in match.group(1).split(",") if item])
+    return results
+
+
 def wait_result(root: subprocess.Popen[str]) -> dict[str, Any]:
     while True:
         line = root.stdout.readline() if root.stdout is not None else ""
@@ -110,6 +126,15 @@ def main() -> int:
         raise SystemExit("--qwen-mtp-tokens must be non-negative")
     if args.qwen_mtp_tokens > 0 and args.layers != 0:
         raise SystemExit("native MTP validation requires --layers 0")
+    if args.qwen_dspark and args.qwen_mtp_tokens > 0:
+        raise SystemExit("--qwen-dspark and native MTP are mutually exclusive")
+    dspark = Path(args.qwen_dspark).resolve() if args.qwen_dspark else None
+    if dspark is not None and (
+        args.layers != 0
+        or not (dspark / "config.json").is_file()
+        or not (dspark / "model.safetensors").is_file()
+    ):
+        raise SystemExit("DSpark requires --layers 0 and a complete checkpoint")
 
     id_path = Path(args.nccl_id_path).resolve()
     id_path.parent.mkdir(parents=True, exist_ok=True)
@@ -146,6 +171,8 @@ def main() -> int:
                 commands[-1] += ["--qwen-mtp-tokens", str(args.qwen_mtp_tokens)]
                 if args.qwen_mtp_adaptive:
                     commands[-1].append("--qwen-mtp-adaptive")
+            if dspark is not None:
+                commands[-1] += ["--qwen-dspark", str(dspark)]
         for rank in range(1, args.tp_world):
             log_path = log_dir / f"rank{rank}.log"
             log = log_path.open("wb")
@@ -162,6 +189,7 @@ def main() -> int:
         # First request uses the base fixture. Later requests include the
         # previous assistant output and a deterministic new suffix.
         prompt = list(base)
+        root_tokens: list[list[int]] = []
         requests = 3
         if args.compression_prefix_tokens > 0:
             requests += 1
@@ -199,6 +227,7 @@ def main() -> int:
             generated = result.get("tokens")
             if not isinstance(generated, list) or not generated:
                 raise RuntimeError(f"invalid generated token list: {result}")
+            root_tokens.append([int(token) for token in generated])
             # The engine has already executed all but the final generated token
             # into its recurrent/KV state. Including the complete assistant
             # output therefore exercises live reuse for the next request and
@@ -215,6 +244,14 @@ def main() -> int:
                 f"persistent processes failed root={root.returncode} "
                 f"workers={[worker.returncode for worker in workers]}"
             )
+        if dspark is not None:
+            for rank in range(1, args.tp_world):
+                worker_tokens = parse_worker_tokens(log_dir / f"rank{rank}.log")
+                if worker_tokens != root_tokens:
+                    raise RuntimeError(
+                        f"DSpark TP-rank token parity failed for rank {rank}"
+                    )
+            print("dspark_rank_token_parity=PASS")
         print(f"elapsed_wall_seconds={time.monotonic() - started:.3f}")
         return 0
     finally:


### PR DESCRIPTION
## Summary
- add opt-in external RadixArk/Qwen3.8-27B-DSpark loading from a single model.safetensors checkpoint
- implement the replicated five-layer BF16/FP16 drafter, target taps, YaRN GQA, Markov correction, confidence telemetry, and fixed seven-draft/eight-row verification
- preserve target transaction rollback/replay, TP rank parity, prefix cache restoration, and FP16/FP8 KV cache paths
- add serial benchmark and prefix-cache parity harnesses plus documentation and metric clarification

## Validation
- `cmake --build build/cpp_engine -j2 --target dsv4_cpp_engine test_qwen_engine test_qwen_dspark test_qwen_dspark_ops`
- `build/cpp_engine/tests/test_qwen_engine`
- `build/cpp_engine/tests/test_qwen_dspark /mnt/data2/Qwen3.8-27B-DSpark`
- `build/cpp_engine/tests/test_qwen_dspark_ops`
- `deepseek/bin/python -m py_compile scripts/bench_qwen_dspark.py scripts/bench_qwen_dspark_prefix_cache.py scripts/bench_qwen_prefix_cache.py`
- `git diff --check`

The feature remains opt-in/default-off; `mtp_accept_rate` is retained for compatibility as draft match ratio, while `spec_accept_length` reports the bonus-inclusive metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)