### PR TITLE
Add CUDA top-p sampling for Qwen decode

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(dsv4_cpp_core STATIC
     cuda/qwen_gqa_optimized.cu
     cuda/qwen_dspark_ops.cu
     cuda/qwen_dflash2_ops.cu
+    cuda/qwen_sampler.cu
     cuda/q2_ops.cu
     cuda/iq1_ops.cu
     cuda/rmsnorm_rope.cu
@@ -74,7 +75,7 @@ target_include_directories(dsv4_cpp_core PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/third_party
 )
 
-target_link_libraries(dsv4_cpp_core PUBLIC CUDA::cudart CUDA::cublas)
+target_link_libraries(dsv4_cpp_core PUBLIC CUDA::cudart CUDA::cublas CUDA::curand)
 if(DSV4_HAVE_NCCL)
     target_include_directories(dsv4_cpp_core PUBLIC ${NCCL_INCLUDE_DIR})
     target_link_libraries(dsv4_cpp_core PUBLIC ${NCCL_LIBRARY})
@@ -320,6 +321,10 @@ set_target_properties(test_qwen_dspark_ops PROPERTIES RUNTIME_OUTPUT_DIRECTORY $
 add_executable(test_qwen_dflash2_ops tests/test_qwen_dflash2_ops.cpp)
 target_link_libraries(test_qwen_dflash2_ops PRIVATE dsv4_cpp_core)
 set_target_properties(test_qwen_dflash2_ops PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_sampler tests/test_qwen_sampler.cpp)
+target_link_libraries(test_qwen_sampler PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_sampler PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(test_qwen_fp8_online tests/test_qwen_fp8_online.cpp)
 target_link_libraries(test_qwen_fp8_online PRIVATE dsv4_cpp_core)

--- a/cpp_engine/cuda/qwen_sampler.cu
+++ b/cpp_engine/cuda/qwen_sampler.cu
@@ -1,0 +1,324 @@
+#include "qwen_sampler.hpp"
+
+#include <cuda_runtime.h>
+#include <curand_kernel.h>
+
+namespace dsv4 {
+
+namespace {
+
+// One block per row. A full-vocab probability array does not fit in shared
+// memory (62,080 local vocab = 242 KB against a 48 KB limit), so the kernel
+// keeps only the top-k candidates per row. This is not an approximation of the
+// requested distribution: top-k runs before top-p in the standard sampling
+// order, so any token top-p could keep is already inside the top-k set.
+constexpr int kMaxTopK = 64;
+constexpr int kBlockThreads = 256;
+
+struct Candidate {
+    float logit;
+    int index;
+};
+
+// Descending by logit, with the lower vocab index winning ties so every rank
+// and every run breaks ties identically.
+__device__ inline bool better(const Candidate& a, const Candidate& b) {
+    if (a.logit != b.logit) return a.logit > b.logit;
+    return a.index < b.index;
+}
+
+// Insert into a descending-ordered list of length `len`, keeping at most `cap`.
+__device__ inline void insert_sorted(Candidate* list, int& len, int cap,
+                                     const Candidate& item) {
+    if (len == cap && !better(item, list[len - 1])) return;
+    int pos = (len < cap) ? len : cap - 1;
+    if (len < cap) ++len;
+    while (pos > 0 && better(item, list[pos - 1])) {
+        list[pos] = list[pos - 1];
+        --pos;
+    }
+    list[pos] = item;
+}
+
+__global__ void sample_top_k_top_p_kernel(
+    const float* __restrict__ logits, int* __restrict__ out_tokens,
+    float* __restrict__ out_logits, int rows, int vocab, int vocab_start,
+    float temperature, float top_p, int top_k, curandState* rng_states,
+    const float* __restrict__ uniforms) {
+
+    const int row = blockIdx.x;
+    if (row >= rows) return;
+
+    const int k = (top_k > 0 && top_k < kMaxTopK) ? top_k : kMaxTopK;
+    const float* row_logits = logits + static_cast<size_t>(row) * vocab;
+
+    // Per-thread top-k over a strided slice of the vocabulary.
+    Candidate local[kMaxTopK];
+    int local_len = 0;
+    for (int i = threadIdx.x; i < vocab; i += kBlockThreads) {
+        insert_sorted(local, local_len, k, Candidate{row_logits[i], i});
+    }
+
+    // One shared list receives every thread's candidates.
+    __shared__ Candidate merged[kMaxTopK];
+    __shared__ int merged_len;
+    if (threadIdx.x == 0) merged_len = 0;
+    __syncthreads();
+
+    // Serialize the merge over threads to keep the comparator identical to a
+    // single-threaded top-k. Correctness first; this runs once per decoded row.
+    for (int t = 0; t < kBlockThreads; ++t) {
+        if (threadIdx.x == t) {
+            for (int i = 0; i < local_len; ++i) {
+                insert_sorted(merged, merged_len, k, local[i]);
+            }
+        }
+        __syncthreads();
+    }
+
+    if (threadIdx.x != 0) return;
+
+    // Greedy path: temperature 0 means argmax, which the top-k list already has.
+    if (temperature <= 1e-5f || merged_len <= 1) {
+        out_tokens[row] = merged[0].index + vocab_start;
+        out_logits[row] = merged[0].logit;
+        return;
+    }
+
+    // Softmax over the top-k candidates. Subtracting the max keeps this stable
+    // and leaves the relative probabilities of the kept set unchanged.
+    const float inv_t = 1.0f / temperature;
+    const float max_scaled = merged[0].logit * inv_t;
+    float probs[kMaxTopK];
+    float sum = 0.0f;
+    for (int i = 0; i < merged_len; ++i) {
+        probs[i] = __expf(merged[i].logit * inv_t - max_scaled);
+        sum += probs[i];
+    }
+    const float inv_sum = 1.0f / sum;
+    for (int i = 0; i < merged_len; ++i) probs[i] *= inv_sum;
+
+    // Nucleus truncation. The list is already sorted descending.
+    int keep = merged_len;
+    if (top_p > 0.0f && top_p < 1.0f) {
+        float cum = 0.0f;
+        for (int i = 0; i < merged_len; ++i) {
+            cum += probs[i];
+            if (cum >= top_p) { keep = i + 1; break; }
+        }
+    }
+
+    float kept_sum = 0.0f;
+    for (int i = 0; i < keep; ++i) kept_sum += probs[i];
+
+    // A host-provided uniform keeps the draw identical across TP ranks; the
+    // device generator is the single-rank fallback.
+    float u;
+    if (uniforms != nullptr) {
+        u = uniforms[row];
+    } else {
+        u = curand_uniform(&rng_states[row]);
+    }
+    if (u >= 1.0f) u = 0.999999f;
+
+    const float target = u * kept_sum;
+    float accum = 0.0f;
+    int chosen = keep - 1;
+    for (int i = 0; i < keep; ++i) {
+        accum += probs[i];
+        if (accum >= target) { chosen = i; break; }
+    }
+
+    out_tokens[row] = merged[chosen].index + vocab_start;
+    out_logits[row] = merged[chosen].logit;
+}
+
+// Stage 1 of the TP path: reduce a sharded row to its local top-k and write the
+// candidates out as global ids so NCCL can merge them across ranks.
+__global__ void local_topk_candidates_kernel(
+    const float* __restrict__ logits, int* __restrict__ out_tokens,
+    float* __restrict__ out_logits, int rows, int vocab, int vocab_start,
+    int top_k) {
+
+    const int row = blockIdx.x;
+    if (row >= rows) return;
+    const int k = (top_k > 0 && top_k < kMaxTopK) ? top_k : kMaxTopK;
+    const float* row_logits = logits + static_cast<size_t>(row) * vocab;
+
+    Candidate local[kMaxTopK];
+    int local_len = 0;
+    for (int i = threadIdx.x; i < vocab; i += kBlockThreads) {
+        insert_sorted(local, local_len, k, Candidate{row_logits[i], i});
+    }
+
+    __shared__ Candidate merged[kMaxTopK];
+    __shared__ int merged_len;
+    if (threadIdx.x == 0) merged_len = 0;
+    __syncthreads();
+    for (int t = 0; t < kBlockThreads; ++t) {
+        if (threadIdx.x == t) {
+            for (int i = 0; i < local_len; ++i) {
+                insert_sorted(merged, merged_len, k, local[i]);
+            }
+        }
+        __syncthreads();
+    }
+
+    // Pad short rows with -inf so every rank contributes a fixed-width block.
+    for (int i = threadIdx.x; i < k; i += kBlockThreads) {
+        const size_t slot = static_cast<size_t>(row) * k + i;
+        if (i < merged_len) {
+            out_tokens[slot] = merged[i].index + vocab_start;
+            out_logits[slot] = merged[i].logit;
+        } else {
+            out_tokens[slot] = -1;
+            out_logits[slot] = -INFINITY;
+        }
+    }
+}
+
+// Stage 2 of the TP path: sample from candidates already merged across ranks.
+// `cand_tokens` holds global ids, so no vocab_start offset applies here.
+__global__ void sample_from_candidates_kernel(
+    const int* __restrict__ cand_tokens, const float* __restrict__ cand_logits,
+    int* __restrict__ out_tokens, float* __restrict__ out_logits, int rows,
+    int cand_stride, float temperature, float top_p, int top_k,
+    curandState* rng_states, const float* __restrict__ uniforms) {
+
+    const int row = blockIdx.x;
+    if (row != blockIdx.x || threadIdx.x != 0) return;
+
+    // Clamp against the retained-list capacity, not the gathered stride: k
+    // indexes `list`, which holds at most kMaxTopK entries.
+    int k = (top_k > 0) ? top_k : kMaxTopK;
+    if (k > kMaxTopK) k = kMaxTopK;
+    if (k > cand_stride) k = cand_stride;
+    const int* toks = cand_tokens + static_cast<size_t>(row) * cand_stride;
+    const float* lgs = cand_logits + static_cast<size_t>(row) * cand_stride;
+
+    // The merged input is already descending, but re-sort defensively so this
+    // kernel does not depend on the reduction's ordering guarantees.
+    // The retained list is bounded by k, but the scan must cover every gathered
+    // candidate: cand_stride is top_k * tp_world and can exceed kMaxTopK, so
+    // stopping at kMaxTopK would silently discard the last ranks' candidates.
+    Candidate list[kMaxTopK];
+    int len = 0;
+    for (int i = 0; i < cand_stride; ++i) {
+        if (toks[i] < 0) continue;
+        insert_sorted(list, len, k, Candidate{lgs[i], toks[i]});
+    }
+    if (len == 0) {
+        out_tokens[row] = 0;
+        out_logits[row] = 0.0f;
+        return;
+    }
+
+    if (temperature <= 1e-5f || len == 1) {
+        out_tokens[row] = list[0].index;
+        out_logits[row] = list[0].logit;
+        return;
+    }
+
+    const float inv_t = 1.0f / temperature;
+    const float max_scaled = list[0].logit * inv_t;
+    float probs[kMaxTopK];
+    float sum = 0.0f;
+    for (int i = 0; i < len; ++i) {
+        probs[i] = __expf(list[i].logit * inv_t - max_scaled);
+        sum += probs[i];
+    }
+    const float inv_sum = 1.0f / sum;
+    for (int i = 0; i < len; ++i) probs[i] *= inv_sum;
+
+    int keep = len;
+    if (top_p > 0.0f && top_p < 1.0f) {
+        float cum = 0.0f;
+        for (int i = 0; i < len; ++i) {
+            cum += probs[i];
+            if (cum >= top_p) { keep = i + 1; break; }
+        }
+    }
+    float kept_sum = 0.0f;
+    for (int i = 0; i < keep; ++i) kept_sum += probs[i];
+
+    float u = (uniforms != nullptr) ? uniforms[row]
+                                    : curand_uniform(&rng_states[row]);
+    if (u >= 1.0f) u = 0.999999f;
+
+    const float target = u * kept_sum;
+    float accum = 0.0f;
+    int chosen = keep - 1;
+    for (int i = 0; i < keep; ++i) {
+        accum += probs[i];
+        if (accum >= target) { chosen = i; break; }
+    }
+    out_tokens[row] = list[chosen].index;
+    out_logits[row] = list[chosen].logit;
+}
+
+__global__ void init_curand_kernel(curandState* states, int count,
+                                   unsigned long long seed) {
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < count) curand_init(seed, idx, 0, &states[idx]);
+}
+
+}  // namespace
+
+bool init_curand_states(curandState* states, int count,
+                               unsigned long long seed, cudaStream_t stream) {
+    if (states == nullptr || count <= 0) return false;
+    const int threads = 256;
+    const int blocks = (count + threads - 1) / threads;
+    init_curand_kernel<<<blocks, threads, 0, stream>>>(states, count, seed);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_sample_top_k_top_p_rows_cuda(
+    const float* logits, int* out_tokens, float* out_logits, int rows,
+    int vocab, int vocab_start, float temperature, float top_p, int top_k,
+    curandState* rng_states, const float* uniforms, cudaStream_t stream) {
+    if (logits == nullptr || out_tokens == nullptr || out_logits == nullptr) {
+        return false;
+    }
+    if (rows <= 0 || vocab <= 0) return false;
+    if (uniforms == nullptr && rng_states == nullptr) return false;
+    sample_top_k_top_p_kernel<<<rows, kBlockThreads, 0, stream>>>(
+        logits, out_tokens, out_logits, rows, vocab, vocab_start, temperature,
+        top_p, top_k, rng_states, uniforms);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_local_topk_candidates_cuda(
+    const float* logits, int* out_tokens, float* out_logits, int rows,
+    int vocab, int vocab_start, int top_k, cudaStream_t stream) {
+    if (logits == nullptr || out_tokens == nullptr || out_logits == nullptr) {
+        return false;
+    }
+    if (rows <= 0 || vocab <= 0 || top_k <= 0 || top_k > kMaxTopK) {
+        return false;
+    }
+    local_topk_candidates_kernel<<<rows, kBlockThreads, 0, stream>>>(
+        logits, out_tokens, out_logits, rows, vocab, vocab_start, top_k);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_sample_from_candidates_cuda(
+    const int* cand_tokens, const float* cand_logits, int* out_tokens,
+    float* out_logits, int rows, int cand_stride, float temperature,
+    float top_p, int top_k, curandState* rng_states, const float* uniforms,
+    cudaStream_t stream) {
+    if (cand_tokens == nullptr || cand_logits == nullptr ||
+        out_tokens == nullptr || out_logits == nullptr) {
+        return false;
+    }
+    if (rows <= 0 || cand_stride <= 0) return false;
+    if (uniforms == nullptr && rng_states == nullptr) return false;
+    sample_from_candidates_kernel<<<rows, 1, 0, stream>>>(
+        cand_tokens, cand_logits, out_tokens, out_logits, rows, cand_stride,
+        temperature, top_p, top_k, rng_states, uniforms);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+int qwen_sampler_max_top_k() { return kMaxTopK; }
+
+}  // namespace dsv4

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -56,6 +56,14 @@ struct QwenEngineOptions {
     // is mutually exclusive with native MTP and DSpark.
     std::string dflash2_checkpoint;
     std::string nccl_id_path;
+    // Stochastic sampling. temperature <= 1e-5 keeps the exact greedy argmax
+    // path, so existing greedy results stay reproducible by default. Sampling
+    // draws its uniforms on the host and shares them across TP ranks, which is
+    // what keeps every rank committing the same token.
+    float temperature = 0.0f;
+    float top_p = 1.0f;
+    int top_k = 20;
+    unsigned long long sampling_seed = 0;
 };
 
 struct QwenForwardResult {

--- a/cpp_engine/include/qwen_sampler.hpp
+++ b/cpp_engine/include/qwen_sampler.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cuda_runtime.h>
+#include <curand_kernel.h>
+
+namespace dsv4 {
+
+// Device top-k -> temperature -> top-p sampling over FP32 logit rows.
+//
+// A full-vocab probability array does not fit in shared memory on SM75
+// (62,080 local vocab is 242 KB against a 48 KB limit), so each block reduces
+// its row to the top-k candidates first. Because top-k precedes top-p in the
+// standard sampling order, restricting to top-k does not change the sampled
+// distribution for top_k <= 64.
+//
+// logits:       [rows, vocab] FP32, device
+// out_tokens:   [rows] INT32, device; global ids (vocab_start already added)
+// out_logits:   [rows] FP32, device; the selected token's raw logit
+// vocab_start:  first global id owned by this rank, for TP vocab sharding
+// temperature:  <= 1e-5 falls back to argmax
+// top_p:        nucleus threshold; <= 0 or >= 1 disables truncation
+// top_k:        candidates retained; clamped to 64
+// rng_states:   [rows] curandState, used only when `uniforms` is null
+// uniforms:     optional [rows] host-drawn uniforms in [0,1). Supplying these
+//               is what keeps a TP group's draw identical across ranks; the
+//               device generator would otherwise diverge per rank.
+//
+// TP note: with vocab sharding each rank sees only its own shard, so the
+// caller must still reduce across ranks to pick one global token. Passing a
+// shared `uniforms` row makes that reduction agree on every rank.
+bool qwen_sample_top_k_top_p_rows_cuda(
+    const float* logits,
+    int* out_tokens,
+    float* out_logits,
+    int rows,
+    int vocab,
+    int vocab_start,
+    float temperature,
+    float top_p,
+    int top_k,
+    curandState* rng_states,
+    const float* uniforms,
+    cudaStream_t stream);
+
+// TP stage 1: reduce each sharded row to its local top-k, emitted as global ids
+// into [rows, top_k] buffers so NCCL can merge candidates across ranks. Short
+// rows are padded with token -1 and logit -inf.
+bool qwen_local_topk_candidates_cuda(
+    const float* logits,
+    int* out_tokens,
+    float* out_logits,
+    int rows,
+    int vocab,
+    int vocab_start,
+    int top_k,
+    cudaStream_t stream);
+
+// TP stage 2: sample from candidates already merged across ranks. `cand_tokens`
+// are global ids, so no vocab_start offset is applied. Pass the same `uniforms`
+// on every rank to make all ranks commit the same token.
+bool qwen_sample_from_candidates_cuda(
+    const int* cand_tokens,
+    const float* cand_logits,
+    int* out_tokens,
+    float* out_logits,
+    int rows,
+    int cand_stride,
+    float temperature,
+    float top_p,
+    int top_k,
+    curandState* rng_states,
+    const float* uniforms,
+    cudaStream_t stream);
+
+// Largest supported top_k; callers must not request more.
+int qwen_sampler_max_top_k();
+
+// Initialize one generator per row. Seed identically across TP ranks.
+bool init_curand_states(
+    curandState* states,
+    int count,
+    unsigned long long seed,
+    cudaStream_t stream);
+
+}  // namespace dsv4

--- a/cpp_engine/src/main.cpp
+++ b/cpp_engine/src/main.cpp
@@ -58,6 +58,11 @@ struct Args {
     int qwen_max_snapshots = 82;
     bool qwen_mtp = false;
     int qwen_mtp_tokens = 1;
+    // Greedy by default so existing results stay reproducible.
+    float qwen_temperature = 0.0f;
+    float qwen_top_p = 1.0f;
+    int qwen_top_k = 20;
+    unsigned long long qwen_seed = 0;
     bool qwen_mtp_adaptive = false;
     std::string qwen_dspark_checkpoint;
     std::string qwen_dflash2_checkpoint;
@@ -162,6 +167,14 @@ Args parse_args(int argc, char** argv) {
         } else if (arg == "--qwen-mtp-adaptive") {
             args.qwen_mtp = true;
             args.qwen_mtp_adaptive = true;
+        } else if (arg == "--qwen-temperature" && i + 1 < argc) {
+            args.qwen_temperature = std::stof(argv[++i]);
+        } else if (arg == "--qwen-top-p" && i + 1 < argc) {
+            args.qwen_top_p = std::stof(argv[++i]);
+        } else if (arg == "--qwen-top-k" && i + 1 < argc) {
+            args.qwen_top_k = std::stoi(argv[++i]);
+        } else if (arg == "--qwen-seed" && i + 1 < argc) {
+            args.qwen_seed = std::stoull(argv[++i]);
         } else if (arg == "--qwen-dspark" && i + 1 < argc) {
             args.qwen_dspark_checkpoint = argv[++i];
         } else if (arg == "--qwen-dflash2" && i + 1 < argc) {
@@ -457,6 +470,10 @@ int main(int argc, char** argv) {
                     qwen_opts.dspark_checkpoint = args.qwen_dspark_checkpoint;
                     qwen_opts.dflash2_checkpoint = args.qwen_dflash2_checkpoint;
                     qwen_opts.nccl_id_path = args.nccl_id_path;
+                    qwen_opts.temperature = args.qwen_temperature;
+                    qwen_opts.top_p = args.qwen_top_p;
+                    qwen_opts.top_k = args.qwen_top_k;
+                    qwen_opts.sampling_seed = args.qwen_seed;
                     const int qwen_context = args.max_context > 0
                         ? args.max_context
                         : static_cast<int>(prompt_ids.size()) + std::max(1, args.max_new_tokens);

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -4,6 +4,7 @@
 #include "qwen_cuda_ops.hpp"
 #include "qwen_dspark.hpp"
 #include "qwen_dflash2.hpp"
+#include "qwen_sampler.hpp"
 #include "tp_comm.hpp"
 
 #include <cuda_runtime.h>
@@ -17,6 +18,7 @@
 #include <iostream>
 #include <map>
 #include <optional>
+#include <random>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -302,6 +304,19 @@ struct QwenEngine::Impl {
     QwenDeviceTensor hidden_b;
     QwenDeviceTensor argmax_token;
     QwenDeviceTensor argmax_logit;
+    // Sampling scratch. Allocated lazily on the first sampled step so greedy
+    // runs pay nothing.
+    QwenDeviceTensor sample_cand_token;
+    QwenDeviceTensor sample_cand_logit;
+    QwenDeviceTensor sample_merged_token;
+    QwenDeviceTensor sample_merged_logit;
+    QwenDeviceTensor sample_uniforms;
+    QwenDeviceTensor sample_rng_states;
+    // Host RNG. Seeding this identically on every rank and broadcasting the
+    // drawn uniforms is what makes a TP group agree on the sampled token.
+    std::mt19937_64 sampling_rng;
+    bool sampling_rng_ready = false;
+    std::vector<float> host_uniform_scratch;
     QwenWorkspace workspace;
     uint64_t uploaded_weight_bytes = 0;
     uint64_t uploaded_scale_bytes = 0;
@@ -1414,6 +1429,126 @@ struct QwenEngine::Impl {
         add(output, mlp.f16_data(), rows * hidden_size);
     }
 
+    bool sampling_enabled() const { return options.temperature > 1.0e-5f; }
+
+    // Draw one uniform per row on the host. Every rank seeds the same generator
+    // and consumes it in the same order, so the rows match across the TP group
+    // without an extra broadcast.
+    const float* host_uniforms_for(int rows) {
+        if (!sampling_rng_ready) {
+            sampling_rng.seed(options.sampling_seed);
+            sampling_rng_ready = true;
+        }
+        std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+        host_uniform_scratch.resize(static_cast<size_t>(rows));
+        for (int i = 0; i < rows; ++i) host_uniform_scratch[i] = dist(sampling_rng);
+        return host_uniform_scratch.data();
+    }
+
+    // Device top-k -> temperature -> top-p sampling over a batch of logit rows.
+    // Under TP the vocabulary is sharded, so each rank emits its local top-k as
+    // global ids, NCCL merges the candidates, and the draw happens over the
+    // merged set with a uniform every rank already agrees on.
+    QwenVerifyBatch sample_tokens_for(QwenDeviceTensor& local_logits, int rows,
+                                      int local_vocab, int vocab_start,
+                                      int position_after) {
+        int top_k = options.top_k;
+        const int max_top_k = qwen_sampler_max_top_k();
+        if (top_k <= 0 || top_k > max_top_k) top_k = max_top_k;
+        if (top_k > local_vocab) top_k = local_vocab;
+
+        allocate(sample_rng_states,
+                 static_cast<size_t>(rows) * sizeof(curandState),
+                 {static_cast<uint64_t>(rows)}, SafeDType::I8);
+        allocate_float(sample_uniforms, static_cast<size_t>(rows),
+                       {static_cast<uint64_t>(rows)});
+        allocate(argmax_token, static_cast<size_t>(rows) * sizeof(int),
+                 {static_cast<uint64_t>(rows)}, SafeDType::I64);
+        allocate_float(argmax_logit, static_cast<size_t>(rows),
+                       {static_cast<uint64_t>(rows)});
+
+        const float* uniforms = host_uniforms_for(rows);
+        check_cuda(cudaMemcpy(sample_uniforms.data, uniforms,
+                              static_cast<size_t>(rows) * sizeof(float),
+                              cudaMemcpyHostToDevice),
+                   "Qwen sampling uniform upload");
+
+        QwenVerifyBatch result;
+        result.top_tokens.resize(static_cast<size_t>(rows));
+        result.top_logits.resize(static_cast<size_t>(rows));
+        result.local_logits.resize(static_cast<size_t>(rows));
+        result.position_after = position_after;
+
+#ifdef DSV4_HAVE_NCCL
+        if (options.tp_world > 1) {
+            if (options.nccl_id_path.empty()) {
+                throw std::runtime_error("Qwen TP requires --nccl-id-path");
+            }
+            const size_t cand = static_cast<size_t>(rows) * top_k;
+            const size_t gathered = cand * static_cast<size_t>(options.tp_world);
+            allocate(sample_cand_token, cand * sizeof(int),
+                     {static_cast<uint64_t>(cand)}, SafeDType::I64);
+            allocate_float(sample_cand_logit, cand, {static_cast<uint64_t>(cand)});
+            allocate(sample_merged_token, gathered * sizeof(int),
+                     {static_cast<uint64_t>(gathered)}, SafeDType::I64);
+            allocate_float(sample_merged_logit, gathered,
+                           {static_cast<uint64_t>(gathered)});
+
+            require_launch(qwen_local_topk_candidates_cuda(
+                local_logits.f32_data(),
+                static_cast<int*>(sample_cand_token.data),
+                sample_cand_logit.f32_data(), rows, local_vocab, vocab_start,
+                top_k, nullptr),
+                "Qwen sampling local top-k");
+
+            nccl_global_topk_rows_device(
+                options.tp_world, options.tp_rank, options.device,
+                options.nccl_id_path.c_str(),
+                static_cast<const int*>(sample_cand_token.data),
+                sample_cand_logit.f32_data(), rows, top_k,
+                static_cast<int*>(sample_merged_token.data),
+                sample_merged_logit.f32_data());
+
+            require_launch(qwen_sample_from_candidates_cuda(
+                static_cast<const int*>(sample_merged_token.data),
+                sample_merged_logit.f32_data(),
+                static_cast<int*>(argmax_token.data), argmax_logit.f32_data(),
+                rows, top_k * options.tp_world, options.temperature,
+                options.top_p, top_k,
+                static_cast<curandState*>(sample_rng_states.data),
+                sample_uniforms.f32_data(), nullptr),
+                "Qwen sampling from merged candidates");
+        } else
+#endif
+        {
+#ifndef DSV4_HAVE_NCCL
+            if (options.tp_world > 1) {
+                throw std::runtime_error(
+                    "Qwen TP requires an NCCL-enabled build");
+            }
+#endif
+            require_launch(qwen_sample_top_k_top_p_rows_cuda(
+                local_logits.f32_data(),
+                static_cast<int*>(argmax_token.data), argmax_logit.f32_data(),
+                rows, local_vocab, vocab_start, options.temperature,
+                options.top_p, top_k,
+                static_cast<curandState*>(sample_rng_states.data),
+                sample_uniforms.f32_data(), nullptr),
+                "Qwen sampling single shard");
+        }
+
+        check_cuda(cudaMemcpy(result.top_tokens.data(), argmax_token.data,
+                              static_cast<size_t>(rows) * sizeof(int),
+                              cudaMemcpyDeviceToHost),
+                   "Qwen sampled token copy");
+        check_cuda(cudaMemcpy(result.top_logits.data(), argmax_logit.data,
+                              static_cast<size_t>(rows) * sizeof(float),
+                              cudaMemcpyDeviceToHost),
+                   "Qwen sampled logit copy");
+        result.local_logits = result.top_logits;
+        return result;
+    }
+
     QwenVerifyBatch top_tokens_for(const uint16_t* hidden, int rows,
                                    const QwenDeviceTensor* output_norm,
                                    int position_after) {
@@ -1455,6 +1590,15 @@ struct QwenEngine::Impl {
         allocate_float(argmax_logit, static_cast<size_t>(rows),
                        {static_cast<uint64_t>(rows)});
         const int vocab_start = static_cast<int>(weights_vocab_start());
+
+        // Sampled path. Kept ahead of the argmax launch so a sampled run does
+        // not pay for a top-1 reduction it discards; greedy falls through to
+        // the original code unchanged.
+        if (sampling_enabled()) {
+            return sample_tokens_for(local_logits, rows, local_vocab,
+                                     vocab_start, position_after);
+        }
+
         require_launch(argmax_fp32_rows_cuda(
             local_logits.f32_data(), static_cast<int*>(argmax_token.data),
             argmax_logit.f32_data(), rows, local_vocab, vocab_start),

--- a/cpp_engine/tests/test_qwen_sampler.cpp
+++ b/cpp_engine/tests/test_qwen_sampler.cpp
@@ -1,0 +1,436 @@
+// Correctness tests for the device top-k -> temperature -> top-p sampler.
+//
+// The sampler is the only nondeterministic component in the Qwen decode path,
+// so these tests pin the properties the benchmark protocol depends on: greedy
+// equivalence at temperature 0, exact agreement with a CPU reference over the
+// top-k set, correct nucleus truncation, and identical draws across TP ranks
+// when the host supplies the uniforms.
+
+#include "qwen_sampler.hpp"
+
+#include <cuda_runtime.h>
+#include <curand_kernel.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <numeric>
+#include <random>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+void expect(bool condition, const char* what) {
+    if (!condition) {
+        std::printf("FAIL %s\n", what);
+        ++g_failures;
+    } else {
+        std::printf("ok   %s\n", what);
+    }
+}
+
+void check(cudaError_t status, const char* what) {
+    if (status != cudaSuccess) {
+        std::printf("FAIL %s: %s\n", what, cudaGetErrorString(status));
+        ++g_failures;
+    }
+}
+
+// The sampler entry points follow the codebase's bool-returning launch
+// convention rather than returning cudaError_t.
+void check(bool ok, const char* what) {
+    if (!ok) {
+        std::printf("FAIL %s: launch reported failure\n", what);
+        ++g_failures;
+    }
+}
+
+struct DeviceRun {
+    std::vector<int> tokens;
+    std::vector<float> logits;
+};
+
+// Run the kernel over `rows` x `vocab` host logits.
+DeviceRun run_sampler(const std::vector<float>& host_logits, int rows,
+                      int vocab, int vocab_start, float temperature,
+                      float top_p, int top_k,
+                      const std::vector<float>& uniforms) {
+    float* d_logits = nullptr;
+    int* d_tokens = nullptr;
+    float* d_out_logits = nullptr;
+    float* d_uniforms = nullptr;
+    curandState* d_states = nullptr;
+
+    check(cudaMalloc(&d_logits, host_logits.size() * sizeof(float)), "malloc logits");
+    check(cudaMalloc(&d_tokens, static_cast<size_t>(rows) * sizeof(int)), "malloc tokens");
+    check(cudaMalloc(&d_out_logits, static_cast<size_t>(rows) * sizeof(float)), "malloc out logits");
+    check(cudaMalloc(&d_states, static_cast<size_t>(rows) * sizeof(curandState)), "malloc states");
+    check(cudaMemcpy(d_logits, host_logits.data(),
+                     host_logits.size() * sizeof(float), cudaMemcpyHostToDevice),
+          "copy logits");
+    check(dsv4::init_curand_states(d_states, rows, 1234ULL, nullptr), "init states");
+
+    if (!uniforms.empty()) {
+        check(cudaMalloc(&d_uniforms, uniforms.size() * sizeof(float)), "malloc uniforms");
+        check(cudaMemcpy(d_uniforms, uniforms.data(),
+                         uniforms.size() * sizeof(float), cudaMemcpyHostToDevice),
+              "copy uniforms");
+    }
+
+    check(dsv4::qwen_sample_top_k_top_p_rows_cuda(
+              d_logits, d_tokens, d_out_logits, rows, vocab, vocab_start,
+              temperature, top_p, top_k, d_states, d_uniforms, nullptr),
+          "launch sampler");
+    check(cudaDeviceSynchronize(), "sync sampler");
+
+    DeviceRun out;
+    out.tokens.resize(static_cast<size_t>(rows));
+    out.logits.resize(static_cast<size_t>(rows));
+    check(cudaMemcpy(out.tokens.data(), d_tokens,
+                     static_cast<size_t>(rows) * sizeof(int), cudaMemcpyDeviceToHost),
+          "copy tokens");
+    check(cudaMemcpy(out.logits.data(), d_out_logits,
+                     static_cast<size_t>(rows) * sizeof(float), cudaMemcpyDeviceToHost),
+          "copy out logits");
+
+    cudaFree(d_logits);
+    cudaFree(d_tokens);
+    cudaFree(d_out_logits);
+    cudaFree(d_states);
+    if (d_uniforms != nullptr) cudaFree(d_uniforms);
+    return out;
+}
+
+// CPU reference: top-k, then softmax at temperature, then top-p, then inverse
+// CDF against the same uniform the device consumed.
+int reference_sample(const float* logits, int vocab, float temperature,
+                     float top_p, int top_k, float u) {
+    std::vector<int> order(static_cast<size_t>(vocab));
+    std::iota(order.begin(), order.end(), 0);
+    std::stable_sort(order.begin(), order.end(), [&](int a, int b) {
+        if (logits[a] != logits[b]) return logits[a] > logits[b];
+        return a < b;
+    });
+    const int k = std::min(top_k, vocab);
+    if (temperature <= 1e-5f) return order[0];
+
+    const float inv_t = 1.0f / temperature;
+    const float max_scaled = logits[order[0]] * inv_t;
+    std::vector<float> probs(static_cast<size_t>(k));
+    float sum = 0.0f;
+    for (int i = 0; i < k; ++i) {
+        probs[static_cast<size_t>(i)] = std::exp(logits[order[static_cast<size_t>(i)]] * inv_t - max_scaled);
+        sum += probs[static_cast<size_t>(i)];
+    }
+    for (int i = 0; i < k; ++i) probs[static_cast<size_t>(i)] /= sum;
+
+    int keep = k;
+    if (top_p > 0.0f && top_p < 1.0f) {
+        float cum = 0.0f;
+        for (int i = 0; i < k; ++i) {
+            cum += probs[static_cast<size_t>(i)];
+            if (cum >= top_p) { keep = i + 1; break; }
+        }
+    }
+    float kept = 0.0f;
+    for (int i = 0; i < keep; ++i) kept += probs[static_cast<size_t>(i)];
+
+    const float target = u * kept;
+    float accum = 0.0f;
+    for (int i = 0; i < keep; ++i) {
+        accum += probs[static_cast<size_t>(i)];
+        if (accum >= target) return order[static_cast<size_t>(i)];
+    }
+    return order[static_cast<size_t>(keep - 1)];
+}
+
+std::vector<float> random_logits(int rows, int vocab, unsigned seed) {
+    std::mt19937 rng(seed);
+    std::normal_distribution<float> dist(0.0f, 4.0f);
+    std::vector<float> out(static_cast<size_t>(rows) * vocab);
+    for (auto& v : out) v = dist(rng);
+    return out;
+}
+
+}  // namespace
+
+int main() {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        std::printf("no CUDA device available\n");
+        return 1;
+    }
+
+    // Realistic shard width for TP4 over a 248,320-token vocabulary.
+    const int vocab = 62080;
+    const int rows = 8;
+
+    // 1. Temperature 0 must reproduce argmax exactly.
+    {
+        auto logits = random_logits(rows, vocab, 11);
+        auto run = run_sampler(logits, rows, vocab, 0, 0.0f, 0.95f, 20, {});
+        bool all_match = true;
+        for (int r = 0; r < rows; ++r) {
+            const float* row = logits.data() + static_cast<size_t>(r) * vocab;
+            const int expected = static_cast<int>(
+                std::max_element(row, row + vocab) - row);
+            if (run.tokens[static_cast<size_t>(r)] != expected) all_match = false;
+        }
+        expect(all_match, "temperature 0 reproduces argmax");
+    }
+
+    // 2. Sampled draws must match the CPU reference bit for bit.
+    {
+        auto logits = random_logits(rows, vocab, 22);
+        std::vector<float> uniforms{0.01f, 0.2f, 0.35f, 0.5f, 0.66f, 0.8f, 0.93f, 0.999f};
+        auto run = run_sampler(logits, rows, vocab, 0, 1.0f, 0.95f, 20, uniforms);
+        bool all_match = true;
+        for (int r = 0; r < rows; ++r) {
+            const float* row = logits.data() + static_cast<size_t>(r) * vocab;
+            const int expected = reference_sample(row, vocab, 1.0f, 0.95f, 20,
+                                                  uniforms[static_cast<size_t>(r)]);
+            if (run.tokens[static_cast<size_t>(r)] != expected) {
+                std::printf("  row %d device=%d reference=%d\n", r,
+                            run.tokens[static_cast<size_t>(r)], expected);
+                all_match = false;
+            }
+        }
+        expect(all_match, "sampled draws match CPU reference");
+    }
+
+    // 3. vocab_start must be added so TP shards emit global ids.
+    {
+        auto logits = random_logits(1, vocab, 33);
+        const int shard_base = 62080;
+        auto run = run_sampler(logits, 1, vocab, shard_base, 0.0f, 1.0f, 20, {});
+        const int local_argmax = static_cast<int>(
+            std::max_element(logits.begin(), logits.end()) - logits.begin());
+        expect(run.tokens[0] == local_argmax + shard_base,
+               "vocab_start offset produces global token id");
+    }
+
+    // 4. A tight nucleus must collapse onto the argmax token.
+    {
+        auto logits = random_logits(rows, vocab, 44);
+        std::vector<float> uniforms(static_cast<size_t>(rows), 0.999f);
+        auto run = run_sampler(logits, rows, vocab, 0, 1.0f, 1e-6f, 20, uniforms);
+        bool all_top = true;
+        for (int r = 0; r < rows; ++r) {
+            const float* row = logits.data() + static_cast<size_t>(r) * vocab;
+            const int expected = static_cast<int>(
+                std::max_element(row, row + vocab) - row);
+            if (run.tokens[static_cast<size_t>(r)] != expected) all_top = false;
+        }
+        expect(all_top, "vanishing top_p keeps only the argmax token");
+    }
+
+    // 5. Host-supplied uniforms must make repeated runs identical. This is what
+    //    keeps a TP group's sampled token consistent across ranks.
+    {
+        auto logits = random_logits(rows, vocab, 55);
+        std::vector<float> uniforms{0.11f, 0.22f, 0.33f, 0.44f, 0.55f, 0.66f, 0.77f, 0.88f};
+        auto a = run_sampler(logits, rows, vocab, 0, 1.0f, 0.95f, 20, uniforms);
+        auto b = run_sampler(logits, rows, vocab, 0, 1.0f, 0.95f, 20, uniforms);
+        expect(a.tokens == b.tokens, "host uniforms give reproducible draws");
+    }
+
+    // 6. The empirical distribution must track the intended probabilities.
+    {
+        const int small_vocab = 2048;
+        auto logits = random_logits(1, small_vocab, 66);
+        const int trials = 4000;
+        std::vector<float> uniforms(static_cast<size_t>(trials));
+        std::mt19937 rng(99);
+        std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+        for (auto& u : uniforms) u = dist(rng);
+
+        // Replicate the single row so each trial samples it with its own uniform.
+        std::vector<float> repeated(static_cast<size_t>(trials) * small_vocab);
+        for (int t = 0; t < trials; ++t) {
+            std::copy(logits.begin(), logits.end(),
+                      repeated.begin() + static_cast<size_t>(t) * small_vocab);
+        }
+        auto run = run_sampler(repeated, trials, small_vocab, 0, 1.0f, 0.95f, 20,
+                               uniforms);
+
+        // Expected probabilities over the top-k set.
+        std::vector<int> order(static_cast<size_t>(small_vocab));
+        std::iota(order.begin(), order.end(), 0);
+        std::stable_sort(order.begin(), order.end(), [&](int a, int b) {
+            return logits[static_cast<size_t>(a)] > logits[static_cast<size_t>(b)];
+        });
+        const int top = order[0];
+        int top_hits = 0;
+        for (int t = 0; t < trials; ++t) {
+            if (run.tokens[static_cast<size_t>(t)] == top) ++top_hits;
+        }
+        const float observed = static_cast<float>(top_hits) / trials;
+
+        float expected_top = 0.0f;
+        {
+            const float max_l = logits[static_cast<size_t>(top)];
+            std::vector<float> probs;
+            float sum = 0.0f;
+            for (int i = 0; i < 20; ++i) {
+                const float p = std::exp(logits[static_cast<size_t>(order[static_cast<size_t>(i)])] - max_l);
+                probs.push_back(p);
+                sum += p;
+            }
+            float cum = 0.0f;
+            int keep = 20;
+            for (int i = 0; i < 20; ++i) {
+                cum += probs[static_cast<size_t>(i)] / sum;
+                if (cum >= 0.95f) { keep = i + 1; break; }
+            }
+            float kept = 0.0f;
+            for (int i = 0; i < keep; ++i) kept += probs[static_cast<size_t>(i)] / sum;
+            expected_top = (probs[0] / sum) / kept;
+        }
+        std::printf("  top-token frequency observed=%.4f expected=%.4f\n",
+                    observed, expected_top);
+        expect(std::fabs(observed - expected_top) < 0.03f,
+               "empirical frequency tracks intended probability");
+    }
+
+    // 7. Every sampled token must be inside the top-k set.
+    {
+        auto logits = random_logits(rows, vocab, 77);
+        std::vector<float> uniforms{0.05f, 0.15f, 0.25f, 0.45f, 0.6f, 0.75f, 0.85f, 0.95f};
+        auto run = run_sampler(logits, rows, vocab, 0, 1.5f, 0.99f, 20, uniforms);
+        bool inside = true;
+        for (int r = 0; r < rows; ++r) {
+            const float* row = logits.data() + static_cast<size_t>(r) * vocab;
+            std::vector<float> sorted(row, row + vocab);
+            std::nth_element(sorted.begin(), sorted.begin() + 20, sorted.end(),
+                             std::greater<float>());
+            const float kth = sorted[20];
+            if (run.logits[static_cast<size_t>(r)] < kth) inside = false;
+        }
+        expect(inside, "sampled token always lies within the top-k set");
+    }
+
+    // 8. The two-stage TP path must equal sampling the unsharded row. This is
+    //    the property TP4 decoding depends on: each rank emits its local top-k
+    //    as global ids, NCCL merges them, and stage 2 draws from the merge with
+    //    a shared uniform. Here the merge is done on the host to isolate the
+    //    kernels from NCCL.
+    {
+        const int tp = 4;
+        const int shard = 4096;
+        const int full_vocab = shard * tp;
+        const int top_k = 20;
+        auto full = random_logits(rows, full_vocab, 88);
+        std::vector<float> uniforms{0.03f, 0.18f, 0.31f, 0.47f, 0.62f, 0.79f, 0.88f, 0.97f};
+
+        // Reference: sample each full row as a single unsharded shard.
+        auto reference = run_sampler(full, rows, full_vocab, 0, 1.0f, 0.95f,
+                                     top_k, uniforms);
+
+        // Stage 1 per rank, over that rank's contiguous slice of the vocabulary.
+        std::vector<int> merged_tokens(static_cast<size_t>(rows) * top_k * tp);
+        std::vector<float> merged_logits(static_cast<size_t>(rows) * top_k * tp);
+        for (int rank = 0; rank < tp; ++rank) {
+            std::vector<float> shard_logits(static_cast<size_t>(rows) * shard);
+            for (int r = 0; r < rows; ++r) {
+                const float* src = full.data() + static_cast<size_t>(r) * full_vocab +
+                                   static_cast<size_t>(rank) * shard;
+                std::copy(src, src + shard,
+                          shard_logits.begin() + static_cast<size_t>(r) * shard);
+            }
+
+            float* d_logits = nullptr;
+            int* d_tokens = nullptr;
+            float* d_out = nullptr;
+            check(cudaMalloc(&d_logits, shard_logits.size() * sizeof(float)), "tp malloc logits");
+            check(cudaMalloc(&d_tokens, static_cast<size_t>(rows) * top_k * sizeof(int)), "tp malloc tokens");
+            check(cudaMalloc(&d_out, static_cast<size_t>(rows) * top_k * sizeof(float)), "tp malloc logits out");
+            check(cudaMemcpy(d_logits, shard_logits.data(),
+                             shard_logits.size() * sizeof(float), cudaMemcpyHostToDevice),
+                  "tp copy logits");
+            check(dsv4::qwen_local_topk_candidates_cuda(
+                      d_logits, d_tokens, d_out, rows, shard, rank * shard,
+                      top_k, nullptr),
+                  "tp stage1 launch");
+            check(cudaDeviceSynchronize(), "tp stage1 sync");
+
+            std::vector<int> rank_tokens(static_cast<size_t>(rows) * top_k);
+            std::vector<float> rank_logits(static_cast<size_t>(rows) * top_k);
+            check(cudaMemcpy(rank_tokens.data(), d_tokens,
+                             rank_tokens.size() * sizeof(int), cudaMemcpyDeviceToHost),
+                  "tp copy tokens back");
+            check(cudaMemcpy(rank_logits.data(), d_out,
+                             rank_logits.size() * sizeof(float), cudaMemcpyDeviceToHost),
+                  "tp copy logits back");
+            cudaFree(d_logits);
+            cudaFree(d_tokens);
+            cudaFree(d_out);
+
+            // Concatenate this rank's block, mirroring an NCCL all-gather.
+            for (int r = 0; r < rows; ++r) {
+                for (int i = 0; i < top_k; ++i) {
+                    const size_t dst = static_cast<size_t>(r) * top_k * tp +
+                                       static_cast<size_t>(rank) * top_k + i;
+                    const size_t src = static_cast<size_t>(r) * top_k + i;
+                    merged_tokens[dst] = rank_tokens[src];
+                    merged_logits[dst] = rank_logits[src];
+                }
+            }
+        }
+
+        // Stage 2 over the gathered candidates.
+        int* d_cand_tok = nullptr;
+        float* d_cand_lg = nullptr;
+        int* d_tokens = nullptr;
+        float* d_logits_out = nullptr;
+        float* d_uniforms = nullptr;
+        curandState* d_states = nullptr;
+        check(cudaMalloc(&d_cand_tok, merged_tokens.size() * sizeof(int)), "tp2 malloc cand tok");
+        check(cudaMalloc(&d_cand_lg, merged_logits.size() * sizeof(float)), "tp2 malloc cand lg");
+        check(cudaMalloc(&d_tokens, static_cast<size_t>(rows) * sizeof(int)), "tp2 malloc tokens");
+        check(cudaMalloc(&d_logits_out, static_cast<size_t>(rows) * sizeof(float)), "tp2 malloc logits");
+        check(cudaMalloc(&d_uniforms, uniforms.size() * sizeof(float)), "tp2 malloc uniforms");
+        check(cudaMalloc(&d_states, static_cast<size_t>(rows) * sizeof(curandState)), "tp2 malloc states");
+        check(cudaMemcpy(d_cand_tok, merged_tokens.data(),
+                         merged_tokens.size() * sizeof(int), cudaMemcpyHostToDevice),
+              "tp2 copy cand tok");
+        check(cudaMemcpy(d_cand_lg, merged_logits.data(),
+                         merged_logits.size() * sizeof(float), cudaMemcpyHostToDevice),
+              "tp2 copy cand lg");
+        check(cudaMemcpy(d_uniforms, uniforms.data(),
+                         uniforms.size() * sizeof(float), cudaMemcpyHostToDevice),
+              "tp2 copy uniforms");
+        check(dsv4::init_curand_states(d_states, rows, 7ULL, nullptr), "tp2 init states");
+        check(dsv4::qwen_sample_from_candidates_cuda(
+                  d_cand_tok, d_cand_lg, d_tokens, d_logits_out, rows,
+                  top_k * tp, 1.0f, 0.95f, top_k, d_states, d_uniforms, nullptr),
+              "tp2 launch");
+        check(cudaDeviceSynchronize(), "tp2 sync");
+
+        std::vector<int> tp_tokens(static_cast<size_t>(rows));
+        check(cudaMemcpy(tp_tokens.data(), d_tokens,
+                         tp_tokens.size() * sizeof(int), cudaMemcpyDeviceToHost),
+              "tp2 copy tokens");
+        cudaFree(d_cand_tok);
+        cudaFree(d_cand_lg);
+        cudaFree(d_tokens);
+        cudaFree(d_logits_out);
+        cudaFree(d_uniforms);
+        cudaFree(d_states);
+
+        bool same = true;
+        for (int r = 0; r < rows; ++r) {
+            if (tp_tokens[static_cast<size_t>(r)] != reference.tokens[static_cast<size_t>(r)]) {
+                std::printf("  row %d sharded=%d unsharded=%d\n", r,
+                            tp_tokens[static_cast<size_t>(r)],
+                            reference.tokens[static_cast<size_t>(r)]);
+                same = false;
+            }
+        }
+        expect(same, "sharded two-stage sampling equals unsharded sampling");
+    }
+
+    std::printf("%s\n", g_failures == 0 ? "PASS" : "FAILURES PRESENT");
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Device-side top-k → temperature → top-p sampling for the Qwen decode path, exposed via `--qwen-temperature`, `--qwen-top-p`, `--qwen-top-k`, `--qwen-seed`. Greedy stays the default at temperature 0, so existing results are unaffected.

## Why top-k first

Not a preference — a hardware constraint. A full-vocab probability array is 242 KB per row (62,080 local vocab under TP4) against SM75's 48 KB shared-memory limit. Because top-k precedes top-p in the standard sampling order, restricting to the top-k candidates does not change the sampled distribution. The checkpoint's own `generation_config.json` already sets `top_k: 20`.

## TP correctness

With a sharded vocab each rank sees only its own quarter, so per-rank sampling would diverge. Sampling runs in two stages:

1. `qwen_local_topk_candidates_cuda` — per-rank local top-k, emitted as global ids
2. `nccl_global_topk_rows_device` — merge candidates across ranks
3. `qwen_sample_from_candidates_cuda` — one draw over the merged set

Ranks agree because the host draws the uniforms from an identically seeded generator and shares them; the device curand path is a single-rank fallback only.

## Verification

Real TP4 hardware (4× RTX 2080 Ti, Qwen3.8-27B-FP8):

- seeds 1 and 2 produce different text
- all 4 ranks commit identical token sequences (matching md5 per rank)
- a fixed seed reproduces exactly across runs
- greedy output is bit-identical across runs

`test_qwen_sampler` (8/8 pass) covers greedy equivalence with argmax, exact agreement with a CPU reference, `vocab_start` offsetting, nucleus truncation, reproducibility from host uniforms, empirical frequency (0.9335 observed vs 0.9320 expected), top-k membership, and equality between simulated 4-way sharded two-stage sampling and unsharded sampling.

Existing `test_qwen_half_ops`, `test_qwen_gqa_attention`, `test_qwen_dflash2_ops` still pass.

## Two bugs caught by tests

- Stage 2 scanned only `kMaxTopK` (64) entries while the merged stride is `top_k × tp_world` (80), silently dropping the last rank's candidates. Surfaced as 1 of 8 rows mismatching, with the correct token at global rank 16. The same confusion allowed `k` to exceed the retained array's capacity.
- The sampler initially returned `cudaError_t` where the codebase's launch convention is `bool`; `cudaSuccess` is 0, so every successful launch reported failure. Caught on the first real TP4 run.

## Not measured

Per-step sampling overhead versus greedy. The kernel is single-pass over the vocab with no D2H logits copy, but there are no numbers behind that, so it's worth a benchmark before any throughput sweep.