### PR TITLE
Fix TP sampling candidate stride mismatch

### DIFF
--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -1484,15 +1484,18 @@ struct QwenEngine::Impl {
             if (options.nccl_id_path.empty()) {
                 throw std::runtime_error("Qwen TP requires --nccl-id-path");
             }
+            // nccl_global_topk_rows_device reduces the gathered candidates back
+            // down to top_k per row, so the merged buffers are rows * top_k --
+            // not rows * top_k * tp_world. The gathered staging lives inside
+            // tp_comm's own workspace.
             const size_t cand = static_cast<size_t>(rows) * top_k;
-            const size_t gathered = cand * static_cast<size_t>(options.tp_world);
             allocate(sample_cand_token, cand * sizeof(int),
                      {static_cast<uint64_t>(cand)}, SafeDType::I64);
             allocate_float(sample_cand_logit, cand, {static_cast<uint64_t>(cand)});
-            allocate(sample_merged_token, gathered * sizeof(int),
-                     {static_cast<uint64_t>(gathered)}, SafeDType::I64);
-            allocate_float(sample_merged_logit, gathered,
-                           {static_cast<uint64_t>(gathered)});
+            allocate(sample_merged_token, cand * sizeof(int),
+                     {static_cast<uint64_t>(cand)}, SafeDType::I64);
+            allocate_float(sample_merged_logit, cand,
+                           {static_cast<uint64_t>(cand)});
 
             require_launch(qwen_local_topk_candidates_cuda(
                 local_logits.f32_data(),
@@ -1513,7 +1516,7 @@ struct QwenEngine::Impl {
                 static_cast<const int*>(sample_merged_token.data),
                 sample_merged_logit.f32_data(),
                 static_cast<int*>(argmax_token.data), argmax_logit.f32_data(),
-                rows, top_k * options.tp_world, options.temperature,
+                rows, top_k, options.temperature,
                 options.top_p, top_k,
                 static_cast<curandState*>(sample_rng_states.data),
                 sample_uniforms.f32_data(), nullptr),


### PR DESCRIPTION
## Summary

`nccl_global_topk_rows_device` reduces the all-gathered candidates back down to `top_k` per row, so its output row stride is `top_k`. The sampler was called with `cand_stride = top_k * tp_world`, and the merged buffers were allocated `rows * top_k * tp_world`, so the resulting over-reads stayed inside the allocation and never faulted.

Two consequences:
- Row `r` was read at offset `r * top_k * tp_world` instead of `r * top_k`, so every row past row 0 read the wrong slice.
- Each row's scan ran `top_k * tp_world` entries across a region only `top_k` wide, walking into uninitialized device memory.

Because that memory differs per process, every rank sampled from a different candidate list. This broke TP rank parity and emitted out-of-vocab tokens (e.g. `723926016` against a ~248k vocab).

## Fix

- Pass `top_k` as the stride, matching what the merge writes.
- Size the merged buffers `rows * top_k` so a future stride error faults instead of silently reading garbage. The wide gathered staging already lives in tp_comm's own workspace.

`qwen_dflash2.cpp` calls the same merge function but already sizes its buffers correctly, so it is unaffected.

## Side effect

MTP draft verification was comparing against the same corrupt candidates, so acceptance was also broken. On gsm8k: acceptance 0.12 -> 0.79, MTP 0.56x slowdown -> 1.22x speedup. Earlier "MTP is slower than plain" numbers were measuring this bug.

## Testing

- 8/8 gsm8k prompts, plain and mtp modes: all 4 ranks produce byte-identical token streams per request.
- All 4096 sampled tokens within vocab (min 1, max 248069).
- `test_qwen_sampler` passes, including "sharded two-stage sampling equals unsharded sampling".
- `test_qwen_dflash2_ops` passes.

Not covered: the dflash2 sampling path needs a `--dflash2` checkpoint and was not exercised here.