### PR TITLE
Optimize Qwen speculative verification hot paths

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -76,6 +76,13 @@ target_include_directories(dsv4_cpp_core PUBLIC
 )
 
 target_link_libraries(dsv4_cpp_core PUBLIC CUDA::cudart CUDA::cublas CUDA::curand)
+if(TARGET CUDA::nvtx3)
+    target_link_libraries(dsv4_cpp_core PUBLIC CUDA::nvtx3)
+elseif(TARGET CUDA::nvToolsExt)
+    target_link_libraries(dsv4_cpp_core PUBLIC CUDA::nvToolsExt)
+else()
+    message(FATAL_ERROR "NVTX is required but was not found in the CUDA toolkit")
+endif()
 if(DSV4_HAVE_NCCL)
     target_include_directories(dsv4_cpp_core PUBLIC ${NCCL_INCLUDE_DIR})
     target_link_libraries(dsv4_cpp_core PUBLIC ${NCCL_LIBRARY})
@@ -358,9 +365,21 @@ add_executable(bench_qwen_fp8_kernels tests/bench_qwen_fp8_kernels.cpp)
 target_link_libraries(bench_qwen_fp8_kernels PRIVATE dsv4_cpp_core)
 set_target_properties(bench_qwen_fp8_kernels PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(bench_qwen_draft_lm_head tests/bench_qwen_draft_lm_head.cpp)
+target_link_libraries(bench_qwen_draft_lm_head PRIVATE dsv4_cpp_core)
+set_target_properties(bench_qwen_draft_lm_head PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(bench_qwen_verify_batch tests/bench_qwen_verify_batch.cpp)
 target_link_libraries(bench_qwen_verify_batch PRIVATE dsv4_cpp_core)
 set_target_properties(bench_qwen_verify_batch PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(bench_qwen_delta_f16 tests/bench_qwen_delta_f16.cpp)
+target_link_libraries(bench_qwen_delta_f16 PRIVATE dsv4_cpp_core)
+set_target_properties(bench_qwen_delta_f16 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(bench_qwen_transaction_copy tests/bench_qwen_transaction_copy.cpp)
+target_link_libraries(bench_qwen_transaction_copy PRIVATE dsv4_cpp_core)
+set_target_properties(bench_qwen_transaction_copy PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(bench_qwen_tp_allreduce tests/bench_qwen_tp_allreduce.cpp)
 target_link_libraries(bench_qwen_tp_allreduce PRIVATE dsv4_cpp_core)
@@ -377,6 +396,10 @@ set_target_properties(bench_qwen_fp8_batch_crossover PROPERTIES RUNTIME_OUTPUT_D
 add_executable(bench_qwen_gqa_prefill tests/bench_qwen_gqa_prefill.cpp)
 target_link_libraries(bench_qwen_gqa_prefill PRIVATE dsv4_cpp_core)
 set_target_properties(bench_qwen_gqa_prefill PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(bench_qwen_gqa_verify tests/bench_qwen_gqa_verify.cpp)
+target_link_libraries(bench_qwen_gqa_verify PRIVATE dsv4_cpp_core)
+set_target_properties(bench_qwen_gqa_verify PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(bench_qwen_dflash2_topk tests/bench_qwen_dflash2_topk.cpp)
 target_link_libraries(bench_qwen_dflash2_topk PRIVATE dsv4_cpp_core)

--- a/cpp_engine/cuda/qwen_dflash2_ops.cu
+++ b/cpp_engine/cuda/qwen_dflash2_ops.cu
@@ -394,6 +394,60 @@ __global__ void local_topk_f32_kernel(
     }
 }
 
+__device__ __forceinline__ uint32_t ordered_float_bits(float value) {
+    // Canonicalize signed zero because the host comparator treats -0 and +0 as
+    // equal and then breaks the tie by token id.
+    if (value == 0.0f) value = 0.0f;
+    const uint32_t bits = __float_as_uint(value);
+    return (bits & 0x80000000u) != 0u
+        ? ~bits
+        : (bits ^ 0x80000000u);
+}
+
+__device__ __forceinline__ float unordered_float_bits(uint32_t ordered) {
+    const uint32_t bits = (ordered & 0x80000000u) != 0u
+        ? (ordered ^ 0x80000000u)
+        : ~ordered;
+    return __uint_as_float(bits);
+}
+
+// Encode the same total order as better_candidate() into one unsigned integer.
+// The high word is monotonic in the FP32 logit; the low word is inverted token
+// id so ncclMax selects the smaller token when logits compare equal. NaNs are
+// represented by zero and therefore lose to every valid logit, including -inf.
+__global__ void pack_top1_key_f32_kernel(
+    const int* __restrict__ tokens, const float* __restrict__ values,
+    uint64_t* __restrict__ keys, int rows) {
+    const int row = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (row >= rows) return;
+    const float value = values[row];
+    if (isnan(value)) {
+        keys[row] = 0ull;
+        return;
+    }
+    const uint32_t ordered = ordered_float_bits(value);
+    const uint32_t inverted_token =
+        0xffffffffu - static_cast<uint32_t>(tokens[row]);
+    keys[row] = (static_cast<uint64_t>(ordered) << 32) |
+                static_cast<uint64_t>(inverted_token);
+}
+
+__global__ void unpack_top1_key_f32_kernel(
+    const uint64_t* __restrict__ keys, int* __restrict__ tokens,
+    float* __restrict__ values, int rows) {
+    const int row = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (row >= rows) return;
+    const uint64_t key = keys[row];
+    if (key == 0ull) {
+        tokens[row] = INT_MAX;
+        values[row] = -INFINITY;
+        return;
+    }
+    tokens[row] = static_cast<int>(0xffffffffu -
+                                   static_cast<uint32_t>(key));
+    values[row] = unordered_float_bits(static_cast<uint32_t>(key >> 32));
+}
+
 __global__ void merge_topk_f32_kernel(
     const int* __restrict__ gathered_tokens,
     const float* __restrict__ gathered_values,
@@ -1054,6 +1108,23 @@ bool qwen_dflash2_merge_topk_f32_cuda(
     }
     merge_topk_f32_kernel<<<rows, 1, 0, static_cast<cudaStream_t>(stream)>>>(
         gathered_tokens, gathered_values, tokens, values, world, rows, top_k);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_dflash2_pack_top1_key_f32_cuda(
+    const int* tokens, const float* values, uint64_t* keys, int rows,
+    void* stream) {
+    if (!tokens || !values || !keys || rows <= 0) return false;
+    pack_top1_key_f32_kernel<<<(rows + kThreads - 1) / kThreads, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(tokens, values, keys, rows);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_dflash2_unpack_top1_key_f32_cuda(
+    const uint64_t* keys, int* tokens, float* values, int rows, void* stream) {
+    if (!keys || !tokens || !values || rows <= 0) return false;
+    unpack_top1_key_f32_kernel<<<(rows + kThreads - 1) / kThreads, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(keys, tokens, values, rows);
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/cuda/qwen_gqa_optimized.cu
+++ b/cpp_engine/cuda/qwen_gqa_optimized.cu
@@ -1,5 +1,6 @@
 #include "qwen_cuda_ops.hpp"
 
+#include <cublas_v2.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 
@@ -19,6 +20,11 @@ constexpr int kMaxHeadDim = 256;
 constexpr int kValuesPerThread = kMaxHeadDim / kThreads;
 constexpr int kPrefillCombos = kHeadsPerGroup * kQueryRows;
 constexpr int kDecodeMaxSplits = 64;
+// Verify attention splits far more finely than decode: it has only a handful of
+// query rows to fill the device with, so a 32-position tile at 8192 context wants
+// 256 splits where the decode ceiling would force 128. Sizes the merge kernel's
+// shared weight array, so 256 costs 1 KiB of shared memory per merge block.
+constexpr int kVerifyMaxSplits = 256;
 constexpr int kDecodeTargetPositions = 2048;
 constexpr int kDecodeMinContext = 4096;
 constexpr int kVerifyMaxRows = 8;
@@ -735,7 +741,7 @@ __global__ void gqa_decode_split_f16_kernel(
 // is loaded once for up to rows * 3 outputs. Splitting the history restores
 // enough parallelism for the 4-32K context regime where a single CTA per group
 // leaves SM75 mostly idle.
-template <int kRows>
+template <int kRows, int kHPG>
 __global__ void gqa_verify_split_f16_kernel(
     const uint16_t* __restrict__ q_rows,
     const uint16_t* __restrict__ k_cache,
@@ -748,15 +754,15 @@ __global__ void gqa_verify_split_f16_kernel(
     int position_offset,
     int splits,
     int positions_per_split) {
-    constexpr int kCombos = kRows * kHeadsPerGroup;
+    constexpr int kCombos = kRows * kHPG;
     const int q_per_kv = q_heads / kv_heads;
     const int groups_per_kv =
-        (q_per_kv + kHeadsPerGroup - 1) / kHeadsPerGroup;
+        (q_per_kv + kHPG - 1) / kHPG;
     const int grouped = static_cast<int>(blockIdx.x) / splits;
     const int split = static_cast<int>(blockIdx.x) % splits;
     const int kv_head = grouped / groups_per_kv;
     const int group = grouped % groups_per_kv;
-    const int first_head = kv_head * q_per_kv + group * kHeadsPerGroup;
+    const int first_head = kv_head * q_per_kv + group * kHPG;
     const int split_start = split * positions_per_split;
     const int split_end = min(
         position_offset + rows, split_start + positions_per_split);
@@ -776,8 +782,8 @@ __global__ void gqa_verify_split_f16_kernel(
     int context_limit[kCombos];
 #pragma unroll
     for (int combo = 0; combo < kCombos; ++combo) {
-        const int row = combo / kHeadsPerGroup;
-        const int head_in_group = combo % kHeadsPerGroup;
+        const int row = combo / kHPG;
+        const int head_in_group = combo % kHPG;
         const int head = first_head + head_in_group;
         active[combo] = row < rows &&
             head < (kv_head + 1) * q_per_kv && head < q_heads;
@@ -854,8 +860,8 @@ __global__ void gqa_verify_split_f16_kernel(
 #pragma unroll
     for (int combo = 0; combo < kCombos; ++combo) {
         if (!active[combo]) continue;
-        const int row = combo / kHeadsPerGroup;
-        const int head_in_group = combo % kHeadsPerGroup;
+        const int row = combo / kHPG;
+        const int head_in_group = combo % kHPG;
         const int head = first_head + head_in_group;
         float* destination = partial_output +
             ((static_cast<size_t>(row) * q_heads + head) * splits + split) *
@@ -882,7 +888,7 @@ __global__ void gqa_verify_merge_f16_kernel(
     const int row = static_cast<int>(blockIdx.y);
     const int head = static_cast<int>(blockIdx.x);
     if (row >= rows || head >= q_heads) return;
-    __shared__ float weights[kDecodeMaxSplits];
+    __shared__ float weights[kVerifyMaxSplits];
     if (threadIdx.x == 0) {
         const int stride = head_dim + 2;
         const size_t base =
@@ -980,17 +986,20 @@ __global__ void gqa_verify_scores_exact_f16_kernel(
 }
 
 __global__ void gqa_verify_softmax_exact_f16_kernel(
-    float* __restrict__ scores, int rows, int q_heads, int context_len) {
+    float* __restrict__ scores, int rows, int q_heads, int context_len,
+    int position_offset) {
     const int row = static_cast<int>(blockIdx.y);
     const int head = static_cast<int>(blockIdx.x);
     if (row >= rows || head >= q_heads) return;
     float* line = scores +
         (static_cast<size_t>(row) * q_heads + head) * context_len;
+    const int context_limit = position_offset + row + 1;
     __shared__ float reduce[kThreads];
     float local_max = -INFINITY;
     for (int position = static_cast<int>(threadIdx.x); position < context_len;
          position += kThreads) {
-        local_max = fmaxf(local_max, line[position]);
+        const float value = position < context_limit ? line[position] : -INFINITY;
+        local_max = fmaxf(local_max, value);
     }
     reduce[threadIdx.x] = local_max;
     __syncthreads();
@@ -1005,7 +1014,8 @@ __global__ void gqa_verify_softmax_exact_f16_kernel(
     float sum = 0.0f;
     for (int position = static_cast<int>(threadIdx.x); position < context_len;
          position += kThreads) {
-        line[position] = expf(line[position] - maximum);
+        line[position] = position < context_limit
+            ? expf(line[position] - maximum) : 0.0f;
         sum += line[position];
     }
     reduce[threadIdx.x] = sum;
@@ -1112,6 +1122,33 @@ __global__ void gqa_decode_merge_f16_kernel(
 bool valid_shape(int q_heads, int kv_heads, int head_dim) {
     return q_heads > 0 && kv_heads > 0 && q_heads % kv_heads == 0 &&
         head_dim > 0 && head_dim <= kMaxHeadDim;
+}
+
+struct GqaCublasWorkspace {
+    int device = -1;
+    cublasHandle_t handle = nullptr;
+    ~GqaCublasWorkspace() {
+        if (handle != nullptr) cublasDestroy(handle);
+    }
+};
+
+GqaCublasWorkspace& gqa_cublas_workspace() {
+    static GqaCublasWorkspace workspace;
+    return workspace;
+}
+
+bool ensure_gqa_cublas_workspace(GqaCublasWorkspace& workspace) {
+    int device = -1;
+    if (cudaGetDevice(&device) != cudaSuccess) return false;
+    if (workspace.handle != nullptr && workspace.device == device) return true;
+    if (workspace.handle != nullptr) {
+        cublasDestroy(workspace.handle);
+        workspace.handle = nullptr;
+    }
+    if (cublasCreate(&workspace.handle) != CUBLAS_STATUS_SUCCESS) return false;
+    (void)cublasSetMathMode(workspace.handle, CUBLAS_TENSOR_OP_MATH);
+    workspace.device = device;
+    return true;
 }
 
 }  // namespace
@@ -1253,6 +1290,60 @@ bool qwen_gqa_prefill_attention_f16_tiled_cuda(
     return cudaGetLastError() == cudaSuccess;
 }
 
+bool qwen_gqa_verify_attention_f16_cublas_qk_cuda(
+    const uint16_t* q, const uint16_t* k_cache,
+    const uint16_t* v_cache, uint16_t* output, float* score_scratch,
+    int rows, int q_heads, int kv_heads, int head_dim,
+    int position_offset, int max_context, void* stream) {
+    if (!q || !k_cache || !v_cache || !output || !score_scratch ||
+        rows < 2 || rows > kVerifyMaxRows || kv_heads != 1 ||
+        position_offset < 0 || position_offset + rows > max_context ||
+        !valid_shape(q_heads, kv_heads, head_dim)) return false;
+    const int context_len = position_offset + rows;
+    GqaCublasWorkspace& workspace = gqa_cublas_workspace();
+    if (!ensure_gqa_cublas_workspace(workspace)) return false;
+    const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
+    if (cublasSetStream(workspace.handle, cuda_stream) != CUBLAS_STATUS_SUCCESS) {
+        return false;
+    }
+
+    // Row-major Q [M,K] times row-major K_cache^T [K,N]. cuBLAS is column
+    // major, so compute C^T [N,M] = K_cache [N,K] * Q^T [K,M]. C's row-major
+    // storage is exactly C^T's column-major storage.
+    const int m = rows * q_heads;
+    const int n = context_len;
+    const int k = head_dim;
+    const float alpha = rsqrtf(static_cast<float>(head_dim));
+    const float beta = 0.0f;
+    if (cublasGemmEx(
+            workspace.handle, CUBLAS_OP_T, CUBLAS_OP_N,
+            n, m, k, &alpha,
+            k_cache, CUDA_R_16F, k,
+            q, CUDA_R_16F, k,
+            &beta, score_scratch, CUDA_R_32F, n,
+            CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP) !=
+        CUBLAS_STATUS_SUCCESS) {
+        return false;
+    }
+
+    const dim3 softmax_grid(static_cast<unsigned>(q_heads),
+                            static_cast<unsigned>(rows), 1);
+    gqa_verify_softmax_exact_f16_kernel<<<
+        softmax_grid, kThreads, 0, cuda_stream>>>(
+        score_scratch, rows, q_heads, context_len, position_offset);
+    if (cudaGetLastError() != cudaSuccess) return false;
+
+    const int groups_per_kv =
+        (q_heads / kv_heads + kHeadsPerGroup - 1) / kHeadsPerGroup;
+    const dim3 value_grid(static_cast<unsigned>(kv_heads * groups_per_kv),
+                          static_cast<unsigned>(rows),
+                          static_cast<unsigned>((head_dim + 31) / 32));
+    gqa_verify_values_exact_f16_kernel<<<value_grid, 32, 0, cuda_stream>>>(
+        score_scratch, v_cache, output, rows, q_heads, kv_heads, head_dim,
+        context_len);
+    return cudaGetLastError() == cudaSuccess;
+}
+
 bool qwen_gqa_verify_attention_f16_exact_cuda(
     const uint16_t* q, const uint16_t* k_cache,
     const uint16_t* v_cache, uint16_t* output, float* score_scratch,
@@ -1289,7 +1380,7 @@ bool qwen_gqa_verify_attention_f16_exact_cuda(
     const dim3 softmax_grid(static_cast<unsigned>(q_heads),
                             static_cast<unsigned>(rows), 1);
     gqa_verify_softmax_exact_f16_kernel<<<softmax_grid, kThreads, 0, cuda_stream>>>(
-        score_scratch, rows, q_heads, context_len);
+        score_scratch, rows, q_heads, context_len, position_offset);
     if (cudaGetLastError() != cudaSuccess) return false;
     const dim3 value_grid(static_cast<unsigned>(kv_heads * groups_per_kv),
                           static_cast<unsigned>(rows),
@@ -1308,18 +1399,20 @@ bool qwen_gqa_verify_attention_f16_cuda(
     if (!q || !k_cache || !v_cache || !output || !partial_scratch ||
         rows < 2 || rows > kVerifyMaxRows || position_offset < 0 ||
         position_offset + rows > max_context || splits <= 0 ||
-        splits > kDecodeMaxSplits ||
+        splits > kVerifyMaxSplits ||
         !valid_shape(q_heads, kv_heads, head_dim)) return false;
     const int context_len = position_offset + rows;
     const int positions_per_split = (context_len + splits - 1) / splits;
+    const int q_per_kv = q_heads / kv_heads;
     const int groups_per_kv =
-        (q_heads / kv_heads + kHeadsPerGroup - 1) / kHeadsPerGroup;
+        (q_per_kv + kHeadsPerGroup - 1) / kHeadsPerGroup;
     const int blocks = kv_heads * groups_per_kv * splits;
     const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
 #define DSV4_LAUNCH_VERIFY(ROWS) \
-    gqa_verify_split_f16_kernel<ROWS><<<blocks, kThreads, 0, cuda_stream>>>( \
-        q, k_cache, v_cache, partial_scratch, rows, q_heads, kv_heads, \
-        head_dim, position_offset, splits, positions_per_split)
+    gqa_verify_split_f16_kernel<ROWS, kHeadsPerGroup> \
+        <<<blocks, kThreads, 0, cuda_stream>>>( \
+            q, k_cache, v_cache, partial_scratch, rows, q_heads, kv_heads, \
+            head_dim, position_offset, splits, positions_per_split)
     switch (rows) {
         case 2: DSV4_LAUNCH_VERIFY(2); break;
         case 3: DSV4_LAUNCH_VERIFY(3); break;

--- a/cpp_engine/cuda/qwen_half_ops.cu
+++ b/cpp_engine/cuda/qwen_half_ops.cu
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <type_traits>
 
 namespace dsv4 {
 namespace {
@@ -245,17 +246,11 @@ __global__ void fp8_matmul_f16_small_batch_kernel(
     }
 }
 
-// Same math again, but the staged activation tile holds floats rather than fp16
-// codes. The fp16 variants re-run half_to_float inside the weight loop, so each
-// of the kWarps warps converts the same activation element again for every weight
-// quad it processes. At batch 8 that is 32 conversions per 4 weight bytes, and
-// SM75 issues conversions at a quarter of its FMA rate, which is what makes an
-// otherwise weight-bandwidth-bound projection lose half its throughput between
-// batch 1 and batch 8. Converting once during the cooperative load leaves the
-// inner loop pure FMA. fp16 -> fp32 is exact and the per-lane column order is
-// unchanged, so results are bit-identical to both fp16 variants.
+// Shared-activation verify kernel. Pairing two 128-column lane strides reduces
+// loop and shared-load instructions while preserving each lane's accumulation
+// order, so the result stays bit-identical to plain decode.
 template <int kWarps, int kBatchCapacity, int kTile>
-__global__ void fp8_matmul_f16_small_batch_fshared_kernel(
+__global__ void fp8_matmul_f16_small_batch_paired_shared_kernel(
     const uint16_t* __restrict__ x, const uint8_t* __restrict__ weight,
     const uint16_t* __restrict__ scale, uint16_t* __restrict__ y,
     int batch, int rows, int cols, int x_stride, int y_stride,
@@ -280,25 +275,32 @@ __global__ void fp8_matmul_f16_small_batch_fshared_kernel(
         const int tile_cols = min(kTile, vec_cols - tile);
         const int vec_count = tile_cols >> 2;
         __syncthreads();
-#pragma unroll
-        for (int sample = 0; sample < kBatchCapacity; ++sample) {
-            if (sample >= batch) break;
-            const uint2* source = reinterpret_cast<const uint2*>(
-                x + static_cast<size_t>(sample) * x_stride + tile);
-            uint2* target = reinterpret_cast<uint2*>(xs + sample * kTile);
-            for (int i = static_cast<int>(threadIdx.x); i < vec_count;
-                 i += threads) {
+        if constexpr (kWarps >= 16) {
+            const int load_count = batch * vec_count;
+            for (int index = static_cast<int>(threadIdx.x); index < load_count;
+                 index += threads) {
+                const int sample = index / vec_count;
+                const int i = index - sample * vec_count;
+                const uint2* source = reinterpret_cast<const uint2*>(
+                    x + static_cast<size_t>(sample) * x_stride + tile);
+                uint2* target = reinterpret_cast<uint2*>(xs + sample * kTile);
                 target[i] = source[i];
+            }
+        } else {
+#pragma unroll
+            for (int sample = 0; sample < kBatchCapacity; ++sample) {
+                if (sample >= batch) break;
+                const uint2* source = reinterpret_cast<const uint2*>(
+                    x + static_cast<size_t>(sample) * x_stride + tile);
+                uint2* target = reinterpret_cast<uint2*>(xs + sample * kTile);
+                for (int i = static_cast<int>(threadIdx.x); i < vec_count;
+                     i += threads) {
+                    target[i] = source[i];
+                }
             }
         }
         __syncthreads();
         if (!active) continue;
-        // Two strided steps fused into one iteration. The batch-8 verify shape is
-        // neither DRAM bound (121 of ~600 GB/s) nor FMA bound (1.94 of 13.4
-        // TFLOP/s), so the cost is loop and shared-load instruction count. Each
-        // lane keeps exactly the columns it owned before and accumulates them in
-        // the same order, so the result stays bit identical to the register-only
-        // kernel that plain decode uses; only the loop overhead is halved.
         const int pair_limit = tile_cols - 128;
         int local = lane * 4;
         for (; local < pair_limit; local += 256) {
@@ -306,7 +308,8 @@ __global__ void fp8_matmul_f16_small_batch_fshared_kernel(
             const uchar4 c0 = *reinterpret_cast<const uchar4*>(w + col);
             const uchar4 c1 = *reinterpret_cast<const uchar4*>(w + col + 128);
             const float scale0 = half_to_float(s[col / kFp8WeightBlock]);
-            const float scale1 = half_to_float(s[(col + 128) / kFp8WeightBlock]);
+            const float scale1 = half_to_float(
+                s[(col + 128) / kFp8WeightBlock]);
             const float a0 = lut[c0.x] * scale0;
             const float a1 = lut[c0.y] * scale0;
             const float a2 = lut[c0.z] * scale0;
@@ -335,11 +338,11 @@ __global__ void fp8_matmul_f16_small_batch_fshared_kernel(
                 sums[sample] = acc;
             }
         }
-        // Odd trailing step when the tile does not hold a whole pair.
         for (; local < tile_cols; local += 128) {
             const int col = tile + local;
             const uchar4 codes = *reinterpret_cast<const uchar4*>(w + col);
-            const float weight_scale = half_to_float(s[col / kFp8WeightBlock]);
+            const float weight_scale = half_to_float(
+                s[col / kFp8WeightBlock]);
             const float w0 = lut[codes.x] * weight_scale;
             const float w1 = lut[codes.y] * weight_scale;
             const float w2 = lut[codes.z] * weight_scale;
@@ -354,96 +357,6 @@ __global__ void fp8_matmul_f16_small_batch_fshared_kernel(
                 const float2 hi = __half22float2(
                     *reinterpret_cast<const __half2*>(&packed.y));
                 sums[sample] += lo.x * w0 + lo.y * w1 + hi.x * w2 + hi.y * w3;
-            }
-        }
-    }
-    if (!active) return;
-    for (int col = vec_cols + lane; col < cols; col += 32) {
-        const float weight_value = lut[w[col]] *
-            half_to_float(s[col / kFp8WeightBlock]);
-#pragma unroll
-        for (int sample = 0; sample < kBatchCapacity; ++sample) {
-            if (sample >= batch) break;
-            sums[sample] += half_to_float(
-                x[static_cast<size_t>(sample) * x_stride + col]) * weight_value;
-        }
-    }
-#pragma unroll
-    for (int sample = 0; sample < kBatchCapacity; ++sample) {
-        if (sample >= batch) break;
-        float sum = sums[sample];
-        for (int offset = 16; offset > 0; offset >>= 1) {
-            sum += __shfl_xor_sync(0xffffffffu, sum, offset);
-        }
-        if (lane == 0) {
-            y[static_cast<size_t>(sample) * y_stride + row] = float_to_half(sum);
-        }
-    }
-}
-
-// Same math as fp8_matmul_f16_small_batch_kernel with the activation tile staged
-// in shared memory. Every warp in a block reads the same activation rows, so the
-// non-staged kernel issues the activation traffic kWarps times and becomes L2
-// bound instead of weight bound once batch > 1. Column tiles are multiples of the
-// 128-element per-lane stride, so each lane still accumulates its columns in the
-// original order and the result is bit-identical.
-template <int kWarps, int kBatchCapacity, int kTile>
-__global__ void fp8_matmul_f16_small_batch_shared_kernel(
-    const uint16_t* __restrict__ x, const uint8_t* __restrict__ weight,
-    const uint16_t* __restrict__ scale, uint16_t* __restrict__ y,
-    int batch, int rows, int cols, int x_stride, int y_stride,
-    int weight_stride, int scale_stride) {
-    __shared__ float lut[256];
-    __shared__ uint16_t xs[kBatchCapacity * kTile];
-    for (int i = static_cast<int>(threadIdx.x); i < 256; i += blockDim.x) {
-        lut[i] = fp8_e4m3_to_float(static_cast<uint8_t>(i));
-    }
-    const int warp = static_cast<int>(threadIdx.x) >> 5;
-    const int lane = static_cast<int>(threadIdx.x) & 31;
-    const int row = static_cast<int>(blockIdx.x) * kWarps + warp;
-    const bool active = row < rows;
-    const uint8_t* w = weight + static_cast<size_t>(active ? row : 0) *
-        weight_stride;
-    const uint16_t* s = scale +
-        static_cast<size_t>((active ? row : 0) / kFp8WeightBlock) * scale_stride;
-    float sums[kBatchCapacity] = {};
-    const int vec_cols = cols & ~3;
-    const int threads = static_cast<int>(blockDim.x);
-    for (int tile = 0; tile < vec_cols; tile += kTile) {
-        const int tile_cols = min(kTile, vec_cols - tile);
-        const int vec_count = tile_cols >> 2;
-        __syncthreads();
-#pragma unroll
-        for (int sample = 0; sample < kBatchCapacity; ++sample) {
-            if (sample >= batch) break;
-            const uint2* source = reinterpret_cast<const uint2*>(
-                x + static_cast<size_t>(sample) * x_stride + tile);
-            uint2* target = reinterpret_cast<uint2*>(xs + sample * kTile);
-            for (int i = static_cast<int>(threadIdx.x); i < vec_count;
-                 i += threads) {
-                target[i] = source[i];
-            }
-        }
-        __syncthreads();
-        if (!active) continue;
-        for (int local = lane * 4; local < tile_cols; local += 128) {
-            const int col = tile + local;
-            const uchar4 codes = *reinterpret_cast<const uchar4*>(w + col);
-            const float weight_scale = half_to_float(s[col / kFp8WeightBlock]);
-            const float w0 = lut[codes.x] * weight_scale;
-            const float w1 = lut[codes.y] * weight_scale;
-            const float w2 = lut[codes.z] * weight_scale;
-            const float w3 = lut[codes.w] * weight_scale;
-#pragma unroll
-            for (int sample = 0; sample < kBatchCapacity; ++sample) {
-                if (sample >= batch) break;
-                const uint2 packed = *reinterpret_cast<const uint2*>(
-                    xs + sample * kTile + local);
-                sums[sample] +=
-                    half_to_float(static_cast<uint16_t>(packed.x)) * w0 +
-                    half_to_float(static_cast<uint16_t>(packed.x >> 16)) * w1 +
-                    half_to_float(static_cast<uint16_t>(packed.y)) * w2 +
-                    half_to_float(static_cast<uint16_t>(packed.y >> 16)) * w3;
             }
         }
     }
@@ -511,20 +424,96 @@ __global__ void fp8_swiglu_small_batch_shared_f16_kernel(
         const int tile_cols = min(kTile, vec_cols - tile);
         const int vec_count = tile_cols >> 2;
         __syncthreads();
-#pragma unroll
-        for (int sample = 0; sample < kBatchCapacity; ++sample) {
-            if (sample >= batch) break;
-            const uint2* source = reinterpret_cast<const uint2*>(
-                x + static_cast<size_t>(sample) * x_stride + tile);
-            uint2* target = reinterpret_cast<uint2*>(xs + sample * kTile);
-            for (int i = static_cast<int>(threadIdx.x); i < vec_count;
-                 i += threads) {
+        if constexpr (kWarps >= 16) {
+            const int load_count = batch * vec_count;
+            for (int index = static_cast<int>(threadIdx.x); index < load_count;
+                 index += threads) {
+                const int sample = index / vec_count;
+                const int i = index - sample * vec_count;
+                const uint2* source = reinterpret_cast<const uint2*>(
+                    x + static_cast<size_t>(sample) * x_stride + tile);
+                uint2* target = reinterpret_cast<uint2*>(xs + sample * kTile);
                 target[i] = source[i];
+            }
+        } else {
+#pragma unroll
+            for (int sample = 0; sample < kBatchCapacity; ++sample) {
+                if (sample >= batch) break;
+                const uint2* source = reinterpret_cast<const uint2*>(
+                    x + static_cast<size_t>(sample) * x_stride + tile);
+                uint2* target = reinterpret_cast<uint2*>(xs + sample * kTile);
+                for (int i = static_cast<int>(threadIdx.x); i < vec_count;
+                     i += threads) {
+                    target[i] = source[i];
+                }
             }
         }
         __syncthreads();
         if (!active) continue;
-        for (int local = lane * 4; local < tile_cols; local += 128) {
+        const int pair_limit = tile_cols - 128;
+        int local = lane * 4;
+        for (; local < pair_limit; local += 256) {
+            const int col = tile + local;
+            const uchar4 gate0 =
+                *reinterpret_cast<const uchar4*>(gate_row + col);
+            const uchar4 gate1 =
+                *reinterpret_cast<const uchar4*>(gate_row + col + 128);
+            const uchar4 up0 = *reinterpret_cast<const uchar4*>(up_row + col);
+            const uchar4 up1 =
+                *reinterpret_cast<const uchar4*>(up_row + col + 128);
+            const float gate_s0 =
+                half_to_float(gate_scale_row[col / kFp8WeightBlock]);
+            const float gate_s1 = half_to_float(
+                gate_scale_row[(col + 128) / kFp8WeightBlock]);
+            const float up_s0 =
+                half_to_float(up_scale_row[col / kFp8WeightBlock]);
+            const float up_s1 =
+                half_to_float(up_scale_row[(col + 128) / kFp8WeightBlock]);
+            const float gw00 = lut[gate0.x] * gate_s0;
+            const float gw01 = lut[gate0.y] * gate_s0;
+            const float gw02 = lut[gate0.z] * gate_s0;
+            const float gw03 = lut[gate0.w] * gate_s0;
+            const float gw10 = lut[gate1.x] * gate_s1;
+            const float gw11 = lut[gate1.y] * gate_s1;
+            const float gw12 = lut[gate1.z] * gate_s1;
+            const float gw13 = lut[gate1.w] * gate_s1;
+            const float uw00 = lut[up0.x] * up_s0;
+            const float uw01 = lut[up0.y] * up_s0;
+            const float uw02 = lut[up0.z] * up_s0;
+            const float uw03 = lut[up0.w] * up_s0;
+            const float uw10 = lut[up1.x] * up_s1;
+            const float uw11 = lut[up1.y] * up_s1;
+            const float uw12 = lut[up1.z] * up_s1;
+            const float uw13 = lut[up1.w] * up_s1;
+#pragma unroll
+            for (int sample = 0; sample < kBatchCapacity; ++sample) {
+                if (sample >= batch) break;
+                const uint16_t* base = xs + sample * kTile + local;
+                const uint2 p0 = *reinterpret_cast<const uint2*>(base);
+                const uint2 p1 = *reinterpret_cast<const uint2*>(base + 128);
+                const float2 lo0 = __half22float2(
+                    *reinterpret_cast<const __half2*>(&p0.x));
+                const float2 hi0 = __half22float2(
+                    *reinterpret_cast<const __half2*>(&p0.y));
+                const float2 lo1 = __half22float2(
+                    *reinterpret_cast<const __half2*>(&p1.x));
+                const float2 hi1 = __half22float2(
+                    *reinterpret_cast<const __half2*>(&p1.y));
+                float gate_acc = gate_sums[sample];
+                float up_acc = up_sums[sample];
+                gate_acc += lo0.x * gw00 + lo0.y * gw01 +
+                    hi0.x * gw02 + hi0.y * gw03;
+                up_acc += lo0.x * uw00 + lo0.y * uw01 +
+                    hi0.x * uw02 + hi0.y * uw03;
+                gate_acc += lo1.x * gw10 + lo1.y * gw11 +
+                    hi1.x * gw12 + hi1.y * gw13;
+                up_acc += lo1.x * uw10 + lo1.y * uw11 +
+                    hi1.x * uw12 + hi1.y * uw13;
+                gate_sums[sample] = gate_acc;
+                up_sums[sample] = up_acc;
+            }
+        }
+        for (; local < tile_cols; local += 128) {
             const int col = tile + local;
             const uchar4 gate_codes =
                 *reinterpret_cast<const uchar4*>(gate_row + col);
@@ -547,14 +536,14 @@ __global__ void fp8_swiglu_small_batch_shared_f16_kernel(
                 if (sample >= batch) break;
                 const uint2 packed = *reinterpret_cast<const uint2*>(
                     xs + sample * kTile + local);
-                const float x0 = half_to_float(static_cast<uint16_t>(packed.x));
-                const float x1 =
-                    half_to_float(static_cast<uint16_t>(packed.x >> 16));
-                const float x2 = half_to_float(static_cast<uint16_t>(packed.y));
-                const float x3 =
-                    half_to_float(static_cast<uint16_t>(packed.y >> 16));
-                gate_sums[sample] += x0 * gw0 + x1 * gw1 + x2 * gw2 + x3 * gw3;
-                up_sums[sample] += x0 * uw0 + x1 * uw1 + x2 * uw2 + x3 * uw3;
+                const float2 lo = __half22float2(
+                    *reinterpret_cast<const __half2*>(&packed.x));
+                const float2 hi = __half22float2(
+                    *reinterpret_cast<const __half2*>(&packed.y));
+                gate_sums[sample] +=
+                    lo.x * gw0 + lo.y * gw1 + hi.x * gw2 + hi.y * gw3;
+                up_sums[sample] +=
+                    lo.x * uw0 + lo.y * uw1 + hi.x * uw2 + hi.y * uw3;
             }
         }
     }
@@ -1048,33 +1037,34 @@ bool ensure_fp8_f16_cublas_workspace(
     return true;
 }
 
-bool fp8_matmul_f16_cublas(
-    const uint16_t* x, const uint8_t* weight, const uint16_t* scale,
-    uint16_t* y, int batch, int rows, int cols, int x_stride,
-    int y_stride, int weight_stride, int scale_stride, cudaStream_t stream) {
-    Fp8F16CublasWorkspace& workspace = fp8_f16_cublas_workspace();
+bool dequantize_fp8_weight_f16(
+    const uint8_t* weight, const uint16_t* scale, uint16_t* output,
+    int rows, int cols, int weight_stride, int scale_stride,
+    cudaStream_t stream) {
     const size_t weight_elements = static_cast<size_t>(rows) * cols;
-    if (!ensure_fp8_f16_cublas_workspace(workspace, weight_elements)) return false;
     constexpr int kThreads = 256;
     const size_t block_count = (weight_elements + kThreads - 1) / kThreads;
     const int blocks = static_cast<int>(block_count > 65535 ? 65535 : block_count);
     fp8_weight_fp16scale_to_half_kernel<<<blocks, kThreads, 0, stream>>>(
-        weight, scale, workspace.weight, rows, cols, weight_stride,
-        scale_stride);
+        weight, scale, output, rows, cols, weight_stride, scale_stride);
     if (cudaGetLastError() != cudaSuccess) return false;
     const int tail = cols & 3;
-    if (tail != 0) {
-        const size_t tail_elements = static_cast<size_t>(rows) * tail;
-        const size_t tail_block_count =
-            (tail_elements + kThreads - 1) / kThreads;
-        const int tail_blocks = static_cast<int>(std::min<size_t>(
-            tail_block_count, 65535));
-        fp8_weight_fp16scale_to_half_tail_kernel<<<
-            tail_blocks, kThreads, 0, stream>>>(
-                weight, scale, workspace.weight, rows, cols,
-                weight_stride, scale_stride);
-        if (cudaGetLastError() != cudaSuccess) return false;
-    }
+    if (tail == 0) return true;
+    const size_t tail_elements = static_cast<size_t>(rows) * tail;
+    const size_t tail_block_count = (tail_elements + kThreads - 1) / kThreads;
+    const int tail_blocks = static_cast<int>(std::min<size_t>(
+        tail_block_count, 65535));
+    fp8_weight_fp16scale_to_half_tail_kernel<<<tail_blocks, kThreads, 0, stream>>>(
+        weight, scale, output, rows, cols, weight_stride, scale_stride);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool fp16_matmul_f16_cublas(
+    const uint16_t* x, const uint16_t* weight, uint16_t* y,
+    int batch, int rows, int cols, int x_stride, int y_stride,
+    int weight_stride, cudaStream_t stream) {
+    Fp8F16CublasWorkspace& workspace = fp8_f16_cublas_workspace();
+    if (!ensure_fp8_f16_cublas_workspace(workspace, 0, false)) return false;
     if (cublasSetStream(workspace.handle, stream) != CUBLAS_STATUS_SUCCESS) {
         return false;
     }
@@ -1083,14 +1073,29 @@ bool fp8_matmul_f16_cublas(
     const cublasGemmAlgo_t algo =
         (rows % 8 == 0 && batch % 8 == 0 && cols % 8 == 0)
             ? CUBLAS_GEMM_DEFAULT_TENSOR_OP : CUBLAS_GEMM_DEFAULT;
-    const cublasStatus_t gemm_status = cublasGemmEx(
+    return cublasGemmEx(
         workspace.handle, CUBLAS_OP_T, CUBLAS_OP_N,
         rows, batch, cols, &alpha,
-        workspace.weight, CUDA_R_16F, cols,
+        weight, CUDA_R_16F, weight_stride,
         x, CUDA_R_16F, x_stride,
         &beta, y, CUDA_R_16F, y_stride,
-        CUBLAS_COMPUTE_32F, algo);
-    return gemm_status == CUBLAS_STATUS_SUCCESS;
+        CUBLAS_COMPUTE_32F, algo) == CUBLAS_STATUS_SUCCESS;
+}
+
+bool fp8_matmul_f16_cublas(
+    const uint16_t* x, const uint8_t* weight, const uint16_t* scale,
+    uint16_t* y, int batch, int rows, int cols, int x_stride,
+    int y_stride, int weight_stride, int scale_stride, cudaStream_t stream) {
+    Fp8F16CublasWorkspace& workspace = fp8_f16_cublas_workspace();
+    const size_t weight_elements = static_cast<size_t>(rows) * cols;
+    if (!ensure_fp8_f16_cublas_workspace(workspace, weight_elements)) return false;
+    if (!dequantize_fp8_weight_f16(weight, scale, workspace.weight, rows, cols,
+                                   weight_stride, scale_stride, stream)) {
+        return false;
+    }
+    return fp16_matmul_f16_cublas(
+        x, workspace.weight, y, batch, rows, cols, x_stride, y_stride, cols,
+        stream);
 }
 
 template <bool kFloatOutput, int kWarps, int kBatchCapacity>
@@ -1286,6 +1291,34 @@ __global__ void rmsnorm_f16_kernel(const uint16_t* x, const uint16_t* gamma,
     }
 }
 
+__global__ void residual_add_rmsnorm_f16_kernel(
+    const uint16_t* hidden, const uint16_t* delta, const uint16_t* gamma,
+    uint16_t* residual, uint16_t* normalized, int rows, int cols, float eps) {
+    const int row = static_cast<int>(blockIdx.x);
+    if (row >= rows) return;
+    const size_t row_offset = static_cast<size_t>(row) * cols;
+    const uint16_t* hidden_row = hidden + row_offset;
+    const uint16_t* delta_row = delta + row_offset;
+    uint16_t* residual_row = residual + row_offset;
+    uint16_t* normalized_row = normalized + row_offset;
+    float sum = 0.0f;
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+        const uint16_t value = float_to_half(
+            half_to_float(hidden_row[col]) + half_to_float(delta_row[col]));
+        residual_row[col] = value;
+        const float rounded = half_to_float(value);
+        sum += rounded * rounded;
+    }
+    extern __shared__ float scratch[];
+    const float inv = rsqrtf(
+        block_reduce_sum(sum, scratch) / static_cast<float>(cols) + eps);
+    for (int col = threadIdx.x; col < cols; col += blockDim.x) {
+        normalized_row[col] = float_to_half(
+            half_to_float(residual_row[col]) * inv *
+            (1.0f + half_to_float(gamma[col])));
+    }
+}
+
 __global__ void gated_rmsnorm_f16_kernel(
     const uint16_t* x, const uint16_t* gamma, const uint16_t* gate,
     uint16_t* y, int rows, int cols, float eps) {
@@ -1432,6 +1465,163 @@ __global__ void gated_delta_step_f16_kernel(
         result += cell * q_shared[i];
     }
     output[static_cast<size_t>(head) * value_dim + value] = float_to_half(result * q_scale);
+}
+
+__global__ void normalize_gated_delta_qk_f16_kernel(
+    const uint16_t* q, const uint16_t* k, float* q_normalized,
+    float* k_normalized, int rows, int key_heads, int key_dim) {
+    const int key_head = static_cast<int>(blockIdx.x);
+    const int token = static_cast<int>(blockIdx.y);
+    const int tid = static_cast<int>(threadIdx.x);
+    const size_t offset =
+        (static_cast<size_t>(token) * key_heads + key_head) * key_dim;
+    float q_partial = 0.0f;
+    float k_partial = 0.0f;
+    for (int i = tid; i < key_dim; i += blockDim.x) {
+        const float qv = half_to_float(q[offset + i]);
+        const float kv = half_to_float(k[offset + i]);
+        q_partial += qv * qv;
+        k_partial += kv * kv;
+    }
+    __shared__ float q_reduce[128];
+    __shared__ float k_reduce[128];
+    q_reduce[tid] = q_partial;
+    k_reduce[tid] = k_partial;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            q_reduce[tid] += q_reduce[tid + stride];
+            k_reduce[tid] += k_reduce[tid + stride];
+        }
+        __syncthreads();
+    }
+    const float q_inv = rsqrtf(q_reduce[0] + 1.0e-6f);
+    const float k_inv = rsqrtf(k_reduce[0] + 1.0e-6f);
+    for (int i = tid; i < key_dim; i += blockDim.x) {
+        q_normalized[offset + i] = half_to_float(q[offset + i]) * q_inv;
+        k_normalized[offset + i] = half_to_float(k[offset + i]) * k_inv;
+    }
+}
+
+template <int kKeyDim>
+__global__ void gated_delta_sequence_normalized_f16_kernel(
+    float* state, const float* q_normalized, const float* k_normalized,
+    const uint16_t* v, const uint16_t* g, const uint16_t* beta,
+    uint16_t* output, int rows, int heads, int key_heads,
+    int value_dim, float q_scale) {
+    const int head = static_cast<int>(blockIdx.x);
+    const int value = static_cast<int>(threadIdx.x);
+    const int repeat = heads / key_heads;
+    const int key_head = head / repeat;
+    const int key_stride = key_heads * kKeyDim;
+    float* sh = state + static_cast<size_t>(head) * kKeyDim * value_dim;
+    float st[kKeyDim];
+#pragma unroll
+    for (int i = 0; i < kKeyDim; ++i) {
+        st[i] = sh[static_cast<size_t>(i) * value_dim + value];
+    }
+    for (int token = 0; token < rows; ++token) {
+        const float* qr = q_normalized +
+            static_cast<size_t>(token) * key_stride +
+            static_cast<size_t>(key_head) * kKeyDim;
+        const float* kr = k_normalized +
+            static_cast<size_t>(token) * key_stride +
+            static_cast<size_t>(key_head) * kKeyDim;
+        const size_t gate_index = static_cast<size_t>(token) * heads + head;
+        const float decay = expf(half_to_float(g[gate_index]));
+        const float b = half_to_float(beta[gate_index]);
+        float kv_mem = 0.0f;
+#pragma unroll
+        for (int i = 0; i < kKeyDim; ++i) {
+            st[i] *= decay;
+            kv_mem += st[i] * kr[i];
+        }
+        const size_t value_index = static_cast<size_t>(token) * heads * value_dim +
+                                   static_cast<size_t>(head) * value_dim + value;
+        const float delta = (half_to_float(v[value_index]) - kv_mem) * b;
+        float result = 0.0f;
+#pragma unroll
+        for (int i = 0; i < kKeyDim; ++i) {
+            st[i] += kr[i] * delta;
+            result += st[i] * qr[i];
+        }
+        output[value_index] = float_to_half(result * q_scale);
+    }
+#pragma unroll
+    for (int i = 0; i < kKeyDim; ++i) {
+        sh[static_cast<size_t>(i) * value_dim + value] = st[i];
+    }
+}
+
+template <int kKeyDim, int kValueTile, int kChunk>
+__global__ void gated_delta_sequence_normalized_shared_f16_kernel(
+    float* state, const float* q_normalized, const float* k_normalized,
+    const uint16_t* v, const uint16_t* g, const uint16_t* beta,
+    uint16_t* output, int rows, int heads, int key_heads,
+    int value_dim, float q_scale) {
+    const int tile = static_cast<int>(blockIdx.x) %
+                     ((value_dim + kValueTile - 1) / kValueTile);
+    const int head = static_cast<int>(blockIdx.x) /
+                     ((value_dim + kValueTile - 1) / kValueTile);
+    const int value = tile * kValueTile + static_cast<int>(threadIdx.x);
+    if (head >= heads || value >= value_dim) return;
+
+    const int repeat = heads / key_heads;
+    const int key_head = head / repeat;
+    const int key_stride = key_heads * kKeyDim;
+    const int lane = static_cast<int>(threadIdx.x);
+    extern __shared__ float state_tile[];
+    float* sh = state + static_cast<size_t>(head) * kKeyDim * value_dim;
+
+    // Keep the recurrent state in shared memory and use a compile-time key
+    // chunk only to control loop unrolling. This preserves the original scalar
+    // FP32 order without keeping the full state vector in registers.
+    for (int i = 0; i < kKeyDim; ++i) {
+        state_tile[i * kValueTile + lane] =
+            sh[static_cast<size_t>(i) * value_dim + value];
+    }
+    for (int token = 0; token < rows; ++token) {
+        const float* qr = q_normalized +
+            static_cast<size_t>(token) * key_stride +
+            static_cast<size_t>(key_head) * kKeyDim;
+        const float* kr = k_normalized +
+            static_cast<size_t>(token) * key_stride +
+            static_cast<size_t>(key_head) * kKeyDim;
+        const size_t gate_index = static_cast<size_t>(token) * heads + head;
+        const float decay = expf(half_to_float(g[gate_index]));
+        const float b = half_to_float(beta[gate_index]);
+        float kv_mem = 0.0f;
+        for (int base = 0; base < kKeyDim; base += kChunk) {
+#pragma unroll
+            for (int j = 0; j < kChunk; ++j) {
+                const int i = base + j;
+                const int index = i * kValueTile + lane;
+                const float cell = state_tile[index] * decay;
+                state_tile[index] = cell;
+                kv_mem += cell * kr[i];
+            }
+        }
+        const size_t value_index = static_cast<size_t>(token) * heads * value_dim +
+                                   static_cast<size_t>(head) * value_dim + value;
+        const float delta = (half_to_float(v[value_index]) - kv_mem) * b;
+        float result = 0.0f;
+        for (int base = 0; base < kKeyDim; base += kChunk) {
+#pragma unroll
+            for (int j = 0; j < kChunk; ++j) {
+                const int i = base + j;
+                const int index = i * kValueTile + lane;
+                const float cell = state_tile[index] + kr[i] * delta;
+                state_tile[index] = cell;
+                result += cell * qr[i];
+            }
+        }
+        output[value_index] = float_to_half(result * q_scale);
+    }
+
+    for (int i = 0; i < kKeyDim; ++i) {
+        sh[static_cast<size_t>(i) * value_dim + value] =
+            state_tile[i * kValueTile + lane];
+    }
 }
 
 template <int kKeyDim>
@@ -1855,6 +2045,113 @@ bool launch_prefill_attention(
     return cudaGetLastError() == cudaSuccess;
 }
 
+template <int kWarps>
+bool launch_fp8_swiglu_small_batch_f16(
+    const uint16_t* x, const uint8_t* gate_weight,
+    const uint16_t* gate_scale, const uint8_t* up_weight,
+    const uint16_t* up_scale, uint16_t* y, int batch, int rows, int cols,
+    int x_stride, int y_stride, int weight_stride, int scale_stride,
+    bool use_shared, int tile, cudaStream_t stream) {
+    const int blocks = (rows + kWarps - 1) / kWarps;
+#define LAUNCH_FP8_SWIGLU_TILED(CAPACITY, TILE) \
+    fp8_swiglu_small_batch_shared_f16_kernel<kWarps, CAPACITY, TILE> \
+        <<<blocks, kWarps * 32, 0, stream>>>( \
+            x, gate_weight, gate_scale, up_weight, up_scale, y, batch, rows, \
+            cols, x_stride, y_stride, weight_stride, scale_stride)
+#define LAUNCH_FP8_SWIGLU_CAP(TILE) \
+    do { \
+        if (batch <= 2) { LAUNCH_FP8_SWIGLU_TILED(2, TILE); } \
+        else if (batch == 3) { LAUNCH_FP8_SWIGLU_TILED(3, TILE); } \
+        else if (batch == 4) { LAUNCH_FP8_SWIGLU_TILED(4, TILE); } \
+        else if (batch == 5) { LAUNCH_FP8_SWIGLU_TILED(5, TILE); } \
+        else { LAUNCH_FP8_SWIGLU_TILED(8, TILE); } \
+    } while (0)
+    if (use_shared) {
+        if (tile == 512) { LAUNCH_FP8_SWIGLU_CAP(512); }
+        else if (tile == 2048) { LAUNCH_FP8_SWIGLU_CAP(2048); }
+        else { LAUNCH_FP8_SWIGLU_CAP(1024); }
+    } else if (batch <= 2) {
+        fp8_swiglu_small_batch_f16_kernel<kWarps, 2>
+            <<<blocks, kWarps * 32, 0, stream>>>(
+                x, gate_weight, gate_scale, up_weight, up_scale, y, batch,
+                rows, cols, x_stride, y_stride, weight_stride, scale_stride);
+    } else if (batch == 3) {
+        fp8_swiglu_small_batch_f16_kernel<kWarps, 3>
+            <<<blocks, kWarps * 32, 0, stream>>>(
+                x, gate_weight, gate_scale, up_weight, up_scale, y, batch,
+                rows, cols, x_stride, y_stride, weight_stride, scale_stride);
+    } else if (batch == 4) {
+        fp8_swiglu_small_batch_f16_kernel<kWarps, 4>
+            <<<blocks, kWarps * 32, 0, stream>>>(
+                x, gate_weight, gate_scale, up_weight, up_scale, y, batch,
+                rows, cols, x_stride, y_stride, weight_stride, scale_stride);
+    } else if (batch == 5) {
+        fp8_swiglu_small_batch_f16_kernel<kWarps, 5>
+            <<<blocks, kWarps * 32, 0, stream>>>(
+                x, gate_weight, gate_scale, up_weight, up_scale, y, batch,
+                rows, cols, x_stride, y_stride, weight_stride, scale_stride);
+    } else {
+        fp8_swiglu_small_batch_f16_kernel<kWarps, 8>
+            <<<blocks, kWarps * 32, 0, stream>>>(
+                x, gate_weight, gate_scale, up_weight, up_scale, y, batch,
+                rows, cols, x_stride, y_stride, weight_stride, scale_stride);
+    }
+#undef LAUNCH_FP8_SWIGLU_CAP
+#undef LAUNCH_FP8_SWIGLU_TILED
+    return cudaGetLastError() == cudaSuccess;
+}
+
+template <int kWarps>
+bool launch_fp8_matmul_f16_small_batch(
+    const uint16_t* x, const uint8_t* weight, const uint16_t* scale,
+    uint16_t* y, int batch, int rows, int cols, int x_stride, int y_stride,
+    int weight_stride, int scale_stride, bool use_shared,
+    cudaStream_t stream) {
+    const int blocks = (rows + kWarps - 1) / kWarps;
+    if (use_shared && batch > 1) {
+#define LAUNCH_FP8_SMALL_PAIRED(CAPACITY) \
+        fp8_matmul_f16_small_batch_paired_shared_kernel< \
+            kWarps, CAPACITY, 1024> \
+            <<<blocks, kWarps * 32, 0, stream>>>( \
+                x, weight, scale, y, batch, rows, cols, x_stride, y_stride, \
+                weight_stride, scale_stride)
+        if (batch == 2) { LAUNCH_FP8_SMALL_PAIRED(2); }
+        else if (batch == 3) { LAUNCH_FP8_SMALL_PAIRED(3); }
+        else if (batch == 4) { LAUNCH_FP8_SMALL_PAIRED(4); }
+        else if (batch == 5) { LAUNCH_FP8_SMALL_PAIRED(5); }
+        else { LAUNCH_FP8_SMALL_PAIRED(8); }
+#undef LAUNCH_FP8_SMALL_PAIRED
+        return cudaGetLastError() == cudaSuccess;
+    }
+    if (batch <= 2) {
+        fp8_matmul_f16_small_batch_kernel<kWarps, 2>
+            <<<blocks, kWarps * 32, 0, stream>>>(
+                x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+                weight_stride, scale_stride);
+    } else if (batch == 3) {
+        fp8_matmul_f16_small_batch_kernel<kWarps, 3>
+            <<<blocks, kWarps * 32, 0, stream>>>(
+                x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+                weight_stride, scale_stride);
+    } else if (batch == 4) {
+        fp8_matmul_f16_small_batch_kernel<kWarps, 4>
+            <<<blocks, kWarps * 32, 0, stream>>>(
+                x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+                weight_stride, scale_stride);
+    } else if (batch == 5) {
+        fp8_matmul_f16_small_batch_kernel<kWarps, 5>
+            <<<blocks, kWarps * 32, 0, stream>>>(
+                x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+                weight_stride, scale_stride);
+    } else {
+        fp8_matmul_f16_small_batch_kernel<kWarps, 8>
+            <<<blocks, kWarps * 32, 0, stream>>>(
+                x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+                weight_stride, scale_stride);
+    }
+    return cudaGetLastError() == cudaSuccess;
+}
+
 }  // namespace
 
 bool qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
@@ -1910,7 +2207,8 @@ bool qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
     const cudaStream_t s = static_cast<cudaStream_t>(stream);
     const char* multirow = std::getenv("QWEN_FP8_F16_MULTIROW");
     const char* rows_env = std::getenv("QWEN_FP8_F16_MULTIROW_ROWS");
-    const bool use_multirow = multirow != nullptr && std::strcmp(multirow, "0") != 0;
+    const bool use_multirow =
+        multirow != nullptr && std::strcmp(multirow, "0") != 0;
     const int requested_rows = rows_env != nullptr ? std::atoi(rows_env) : 0;
     constexpr int kMinBlocks = 136;
     auto blocks_for = [&](int rows_per_warp) {
@@ -1949,54 +2247,55 @@ bool qwen_fp8_e4m3_fp16scale_swiglu_small_batch_f16_cuda(
         scale_stride < (cols + kFp8WeightBlock - 1) / kFp8WeightBlock) {
         return false;
     }
-    constexpr int kWarps = 8;
-    const int blocks = (rows + kWarps - 1) / kWarps;
     const cudaStream_t s = static_cast<cudaStream_t>(stream);
-    // See fp8_matmul_f16_small_batch_shared_kernel: staging the shared activation
-    // tile removes the per-warp activation re-read without changing the result.
     const char* shared_env = std::getenv("QWEN_FP8_F16_SMALL_BATCH_SHARED");
-    if (shared_env == nullptr || std::strcmp(shared_env, "0") != 0) {
-        constexpr int kTile = 1024;
-#define LAUNCH_FP8_SWIGLU_SHARED(CAPACITY) \
-        fp8_swiglu_small_batch_shared_f16_kernel<kWarps, CAPACITY, kTile> \
-            <<<blocks, kWarps * 32, 0, s>>>( \
-                x, gate_weight, gate_scale, up_weight, up_scale, y, batch, \
-                rows, cols, x_stride, y_stride, weight_stride, scale_stride)
-        if (batch <= 2) { LAUNCH_FP8_SWIGLU_SHARED(2); }
-        else if (batch == 3) { LAUNCH_FP8_SWIGLU_SHARED(3); }
-        else if (batch == 4) { LAUNCH_FP8_SWIGLU_SHARED(4); }
-        else if (batch == 5) { LAUNCH_FP8_SWIGLU_SHARED(5); }
-        else { LAUNCH_FP8_SWIGLU_SHARED(8); }
-#undef LAUNCH_FP8_SWIGLU_SHARED
-        return cudaGetLastError() == cudaSuccess;
+    const bool use_shared =
+        shared_env == nullptr || std::strcmp(shared_env, "0") != 0;
+    int tile = 1024;
+    if (const char* tile_env = std::getenv("QWEN_FP8_SWIGLU_TILE")) {
+        const int parsed = std::atoi(tile_env);
+        if (parsed == 512 || parsed == 1024 || parsed == 2048) tile = parsed;
     }
-    if (batch <= 2) {
-        fp8_swiglu_small_batch_f16_kernel<kWarps, 2>
-            <<<blocks, kWarps * 32, 0, s>>>(
-                x, gate_weight, gate_scale, up_weight, up_scale, y, batch,
-                rows, cols, x_stride, y_stride, weight_stride, scale_stride);
-    } else if (batch == 3) {
-        fp8_swiglu_small_batch_f16_kernel<kWarps, 3>
-            <<<blocks, kWarps * 32, 0, s>>>(
-                x, gate_weight, gate_scale, up_weight, up_scale, y, batch,
-                rows, cols, x_stride, y_stride, weight_stride, scale_stride);
-    } else if (batch == 4) {
-        fp8_swiglu_small_batch_f16_kernel<kWarps, 4>
-            <<<blocks, kWarps * 32, 0, s>>>(
-                x, gate_weight, gate_scale, up_weight, up_scale, y, batch,
-                rows, cols, x_stride, y_stride, weight_stride, scale_stride);
-    } else if (batch == 5) {
-        fp8_swiglu_small_batch_f16_kernel<kWarps, 5>
-            <<<blocks, kWarps * 32, 0, s>>>(
-                x, gate_weight, gate_scale, up_weight, up_scale, y, batch,
-                rows, cols, x_stride, y_stride, weight_stride, scale_stride);
-    } else {
-        fp8_swiglu_small_batch_f16_kernel<kWarps, 8>
-            <<<blocks, kWarps * 32, 0, s>>>(
-                x, gate_weight, gate_scale, up_weight, up_scale, y, batch,
-                rows, cols, x_stride, y_stride, weight_stride, scale_stride);
+    int warps = batch >= 3 ? 16 : 8;
+    if (const char* warps_env = std::getenv("QWEN_FP8_SWIGLU_WARPS")) {
+        const int parsed = std::atoi(warps_env);
+        if (parsed == 8 || parsed == 16) warps = parsed;
     }
-    return cudaGetLastError() == cudaSuccess;
+    if (warps == 16) {
+        return launch_fp8_swiglu_small_batch_f16<16>(
+            x, gate_weight, gate_scale, up_weight, up_scale, y, batch, rows,
+            cols, x_stride, y_stride, weight_stride, scale_stride, use_shared,
+            tile, s);
+    }
+    return launch_fp8_swiglu_small_batch_f16<8>(
+        x, gate_weight, gate_scale, up_weight, up_scale, y, batch, rows, cols,
+        x_stride, y_stride, weight_stride, scale_stride, use_shared, tile, s);
+}
+
+bool qwen_fp8_e4m3_fp16scale_dequantize_f16_cuda(
+    const uint8_t* weight, const uint16_t* scale, uint16_t* output,
+    int rows, int cols, int weight_stride, int scale_stride, void* stream) {
+    if (!weight || !scale || !output || rows <= 0 || cols <= 0 ||
+        weight_stride < cols ||
+        scale_stride < (cols + kFp8WeightBlock - 1) / kFp8WeightBlock) {
+        return false;
+    }
+    return dequantize_fp8_weight_f16(
+        weight, scale, output, rows, cols, weight_stride, scale_stride,
+        static_cast<cudaStream_t>(stream));
+}
+
+bool qwen_fp16_matmul_rows_f16_cublas_cuda(
+    const uint16_t* x, const uint16_t* weight, uint16_t* y,
+    int batch, int rows, int cols, int x_stride, int y_stride,
+    int weight_stride, void* stream) {
+    if (!x || !weight || !y || batch <= 0 || rows <= 0 || cols <= 0 ||
+        x_stride < cols || y_stride < rows || weight_stride < cols) {
+        return false;
+    }
+    return fp16_matmul_f16_cublas(
+        x, weight, y, batch, rows, cols, x_stride, y_stride, weight_stride,
+        static_cast<cudaStream_t>(stream));
 }
 
 bool qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
@@ -2019,105 +2318,28 @@ bool qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
     // full.q_gate 1.97 -> 0.52, linear.out 0.97 -> 0.26 (3.8x-5.0x). Set
     // QWEN_FP8_F16_PREFILL_CUBLAS=0 to fall back to the previous kernels.
     const char* cublas_env = std::getenv("QWEN_FP8_F16_PREFILL_CUBLAS");
-    const bool use_cublas = cublas_env == nullptr ||
-        std::strcmp(cublas_env, "0") != 0;
-    constexpr int kSmallBatchWarps = 8;
+    const bool use_cublas =
+        cublas_env == nullptr || std::strcmp(cublas_env, "0") != 0;
     if (use_small_batch && batch <= 8 && x_stride % 4 == 0 &&
         weight_stride % 4 == 0) {
-        const int blocks = (rows + kSmallBatchWarps - 1) / kSmallBatchWarps;
-        // Speculative verify batches re-read the same activation rows from every
-        // warp in the block. Staging that tile in shared memory keeps the kernel
-        // weight-bound; the per-lane column order is unchanged so results match
-        // the non-staged kernel bit for bit.
-        const char* shared_env = std::getenv("QWEN_FP8_F16_SMALL_BATCH_SHARED");
-        const bool use_shared = shared_env == nullptr ||
-            std::strcmp(shared_env, "0") != 0;
-        constexpr int kSmallBatchTile = 1024;
-        // Packed-conversion variant. Bit-identical to the fp16-staged kernel; the
-        // activation conversions issue as packed pairs.
-        int fshared_tile = 1024;
-        if (const char* tile_env = std::getenv("QWEN_FP8_F16_SMALL_BATCH_TILE")) {
-            const int parsed = std::atoi(tile_env);
-            if (parsed == 256 || parsed == 512 || parsed == 2048) {
-                fshared_tile = parsed;
-            }
+        const char* shared_env =
+            std::getenv("QWEN_FP8_F16_SMALL_BATCH_SHARED");
+        const bool use_shared =
+            shared_env == nullptr || std::strcmp(shared_env, "0") != 0;
+        int warps = batch >= 3 ? 16 : 8;
+        if (const char* warps_env =
+                std::getenv("QWEN_FP8_F16_SMALL_BATCH_WARPS")) {
+            const int parsed = std::atoi(warps_env);
+            if (parsed == 8 || parsed == 16) warps = parsed;
         }
-        // Default. Fusing two strided steps per iteration halves the loop overhead
-        // of the batch-8 speculative-verify shape, which is limited by instruction
-        // issue rather than by DRAM or FMA throughput. Measured on SM75 at the real
-        // TP4 shard shapes, batch 8: mlp.gate 0.1838 -> 0.1539 ms, mlp.down 0.1564
-        // -> 0.1307, linear.qkv 0.0908 -> 0.0739, full.q_gate 0.0943 -> 0.0858,
-        // linear.out 0.0592 -> 0.0517. Each lane keeps its own columns and their
-        // addition order, so it is bit identical to the register-only kernel plain
-        // decode uses; test_qwen_half_ops gates that. Set
-        // QWEN_FP8_F16_SMALL_BATCH_FSHARED=0 to fall back.
-        const char* fshared_env = std::getenv("QWEN_FP8_F16_SMALL_BATCH_FSHARED");
-        const bool use_fshared = fshared_env == nullptr ||
-            std::strcmp(fshared_env, "0") != 0;
-        if (use_fshared && use_shared && batch > 1) {
-#define LAUNCH_FP8_SMALL_FSHARED_T(CAPACITY, TILE) \
-            fp8_matmul_f16_small_batch_fshared_kernel< \
-                kSmallBatchWarps, CAPACITY, TILE> \
-                <<<blocks, kSmallBatchWarps * 32, 0, s>>>( \
-                    x, weight, scale, y, batch, rows, cols, x_stride, y_stride, \
-                    weight_stride, scale_stride)
-#define LAUNCH_FP8_SMALL_FSHARED(CAPACITY) \
-            do { \
-                if (fshared_tile == 256) { LAUNCH_FP8_SMALL_FSHARED_T(CAPACITY, 256); } \
-                else if (fshared_tile == 512) { LAUNCH_FP8_SMALL_FSHARED_T(CAPACITY, 512); } \
-                else if (fshared_tile == 2048) { LAUNCH_FP8_SMALL_FSHARED_T(CAPACITY, 2048); } \
-                else { LAUNCH_FP8_SMALL_FSHARED_T(CAPACITY, 1024); } \
-            } while (0)
-            if (batch == 2) { LAUNCH_FP8_SMALL_FSHARED(2); }
-            else if (batch == 3) { LAUNCH_FP8_SMALL_FSHARED(3); }
-            else if (batch == 4) { LAUNCH_FP8_SMALL_FSHARED(4); }
-            else if (batch == 5) { LAUNCH_FP8_SMALL_FSHARED(5); }
-            else { LAUNCH_FP8_SMALL_FSHARED(8); }
-#undef LAUNCH_FP8_SMALL_FSHARED
-#undef LAUNCH_FP8_SMALL_FSHARED_T
-            return cudaGetLastError() == cudaSuccess;
+        if (warps == 16) {
+            return launch_fp8_matmul_f16_small_batch<16>(
+                x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+                weight_stride, scale_stride, use_shared, s);
         }
-        if (use_shared && batch > 1) {
-#define LAUNCH_FP8_SMALL_SHARED(CAPACITY) \
-            fp8_matmul_f16_small_batch_shared_kernel< \
-                kSmallBatchWarps, CAPACITY, kSmallBatchTile> \
-                <<<blocks, kSmallBatchWarps * 32, 0, s>>>( \
-                    x, weight, scale, y, batch, rows, cols, x_stride, y_stride, \
-                    weight_stride, scale_stride)
-            if (batch == 2) { LAUNCH_FP8_SMALL_SHARED(2); }
-            else if (batch == 3) { LAUNCH_FP8_SMALL_SHARED(3); }
-            else if (batch == 4) { LAUNCH_FP8_SMALL_SHARED(4); }
-            else if (batch == 5) { LAUNCH_FP8_SMALL_SHARED(5); }
-            else { LAUNCH_FP8_SMALL_SHARED(8); }
-#undef LAUNCH_FP8_SMALL_SHARED
-            return cudaGetLastError() == cudaSuccess;
-        }
-        if (batch <= 2) {
-            fp8_matmul_f16_small_batch_kernel<kSmallBatchWarps, 2>
-                <<<blocks, kSmallBatchWarps * 32, 0, s>>>(
-                    x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
-                    weight_stride, scale_stride);
-        } else if (batch == 3) {
-            fp8_matmul_f16_small_batch_kernel<kSmallBatchWarps, 3>
-                <<<blocks, kSmallBatchWarps * 32, 0, s>>>(
-                    x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
-                    weight_stride, scale_stride);
-        } else if (batch == 4) {
-            fp8_matmul_f16_small_batch_kernel<kSmallBatchWarps, 4>
-                <<<blocks, kSmallBatchWarps * 32, 0, s>>>(
-                    x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
-                    weight_stride, scale_stride);
-        } else if (batch == 5) {
-            fp8_matmul_f16_small_batch_kernel<kSmallBatchWarps, 5>
-                <<<blocks, kSmallBatchWarps * 32, 0, s>>>(
-                    x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
-                    weight_stride, scale_stride);
-        } else {
-            fp8_matmul_f16_small_batch_kernel<kSmallBatchWarps, 8>
-                <<<blocks, kSmallBatchWarps * 32, 0, s>>>(
-                    x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
-                    weight_stride, scale_stride);
-        }
+        return launch_fp8_matmul_f16_small_batch<8>(
+            x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
+            weight_stride, scale_stride, use_shared, s);
     } else {
         // cuBLAS needs the dequantised weight to be a dense `rows x cols` matrix
         // with leading dimension `cols`. The expansion kernels write that layout
@@ -2129,8 +2351,10 @@ bool qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
                 x, weight, scale, y, batch, rows, cols, x_stride, y_stride,
                 weight_stride, scale_stride, s);
         }
-        const char* wide = std::getenv("QWEN_FP8_F16_PREFILL_WIDE_N64");
-        const bool use_wide = wide == nullptr || std::strcmp(wide, "0") != 0;
+        const char* wide_env =
+            std::getenv("QWEN_FP8_F16_PREFILL_WIDE_N64");
+        const bool use_wide =
+            wide_env == nullptr || std::strcmp(wide_env, "0") != 0;
         if (use_wide && batch >= 96 && x_stride % 4 == 0 &&
             weight_stride % 4 == 0) {
             dim3 grid(static_cast<unsigned>((rows + 63) / 64),
@@ -2309,12 +2533,103 @@ bool qwen_copy_rows_strided_f16_cuda(
     return status == cudaSuccess;
 }
 
+namespace {
+
+template <bool kGather>
+__global__ void copy_regions_kernel(
+    const QwenCopyRegion* __restrict__ regions, int region_count,
+    uint8_t* __restrict__ packed) {
+    const uint64_t global_block = static_cast<uint64_t>(blockIdx.x);
+    int lo = 0;
+    int hi = region_count;
+    while (lo + 1 < hi) {
+        const int mid = lo + (hi - lo) / 2;
+        if (regions[mid].first_block <= global_block) lo = mid;
+        else hi = mid;
+    }
+    const QwenCopyRegion region = regions[lo];
+    const uint64_t local_block = global_block - region.first_block;
+    const uint64_t local_offset = local_block * kQwenCopyRegionBlockBytes;
+    if (local_offset >= region.bytes) return;
+    const uint64_t remaining = region.bytes - local_offset;
+    const uint64_t bytes = remaining < kQwenCopyRegionBlockBytes
+        ? remaining : kQwenCopyRegionBlockBytes;
+    uint8_t* region_data = reinterpret_cast<uint8_t*>(region.device_address) +
+        local_offset;
+    uint8_t* packed_data = packed + region.packed_offset + local_offset;
+    const uint8_t* source = kGather ? region_data : packed_data;
+    uint8_t* destination = kGather ? packed_data : region_data;
+
+    const uintptr_t alignment = reinterpret_cast<uintptr_t>(source) |
+        reinterpret_cast<uintptr_t>(destination);
+    if ((alignment & 0xfu) == 0 && (bytes & 0xfu) == 0) {
+        const uint4* source4 = reinterpret_cast<const uint4*>(source);
+        uint4* destination4 = reinterpret_cast<uint4*>(destination);
+        for (uint64_t index = threadIdx.x; index < bytes / sizeof(uint4);
+             index += blockDim.x) {
+            destination4[index] = source4[index];
+        }
+    } else {
+        for (uint64_t index = threadIdx.x; index < bytes;
+             index += blockDim.x) {
+            destination[index] = source[index];
+        }
+    }
+}
+
+template <bool kGather>
+bool launch_copy_regions(
+    const QwenCopyRegion* regions, int region_count, uint8_t* packed,
+    uint64_t total_blocks, void* stream) {
+    if (!regions || !packed || region_count <= 0 || total_blocks == 0 ||
+        total_blocks > static_cast<uint64_t>(UINT32_MAX)) {
+        return false;
+    }
+    copy_regions_kernel<kGather><<<
+        static_cast<unsigned>(total_blocks), kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(regions, region_count, packed);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+}  // namespace
+
+bool qwen_gather_copy_regions_cuda(
+    const QwenCopyRegion* regions, int region_count, uint8_t* packed,
+    uint64_t total_blocks, void* stream) {
+    return launch_copy_regions<true>(
+        regions, region_count, packed, total_blocks, stream);
+}
+
+bool qwen_scatter_copy_regions_cuda(
+    const QwenCopyRegion* regions, int region_count, const uint8_t* packed,
+    uint64_t total_blocks, void* stream) {
+    return launch_copy_regions<false>(
+        regions, region_count, const_cast<uint8_t*>(packed), total_blocks,
+        stream);
+}
+
 bool qwen_rmsnorm_fp16_gamma_rows_f16_cuda(
     const uint16_t* x, const uint16_t* gamma, uint16_t* y,
     int rows, int cols, float eps, void* stream) {
     if (!x || !gamma || !y || rows <= 0 || cols <= 0 || eps < 0.0f) return false;
     rmsnorm_f16_kernel<<<rows, kThreads, kThreads * sizeof(float),
         static_cast<cudaStream_t>(stream)>>>(x, gamma, y, rows, cols, eps);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_residual_add_rmsnorm_fp16_gamma_rows_f16_cuda(
+    const uint16_t* hidden, const uint16_t* delta, const uint16_t* gamma,
+    uint16_t* residual, uint16_t* normalized, int rows, int cols, float eps,
+    void* stream) {
+    if (!hidden || !delta || !gamma || !residual || !normalized || rows <= 0 ||
+        cols <= 0 || eps < 0.0f || residual == hidden || residual == delta ||
+        normalized == hidden || normalized == delta || normalized == residual) {
+        return false;
+    }
+    residual_add_rmsnorm_f16_kernel<<<
+        rows, kThreads, kThreads * sizeof(float),
+        static_cast<cudaStream_t>(stream)>>>(
+        hidden, delta, gamma, residual, normalized, rows, cols, eps);
     return cudaGetLastError() == cudaSuccess;
 }
 
@@ -2334,6 +2649,29 @@ bool qwen_split_packed_qkv_f16_cuda(
     const int total = rows * (2 * key_dim + value_dim);
     split_packed_qkv_f16_kernel<<<(total + kThreads - 1) / kThreads, kThreads, 0,
         static_cast<cudaStream_t>(stream)>>>(packed, q, k, v, rows, key_dim, value_dim);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+__global__ void split_rows_pair_f16_kernel(const uint16_t* __restrict__ packed,
+                                           uint16_t* __restrict__ first,
+                                           uint16_t* __restrict__ second,
+                                           int rows, int width) {
+    const int index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (index >= rows * width) return;
+    const int row = index / width;
+    const int column = index - row * width;
+    const int packed_row = row * 2 * width;
+    first[index] = packed[packed_row + column];
+    second[index] = packed[packed_row + width + column];
+}
+
+bool qwen_split_rows_pair_f16_cuda(const uint16_t* packed, uint16_t* first,
+                                   uint16_t* second, int rows, int width,
+                                   void* stream) {
+    if (!packed || !first || !second || rows <= 0 || width <= 0) return false;
+    const int total = rows * width;
+    split_rows_pair_f16_kernel<<<(total + kThreads - 1) / kThreads, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(packed, first, second, rows, width);
     return cudaGetLastError() == cudaSuccess;
 }
 
@@ -2383,10 +2721,112 @@ bool qwen_gated_delta_sequence_f16_cuda(
         heads <= 0 || key_heads <= 0 || heads % key_heads != 0 || key_dim != 128 ||
         value_dim != 128 || q_scale <= 0.0f) return false;
     gated_delta_sequence_f16_kernel<128><<<heads, value_dim,
-        static_cast<size_t>(value_dim) * sizeof(float), static_cast<cudaStream_t>(stream)>>>(
-        state, q, k, v, g, beta, output, rows, heads, key_heads,
-        value_dim, q_scale);
+        static_cast<size_t>(value_dim) * sizeof(float),
+        static_cast<cudaStream_t>(stream)>>>(
+            state, q, k, v, g, beta, output, rows, heads, key_heads,
+            value_dim, q_scale);
     return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_normalize_gated_delta_qk_f16_cuda(
+    const uint16_t* q, const uint16_t* k, float* q_normalized,
+    float* k_normalized, int rows, int key_heads, int key_dim, void* stream) {
+    if (!q || !k || !q_normalized || !k_normalized || rows <= 0 ||
+        key_heads <= 0 || key_dim != 128) {
+        return false;
+    }
+    dim3 grid(static_cast<unsigned>(key_heads),
+              static_cast<unsigned>(rows), 1);
+    normalize_gated_delta_qk_f16_kernel<<<
+        grid, key_dim, 0, static_cast<cudaStream_t>(stream)>>>(
+            q, k, q_normalized, k_normalized, rows, key_heads, key_dim);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gated_delta_sequence_normalized_f16_cuda(
+    float* state, const float* q_normalized, const float* k_normalized,
+    const uint16_t* v, const uint16_t* g, const uint16_t* beta,
+    uint16_t* output, int rows, int heads, int key_heads, int key_dim,
+    int value_dim, float q_scale, void* stream) {
+    if (!state || !q_normalized || !k_normalized || !v || !g || !beta ||
+        !output || rows <= 0 || heads <= 0 || key_heads <= 0 ||
+        heads % key_heads != 0 || key_dim != 128 || value_dim != 128 ||
+        q_scale <= 0.0f) {
+        return false;
+    }
+    gated_delta_sequence_normalized_f16_kernel<128><<<
+        heads, value_dim, 0, static_cast<cudaStream_t>(stream)>>>(
+            state, q_normalized, k_normalized, v, g, beta, output, rows,
+            heads, key_heads, value_dim, q_scale);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gated_delta_sequence_normalized_shared_f16_cuda(
+    float* state, const float* q_normalized, const float* k_normalized,
+    const uint16_t* v, const uint16_t* g, const uint16_t* beta,
+    uint16_t* output, int rows, int heads, int key_heads, int key_dim,
+    int value_dim, float q_scale, void* stream) {
+    if (!state || !q_normalized || !k_normalized || !v || !g || !beta ||
+        !output || rows <= 0 || heads <= 0 || key_heads <= 0 ||
+        heads % key_heads != 0 || key_dim != 128 || value_dim != 128 ||
+        q_scale <= 0.0f) {
+        return false;
+    }
+    // 32 lanes keeps one warp per block with a 16 KiB state tile. 16 halves the
+    // tile but doubles the block count, 64 needs 32 KiB and drops to one block
+    // per SM pair; the sweep below picks between them at build-probe time.
+    auto launch = [&](auto tile_tag, auto chunk_tag) -> bool {
+        constexpr int kValueTile = decltype(tile_tag)::value;
+        constexpr int kChunk = decltype(chunk_tag)::value;
+        const int tiles = (value_dim + kValueTile - 1) / kValueTile;
+        const size_t shared_bytes = static_cast<size_t>(key_dim) * kValueTile *
+                                    sizeof(float);
+        if (shared_bytes > 48u * 1024u) {
+            const cudaError_t attribute = cudaFuncSetAttribute(
+                gated_delta_sequence_normalized_shared_f16_kernel<
+                    128, kValueTile, kChunk>,
+                cudaFuncAttributeMaxDynamicSharedMemorySize,
+                static_cast<int>(shared_bytes));
+            if (attribute != cudaSuccess) return false;
+        }
+        gated_delta_sequence_normalized_shared_f16_kernel<
+            128, kValueTile, kChunk><<<
+                heads * tiles, kValueTile, shared_bytes,
+                static_cast<cudaStream_t>(stream)>>>(
+            state, q_normalized, k_normalized, v, g, beta, output, rows,
+            heads, key_heads, value_dim, q_scale);
+        return cudaGetLastError() == cudaSuccess;
+    };
+    auto launch_chunk = [&](auto tile_tag, int chunk) -> bool {
+        if (chunk == 4) {
+            return launch(tile_tag, std::integral_constant<int, 4>{});
+        }
+        if (chunk == 16) {
+            return launch(tile_tag, std::integral_constant<int, 16>{});
+        }
+        if (chunk == 32) {
+            return launch(tile_tag, std::integral_constant<int, 32>{});
+        }
+        return launch(tile_tag, std::integral_constant<int, 8>{});
+    };
+    static const int tile_choice = [] {
+        const char* raw = std::getenv("QWEN_GATED_DELTA_VALUE_TILE");
+        const int parsed = raw != nullptr ? std::atoi(raw) : 32;
+        return (parsed == 16 || parsed == 32 || parsed == 64) ? parsed : 32;
+    }();
+    static const int chunk_choice = [] {
+        const char* raw = std::getenv("QWEN_GATED_DELTA_CHUNK");
+        const int parsed = raw != nullptr ? std::atoi(raw) : 8;
+        return (parsed == 4 || parsed == 8 || parsed == 16 || parsed == 32)
+            ? parsed : 8;
+    }();
+    if (tile_choice == 16) {
+        return launch_chunk(std::integral_constant<int, 16>{}, chunk_choice);
+    }
+    if (tile_choice == 64) {
+        return launch_chunk(std::integral_constant<int, 64>{}, chunk_choice);
+    }
+    return launch_chunk(std::integral_constant<int, 32>{}, chunk_choice);
 }
 
 bool qwen_partial_rope_f16_cuda(

--- a/cpp_engine/include/qwen_cuda_ops.hpp
+++ b/cpp_engine/include/qwen_cuda_ops.hpp
@@ -121,6 +121,15 @@ bool qwen_dflash2_merge_topk_f32_cuda(
     const int* d_gathered_tokens, const float* d_gathered_logits,
     int* d_tokens, float* d_values, int world, int rows, int top_k,
     void* stream = nullptr);
+// Pack/unpack one deterministic global top-1 candidate per row. The packed key
+// is suitable for NCCL uint64 Max: larger logit wins, equal logit picks the
+// smaller token id, and NaN loses to every finite or -inf candidate.
+bool qwen_dflash2_pack_top1_key_f32_cuda(
+    const int* d_tokens, const float* d_values, uint64_t* d_keys, int rows,
+    void* stream = nullptr);
+bool qwen_dflash2_unpack_top1_key_f32_cuda(
+    const uint64_t* d_keys, int* d_tokens, float* d_values, int rows,
+    void* stream = nullptr);
 bool qwen_dflash2_selector_path_f16_cuda(
     const uint16_t* d_hidden_fp16, const int* d_candidates,
     const float* d_unary, const uint16_t* d_predecessor,
@@ -253,6 +262,21 @@ bool qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
     int weight_stride,
     int scale_stride,
     void* stream = nullptr);
+
+// Materialize a dense FP16 matrix from the checkpoint's raw FP8 codes and block
+// scales. This is intended for long-lived verify caches; decode and prefill keep
+// using the raw quantized storage paths.
+bool qwen_fp8_e4m3_fp16scale_dequantize_f16_cuda(
+    const uint8_t* d_weight, const uint16_t* d_scale_fp16,
+    uint16_t* d_output_fp16, int rows, int cols, int weight_stride,
+    int scale_stride, void* stream = nullptr);
+
+// FP16 input/weight tensor-op GEMM with FP16 output. Weight storage is row-major
+// [output_rows, columns], matching the target projection layout.
+bool qwen_fp16_matmul_rows_f16_cublas_cuda(
+    const uint16_t* d_x_fp16, const uint16_t* d_weight_fp16,
+    uint16_t* d_y_fp16, int batch, int rows, int cols, int x_stride,
+    int y_stride, int weight_stride, void* stream = nullptr);
 
 // FP16 input/weight tensor-op GEMM with FP32 output. This is kept separate from
 // the exact reduction-order reference path and enabled only by runtime A/B gates.
@@ -477,11 +501,43 @@ bool qwen_copy_rows_strided_f16_cuda(
     const uint16_t* d_source_fp16, int source_row_stride,
     uint16_t* d_destination_fp16, int destination_row_stride,
     int rows, int columns, void* stream = nullptr);
+
+// Device-resident scatter/gather for independently allocated byte regions. The
+// host builds a descriptor table once; every block copies one fixed-size chunk
+// of a region to or from its offset in a contiguous transaction buffer.
+struct QwenCopyRegion {
+    uint64_t device_address = 0;
+    uint64_t packed_offset = 0;
+    uint64_t bytes = 0;
+    uint64_t first_block = 0;
+};
+
+constexpr uint64_t kQwenCopyRegionBlockBytes = 64 * 1024;
+constexpr uint64_t qwen_copy_region_blocks(uint64_t bytes) {
+    return (bytes + kQwenCopyRegionBlockBytes - 1) /
+           kQwenCopyRegionBlockBytes;
+}
+
+bool qwen_gather_copy_regions_cuda(
+    const QwenCopyRegion* d_regions, int region_count, uint8_t* d_packed,
+    uint64_t total_blocks, void* stream = nullptr);
+bool qwen_scatter_copy_regions_cuda(
+    const QwenCopyRegion* d_regions, int region_count, const uint8_t* d_packed,
+    uint64_t total_blocks, void* stream = nullptr);
+
 bool qwen_rmsnorm_fp16_gamma_rows_f16_cuda(const uint16_t* d_x_fp16,
                                            const uint16_t* d_gamma_fp16,
                                            uint16_t* d_y_fp16, int rows,
                                            int cols, float eps,
                                            void* stream = nullptr);
+// Fuses the attention residual boundary with post-attention RMSNorm. The sum is
+// rounded to FP16 before it contributes to the RMS statistic, exactly matching
+// copy(hidden) -> FP16 add(attention) -> RMSNorm(residual).
+bool qwen_residual_add_rmsnorm_fp16_gamma_rows_f16_cuda(
+    const uint16_t* d_hidden_fp16, const uint16_t* d_delta_fp16,
+    const uint16_t* d_gamma_fp16, uint16_t* d_residual_fp16,
+    uint16_t* d_normalized_fp16, int rows, int cols, float eps,
+    void* stream = nullptr);
 bool qwen_gated_rmsnorm_fp16_gamma_rows_f16_cuda(
     const uint16_t* d_x_fp16, const uint16_t* d_gamma_fp16,
     const uint16_t* d_gate_fp16, uint16_t* d_y_fp16, int rows, int cols,
@@ -491,6 +547,12 @@ bool qwen_split_packed_qkv_f16_cuda(const uint16_t* d_packed_fp16,
                                     uint16_t* d_v_fp16, int rows,
                                     int key_dim, int value_dim,
                                     void* stream = nullptr);
+// Splits a [rows, 2*width] row-major tensor into two [rows, width] tensors.
+// Used to unpack a fused projection whose weight was row-concatenated.
+bool qwen_split_rows_pair_f16_cuda(const uint16_t* d_packed_fp16,
+                                   uint16_t* d_first_fp16,
+                                   uint16_t* d_second_fp16, int rows,
+                                   int width, void* stream = nullptr);
 bool qwen_causal_depthwise_conv_silu_f16_cuda(
     const uint16_t* d_x_fp16, const uint16_t* d_weight_fp16,
     uint16_t* d_tail_fp16, uint16_t* d_y_fp16, int seq_len, int channels,
@@ -512,6 +574,27 @@ bool qwen_gated_delta_sequence_f16_cuda(
     const uint16_t* d_beta_fp16, uint16_t* d_out_fp16, int rows,
     int heads, int key_heads, int key_dim, int value_dim, float q_scale,
     void* stream = nullptr);
+// Same recurrence with Q/K already L2-normalized as FP32. Separating the
+// normalization lets one key head serve all repeated value heads.
+bool qwen_gated_delta_sequence_normalized_f16_cuda(
+    float* d_state, const float* d_q_normalized, const float* d_k_normalized,
+    const uint16_t* d_v_fp16, const uint16_t* d_g_fp16,
+    const uint16_t* d_beta_fp16, uint16_t* d_out_fp16, int rows,
+    int heads, int key_heads, int key_dim, int value_dim, float q_scale,
+    void* stream = nullptr);
+// Optional verify path that keeps the recurrent state in shared memory instead
+// of a 128-element per-thread register vector. Set
+// QWEN_GATED_DELTA_SHARED_STATE=1 to compare it with the fallback.
+bool qwen_gated_delta_sequence_normalized_shared_f16_cuda(
+    float* d_state, const float* d_q_normalized, const float* d_k_normalized,
+    const uint16_t* d_v_fp16, const uint16_t* d_g_fp16,
+    const uint16_t* d_beta_fp16, uint16_t* d_out_fp16, int rows,
+    int heads, int key_heads, int key_dim, int value_dim, float q_scale,
+    void* stream = nullptr);
+bool qwen_normalize_gated_delta_qk_f16_cuda(
+    const uint16_t* d_q_fp16, const uint16_t* d_k_fp16,
+    float* d_q_normalized, float* d_k_normalized, int rows, int key_heads,
+    int key_dim, void* stream = nullptr);
 bool qwen_partial_rope_f16_cuda(uint16_t* d_q_fp16, uint16_t* d_k_fp16,
                                 int position, int rotary_dim, float theta,
                                 int q_heads, int kv_heads, int head_dim,
@@ -587,6 +670,16 @@ bool qwen_gqa_verify_attention_f16_exact_cuda(
 // Context splits run in parallel while every K/V load serves every verify row
 // in the CTA. Its online-softmax order may change near-tie downstream logits.
 // Scratch contains rows * q_heads * splits * (head_dim + 2) FP32 elements.
+// Tensor-core QK + FP32 masked softmax + deterministic SIMT PV. Optimized for
+// TP shards with one KV head, where all local Q heads share a contiguous K/V
+// matrix and QK becomes one large GEMM.
+bool qwen_gqa_verify_attention_f16_cublas_qk_cuda(
+    const uint16_t* d_q_fp16, const uint16_t* d_k_cache_fp16,
+    const uint16_t* d_v_cache_fp16, uint16_t* d_output_fp16,
+    float* d_score_scratch, int rows, int q_heads, int kv_heads,
+    int head_dim, int position_offset, int max_context,
+    void* stream = nullptr);
+
 bool qwen_gqa_verify_attention_f16_cuda(
     const uint16_t* d_q_rows_fp16, const uint16_t* d_k_cache_fp16,
     const uint16_t* d_v_cache_fp16, uint16_t* d_out_rows_fp16,

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -158,6 +158,7 @@ public:
     int position() const { return position_; }
     uint64_t resident_weight_bytes() const { return resident_weight_bytes_; }
     uint64_t resident_scale_bytes() const { return resident_scale_bytes_; }
+    uint64_t verify_weight_bytes() const;
     uint64_t activation_workspace_peak_bytes() const;
     uint64_t kv_cache_bytes() const;
     uint64_t kv_cache_scale_bytes() const;

--- a/cpp_engine/include/tp_comm.hpp
+++ b/cpp_engine/include/tp_comm.hpp
@@ -17,11 +17,29 @@ TpTopResult nccl_global_top1(int world, int rank, int device, const char* id_pat
 void nccl_global_top1_rows(int world, int rank, int device, const char* id_path,
                            const int* d_local_tokens,
                            const float* d_local_logits, int rows,
-                           int* global_tokens, float* global_logits);
+                           int* global_tokens, float* global_logits,
+                           void* stream = nullptr);
+// Device-resident top-1 merge. The all-gather and deterministic comparator run
+// on `stream`; no host synchronization or device-to-host copy is performed.
+void nccl_global_top1_rows_device(int world, int rank, int device,
+                                  const char* id_path,
+                                  const int* d_local_tokens,
+                                  const float* d_local_logits, int rows,
+                                  int* d_global_tokens,
+                                  float* d_global_logits,
+                                  void* stream = nullptr);
+// Device-resident top-1 using one packed uint64 NCCL Max per row instead of
+// all-gathering both arrays. The packed order is deterministic and matches the
+// host/device comparator: larger logit wins, ties pick the smaller token id.
+void nccl_global_top1_rows_packed_device(
+    int world, int rank, int device, const char* id_path,
+    const int* d_local_tokens, const float* d_local_logits, int rows,
+    int* d_global_tokens, float* d_global_logits, void* stream = nullptr);
 void nccl_global_topk_rows(int world, int rank, int device, const char* id_path,
                            const int* d_local_tokens,
                            const float* d_local_logits, int rows, int top_k,
-                           int* global_tokens, float* global_logits);
+                           int* global_tokens, float* global_logits,
+                           void* stream = nullptr);
 // All-gather and merge batched top-k candidates without synchronizing to the
 // host. The output buffers remain device-resident for the next CUDA stage.
 void nccl_global_topk_rows_device(int world, int rank, int device,
@@ -29,10 +47,11 @@ void nccl_global_topk_rows_device(int world, int rank, int device,
                                   const int* d_local_tokens,
                                   const float* d_local_logits, int rows,
                                   int top_k, int* d_global_tokens,
-                                  float* d_global_logits);
-void nccl_all_reduce_sum_float_inplace(int world, int rank, int device, const char* id_path, float* d_values, int count);
-void nccl_all_reduce_sum_f16_inplace(int world, int rank, int device, const char* id_path, uint16_t* d_values, int count);
-void nccl_all_reduce_sum_bf16_inplace(int world, int rank, int device, const char* id_path, uint16_t* d_values, int count);
+                                  float* d_global_logits,
+                                  void* stream = nullptr);
+void nccl_all_reduce_sum_float_inplace(int world, int rank, int device, const char* id_path, float* d_values, int count, void* stream = nullptr);
+void nccl_all_reduce_sum_f16_inplace(int world, int rank, int device, const char* id_path, uint16_t* d_values, int count, void* stream = nullptr);
+void nccl_all_reduce_sum_bf16_inplace(int world, int rank, int device, const char* id_path, uint16_t* d_values, int count, void* stream = nullptr);
 // Broadcast a small int32 buffer from rank `root` to all ranks. Synchronous.
 void nccl_broadcast_int32(int world, int rank, int device, const char* id_path, int32_t* buf, int count, int root);
 // Gather equal-sized float32 chunks from every rank to `root`. `h_local` is read on

--- a/cpp_engine/src/main.cpp
+++ b/cpp_engine/src/main.cpp
@@ -697,6 +697,7 @@ int main(int argc, char** argv) {
                         std::cout << "qwen_runtime=1 layers=" << generated.front().layers
                                   << " resident_weight_bytes=" << qwen.resident_weight_bytes()
                                   << " resident_scale_bytes=" << qwen.resident_scale_bytes()
+                                  << " verify_weight_bytes=" << qwen.verify_weight_bytes()
                                   << " activation_workspace_peak_bytes=" << qwen.activation_workspace_peak_bytes()
                                   << " kv_cache_bytes=" << qwen.kv_cache_bytes()
                                   << " kv_cache_scale_bytes=" << qwen.kv_cache_scale_bytes()
@@ -773,6 +774,7 @@ int main(int argc, char** argv) {
                                   << " position=" << result.position
                                   << " resident_weight_bytes=" << qwen.resident_weight_bytes()
                                   << " resident_scale_bytes=" << qwen.resident_scale_bytes()
+                                  << " verify_weight_bytes=" << qwen.verify_weight_bytes()
                                   << " activation_workspace_peak_bytes=" << qwen.activation_workspace_peak_bytes()
                                   << " kv_cache_bytes=" << qwen.kv_cache_bytes()
                                   << " kv_cache_scale_bytes=" << qwen.kv_cache_scale_bytes()

--- a/cpp_engine/src/qwen_dspark.cpp
+++ b/cpp_engine/src/qwen_dspark.cpp
@@ -550,6 +550,16 @@ struct QwenDSparkRuntime::Impl {
                    "upload Qwen DSpark YaRN frequencies");
     }
 
+    // The draft LM head is a batch=block_size by vocab by hidden GEMM. The
+    // generic FP32 kernel launches a rows x batch grid, so it re-reads the
+    // whole vocab-sized weight matrix once per draft row and lands about an
+    // order of magnitude off the memory-bound floor. cuBLAS reuses the weights
+    // across rows instead. Set DSV4_DSPARK_LM_HEAD_CUBLAS=0 to fall back.
+    static bool lm_head_cublas_enabled() {
+        const char* value = std::getenv("DSV4_DSPARK_LM_HEAD_CUBLAS");
+        return value == nullptr || std::strcmp(value, "0") != 0;
+    }
+
     void all_reduce_half(uint16_t* values, int count) {
         if (tp_world == 1) return;
 #ifdef DSV4_HAVE_NCCL
@@ -776,9 +786,16 @@ struct QwenDSparkRuntime::Impl {
         allocate_float(logits, static_cast<size_t>(rows) * local_vocab,
                        {static_cast<uint64_t>(rows),
                         static_cast<uint64_t>(local_vocab)});
-        require_launch(qwen_fp16_matmul_rows_f16_f32_cuda(
-            normalized.f16_data(), target_lm_head.f16_data(), logits.f32_data(),
-            rows, local_vocab, hidden, hidden, local_vocab, hidden),
+        static const bool lm_head_cublas = lm_head_cublas_enabled();
+        require_launch(lm_head_cublas && rows > 1
+            ? qwen_fp16_matmul_rows_f16_f32_cublas_cuda(
+                  normalized.f16_data(), target_lm_head.f16_data(),
+                  logits.f32_data(), rows, local_vocab, hidden, hidden,
+                  local_vocab, hidden)
+            : qwen_fp16_matmul_rows_f16_f32_cuda(
+                  normalized.f16_data(), target_lm_head.f16_data(),
+                  logits.f32_data(), rows, local_vocab, hidden, hidden,
+                  local_vocab, hidden),
             "draft base logits");
         allocate_half(markov_embeddings,
                       static_cast<size_t>(rows) * config.markov_rank,

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -8,6 +8,7 @@
 #include "tp_comm.hpp"
 
 #include <cuda_runtime.h>
+#include <nvtx3/nvToolsExt.h>
 
 #include <algorithm>
 #include <cmath>
@@ -48,6 +49,13 @@ bool qwen_env_enabled(const char* name) {
            std::strcmp(value, "OFF") != 0;
 }
 
+// Opt-out switch for defaults that are on unless explicitly disabled.
+bool qwen_env_enabled_default(const char* name) {
+    const char* value = std::getenv(name);
+    if (value == nullptr || *value == '\0') return true;
+    return qwen_env_enabled(name);
+}
+
 int qwen_env_int(const char* name, int fallback) {
     const char* value = std::getenv(name);
     if (value == nullptr || *value == '\0') return fallback;
@@ -62,6 +70,9 @@ int qwen_env_int(const char* name, int fallback) {
 struct DeviceLinear {
     QwenDeviceTensor weight;
     QwenDeviceTensor scale;
+    // Optional dense FP16 expansion used only by batched target verification.
+    // The raw FP8 matrix remains canonical and serves decode/prefill.
+    QwenDeviceTensor verify_weight;
     bool fp8 = false;
 };
 
@@ -71,6 +82,8 @@ struct DeviceLinearAttention {
     DeviceLinear out;
     DeviceLinear a;
     DeviceLinear b;
+    // Row-concat of a and b; empty when the two cannot be fused.
+    DeviceLinear ab;
     QwenDeviceTensor conv;
     QwenDeviceTensor a_log;
     QwenDeviceTensor dt_bias;
@@ -83,6 +96,9 @@ struct DeviceFullAttention {
     DeviceLinear q;
     DeviceLinear k;
     DeviceLinear v;
+    // Row-concat of K and V for batched verify/prefill. Decode keeps the
+    // individual projections so its established one-row path is unchanged.
+    DeviceLinear kv;
     DeviceLinear out;
     QwenDeviceTensor q_norm;
     QwenDeviceTensor k_norm;
@@ -112,6 +128,61 @@ DeviceLinear upload_linear(const SafeTensorsIndex& index, const QwenLinearRef& r
     output.fp8 = ref.weight.device_dtype == SafeDType::F8_E4M3;
     if (ref.has_scale) output.scale = upload(index, ref.scale);
     return output;
+}
+
+void allocate(QwenDeviceTensor& tensor, size_t bytes,
+              const std::vector<uint64_t>& shape, SafeDType dtype);
+
+// Concatenates two linear weights along output rows so one GEMM can produce both
+// results. FP8 scales are row-concatenated in lockstep. Only the input width and
+// dtypes must match; output row counts may differ (Q/K/V fusion relies on this).
+DeviceLinear fuse_linear_rows(const DeviceLinear& first,
+                              const DeviceLinear& second) {
+    DeviceLinear fused;
+    if (first.weight.data == nullptr || second.weight.data == nullptr) return fused;
+    if (first.weight.shape.size() != 2 || second.weight.shape.size() != 2) return fused;
+    if (first.weight.shape[1] != second.weight.shape[1] ||
+        first.weight.device_dtype != second.weight.device_dtype ||
+        first.fp8 != second.fp8) {
+        return fused;
+    }
+    if (first.fp8 &&
+        (first.scale.data == nullptr || second.scale.data == nullptr ||
+         first.scale.shape.size() != 2 || second.scale.shape.size() != 2 ||
+         first.scale.shape[1] != second.scale.shape[1] ||
+         first.scale.device_dtype != second.scale.device_dtype)) {
+        return fused;
+    }
+
+    const uint64_t first_rows = first.weight.shape[0];
+    const uint64_t second_rows = second.weight.shape[0];
+    const uint64_t columns = first.weight.shape[1];
+    allocate(fused.weight, first.weight.nbytes + second.weight.nbytes,
+             {first_rows + second_rows, columns}, first.weight.device_dtype);
+    check_cuda(cudaMemcpy(fused.weight.data, first.weight.data,
+                          first.weight.nbytes, cudaMemcpyDeviceToDevice),
+               "Qwen fused projection first weight copy");
+    check_cuda(cudaMemcpy(static_cast<uint8_t*>(fused.weight.data) +
+                              first.weight.nbytes,
+                          second.weight.data, second.weight.nbytes,
+                          cudaMemcpyDeviceToDevice),
+               "Qwen fused projection second weight copy");
+    fused.fp8 = first.fp8;
+    if (first.fp8) {
+        const uint64_t scale_columns = first.scale.shape[1];
+        allocate(fused.scale, first.scale.nbytes + second.scale.nbytes,
+                 {first.scale.shape[0] + second.scale.shape[0], scale_columns},
+                 first.scale.device_dtype);
+        check_cuda(cudaMemcpy(fused.scale.data, first.scale.data,
+                              first.scale.nbytes, cudaMemcpyDeviceToDevice),
+                   "Qwen fused projection first scale copy");
+        check_cuda(cudaMemcpy(static_cast<uint8_t*>(fused.scale.data) +
+                                  first.scale.nbytes,
+                              second.scale.data, second.scale.nbytes,
+                              cudaMemcpyDeviceToDevice),
+                   "Qwen fused projection second scale copy");
+    }
+    return fused;
 }
 
 void allocate(QwenDeviceTensor& tensor, size_t bytes,
@@ -245,9 +316,10 @@ struct QwenEngine::Impl {
     QwenEngineOptions options;
     int max_context = 0;
     std::vector<DeviceLayer> layers;
-    std::vector<QwenDeviceTensor> transaction_states;
-    std::vector<QwenDeviceTensor> transaction_conv_tails;
-    QwenDeviceTensor transaction_target_hidden;
+    QwenDeviceTensor transaction_packed;
+    QwenDeviceTensor transaction_regions;
+    std::vector<QwenCopyRegion> host_transaction_regions;
+    uint64_t transaction_total_blocks = 0;
     QwenDeviceTensor embed;
     QwenDeviceTensor final_norm;
     QwenDeviceTensor lm_head;
@@ -318,8 +390,18 @@ struct QwenEngine::Impl {
     bool sampling_rng_ready = false;
     std::vector<float> host_uniform_scratch;
     QwenWorkspace workspace;
+    // Optional NCCL stream candidate. Every collective is bracketed by events
+    // on the default compute stream, so enabling this cannot expose a partially
+    // reduced tensor to the next layer. It is opt-in because the dependency
+    // chain may leave no useful work to overlap on the target verify topology.
+    const bool use_nccl_comm_stream = qwen_env_enabled("QWEN_NCCL_COMM_STREAM");
+    cudaStream_t nccl_comm_stream = nullptr;
+    cudaEvent_t nccl_comm_ready = nullptr;
+    cudaEvent_t nccl_comm_done = nullptr;
+    bool nccl_comm_stream_initialized = false;
     uint64_t uploaded_weight_bytes = 0;
     uint64_t uploaded_scale_bytes = 0;
+    uint64_t verify_weight_bytes = 0;
     uint64_t cache_data_bytes = 0;
     uint64_t cache_scale_bytes = 0;
     // Prompt whose KV cache and recurrent state are currently materialized.
@@ -329,6 +411,49 @@ struct QwenEngine::Impl {
     std::vector<QwenRecurrentSnapshot> snapshots;
     int prefix_hits = 0;
     int prefix_misses = 0;
+
+    void ensure_nccl_comm_stream() {
+        if (!use_nccl_comm_stream || nccl_comm_stream_initialized) return;
+        check_cuda(cudaStreamCreateWithFlags(&nccl_comm_stream,
+                                             cudaStreamNonBlocking),
+                   "Qwen NCCL communication stream");
+        check_cuda(cudaEventCreateWithFlags(&nccl_comm_ready,
+                                            cudaEventDisableTiming),
+                   "Qwen NCCL ready event");
+        check_cuda(cudaEventCreateWithFlags(&nccl_comm_done,
+                                            cudaEventDisableTiming),
+                   "Qwen NCCL done event");
+        nccl_comm_stream_initialized = true;
+    }
+
+    // The compute kernels all use the legacy default stream. Bracket a
+    // communication-stream collective with events so the collective sees the
+    // complete producer work and the next compute kernel sees its result.
+    void begin_nccl_collective() {
+        ensure_nccl_comm_stream();
+        check_cuda(cudaEventRecord(nccl_comm_ready, nullptr),
+                   "Qwen record NCCL ready event");
+        check_cuda(cudaStreamWaitEvent(nccl_comm_stream, nccl_comm_ready, 0),
+                   "Qwen NCCL stream wait");
+    }
+
+    void end_nccl_collective() {
+        check_cuda(cudaEventRecord(nccl_comm_done, nccl_comm_stream),
+                   "Qwen record NCCL done event");
+        check_cuda(cudaStreamWaitEvent(nullptr, nccl_comm_done, 0),
+                   "Qwen compute stream wait");
+    }
+
+    ~Impl() {
+        if (nccl_comm_stream != nullptr) {
+            // The default stream wait above normally makes this unnecessary;
+            // keep destruction safe if construction or a caller failed midway.
+            cudaStreamSynchronize(nccl_comm_stream);
+        }
+        if (nccl_comm_done != nullptr) cudaEventDestroy(nccl_comm_done);
+        if (nccl_comm_ready != nullptr) cudaEventDestroy(nccl_comm_ready);
+        if (nccl_comm_stream != nullptr) cudaStreamDestroy(nccl_comm_stream);
+    }
 
     Impl(SafeTensorsIndex& index_, QwenConfig& config_,
          const QwenWeightMap& map, const QwenEngineOptions& options_,
@@ -358,6 +483,11 @@ struct QwenEngine::Impl {
         const int local_kv_heads =
             static_cast<int>(config.full_attention.num_key_value_heads / world);
         const int head_dim = static_cast<int>(config.full_attention.head_dim);
+        const bool speculative_target = options.mtp ||
+            !options.dspark_checkpoint.empty() ||
+            !options.dflash2_checkpoint.empty();
+        const bool fuse_kv_projection = speculative_target &&
+            qwen_env_enabled("QWEN_FUSE_KV_PROJECTION");
 
         for (size_t layer_index = 0; layer_index < layer_limit; ++layer_index) {
             const QwenLayerWeights& source = map.layers()[layer_index];
@@ -414,6 +544,13 @@ struct QwenEngine::Impl {
                     upload_linear(index, source.linear_attention.in_proj_a);
                 destination.linear.b =
                     upload_linear(index, source.linear_attention.in_proj_b);
+                // in_proj_a and in_proj_b are both BF16 [num_v_heads, hidden]
+                // and read the same activation, so a row-concat lets one GEMM
+                // replace two. Each alone is far too small to fill the device
+                // (12 rows per rank), and together they cost ~6.9 ms/step of
+                // verify. Rows [0, n) are a; rows [n, 2n) are b.
+                destination.linear.ab = fuse_linear_rows(
+                    destination.linear.a, destination.linear.b);
                 destination.linear.conv =
                     upload(index, source.linear_attention.conv1d);
                 destination.linear.a_log =
@@ -442,6 +579,10 @@ struct QwenEngine::Impl {
                 destination.full.q = upload_linear(index, source.full_attention.q_proj);
                 destination.full.k = upload_linear(index, source.full_attention.k_proj);
                 destination.full.v = upload_linear(index, source.full_attention.v_proj);
+                if (fuse_kv_projection) {
+                    destination.full.kv = fuse_linear_rows(
+                        destination.full.k, destination.full.v);
+                }
                 destination.full.out = upload_linear(index, source.full_attention.o_proj);
                 destination.full.q_norm = upload(index, source.full_attention.q_norm);
                 destination.full.k_norm = upload(index, source.full_attention.k_norm);
@@ -476,6 +617,56 @@ struct QwenEngine::Impl {
                 }
             }
             layers.push_back(std::move(destination));
+        }
+
+        // On SM75 the verify batch is too narrow to amortize online FP8 decode.
+        // A dense FP16 cache lets cuBLAS reuse tensor-core tiles across all rows,
+        // but expanding the whole model would consume ~17 GiB/rank. Keep only the
+        // most frequently executed target projections: qkv/z/out/down on the 48
+        // linear-attention layers and q/k/v/down on the 16 full-attention layers.
+        // Gate/up stay raw FP8 because their fused kernel is close to the two-GEMM
+        // resident alternative while costing another ~5.3 GiB; full-attention out
+        // saves only ~0.15 ms/verify for another 240 MiB and stays raw FP8. Set
+        // QWEN_VERIFY_RESIDENT_FP16=0 to keep the former all-FP8 verify path.
+        // Plain decoding never consumes these matrices, so do not spend the fixed
+        // cache unless this engine actually owns a speculative target.
+        const bool verify_resident_weights = speculative_target &&
+            qwen_env_enabled_default("QWEN_VERIFY_RESIDENT_FP16");
+        if (verify_resident_weights) {
+            auto materialize_verify_weight = [this](DeviceLinear& linear) {
+                if (!linear.fp8 || linear.weight.data == nullptr ||
+                    linear.weight.shape.size() != 2 ||
+                    linear.scale.data == nullptr || linear.scale.shape.size() != 2) {
+                    return;
+                }
+                const int rows = static_cast<int>(linear.weight.shape[0]);
+                const int cols = static_cast<int>(linear.weight.shape[1]);
+                const size_t elements = static_cast<size_t>(rows) * cols;
+                allocate_half(linear.verify_weight, elements,
+                              {linear.weight.shape[0], linear.weight.shape[1]});
+                require_launch(qwen_fp8_e4m3_fp16scale_dequantize_f16_cuda(
+                    linear.weight.fp8_data(), linear.scale.f16_data(),
+                    linear.verify_weight.f16_data(), rows, cols, cols,
+                    static_cast<int>(linear.scale.shape[1])),
+                    "Qwen resident verify weight expansion");
+                verify_weight_bytes += linear.verify_weight.nbytes;
+            };
+            for (DeviceLayer& layer : layers) {
+                materialize_verify_weight(layer.down);
+                if (layer.linear.qkv.weight.data != nullptr) {
+                    materialize_verify_weight(layer.linear.qkv);
+                    materialize_verify_weight(layer.linear.z);
+                    materialize_verify_weight(layer.linear.out);
+                } else {
+                    materialize_verify_weight(layer.full.q);
+                    if (layer.full.kv.weight.data != nullptr) {
+                        materialize_verify_weight(layer.full.kv);
+                    } else {
+                        materialize_verify_weight(layer.full.k);
+                        materialize_verify_weight(layer.full.v);
+                    }
+                }
+            }
         }
 
         if (!options.dspark_checkpoint.empty()) {
@@ -639,81 +830,94 @@ struct QwenEngine::Impl {
         mtp_next_checksum = 0.0f;
     }
 
+    void append_transaction_region(void* data, uint64_t bytes,
+                                   uint64_t& packed_offset) {
+        if (data == nullptr || bytes == 0) return;
+        if (packed_offset > UINT64_MAX - bytes) {
+            throw std::runtime_error("Qwen transaction byte extent overflow");
+        }
+        QwenCopyRegion region;
+        region.device_address = reinterpret_cast<uint64_t>(data);
+        region.packed_offset = packed_offset;
+        region.bytes = bytes;
+        region.first_block = transaction_total_blocks;
+        host_transaction_regions.push_back(region);
+        const uint64_t blocks = qwen_copy_region_blocks(bytes);
+        if (transaction_total_blocks > UINT64_MAX - blocks) {
+            throw std::runtime_error("Qwen transaction block extent overflow");
+        }
+        transaction_total_blocks += blocks;
+        packed_offset += bytes;
+    }
+
+    void initialize_packed_transaction_state() {
+        if (!host_transaction_regions.empty()) return;
+        uint64_t packed_bytes = 0;
+        transaction_total_blocks = 0;
+        host_transaction_regions.reserve(layers.size() * 2 +
+                                         (mtp_enabled ? 1 : 0));
+        for (DeviceLayer& layer : layers) {
+            if (layer.linear.state.data == nullptr) continue;
+            append_transaction_region(layer.linear.state.data,
+                                      layer.linear.state.nbytes, packed_bytes);
+            append_transaction_region(layer.linear.conv_tail.data,
+                                      layer.linear.conv_tail.nbytes,
+                                      packed_bytes);
+        }
+        if (mtp_enabled) {
+            if (!has_target_last_hidden || target_last_hidden.data == nullptr) {
+                throw std::runtime_error(
+                    "Qwen MTP transaction requires the committed target hidden");
+            }
+            append_transaction_region(
+                target_last_hidden.data,
+                static_cast<uint64_t>(config.hidden_size) * sizeof(uint16_t),
+                packed_bytes);
+        }
+        if (host_transaction_regions.empty() || packed_bytes == 0 ||
+            transaction_total_blocks == 0) {
+            throw std::runtime_error("Qwen transaction has no recurrent state");
+        }
+        allocate(transaction_packed, packed_bytes, {packed_bytes}, SafeDType::I8);
+        const uint64_t descriptor_bytes =
+            host_transaction_regions.size() * sizeof(QwenCopyRegion);
+        allocate(transaction_regions, descriptor_bytes,
+                 {static_cast<uint64_t>(host_transaction_regions.size())},
+                 SafeDType::I8);
+        check_cuda(cudaMemcpy(transaction_regions.data,
+                              host_transaction_regions.data(), descriptor_bytes,
+                              cudaMemcpyHostToDevice),
+                   "Qwen transaction descriptor upload");
+    }
+
     // Copies the recurrent half of the network to device-resident snapshots.
     // Only the 48 DeltaNet layers carry order-dependent state; full attention
     // is skipped because its KV cache is addressed by absolute position.
     void prepare_transaction_state() {
         PhaseScope scope(this, "transaction_snapshot");
-        if (transaction_states.size() != layers.size()) {
-            transaction_states.clear();
-            transaction_conv_tails.clear();
-            transaction_states.resize(layers.size());
-            transaction_conv_tails.resize(layers.size());
-            for (size_t index = 0; index < layers.size(); ++index) {
-                const DeviceLayer& layer = layers[index];
-                if (layer.linear.state.data == nullptr) continue;
-                allocate_float(transaction_states[index],
-                               layer.linear.state.nbytes / sizeof(float),
-                               layer.linear.state.shape);
-                allocate_half(transaction_conv_tails[index],
-                              layer.linear.conv_tail.nbytes / sizeof(uint16_t),
-                              layer.linear.conv_tail.shape);
-            }
-        }
-        if (mtp_enabled) {
-            allocate_half(transaction_target_hidden, config.hidden_size,
-                          {config.hidden_size});
-        }
-        for (size_t index = 0; index < layers.size(); ++index) {
-            const DeviceLayer& layer = layers[index];
-            if (layer.linear.state.data == nullptr) continue;
-            check_cuda(cudaMemcpy(transaction_states[index].data,
-                                  layer.linear.state.data,
-                                  layer.linear.state.nbytes,
-                                  cudaMemcpyDeviceToDevice),
-                       "Qwen transaction state copy");
-            check_cuda(cudaMemcpy(transaction_conv_tails[index].data,
-                                  layer.linear.conv_tail.data,
-                                  layer.linear.conv_tail.nbytes,
-                                  cudaMemcpyDeviceToDevice),
-                       "Qwen transaction convolution copy");
-        }
-        if (mtp_enabled) {
-            check_cuda(cudaMemcpy(transaction_target_hidden.data,
-                                  target_last_hidden.data,
-                                  static_cast<size_t>(config.hidden_size) *
-                                      sizeof(uint16_t),
-                                  cudaMemcpyDeviceToDevice),
-                       "Qwen transaction hidden copy");
-        }
+        initialize_packed_transaction_state();
+        require_launch(qwen_gather_copy_regions_cuda(
+            static_cast<const QwenCopyRegion*>(transaction_regions.data),
+            static_cast<int>(host_transaction_regions.size()),
+            static_cast<uint8_t*>(transaction_packed.data),
+            transaction_total_blocks),
+            "Qwen packed transaction snapshot");
     }
 
     void restore_transaction_state(int position) {
         PhaseScope scope(this, "transaction_restore");
-        if (transaction_states.size() != layers.size()) {
+        if (host_transaction_regions.empty() ||
+            transaction_regions.data == nullptr ||
+            transaction_packed.data == nullptr) {
             throw std::runtime_error("Qwen transaction state is unavailable");
         }
-        for (size_t index = 0; index < layers.size(); ++index) {
-            DeviceLayer& layer = layers[index];
-            if (layer.linear.state.data == nullptr) continue;
-            check_cuda(cudaMemcpy(layer.linear.state.data,
-                                  transaction_states[index].data,
-                                  layer.linear.state.nbytes,
-                                  cudaMemcpyDeviceToDevice),
-                       "Qwen transaction state restore");
-            check_cuda(cudaMemcpy(layer.linear.conv_tail.data,
-                                  transaction_conv_tails[index].data,
-                                  layer.linear.conv_tail.nbytes,
-                                  cudaMemcpyDeviceToDevice),
-                       "Qwen transaction convolution restore");
-        }
+        require_launch(qwen_scatter_copy_regions_cuda(
+            static_cast<const QwenCopyRegion*>(transaction_regions.data),
+            static_cast<int>(host_transaction_regions.size()),
+            static_cast<const uint8_t*>(transaction_packed.data),
+            transaction_total_blocks),
+            "Qwen packed transaction restore");
         if (mtp_enabled) {
-            check_cuda(cudaMemcpy(target_last_hidden.data,
-                                  transaction_target_hidden.data,
-                                  static_cast<size_t>(config.hidden_size) *
-                                      sizeof(uint16_t),
-                                  cudaMemcpyDeviceToDevice),
-                       "Qwen transaction hidden restore");
             has_target_last_hidden = true;
             mtp_seed_ready = false;
             mtp_position = position;
@@ -970,7 +1174,7 @@ struct QwenEngine::Impl {
 
     class PhaseScope {
     public:
-        PhaseScope(Impl* owner, const char* name) : owner_(owner), name_(name) {
+        PhaseScope(Impl* owner, std::string name) : owner_(owner), name_(std::move(name)) {
             if (owner_->phase_profile) {
                 cudaDeviceSynchronize();
                 started_ = std::chrono::steady_clock::now();
@@ -993,6 +1197,14 @@ struct QwenEngine::Impl {
         std::chrono::steady_clock::time_point started_;
     };
 
+    class NvtxScope {
+    public:
+        explicit NvtxScope(const char* name) { nvtxRangePushA(name); }
+        ~NvtxScope() { nvtxRangePop(); }
+        NvtxScope(const NvtxScope&) = delete;
+        NvtxScope& operator=(const NvtxScope&) = delete;
+    };
+
     void report_phase_profile(const char* tag) const {
         if (!phase_profile) return;
         double total = 0.0;
@@ -1010,7 +1222,8 @@ struct QwenEngine::Impl {
         std::cout.flush();
     }
 
-    void all_reduce_half(uint16_t* values, int count) {
+    void all_reduce_half(uint16_t* values, int count, const char* site = "other") {
+        PhaseScope scope(this, std::string("ar.") + site);
         if (options.tp_world == 1) return;
 #ifdef DSV4_HAVE_NCCL
         if (options.nccl_id_path.empty()) {
@@ -1018,9 +1231,18 @@ struct QwenEngine::Impl {
         }
         {
             PhaseScope scope(this, "tp_all_reduce");
-            nccl_all_reduce_sum_f16_inplace(
-                options.tp_world, options.tp_rank, options.device,
-                options.nccl_id_path.c_str(), values, count);
+            if (use_nccl_comm_stream) {
+                begin_nccl_collective();
+                nccl_all_reduce_sum_f16_inplace(
+                    options.tp_world, options.tp_rank, options.device,
+                    options.nccl_id_path.c_str(), values, count,
+                    nccl_comm_stream);
+                end_nccl_collective();
+            } else {
+                nccl_all_reduce_sum_f16_inplace(
+                    options.tp_world, options.tp_rank, options.device,
+                    options.nccl_id_path.c_str(), values, count);
+            }
         }
 #else
         (void)values;
@@ -1030,8 +1252,8 @@ struct QwenEngine::Impl {
     }
 
     void projection(const DeviceLinear& linear, const uint16_t* input,
-                    uint16_t* output, int rows) {
-        PhaseScope scope(this, rows == 1 ? "projection_decode" : "projection_rows");
+                    uint16_t* output, int rows, const char* site = "other") {
+        PhaseScope scope(this, std::string(rows == 1 ? "pd." : "pr.") + site);
         const int output_rows = static_cast<int>(linear.weight.shape[0]);
         const int columns = static_cast<int>(linear.weight.shape[1]);
         if (linear.fp8) {
@@ -1041,6 +1263,11 @@ struct QwenEngine::Impl {
                     output, output_rows, columns, columns,
                     static_cast<int>(linear.scale.shape[1])),
                     "FP8 FP16-activation decode projection");
+            } else if (rows <= 8 && linear.verify_weight.data != nullptr) {
+                require_launch(qwen_fp16_matmul_rows_f16_cublas_cuda(
+                    input, linear.verify_weight.f16_data(), output, rows,
+                    output_rows, columns, columns, output_rows, columns),
+                    "resident FP16 verify projection");
             } else {
                 require_launch(qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
                     input, linear.weight.fp8_data(), linear.scale.f16_data(),
@@ -1049,21 +1276,37 @@ struct QwenEngine::Impl {
                     "FP8 FP16-activation projection");
             }
         } else {
-            require_launch(qwen_fp16_matmul_rows_f16_cuda(
-                input, linear.weight.f16_data(), output, rows, output_rows,
-                columns, columns, output_rows, columns),
-                "FP16 activation/weight projection");
+            // The fused DeltaNet a/b matrix is only 24 rows per TP4 rank. At
+            // verify width 8, tensor cores are ~5x faster than the generic
+            // warp-per-output-row reduction. Decode keeps its established
+            // reduction order, and wider prefill remains on the existing path.
+            const bool verify_cublas = rows >= 4 && rows <= 8 &&
+                output_rows <= 32 && columns % 8 == 0 &&
+                qwen_env_enabled_default("QWEN_VERIFY_SMALL_FP16_CUBLAS");
+            if (verify_cublas) {
+                require_launch(qwen_fp16_matmul_rows_f16_cublas_cuda(
+                    input, linear.weight.f16_data(), output, rows, output_rows,
+                    columns, columns, output_rows, columns),
+                    "small FP16 verify cuBLAS projection");
+            } else {
+                require_launch(qwen_fp16_matmul_rows_f16_cuda(
+                    input, linear.weight.f16_data(), output, rows, output_rows,
+                    columns, columns, output_rows, columns),
+                    "FP16 activation/weight projection");
+            }
         }
     }
 
     void norm(const QwenDeviceTensor& gamma, const uint16_t* input,
               uint16_t* output, int rows, int columns) {
+        PhaseScope scope(this, "norm");
         require_launch(qwen_rmsnorm_fp16_gamma_rows_f16_cuda(
             input, gamma.f16_data(), output, rows, columns,
             static_cast<float>(config.rms_norm_eps)), "Qwen FP16 RMSNorm");
     }
 
     void add(uint16_t* output, const uint16_t* input, int count) {
+        PhaseScope scope(this, "add");
         require_launch(qwen_add_inplace_f16_cuda(output, input, count),
                        "Qwen FP16 residual add");
     }
@@ -1118,7 +1361,7 @@ struct QwenEngine::Impl {
         QwenDeviceTensor& z = workspace_half(value_elements, v.shape);
         QwenDeviceTensor& normalized = workspace_half(value_elements, v.shape);
 
-        projection(layer.linear.qkv, hidden, packed.f16_data(), rows);
+        projection(layer.linear.qkv, hidden, packed.f16_data(), rows, "lin.qkv");
         require_launch(qwen_causal_depthwise_conv_silu_f16_cuda(
             packed.f16_data(), layer.linear.conv.f16_data(),
             layer.linear.conv_tail.f16_data(), convolved.f16_data(), rows,
@@ -1126,8 +1369,23 @@ struct QwenEngine::Impl {
         require_launch(qwen_split_packed_qkv_f16_cuda(
             convolved.f16_data(), q.f16_data(), k.f16_data(), v.f16_data(),
             rows, key_dim, value_dim), "FP16 linear QKV split");
-        projection(layer.linear.a, hidden, a.f16_data(), rows);
-        projection(layer.linear.b, hidden, b.f16_data(), rows);
+        if (layer.linear.ab.weight.data != nullptr &&
+            qwen_env_enabled_default("QWEN_FUSE_AB_PROJECTION")) {
+            // One GEMM over the row-concatenated [2*gate, hidden] weight. The
+            // output is [rows, 2*gate] interleaved per row, so a and b are
+            // strided slices of it rather than contiguous halves.
+            QwenDeviceTensor& ab = workspace_half(
+                gate_elements * 2,
+                {static_cast<uint64_t>(rows),
+                 static_cast<uint64_t>(value_heads * 2)});
+            projection(layer.linear.ab, hidden, ab.f16_data(), rows, "lin.ab");
+            require_launch(qwen_split_rows_pair_f16_cuda(
+                ab.f16_data(), a.f16_data(), b.f16_data(), rows, value_heads),
+                "FP16 fused a/b split");
+        } else {
+            projection(layer.linear.a, hidden, a.f16_data(), rows, "lin.a");
+            projection(layer.linear.b, hidden, b.f16_data(), rows, "lin.b");
+        }
         require_launch(qwen_linear_attn_gates_f16_cuda(
             a.f16_data(), b.f16_data(), layer.linear.a_log.f16_data(),
             layer.linear.dt_bias.f16_data(), gates.f16_data(), beta.f16_data(),
@@ -1136,12 +1394,43 @@ struct QwenEngine::Impl {
             static_cast<float>(config.linear_attention.key_head_dim));
         std::optional<PhaseScope> delta_scope;
         delta_scope.emplace(this, "gated_delta");
-        const bool sequenced = rows > 1 && qwen_gated_delta_sequence_f16_cuda(
-            layer.linear.state.f32_data(), q.f16_data(), k.f16_data(),
-            v.f16_data(), gates.f16_data(), beta.f16_data(),
-            core.f16_data(), rows, value_heads, key_heads,
-            static_cast<int>(config.linear_attention.key_head_dim),
-            static_cast<int>(config.linear_attention.value_head_dim), q_scale);
+        bool sequenced = false;
+        if (rows >= 5 && key_heads < value_heads &&
+            qwen_env_enabled_default("QWEN_GATED_DELTA_PRENORMALIZE")) {
+            QwenDeviceTensor& q_normalized = workspace_float(
+                key_elements, {static_cast<uint64_t>(rows),
+                               static_cast<uint64_t>(key_dim)});
+            QwenDeviceTensor& k_normalized = workspace_float(
+                key_elements, q_normalized.shape);
+            sequenced = qwen_normalize_gated_delta_qk_f16_cuda(
+                q.f16_data(), k.f16_data(), q_normalized.f32_data(),
+                k_normalized.f32_data(), rows, key_heads,
+                static_cast<int>(config.linear_attention.key_head_dim)) &&
+                (qwen_env_enabled("QWEN_GATED_DELTA_SHARED_STATE")
+                 ? qwen_gated_delta_sequence_normalized_shared_f16_cuda(
+                        layer.linear.state.f32_data(), q_normalized.f32_data(),
+                        k_normalized.f32_data(), v.f16_data(), gates.f16_data(),
+                        beta.f16_data(), core.f16_data(), rows, value_heads,
+                        key_heads,
+                        static_cast<int>(config.linear_attention.key_head_dim),
+                        static_cast<int>(config.linear_attention.value_head_dim),
+                        q_scale)
+                    : qwen_gated_delta_sequence_normalized_f16_cuda(
+                        layer.linear.state.f32_data(), q_normalized.f32_data(),
+                        k_normalized.f32_data(), v.f16_data(), gates.f16_data(),
+                        beta.f16_data(), core.f16_data(), rows, value_heads,
+                        key_heads,
+                        static_cast<int>(config.linear_attention.key_head_dim),
+                        static_cast<int>(config.linear_attention.value_head_dim),
+                        q_scale));
+        } else if (rows > 1) {
+            sequenced = qwen_gated_delta_sequence_f16_cuda(
+                layer.linear.state.f32_data(), q.f16_data(), k.f16_data(),
+                v.f16_data(), gates.f16_data(), beta.f16_data(),
+                core.f16_data(), rows, value_heads, key_heads,
+                static_cast<int>(config.linear_attention.key_head_dim),
+                static_cast<int>(config.linear_attention.value_head_dim), q_scale);
+        }
         for (int token = 0; !sequenced && token < rows; ++token) {
             require_launch(qwen_gated_delta_step_f16_cuda(
                 layer.linear.state.f32_data(),
@@ -1157,15 +1446,15 @@ struct QwenEngine::Impl {
                 "FP16 linear recurrent state");
         }
         delta_scope.reset();
-        projection(layer.linear.z, hidden, z.f16_data(), rows);
+        projection(layer.linear.z, hidden, z.f16_data(), rows, "lin.z");
         require_launch(qwen_gated_rmsnorm_fp16_gamma_rows_f16_cuda(
             core.f16_data(), layer.linear.norm.f16_data(), z.f16_data(),
             normalized.f16_data(), rows * value_heads,
             static_cast<int>(config.linear_attention.value_head_dim),
             static_cast<float>(config.rms_norm_eps)),
             "FP16 linear gated RMSNorm");
-        projection(layer.linear.out, normalized.f16_data(), output, rows);
-        all_reduce_half(output, rows * hidden_size);
+        projection(layer.linear.out, normalized.f16_data(), output, rows, "lin.out");
+        all_reduce_half(output, rows * hidden_size, "lin.out");
         (void)position_offset;
     }
 
@@ -1197,17 +1486,37 @@ struct QwenEngine::Impl {
                           static_cast<uint64_t>(kv_heads),
                           static_cast<uint64_t>(head_dim)});
         QwenDeviceTensor& v = workspace_half(kv_elements, k.shape);
+        QwenDeviceTensor* kv_projection = nullptr;
+        // Keep the candidate isolated to the fixed-width target verify batch;
+        // prefill and one-row decode retain their established K/V projections.
+        const bool fused_kv = rows > 1 && rows <= 8 &&
+            layer.full.kv.weight.data != nullptr;
+        if (fused_kv) {
+            kv_projection = &workspace_half(
+                static_cast<size_t>(rows) * 2 * kv_heads * head_dim,
+                {static_cast<uint64_t>(rows),
+                 static_cast<uint64_t>(2 * kv_heads * head_dim)});
+        }
         QwenDeviceTensor& q_norm = workspace_half(attention_elements, q.shape);
         QwenDeviceTensor& k_norm = workspace_half(kv_elements, k.shape);
         QwenDeviceTensor& attention = workspace_half(attention_elements, q.shape);
         QwenDeviceTensor& merged = workspace_half(attention_elements, q.shape);
 
-        projection(layer.full.q, hidden, q_projection.f16_data(), rows);
+        { PhaseScope sub(this, "full.q_proj"); projection(layer.full.q, hidden, q_projection.f16_data(), rows, "full.q"); }
+        if (fused_kv) {
+            { PhaseScope sub(this, "full.kv_proj"); projection(
+                layer.full.kv, hidden, kv_projection->f16_data(), rows,
+                "full.kv"); }
+            require_launch(qwen_split_rows_pair_f16_cuda(
+                kv_projection->f16_data(), k.f16_data(), v.f16_data(), rows,
+                kv_heads * head_dim), "FP16 fused full K/V split");
+        } else {
+            { PhaseScope sub(this, "full.k_proj"); projection(layer.full.k, hidden, k.f16_data(), rows, "full.k"); }
+            { PhaseScope sub(this, "full.v_proj"); projection(layer.full.v, hidden, v.f16_data(), rows, "full.v"); }
+        }
         require_launch(qwen_split_q_gate_f16_cuda(
             q_projection.f16_data(), q.f16_data(), gate.f16_data(), rows,
             q_heads, head_dim), "FP16 full Q/gate split");
-        projection(layer.full.k, hidden, k.f16_data(), rows);
-        projection(layer.full.v, hidden, v.f16_data(), rows);
         norm(layer.full.q_norm, q.f16_data(), q_norm.f16_data(),
              rows * q_heads, head_dim);
         norm(layer.full.k_norm, k.f16_data(), k_norm.f16_data(),
@@ -1298,12 +1607,39 @@ struct QwenEngine::Impl {
                 max_context), "prefill FP8-cache GQA");
         } else if (rows <= 8 && attention_window == 0) {
             const int context_length = position_offset + rows;
-            if (qwen_env_enabled("QWEN_GQA_VERIFY_SPLIT")) {
-                const int verify_target_positions =
-                    qwen_env_int("QWEN_GQA_VERIFY_TILE", 64);
-                const int verify_splits = std::max(1, std::min(
-                    64, (context_length + verify_target_positions - 1) /
-                            verify_target_positions));
+            // Tensor-core QK experiment for the real TP4 shape (one KV head per
+            // rank). Keeps the existing FP32 softmax/PV order; opt-in until real
+            // parity and latency are validated.
+            if (qwen_env_enabled("QWEN_GQA_VERIFY_CUBLAS_QK") &&
+                kv_heads == 1) {
+                const size_t score_elements =
+                    static_cast<size_t>(rows) * q_heads * context_length;
+                QwenDeviceTensor& scores = workspace_float(
+                    score_elements,
+                    {static_cast<uint64_t>(rows),
+                     static_cast<uint64_t>(q_heads),
+                     static_cast<uint64_t>(context_length)});
+                PhaseScope sub(this, "full.attn_kernel");
+                require_launch(qwen_gqa_verify_attention_f16_cublas_qk_cuda(
+                    q_norm.f16_data(), layer.full.k_cache.f16_data(),
+                    layer.full.v_cache.f16_data(), attention.f16_data(),
+                    scores.f32_data(), rows, q_heads, kv_heads, head_dim,
+                    position_offset, max_context),
+                    "verify cuBLAS-QK FP16-cache GQA");
+            // The exact three-kernel path avoids split partials below 1K context;
+            // the split-K path crosses over above that and remains faster at long
+            // context. QWEN_GQA_VERIFY_SPLIT explicitly overrides the crossover.
+            } else if ((std::getenv("QWEN_GQA_VERIFY_SPLIT") != nullptr
+                            ? qwen_env_enabled("QWEN_GQA_VERIFY_SPLIT")
+                            : context_length > 1024)) {
+                // 32 splits stay slightly faster end-to-end at short context;
+                // 64 cross over at 1K and remain best through 32K.
+                const int default_splits = context_length >= 1024 ? 64 : 32;
+                int target_splits = qwen_env_int(
+                    "QWEN_GQA_VERIFY_SPLITS", default_splits);
+                if (target_splits <= 0) target_splits = default_splits;
+                const int verify_splits = std::max(
+                    1, std::min(target_splits, context_length));
                 const size_t partial_elements =
                     static_cast<size_t>(rows) * q_heads * verify_splits *
                     static_cast<size_t>(head_dim + 2);
@@ -1313,6 +1649,7 @@ struct QwenEngine::Impl {
                      static_cast<uint64_t>(q_heads),
                      static_cast<uint64_t>(verify_splits),
                      static_cast<uint64_t>(head_dim + 2)});
+                PhaseScope sub(this, "full.attn_kernel");
                 require_launch(qwen_gqa_verify_attention_f16_cuda(
                     q_norm.f16_data(), layer.full.k_cache.f16_data(),
                     layer.full.v_cache.f16_data(), attention.f16_data(),
@@ -1327,12 +1664,12 @@ struct QwenEngine::Impl {
                     {static_cast<uint64_t>(rows),
                      static_cast<uint64_t>(q_heads),
                      static_cast<uint64_t>(context_length)});
-                require_launch(qwen_gqa_verify_attention_f16_exact_cuda(
+                { PhaseScope sub(this, "full.attn_kernel"); require_launch(qwen_gqa_verify_attention_f16_exact_cuda(
                     q_norm.f16_data(), layer.full.k_cache.f16_data(),
                     layer.full.v_cache.f16_data(), attention.f16_data(),
                     scores.f32_data(), rows, q_heads, kv_heads, head_dim,
                     position_offset, max_context),
-                    "verify exact FP16-cache GQA");
+                    "verify exact FP16-cache GQA"); }
             }
         } else if (qwen_env_enabled("DSV4_QWEN_GQA_OPTIMIZED") ||
                    attention_window > 0) {
@@ -1352,8 +1689,8 @@ struct QwenEngine::Impl {
         require_launch(qwen_sigmoid_mul_f16_cuda(
             attention.f16_data(), gate.f16_data(), merged.f16_data(),
             rows * attention_dim), "FP16 full attention output gate");
-        projection(layer.full.out, merged.f16_data(), output, rows);
-        all_reduce_half(output, rows * static_cast<int>(config.hidden_size));
+        { PhaseScope sub(this, "full.out_proj"); projection(layer.full.out, merged.f16_data(), output, rows, "full.out"); }
+        all_reduce_half(output, rows * static_cast<int>(config.hidden_size), "full.out");
     }
 
     void layer_forward(DeviceLayer& layer, const uint16_t* hidden,
@@ -1394,12 +1731,26 @@ struct QwenEngine::Impl {
             full_attention(layer, normalized.f16_data(), attention.f16_data(),
                            rows, position_offset);
         }
-        check_cuda(cudaMemcpy(output, hidden,
-            hidden_elements * sizeof(uint16_t), cudaMemcpyDeviceToDevice),
-            "Qwen FP16 residual copy");
-        add(output, attention.f16_data(), rows * hidden_size);
-        norm(layer.post_norm, output, post.f16_data(), rows, hidden_size);
+        if (qwen_env_enabled("QWEN_FUSE_ATTN_RESID_NORM")) {
+            PhaseScope scope(this, "attn_resid_norm");
+            require_launch(
+                qwen_residual_add_rmsnorm_fp16_gamma_rows_f16_cuda(
+                    hidden, attention.f16_data(), layer.post_norm.f16_data(),
+                    output, post.f16_data(), rows, hidden_size,
+                    static_cast<float>(config.rms_norm_eps)),
+                "Qwen fused attention residual RMSNorm");
+        } else {
+            {
+                PhaseScope scope(this, "resid_copy");
+                check_cuda(cudaMemcpy(output, hidden,
+                    hidden_elements * sizeof(uint16_t), cudaMemcpyDeviceToDevice),
+                    "Qwen FP16 residual copy");
+            }
+            add(output, attention.f16_data(), rows * hidden_size);
+            norm(layer.post_norm, output, post.f16_data(), rows, hidden_size);
+        }
         if (fused_decode_swiglu) {
+            PhaseScope scope(this, "swiglu.d");
             require_launch(qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
                 post.f16_data(), layer.gate.weight.fp8_data(),
                 layer.gate.scale.f16_data(), layer.up.weight.fp8_data(),
@@ -1408,6 +1759,7 @@ struct QwenEngine::Impl {
                 hidden_size, static_cast<int>(layer.gate.scale.shape[1])),
                 "FP16 fused decode SwiGLU");
         } else if (fused_small_batch_swiglu) {
+            PhaseScope scope(this, "swiglu.r");
             require_launch(
                 qwen_fp8_e4m3_fp16scale_swiglu_small_batch_f16_cuda(
                     post.f16_data(), layer.gate.weight.fp8_data(),
@@ -1418,14 +1770,14 @@ struct QwenEngine::Impl {
                     hidden_size, static_cast<int>(layer.gate.scale.shape[1])),
                 "FP16 fused small-batch SwiGLU");
         } else {
-            projection(layer.gate, post.f16_data(), gate->f16_data(), rows);
-            projection(layer.up, post.f16_data(), up->f16_data(), rows);
+            projection(layer.gate, post.f16_data(), gate->f16_data(), rows, "mlp.gate");
+            projection(layer.up, post.f16_data(), up->f16_data(), rows, "mlp.up");
             require_launch(qwen_silu_mul_rows_f16_cuda(
                 gate->f16_data(), up->f16_data(), intermediate.f16_data(), rows,
                 static_cast<int>(layer.gate.weight.shape[0])), "FP16 SwiGLU");
         }
-        projection(layer.down, intermediate.f16_data(), mlp.f16_data(), rows);
-        all_reduce_half(mlp.f16_data(), rows * hidden_size);
+        projection(layer.down, intermediate.f16_data(), mlp.f16_data(), rows, "mlp.down");
+        all_reduce_half(mlp.f16_data(), rows * hidden_size, "mlp");
         add(output, mlp.f16_data(), rows * hidden_size);
     }
 
@@ -1576,18 +1928,24 @@ struct QwenEngine::Impl {
         QwenDeviceTensor& local_logits = workspace_float(
             static_cast<size_t>(rows) * local_vocab,
             {static_cast<uint64_t>(rows), static_cast<uint64_t>(local_vocab)});
+        // The hand-rolled matvec wins at rows==1, but cuBLAS is far better once
+        // the LM head GEMM is batched: verify measured 57.6 vs 70.2 ms/step at
+        // 8192 context. Set QWEN_FP16_LOGITS_CUBLAS=0 to force the custom kernel.
         const bool cublas_logits = rows > 1 &&
-            qwen_env_enabled("QWEN_FP16_LOGITS_CUBLAS");
-        require_launch(cublas_logits
-            ? qwen_fp16_matmul_rows_f16_f32_cublas_cuda(
-                  normalized.f16_data(), lm_head.f16_data(),
-                  local_logits.f32_data(), rows, local_vocab, hidden_size,
-                  hidden_size, local_vocab, hidden_size)
-            : qwen_fp16_matmul_rows_f16_f32_cuda(
-                  normalized.f16_data(), lm_head.f16_data(),
-                  local_logits.f32_data(), rows, local_vocab, hidden_size,
-                  hidden_size, local_vocab, hidden_size),
-            "Qwen batched FP32 logits");
+            qwen_env_enabled_default("QWEN_FP16_LOGITS_CUBLAS");
+        {
+            PhaseScope scope(this, rows == 1 ? "lmhead.d" : "lmhead.r");
+            require_launch(cublas_logits
+                ? qwen_fp16_matmul_rows_f16_f32_cublas_cuda(
+                      normalized.f16_data(), lm_head.f16_data(),
+                      local_logits.f32_data(), rows, local_vocab, hidden_size,
+                      hidden_size, local_vocab, hidden_size)
+                : qwen_fp16_matmul_rows_f16_f32_cuda(
+                      normalized.f16_data(), lm_head.f16_data(),
+                      local_logits.f32_data(), rows, local_vocab, hidden_size,
+                      hidden_size, local_vocab, hidden_size),
+                "Qwen batched FP32 logits");
+        }
         allocate(argmax_token, static_cast<size_t>(rows) * sizeof(int),
                  {static_cast<uint64_t>(rows)}, SafeDType::I64);
         allocate_float(argmax_logit, static_cast<size_t>(rows),
@@ -1602,10 +1960,13 @@ struct QwenEngine::Impl {
                                      vocab_start, position_after);
         }
 
-        require_launch(argmax_fp32_rows_cuda(
-            local_logits.f32_data(), static_cast<int*>(argmax_token.data),
-            argmax_logit.f32_data(), rows, local_vocab, vocab_start),
-            "Qwen batched local argmax");
+        {
+            PhaseScope scope(this, "argmax");
+            require_launch(argmax_fp32_rows_cuda(
+                local_logits.f32_data(), static_cast<int*>(argmax_token.data),
+                argmax_logit.f32_data(), rows, local_vocab, vocab_start),
+                "Qwen batched local argmax");
+        }
 
         QwenVerifyBatch result;
         result.top_tokens.resize(static_cast<size_t>(rows));
@@ -1617,12 +1978,60 @@ struct QwenEngine::Impl {
             if (options.nccl_id_path.empty()) {
                 throw std::runtime_error("Qwen TP requires --nccl-id-path");
             }
-            nccl_global_top1_rows(
-                options.tp_world, options.tp_rank, options.device,
-                options.nccl_id_path.c_str(),
-                static_cast<const int*>(argmax_token.data),
-                argmax_logit.f32_data(), rows, result.top_tokens.data(),
-                result.top_logits.data());
+            const bool device_top1 = qwen_env_enabled("QWEN_VERIFY_DEVICE_TOP1");
+            const bool packed_device_top1 = device_top1 &&
+                qwen_env_enabled("QWEN_VERIFY_DEVICE_TOP1_PACKED");
+            {
+                PhaseScope scope(this, device_top1
+                    ? (packed_device_top1 ? "top1_packed_merge"
+                                          : "top1_device_merge")
+                    : "top1_allreduce");
+                if (device_top1) {
+                    // Keep local argmax values intact for `local_logits`; the
+                    // merged result has separate workspace buffers because the
+                    // verifier reports both local and global TP logits.
+                    QwenDeviceTensor& global_token = workspace.tensor(
+                        static_cast<size_t>(rows),
+                        {static_cast<uint64_t>(rows)}, SafeDType::I64);
+                    QwenDeviceTensor& global_logit = workspace_float(
+                        static_cast<size_t>(rows),
+                        {static_cast<uint64_t>(rows)});
+                    if (packed_device_top1) {
+                        nccl_global_top1_rows_packed_device(
+                            options.tp_world, options.tp_rank, options.device,
+                            options.nccl_id_path.c_str(),
+                            static_cast<const int*>(argmax_token.data),
+                            argmax_logit.f32_data(), rows,
+                            static_cast<int*>(global_token.data),
+                            global_logit.f32_data());
+                    } else {
+                        nccl_global_top1_rows_device(
+                            options.tp_world, options.tp_rank, options.device,
+                            options.nccl_id_path.c_str(),
+                            static_cast<const int*>(argmax_token.data),
+                            argmax_logit.f32_data(), rows,
+                            static_cast<int*>(global_token.data),
+                            global_logit.f32_data());
+                    }
+                    check_cuda(cudaMemcpy(result.top_tokens.data(),
+                                          global_token.data,
+                                          static_cast<size_t>(rows) * sizeof(int),
+                                          cudaMemcpyDeviceToHost),
+                               "Qwen device top-1 token copy");
+                    check_cuda(cudaMemcpy(result.top_logits.data(),
+                                          global_logit.data,
+                                          static_cast<size_t>(rows) * sizeof(float),
+                                          cudaMemcpyDeviceToHost),
+                               "Qwen device top-1 logit copy");
+                } else {
+                    nccl_global_top1_rows(
+                        options.tp_world, options.tp_rank, options.device,
+                        options.nccl_id_path.c_str(),
+                        static_cast<const int*>(argmax_token.data),
+                        argmax_logit.f32_data(), rows, result.top_tokens.data(),
+                        result.top_logits.data());
+                }
+            }
             check_cuda(cudaMemcpy(result.local_logits.data(), argmax_logit.data,
                                   static_cast<size_t>(rows) * sizeof(float),
                                   cudaMemcpyDeviceToHost),
@@ -1712,7 +2121,7 @@ struct QwenEngine::Impl {
             mtp_embedding.f16_data(), rows, hidden_size,
             static_cast<int>(weights_vocab_start()),
             static_cast<int>(embed.shape[0])), "Qwen MTP embedding lookup");
-        all_reduce_half(mtp_embedding.f16_data(), rows * hidden_size);
+        all_reduce_half(mtp_embedding.f16_data(), rows * hidden_size, "mtp.emb");
 
         allocate_half(mtp_normalized_embedding, hidden_elements, hidden_shape);
         allocate_half(mtp_normalized_hidden, hidden_elements, hidden_shape);
@@ -1728,7 +2137,7 @@ struct QwenEngine::Impl {
             mtp_normalized_hidden.f16_data(), mtp_concat.f16_data(), rows,
             hidden_size), "Qwen MTP fusion concat");
         allocate_half(mtp_fused, hidden_elements, hidden_shape);
-        projection(mtp_fc, mtp_concat.f16_data(), mtp_fused.f16_data(), rows);
+        projection(mtp_fc, mtp_concat.f16_data(), mtp_fused.f16_data(), rows, "mtp.fc");
         allocate_half(mtp_next_hidden, hidden_elements, hidden_shape);
         layer_forward(mtp_layer, mtp_fused.f16_data(),
                       mtp_next_hidden.f16_data(), rows, position);
@@ -1936,7 +2345,11 @@ struct QwenEngine::Impl {
         const int committed_position = dspark->committed_position();
         prepare_transaction_state();
         const auto draft_started = std::chrono::steady_clock::now();
-        const QwenDSparkProposal proposal = dspark->propose(input_token);
+        QwenDSparkProposal proposal;
+        {
+            NvtxScope scope("qwen.dspark.draft");
+            proposal = dspark->propose(input_token);
+        }
         if (stats != nullptr) {
             stats->draft_seconds += std::chrono::duration<double>(
                 std::chrono::steady_clock::now() - draft_started).count();
@@ -1966,8 +2379,11 @@ struct QwenEngine::Impl {
                              proposal.tokens.end());
         QwenVerifyBatch verify;
         const auto verify_started = std::chrono::steady_clock::now();
-        (void)run_chunk(verify_inputs, committed_position,
-                        static_cast<int>(layers.size()), false, &verify);
+        {
+            NvtxScope scope("qwen.target.verify");
+            (void)run_chunk(verify_inputs, committed_position,
+                            static_cast<int>(layers.size()), false, &verify);
+        }
         if (stats != nullptr) {
             stats->verify_seconds += std::chrono::duration<double>(
                 std::chrono::steady_clock::now() - verify_started).count();
@@ -2136,7 +2552,7 @@ struct QwenEngine::Impl {
             hidden_a.f16_data(), rows, hidden_size,
             static_cast<int>(weights_vocab_start()),
             static_cast<int>(embed.shape[0])), "Qwen FP16 embedding lookup");
-        all_reduce_half(hidden_a.f16_data(), rows * hidden_size);
+        all_reduce_half(hidden_a.f16_data(), rows * hidden_size, "hidden_a");
         uint16_t* hidden = hidden_a.f16_data();
         uint16_t* output = hidden_b.f16_data();
         const int dspark_tap_count = dspark_enabled
@@ -2164,8 +2580,11 @@ struct QwenEngine::Impl {
         int dspark_tap_index = 0;
         int dflash2_tap_index = 0;
         for (int layer_index = 0; layer_index < active_layers; ++layer_index) {
-            layer_forward(layers[static_cast<size_t>(layer_index)], hidden,
-                          output, rows, position_offset);
+            {
+                PhaseScope scope(this, rows == 1 ? "STACK.d" : "STACK.r");
+                layer_forward(layers[static_cast<size_t>(layer_index)], hidden,
+                              output, rows, position_offset);
+            }
             std::swap(hidden, output);
             if (dspark_enabled && dspark_tap_index < dspark_tap_count &&
                 layer_index == dspark_config->target_layer_ids[
@@ -2370,6 +2789,10 @@ QwenEngine::~QwenEngine() {
     impl_ = nullptr;
 }
 
+uint64_t QwenEngine::verify_weight_bytes() const {
+    return impl_->verify_weight_bytes;
+}
+
 uint64_t QwenEngine::activation_workspace_peak_bytes() const {
     return impl_->activation_capacity_bytes();
 }
@@ -2424,7 +2847,7 @@ void QwenEngine::warmup_tp() {
     QwenDeviceTensor scratch;
     allocate_half(scratch, 1, {1});
     zero_tensor(scratch);
-    impl_->all_reduce_half(scratch.f16_data(), 1);
+    impl_->all_reduce_half(scratch.f16_data(), 1, "scratch");
     check_cuda(cudaDeviceSynchronize(), "Qwen TP warmup synchronization");
 }
 

--- a/cpp_engine/src/tp_comm.cpp
+++ b/cpp_engine/src/tp_comm.cpp
@@ -8,10 +8,11 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
+#include <climits>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
-#include <cmath>
 #include <iostream>
 #include <stdexcept>
 #include <thread>
@@ -85,6 +86,11 @@ struct Top1RowsWorkspace {
     size_t capacity = 0;
 };
 
+struct PackedTop1RowsWorkspace {
+    uint64_t* d_keys = nullptr;
+    size_t capacity = 0;
+};
+
 struct TopKRowsWorkspace {
     int* d_tokens = nullptr;
     float* d_logits = nullptr;
@@ -133,6 +139,44 @@ Top1RowsWorkspace& top1_rows_workspace(int device, size_t count) {
     return workspace;
 }
 
+PackedTop1RowsWorkspace& packed_top1_rows_workspace(int device, size_t count) {
+    static std::unordered_map<int, PackedTop1RowsWorkspace> workspaces;
+    PackedTop1RowsWorkspace& workspace = workspaces[device];
+    if (workspace.capacity >= count) return workspace;
+    check_cuda(cudaSetDevice(device), "cudaSetDevice packed top1 workspace");
+    if (workspace.d_keys != nullptr) {
+        check_cuda(cudaFree(workspace.d_keys), "cudaFree packed top1 keys");
+        workspace.d_keys = nullptr;
+    }
+    check_cuda(cudaMalloc(&workspace.d_keys, count * sizeof(uint64_t)),
+               "cudaMalloc packed top1 keys");
+    workspace.capacity = count;
+    return workspace;
+}
+
+void nccl_all_reduce_max_u64(ncclComm_t comm, uint64_t* d_values, int count,
+                             cudaStream_t stream) {
+    check_nccl(ncclAllReduce(d_values, d_values, count, ncclUint64, ncclMax,
+                             comm, stream), "ncclAllReduce packed top1");
+}
+
+void unpack_packed_top1(uint64_t* d_keys, int* d_tokens, float* d_logits,
+                        int rows, cudaStream_t stream) {
+    if (!qwen_dflash2_unpack_top1_key_f32_cuda(
+            d_keys, d_tokens, d_logits, rows, stream)) {
+        throw std::runtime_error("Qwen packed top-1 unpack launch failed");
+    }
+}
+
+void pack_top1(const int* d_tokens, const float* d_logits, uint64_t* d_keys,
+               int rows, cudaStream_t stream) {
+    if (!qwen_dflash2_pack_top1_key_f32_cuda(
+            d_tokens, d_logits, d_keys, rows, stream)) {
+        throw std::runtime_error("Qwen packed top-1 pack launch failed");
+    }
+}
+
+
 ncclComm_t cached_comm(int world, int rank, int device, const char* id_path) {
     static std::unordered_map<std::string, CachedComm> comms;
     const std::string key = std::to_string(world) + ":" + std::to_string(rank) + ":" + std::to_string(device) + ":" + id_path;
@@ -172,7 +216,8 @@ void run_nccl_float_sum_smoke(int world, int rank, int device, const char* id_pa
 void nccl_global_topk_rows(int world, int rank, int device, const char* id_path,
                            const int* d_local_tokens,
                            const float* d_local_logits, int rows, int top_k,
-                           int* global_tokens, float* global_logits) {
+                           int* global_tokens, float* global_logits,
+                           void* stream) {
     if (world <= 0 || rank < 0 || rank >= world || rows <= 0 || top_k <= 0 ||
         d_local_tokens == nullptr || d_local_logits == nullptr ||
         global_tokens == nullptr || global_logits == nullptr) {
@@ -181,23 +226,30 @@ void nccl_global_topk_rows(int world, int rank, int device, const char* id_path,
     ncclComm_t comm = cached_comm(world, rank, device, id_path);
     const size_t local_count = static_cast<size_t>(rows) * top_k;
     const size_t gathered_count = static_cast<size_t>(world) * local_count;
-    Top1RowsWorkspace& workspace = top1_rows_workspace(device, gathered_count);
+    TopKRowsWorkspace& workspace = topk_rows_workspace(device, gathered_count);
+    const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
     check_nccl(ncclGroupStart(), "ncclGroupStart batched top-k");
     check_nccl(ncclAllGather(d_local_tokens, workspace.d_tokens, local_count,
-                             ncclInt32, comm, nullptr),
+                             ncclInt32, comm, cuda_stream),
                "ncclAllGather batched top-k tokens");
     check_nccl(ncclAllGather(d_local_logits, workspace.d_logits, local_count,
-                             ncclFloat, comm, nullptr),
+                             ncclFloat, comm, cuda_stream),
                "ncclAllGather batched top-k logits");
     check_nccl(ncclGroupEnd(), "ncclGroupEnd batched top-k");
+    check_cuda(cudaStreamSynchronize(cuda_stream),
+               "sync gathered batched top-k");
     std::vector<int> all_tokens(gathered_count);
     std::vector<float> all_logits(gathered_count);
-    check_cuda(cudaMemcpy(all_tokens.data(), workspace.d_tokens,
-                          gathered_count * sizeof(int), cudaMemcpyDeviceToHost),
+    check_cuda(cudaMemcpyAsync(all_tokens.data(), workspace.d_tokens,
+                               gathered_count * sizeof(int),
+                               cudaMemcpyDeviceToHost, cuda_stream),
                "copy gathered batched top-k tokens");
-    check_cuda(cudaMemcpy(all_logits.data(), workspace.d_logits,
-                          gathered_count * sizeof(float), cudaMemcpyDeviceToHost),
+    check_cuda(cudaMemcpyAsync(all_logits.data(), workspace.d_logits,
+                               gathered_count * sizeof(float),
+                               cudaMemcpyDeviceToHost, cuda_stream),
                "copy gathered batched top-k logits");
+    check_cuda(cudaStreamSynchronize(cuda_stream),
+               "sync copied batched top-k");
     for (int row = 0; row < rows; ++row) {
         std::vector<std::pair<float, int>> candidates;
         candidates.reserve(static_cast<size_t>(world) * top_k);
@@ -227,7 +279,7 @@ void nccl_global_topk_rows_device(int world, int rank, int device,
                                   const int* d_local_tokens,
                                   const float* d_local_logits, int rows,
                                   int top_k, int* d_global_tokens,
-                                  float* d_global_logits) {
+                                  float* d_global_logits, void* stream) {
     if (world <= 0 || rank < 0 || rank >= world || rows <= 0 || top_k <= 0 ||
         d_local_tokens == nullptr || d_local_logits == nullptr ||
         d_global_tokens == nullptr || d_global_logits == nullptr) {
@@ -235,59 +287,123 @@ void nccl_global_topk_rows_device(int world, int rank, int device,
     }
     check_cuda(cudaSetDevice(device), "cudaSetDevice device top-k");
     ncclComm_t comm = cached_comm(world, rank, device, id_path);
+    const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
     const size_t local_count = static_cast<size_t>(rows) * top_k;
     const size_t gathered_count = static_cast<size_t>(world) * local_count;
     TopKRowsWorkspace& workspace = topk_rows_workspace(device, gathered_count);
     check_nccl(ncclGroupStart(), "ncclGroupStart device top-k");
     check_nccl(ncclAllGather(d_local_tokens, workspace.d_tokens, local_count,
-                             ncclInt32, comm, nullptr),
+                             ncclInt32, comm, cuda_stream),
                "ncclAllGather device top-k tokens");
     check_nccl(ncclAllGather(d_local_logits, workspace.d_logits, local_count,
-                             ncclFloat, comm, nullptr),
+                             ncclFloat, comm, cuda_stream),
                "ncclAllGather device top-k logits");
     check_nccl(ncclGroupEnd(), "ncclGroupEnd device top-k");
     if (!qwen_dflash2_merge_topk_f32_cuda(
             workspace.d_tokens, workspace.d_logits, d_global_tokens,
-            d_global_logits, world, rows, top_k)) {
+            d_global_logits, world, rows, top_k, cuda_stream)) {
         throw std::runtime_error("Qwen DFlash2 device top-k merge launch failed");
     }
+}
+
+void nccl_global_top1_rows_device(int world, int rank, int device,
+                                  const char* id_path,
+                                  const int* d_local_tokens,
+                                  const float* d_local_logits, int rows,
+                                  int* d_global_tokens,
+                                  float* d_global_logits, void* stream) {
+    if (world <= 0 || rank < 0 || rank >= world || rows <= 0 ||
+        d_local_tokens == nullptr || d_local_logits == nullptr ||
+        d_global_tokens == nullptr || d_global_logits == nullptr) {
+        throw std::runtime_error("invalid NCCL device top args");
+    }
+    check_cuda(cudaSetDevice(device), "cudaSetDevice device top");
+    ncclComm_t comm = cached_comm(world, rank, device, id_path);
+    const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
+    const size_t gathered_count = static_cast<size_t>(world) * rows;
+    Top1RowsWorkspace& workspace = top1_rows_workspace(device, gathered_count);
+    check_nccl(ncclGroupStart(), "ncclGroupStart device top");
+    check_nccl(ncclAllGather(d_local_tokens, workspace.d_tokens, rows,
+                             ncclInt32, comm, cuda_stream),
+               "ncclAllGather device top tokens");
+    check_nccl(ncclAllGather(d_local_logits, workspace.d_logits, rows,
+                             ncclFloat, comm, cuda_stream),
+               "ncclAllGather device top logits");
+    check_nccl(ncclGroupEnd(), "ncclGroupEnd device top");
+    if (!qwen_dflash2_merge_topk_f32_cuda(
+            workspace.d_tokens, workspace.d_logits, d_global_tokens,
+            d_global_logits, world, rows, 1, cuda_stream)) {
+        throw std::runtime_error("Qwen device top-1 merge launch failed");
+    }
+}
+
+void nccl_global_top1_rows_packed_device(
+    int world, int rank, int device, const char* id_path,
+    const int* d_local_tokens, const float* d_local_logits, int rows,
+    int* d_global_tokens, float* d_global_logits, void* stream) {
+    if (world <= 0 || rank < 0 || rank >= world || rows <= 0 ||
+        d_local_tokens == nullptr || d_local_logits == nullptr ||
+        d_global_tokens == nullptr || d_global_logits == nullptr) {
+        throw std::runtime_error("invalid NCCL packed device top args");
+    }
+    check_cuda(cudaSetDevice(device), "cudaSetDevice packed device top");
+    ncclComm_t comm = cached_comm(world, rank, device, id_path);
+    const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
+    PackedTop1RowsWorkspace& workspace =
+        packed_top1_rows_workspace(device, static_cast<size_t>(rows));
+    pack_top1(d_local_tokens, d_local_logits, workspace.d_keys, rows,
+              cuda_stream);
+    nccl_all_reduce_max_u64(comm, workspace.d_keys, rows, cuda_stream);
+    unpack_packed_top1(workspace.d_keys, d_global_tokens, d_global_logits,
+                       rows, cuda_stream);
 }
 
 void nccl_global_top1_rows(int world, int rank, int device, const char* id_path,
                            const int* d_local_tokens,
                            const float* d_local_logits, int rows,
-                           int* global_tokens, float* global_logits) {
+                           int* global_tokens, float* global_logits,
+                           void* stream) {
     if (world <= 0 || rank < 0 || rank >= world || rows <= 0 ||
         d_local_tokens == nullptr || d_local_logits == nullptr ||
         global_tokens == nullptr || global_logits == nullptr) {
         throw std::runtime_error("invalid NCCL batched top args");
     }
     ncclComm_t comm = cached_comm(world, rank, device, id_path);
+    const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
     const size_t gathered_count = static_cast<size_t>(world) * rows;
     Top1RowsWorkspace& workspace = top1_rows_workspace(device, gathered_count);
     check_nccl(ncclGroupStart(), "ncclGroupStart batched top");
     check_nccl(ncclAllGather(d_local_tokens, workspace.d_tokens, rows, ncclInt32,
-                             comm, nullptr),
+                             comm, cuda_stream),
                "ncclAllGather batched top tokens");
     check_nccl(ncclAllGather(d_local_logits, workspace.d_logits, rows, ncclFloat,
-                             comm, nullptr),
+                             comm, cuda_stream),
                "ncclAllGather batched top logits");
     check_nccl(ncclGroupEnd(), "ncclGroupEnd batched top");
+    check_cuda(cudaStreamSynchronize(cuda_stream), "sync gathered batched top");
     std::vector<int> all_tokens(gathered_count);
     std::vector<float> all_logits(gathered_count);
-    check_cuda(cudaMemcpy(all_tokens.data(), workspace.d_tokens,
-                          gathered_count * sizeof(int), cudaMemcpyDeviceToHost),
+    check_cuda(cudaMemcpyAsync(all_tokens.data(), workspace.d_tokens,
+                               gathered_count * sizeof(int),
+                               cudaMemcpyDeviceToHost, cuda_stream),
                "copy gathered batched top tokens");
-    check_cuda(cudaMemcpy(all_logits.data(), workspace.d_logits,
-                          gathered_count * sizeof(float), cudaMemcpyDeviceToHost),
+    check_cuda(cudaMemcpyAsync(all_logits.data(), workspace.d_logits,
+                               gathered_count * sizeof(float),
+                               cudaMemcpyDeviceToHost, cuda_stream),
                "copy gathered batched top logits");
+    check_cuda(cudaStreamSynchronize(cuda_stream), "sync copied batched top");
+
+    // The device-resident sibling below uses the same gathered layout and
+    // comparator. Keep this synchronous API's CPU merge for compatibility.
+    if (rows <= 0) return;
     for (int row = 0; row < rows; ++row) {
         float best_logit = -INFINITY;
-        int best_token = 0;
+        int best_token = INT_MAX;
         for (int r = 0; r < world; ++r) {
             const size_t at = static_cast<size_t>(r) * rows + row;
             const float logit = all_logits[at];
             const int token = all_tokens[at];
+            if (std::isnan(logit)) continue;
             if (logit > best_logit ||
                 (logit == best_logit && token < best_token)) {
                 best_logit = logit;
@@ -299,22 +415,25 @@ void nccl_global_top1_rows(int world, int rank, int device, const char* id_path,
     }
 }
 
-void nccl_all_reduce_sum_float_inplace(int world, int rank, int device, const char* id_path, float* d_values, int count) {
+void nccl_all_reduce_sum_float_inplace(int world, int rank, int device, const char* id_path, float* d_values, int count, void* stream) {
     if (world <= 0 || rank < 0 || rank >= world || d_values == nullptr || count <= 0) throw std::runtime_error("invalid NCCL all-reduce args");
     ncclComm_t comm = cached_comm(world, rank, device, id_path);
-    check_nccl(ncclAllReduce(d_values, d_values, count, ncclFloat, ncclSum, comm, nullptr), "ncclAllReduce inplace");
+    check_nccl(ncclAllReduce(d_values, d_values, count, ncclFloat, ncclSum, comm,
+                             static_cast<cudaStream_t>(stream)), "ncclAllReduce inplace");
 }
 
-void nccl_all_reduce_sum_f16_inplace(int world, int rank, int device, const char* id_path, uint16_t* d_values, int count) {
+void nccl_all_reduce_sum_f16_inplace(int world, int rank, int device, const char* id_path, uint16_t* d_values, int count, void* stream) {
     if (world <= 0 || rank < 0 || rank >= world || d_values == nullptr || count <= 0) throw std::runtime_error("invalid NCCL fp16 all-reduce args");
     ncclComm_t comm = cached_comm(world, rank, device, id_path);
-    check_nccl(ncclAllReduce(d_values, d_values, count, ncclHalf, ncclSum, comm, nullptr), "ncclAllReduce fp16 inplace");
+    check_nccl(ncclAllReduce(d_values, d_values, count, ncclHalf, ncclSum, comm,
+                             static_cast<cudaStream_t>(stream)), "ncclAllReduce fp16 inplace");
 }
 
-void nccl_all_reduce_sum_bf16_inplace(int world, int rank, int device, const char* id_path, uint16_t* d_values, int count) {
+void nccl_all_reduce_sum_bf16_inplace(int world, int rank, int device, const char* id_path, uint16_t* d_values, int count, void* stream) {
     if (world <= 0 || rank < 0 || rank >= world || d_values == nullptr || count <= 0) throw std::runtime_error("invalid NCCL bf16 all-reduce args");
     ncclComm_t comm = cached_comm(world, rank, device, id_path);
-    check_nccl(ncclAllReduce(d_values, d_values, count, ncclBfloat16, ncclSum, comm, nullptr), "ncclAllReduce bf16 inplace");
+    check_nccl(ncclAllReduce(d_values, d_values, count, ncclBfloat16, ncclSum, comm,
+                             static_cast<cudaStream_t>(stream)), "ncclAllReduce bf16 inplace");
 }
 
 void nccl_broadcast_int32(int world, int rank, int device, const char* id_path, int32_t* buf, int count, int root) {

--- a/cpp_engine/tests/bench_qwen_delta_f16.cpp
+++ b/cpp_engine/tests/bench_qwen_delta_f16.cpp
@@ -1,0 +1,161 @@
+#include "qwen_cuda_ops.hpp"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <vector>
+
+namespace {
+
+void check(cudaError_t status, const char* what) {
+    if (status != cudaSuccess) {
+        std::fprintf(stderr, "%s: %s\n", what, cudaGetErrorString(status));
+        std::exit(1);
+    }
+}
+
+uint16_t to_half(float value) {
+    const __half h = __float2half(value);
+    uint16_t bits;
+    std::memcpy(&bits, &h, sizeof(bits));
+    return bits;
+}
+
+template <typename Launch>
+double time_launch(Launch launch, int iters) {
+    if (!launch()) std::exit(1);
+    check(cudaDeviceSynchronize(), "warmup");
+    cudaEvent_t start = nullptr;
+    cudaEvent_t stop = nullptr;
+    check(cudaEventCreate(&start), "create start");
+    check(cudaEventCreate(&stop), "create stop");
+    check(cudaEventRecord(start), "record start");
+    for (int i = 0; i < iters; ++i) {
+        if (!launch()) std::exit(1);
+    }
+    check(cudaEventRecord(stop), "record stop");
+    check(cudaEventSynchronize(stop), "sync stop");
+    float elapsed = 0.0f;
+    check(cudaEventElapsedTime(&elapsed, start, stop), "elapsed");
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+    return elapsed / iters;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    int rows = 8;
+    int iters = 1000;
+    if (argc > 1) rows = std::atoi(argv[1]);
+    if (argc > 2) iters = std::atoi(argv[2]);
+    constexpr int kHeads = 12;
+    constexpr int kKeyHeads = 4;
+    constexpr int kDim = 128;
+    const size_t state_elements = static_cast<size_t>(kHeads) * kDim * kDim;
+    const size_t key_elements = static_cast<size_t>(rows) * kKeyHeads * kDim;
+    const size_t value_elements = static_cast<size_t>(rows) * kHeads * kDim;
+    const size_t gate_elements = static_cast<size_t>(rows) * kHeads;
+
+    float* state = nullptr;
+    uint16_t* q = nullptr;
+    uint16_t* k = nullptr;
+    uint16_t* v = nullptr;
+    uint16_t* g = nullptr;
+    uint16_t* beta = nullptr;
+    uint16_t* output = nullptr;
+    float* q_normalized = nullptr;
+    float* k_normalized = nullptr;
+    check(cudaMalloc(&state, state_elements * sizeof(float)), "malloc state");
+    check(cudaMalloc(&q, key_elements * sizeof(uint16_t)), "malloc q");
+    check(cudaMalloc(&k, key_elements * sizeof(uint16_t)), "malloc k");
+    check(cudaMalloc(&v, value_elements * sizeof(uint16_t)), "malloc v");
+    check(cudaMalloc(&g, gate_elements * sizeof(uint16_t)), "malloc g");
+    check(cudaMalloc(&beta, gate_elements * sizeof(uint16_t)), "malloc beta");
+    check(cudaMalloc(&output, value_elements * sizeof(uint16_t)), "malloc output");
+    check(cudaMalloc(&q_normalized, key_elements * sizeof(float)),
+          "malloc normalized q");
+    check(cudaMalloc(&k_normalized, key_elements * sizeof(float)),
+          "malloc normalized k");
+    check(cudaMemset(state, 0, state_elements * sizeof(float)), "zero state");
+
+    std::mt19937 rng(1234);
+    std::uniform_real_distribution<float> dist(-0.2f, 0.2f);
+    auto fill = [&](uint16_t* device, size_t elements, float bias) {
+        std::vector<uint16_t> host(elements);
+        for (uint16_t& x : host) x = to_half(dist(rng) + bias);
+        check(cudaMemcpy(device, host.data(), elements * sizeof(uint16_t),
+                         cudaMemcpyHostToDevice), "copy input");
+    };
+    fill(q, key_elements, 0.0f);
+    fill(k, key_elements, 0.0f);
+    fill(v, value_elements, 0.0f);
+    fill(g, gate_elements, -0.2f);
+    fill(beta, gate_elements, 0.5f);
+
+    auto sequence = [&]() {
+        return dsv4::qwen_gated_delta_sequence_f16_cuda(
+            state, q, k, v, g, beta, output, rows, kHeads, kKeyHeads,
+            kDim, kDim, 1.0f / 11.3137085f);
+    };
+    auto normalized = [&]() {
+        return dsv4::qwen_normalize_gated_delta_qk_f16_cuda(
+                   q, k, q_normalized, k_normalized, rows, kKeyHeads, kDim) &&
+               dsv4::qwen_gated_delta_sequence_normalized_f16_cuda(
+                   state, q_normalized, k_normalized, v, g, beta, output,
+                   rows, kHeads, kKeyHeads, kDim, kDim,
+                   1.0f / 11.3137085f);
+    };
+    auto shared_state_variant = [&]() {
+        return dsv4::qwen_normalize_gated_delta_qk_f16_cuda(
+                   q, k, q_normalized, k_normalized, rows, kKeyHeads, kDim) &&
+               dsv4::qwen_gated_delta_sequence_normalized_shared_f16_cuda(
+                   state, q_normalized, k_normalized, v, g, beta, output,
+                   rows, kHeads, kKeyHeads, kDim, kDim,
+                   1.0f / 11.3137085f);
+    };
+    auto steps = [&]() {
+        for (int row = 0; row < rows; ++row) {
+            if (!dsv4::qwen_gated_delta_step_f16_cuda(
+                    state, q + static_cast<size_t>(row) * kKeyHeads * kDim,
+                    k + static_cast<size_t>(row) * kKeyHeads * kDim,
+                    v + static_cast<size_t>(row) * kHeads * kDim,
+                    g + static_cast<size_t>(row) * kHeads,
+                    beta + static_cast<size_t>(row) * kHeads,
+                    output + static_cast<size_t>(row) * kHeads * kDim,
+                    kHeads, kKeyHeads, kDim, kDim,
+                    1.0f / 11.3137085f)) return false;
+        }
+        return true;
+    };
+    const double seq_ms = time_launch(sequence, iters);
+    check(cudaMemset(state, 0, state_elements * sizeof(float)), "reset state");
+    const double normalized_ms = time_launch(normalized, iters);
+    check(cudaMemset(state, 0, state_elements * sizeof(float)), "reset state");
+    const double shared_ms = time_launch(shared_state_variant, iters);
+    check(cudaMemset(state, 0, state_elements * sizeof(float)), "reset state");
+    const double step_ms = time_launch(steps, iters);
+    std::printf("qwen_gated_delta_f16 rows=%d heads=%d key_heads=%d dim=%d "
+                "sequence=%.6f ms normalized=%.6f ms shared=%.6f ms "
+                "steps=%.6f ms normalized_speedup=%.3f shared_speedup=%.3f "
+                "sequence_speedup=%.3f\n",
+                rows, kHeads, kKeyHeads, kDim, seq_ms, normalized_ms, shared_ms,
+                step_ms, seq_ms / normalized_ms, normalized_ms / shared_ms,
+                step_ms / seq_ms);
+    cudaFree(state);
+    cudaFree(q);
+    cudaFree(k);
+    cudaFree(v);
+    cudaFree(g);
+    cudaFree(beta);
+    cudaFree(output);
+    cudaFree(q_normalized);
+    cudaFree(k_normalized);
+    return 0;
+}

--- a/cpp_engine/tests/bench_qwen_draft_lm_head.cpp
+++ b/cpp_engine/tests/bench_qwen_draft_lm_head.cpp
@@ -1,0 +1,145 @@
+// Microbenchmark for the drafter LM head shape (batch 7, vocab 62080, hidden
+// 5120). The generic FP32 matmul launches a rows x batch grid and therefore
+// re-reads the whole weight matrix once per draft row. This measures that
+// against the weight-reuse small-batch kernel and cuBLAS on the same shape.
+#include "qwen_cuda_ops.hpp"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <vector>
+
+using namespace dsv4;
+
+namespace {
+
+uint16_t to_half(float value) {
+    uint16_t out = 0;
+    const __half h = __float2half(value);
+    std::memcpy(&out, &h, sizeof(out));
+    return out;
+}
+
+double median(std::vector<double>& values) {
+    std::sort(values.begin(), values.end());
+    return values[values.size() / 2];
+}
+
+struct Timing {
+    double ms;
+    double gbps;
+};
+
+template <typename Fn>
+Timing time_kernel(Fn fn, int rows, int cols, int iters = 30) {
+    for (int i = 0; i < 5; ++i) {
+        if (!fn()) {
+            std::printf("    launch failed\n");
+            return {0.0, 0.0};
+        }
+    }
+    cudaDeviceSynchronize();
+    std::vector<double> samples;
+    samples.reserve(static_cast<size_t>(iters));
+    for (int i = 0; i < iters; ++i) {
+        const auto started = std::chrono::steady_clock::now();
+        fn();
+        cudaDeviceSynchronize();
+        samples.push_back(std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - started).count() * 1000.0);
+    }
+    const double ms = median(samples);
+    const double bytes = static_cast<double>(rows) * cols * sizeof(uint16_t);
+    return {ms, bytes / (ms / 1000.0) / 1e9};
+}
+
+}  // namespace
+
+int main() {
+    const int batch = 7;
+    const int rows = 62080;   // local vocab shard
+    const int cols = 5120;    // hidden
+    const int x_stride = cols;
+    const int y_stride = rows;
+    const int weight_stride = cols;
+
+    std::mt19937 rng(1234);
+    std::uniform_real_distribution<float> dist(-0.05f, 0.05f);
+    std::vector<uint16_t> host_x(static_cast<size_t>(batch) * x_stride);
+    std::vector<uint16_t> host_w(static_cast<size_t>(rows) * weight_stride);
+    for (uint16_t& v : host_x) v = to_half(dist(rng));
+    for (uint16_t& v : host_w) v = to_half(dist(rng));
+
+    uint16_t* d_x = nullptr;
+    uint16_t* d_w = nullptr;
+    float* d_generic = nullptr;
+    float* d_cublas = nullptr;
+    if (cudaMalloc(&d_x, host_x.size() * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_w, host_w.size() * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_generic, static_cast<size_t>(batch) * y_stride * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&d_cublas, static_cast<size_t>(batch) * y_stride * sizeof(float)) != cudaSuccess) {
+        std::printf("allocation failed\n");
+        return 1;
+    }
+    cudaMemcpy(d_x, host_x.data(), host_x.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_w, host_w.data(), host_w.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
+
+    const double weight_mb = static_cast<double>(rows) * cols * sizeof(uint16_t) / 1e6;
+    std::printf("draft LM head batch=%d rows=%d cols=%d weight=%.1f MB\n",
+                batch, rows, cols, weight_mb);
+
+    // Current production path: FP32 output, small-batch reuse disabled.
+    const Timing generic = time_kernel([&]() {
+        return qwen_fp16_matmul_rows_f16_f32_cuda(
+            d_x, d_w, d_generic, batch, rows, cols, x_stride, y_stride,
+            weight_stride);
+    }, rows, cols);
+    std::printf("  generic (rows x batch grid)  %7.2f ms  %6.1f GB/s effective\n",
+                generic.ms, generic.gbps);
+
+    const Timing cublas = time_kernel([&]() {
+        return qwen_fp16_matmul_rows_f16_f32_cublas_cuda(
+            d_x, d_w, d_cublas, batch, rows, cols, x_stride, y_stride,
+            weight_stride);
+    }, rows, cols);
+    std::printf("  cublasGemmEx                 %7.2f ms  %6.1f GB/s effective\n",
+                cublas.ms, cublas.gbps);
+
+    if (generic.ms > 0.0 && cublas.ms > 0.0) {
+        std::printf("  cublas speedup %.2fx\n", generic.ms / cublas.ms);
+    }
+
+    // Numerical agreement between the two paths on this shape.
+    std::vector<float> a(static_cast<size_t>(batch) * y_stride);
+    std::vector<float> b(a.size());
+    cudaMemcpy(a.data(), d_generic, a.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(b.data(), d_cublas, b.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    double worst = 0.0;
+    size_t argmax_disagreements = 0;
+    for (int sample = 0; sample < batch; ++sample) {
+        int best_a = 0;
+        int best_b = 0;
+        for (int row = 0; row < rows; ++row) {
+            const size_t at = static_cast<size_t>(sample) * y_stride + row;
+            worst = std::max(worst, std::fabs(static_cast<double>(a[at]) - b[at]));
+            if (a[at] > a[static_cast<size_t>(sample) * y_stride + best_a]) best_a = row;
+            if (b[at] > b[static_cast<size_t>(sample) * y_stride + best_b]) best_b = row;
+        }
+        if (best_a != best_b) ++argmax_disagreements;
+    }
+    std::printf("  max |generic - cublas| = %.3e, argmax disagreements = %zu/%d\n",
+                worst, argmax_disagreements, batch);
+
+    cudaFree(d_x);
+    cudaFree(d_w);
+    cudaFree(d_generic);
+    cudaFree(d_cublas);
+    return 0;
+}

--- a/cpp_engine/tests/bench_qwen_gqa_verify.cpp
+++ b/cpp_engine/tests/bench_qwen_gqa_verify.cpp
@@ -1,0 +1,169 @@
+#include "qwen_cuda_ops.hpp"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+void check(cudaError_t error, const char* what) {
+    if (error != cudaSuccess) {
+        std::fprintf(stderr, "%s: %s\n", what, cudaGetErrorString(error));
+        std::exit(1);
+    }
+}
+
+uint16_t to_half(float value) {
+    uint16_t bits = 0;
+    const __half h = __float2half(value);
+    std::memcpy(&bits, &h, sizeof(bits));
+    return bits;
+}
+
+template <typename Launch>
+double time_ms(Launch launch, int iters) {
+    for (int i = 0; i < 10; ++i) {
+        if (!launch()) {
+            std::fprintf(stderr, "launch failed\n");
+            std::exit(1);
+        }
+    }
+    check(cudaDeviceSynchronize(), "warmup sync");
+    cudaEvent_t start = nullptr;
+    cudaEvent_t stop = nullptr;
+    check(cudaEventCreate(&start), "create start");
+    check(cudaEventCreate(&stop), "create stop");
+    check(cudaEventRecord(start), "record start");
+    for (int i = 0; i < iters; ++i) (void)launch();
+    check(cudaEventRecord(stop), "record stop");
+    check(cudaEventSynchronize(stop), "sync stop");
+    float elapsed = 0.0f;
+    check(cudaEventElapsedTime(&elapsed, start, stop), "event elapsed");
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+    return static_cast<double>(elapsed) / iters;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    int context = 8192;
+    int rows = 8;
+    int splits = 64;
+    int iters = 200;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--context" && i + 1 < argc) context = std::atoi(argv[++i]);
+        else if (arg == "--rows" && i + 1 < argc) rows = std::atoi(argv[++i]);
+        else if (arg == "--splits" && i + 1 < argc) splits = std::atoi(argv[++i]);
+        else if (arg == "--iters" && i + 1 < argc) iters = std::atoi(argv[++i]);
+    }
+    constexpr int q_heads = 6;
+    constexpr int kv_heads = 1;
+    constexpr int head_dim = 256;
+    const int position_offset = context - rows;
+
+    const size_t q_elements = static_cast<size_t>(rows) * q_heads * head_dim;
+    const size_t kv_elements = static_cast<size_t>(context) * kv_heads * head_dim;
+    const size_t output_elements = static_cast<size_t>(rows) * q_heads * head_dim;
+    const size_t exact_scores = static_cast<size_t>(rows) * q_heads * context;
+    const size_t partials = static_cast<size_t>(rows) * q_heads * splits *
+        static_cast<size_t>(head_dim + 2);
+
+    uint16_t* q = nullptr;
+    uint16_t* k = nullptr;
+    uint16_t* v = nullptr;
+    uint16_t* split_output = nullptr;
+    uint16_t* exact_output = nullptr;
+    uint16_t* cublas_output = nullptr;
+    float* split_scratch = nullptr;
+    float* exact_scratch = nullptr;
+    check(cudaMalloc(&q, q_elements * sizeof(uint16_t)), "malloc q");
+    check(cudaMalloc(&k, kv_elements * sizeof(uint16_t)), "malloc k");
+    check(cudaMalloc(&v, kv_elements * sizeof(uint16_t)), "malloc v");
+    check(cudaMalloc(&split_output, output_elements * sizeof(uint16_t)), "malloc split output");
+    check(cudaMalloc(&exact_output, output_elements * sizeof(uint16_t)), "malloc exact output");
+    check(cudaMalloc(&cublas_output, output_elements * sizeof(uint16_t)), "malloc cublas output");
+    check(cudaMalloc(&split_scratch, partials * sizeof(float)), "malloc partials");
+    check(cudaMalloc(&exact_scratch, exact_scores * sizeof(float)), "malloc scores");
+
+    std::mt19937 rng(1234);
+    std::uniform_real_distribution<float> dist(-0.1f, 0.1f);
+    std::vector<uint16_t> host_q(q_elements);
+    std::vector<uint16_t> host_k(kv_elements);
+    std::vector<uint16_t> host_v(kv_elements);
+    for (uint16_t& x : host_q) x = to_half(dist(rng));
+    for (uint16_t& x : host_k) x = to_half(dist(rng));
+    for (uint16_t& x : host_v) x = to_half(dist(rng));
+    check(cudaMemcpy(q, host_q.data(), host_q.size() * sizeof(uint16_t), cudaMemcpyHostToDevice), "copy q");
+    check(cudaMemcpy(k, host_k.data(), host_k.size() * sizeof(uint16_t), cudaMemcpyHostToDevice), "copy k");
+    check(cudaMemcpy(v, host_v.data(), host_v.size() * sizeof(uint16_t), cudaMemcpyHostToDevice), "copy v");
+
+    auto split = [&]() {
+        return dsv4::qwen_gqa_verify_attention_f16_cuda(
+            q, k, v, split_output, split_scratch, rows, q_heads, kv_heads,
+            head_dim, position_offset, context, splits);
+    };
+    auto exact = [&]() {
+        return dsv4::qwen_gqa_verify_attention_f16_exact_cuda(
+            q, k, v, exact_output, exact_scratch, rows, q_heads, kv_heads,
+            head_dim, position_offset, context);
+    };
+    auto cublas_qk = [&]() {
+        return dsv4::qwen_gqa_verify_attention_f16_cublas_qk_cuda(
+            q, k, v, cublas_output, exact_scratch, rows, q_heads, kv_heads,
+            head_dim, position_offset, context);
+    };
+
+    const double split_ms = time_ms(split, iters);
+    const double exact_ms = time_ms(exact, iters);
+    const double cublas_ms = time_ms(cublas_qk, iters);
+
+    split();
+    exact();
+    cublas_qk();
+    check(cudaDeviceSynchronize(), "result sync");
+    std::vector<uint16_t> a(output_elements), b(output_elements), c(output_elements);
+    check(cudaMemcpy(a.data(), split_output, a.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost), "copy split");
+    check(cudaMemcpy(b.data(), exact_output, b.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost), "copy exact");
+    check(cudaMemcpy(c.data(), cublas_output, c.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost), "copy cublas");
+    double split_error = 0.0;
+    double cublas_error = 0.0;
+    for (size_t i = 0; i < a.size(); ++i) {
+        __half ah, bh, ch;
+        std::memcpy(&ah, &a[i], 2);
+        std::memcpy(&bh, &b[i], 2);
+        std::memcpy(&ch, &c[i], 2);
+        const float af = __half2float(ah);
+        const float bf = __half2float(bh);
+        const float cf = __half2float(ch);
+        split_error = std::max(split_error, static_cast<double>(std::fabs(af - bf)));
+        cublas_error = std::max(cublas_error, static_cast<double>(std::fabs(cf - bf)));
+    }
+
+    const double kv_gb = static_cast<double>(2 * kv_elements * sizeof(uint16_t)) / 1e9;
+    std::printf("gqa_verify rows=%d context=%d splits=%d iters=%d\n", rows, context, splits, iters);
+    std::printf("  split      %.4f ms  %.1f GB/s  max_err=%.3e\n",
+                split_ms, kv_gb / (split_ms / 1000.0), split_error);
+    std::printf("  exact      %.4f ms  %.1f GB/s\n",
+                exact_ms, kv_gb / (exact_ms / 1000.0));
+    std::printf("  cublas_qk  %.4f ms  %.1f GB/s  max_err=%.3e\n",
+                cublas_ms, kv_gb / (cublas_ms / 1000.0), cublas_error);
+    cudaFree(q);
+    cudaFree(k);
+    cudaFree(v);
+    cudaFree(split_output);
+    cudaFree(exact_output);
+    cudaFree(cublas_output);
+    cudaFree(split_scratch);
+    cudaFree(exact_scratch);
+    return 0;
+}

--- a/cpp_engine/tests/bench_qwen_transaction_copy.cpp
+++ b/cpp_engine/tests/bench_qwen_transaction_copy.cpp
@@ -1,0 +1,206 @@
+// Compares the current per-layer Qwen transaction snapshot copies against one
+// descriptor-driven gather/scatter launch at the exact TP4 recurrent-state sizes.
+
+#include "qwen_cuda_ops.hpp"
+
+#include <cuda_runtime.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr int kLayers = 48;
+constexpr size_t kStateBytes = 12u * 128u * 128u * sizeof(float);
+constexpr size_t kTailBytes = 3u * 2560u * sizeof(uint16_t);
+
+void check(cudaError_t status, const char* what) {
+    if (status != cudaSuccess) {
+        std::fprintf(stderr, "%s: %s\n", what, cudaGetErrorString(status));
+        std::exit(1);
+    }
+}
+
+struct Buffers {
+    std::vector<uint8_t*> state;
+    std::vector<uint8_t*> tail;
+    std::vector<uint8_t*> state_copy;
+    std::vector<uint8_t*> tail_copy;
+    uint8_t* packed = nullptr;
+    dsv4::QwenCopyRegion* descriptors = nullptr;
+
+    Buffers() {
+        state.resize(kLayers);
+        tail.resize(kLayers);
+        state_copy.resize(kLayers);
+        tail_copy.resize(kLayers);
+    }
+
+    ~Buffers() {
+        for (uint8_t* value : state) cudaFree(value);
+        for (uint8_t* value : tail) cudaFree(value);
+        for (uint8_t* value : state_copy) cudaFree(value);
+        for (uint8_t* value : tail_copy) cudaFree(value);
+        cudaFree(packed);
+        cudaFree(descriptors);
+    }
+};
+
+struct Timing {
+    double event_ms = 0.0;
+    double submit_ms = 0.0;
+    double wall_ms = 0.0;
+};
+
+template <typename Launch>
+Timing time_launch(Launch launch, int iters) {
+    if (!launch()) std::exit(1);
+    check(cudaDeviceSynchronize(), "warmup sync");
+
+    cudaEvent_t start = nullptr;
+    cudaEvent_t stop = nullptr;
+    check(cudaEventCreate(&start), "event create");
+    check(cudaEventCreate(&stop), "event create");
+    check(cudaEventRecord(start), "event start");
+    for (int iteration = 0; iteration < iters; ++iteration) {
+        if (!launch()) std::exit(1);
+    }
+    check(cudaEventRecord(stop), "event stop");
+    check(cudaEventSynchronize(stop), "event sync");
+    float event_ms = 0.0f;
+    check(cudaEventElapsedTime(&event_ms, start, stop), "event elapsed");
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+
+    check(cudaDeviceSynchronize(), "host warmup sync");
+    const auto wall_started = std::chrono::steady_clock::now();
+    for (int iteration = 0; iteration < iters; ++iteration) {
+        if (!launch()) std::exit(1);
+    }
+    const auto submitted = std::chrono::steady_clock::now();
+    check(cudaDeviceSynchronize(), "host final sync");
+    const auto completed = std::chrono::steady_clock::now();
+
+    Timing result;
+    result.event_ms = event_ms / iters;
+    result.submit_ms = std::chrono::duration<double, std::milli>(
+        submitted - wall_started).count() / iters;
+    result.wall_ms = std::chrono::duration<double, std::milli>(
+        completed - wall_started).count() / iters;
+    return result;
+}
+
+void print_timing(const char* name, const Timing& timing, uint64_t bytes) {
+    const double bandwidth = bytes / (timing.event_ms * 1.0e6);
+    std::printf("  %-14s event=%8.4f ms (%6.1f GB/s) submit=%8.4f ms "
+                "wall=%8.4f ms\n",
+                name, timing.event_ms, bandwidth, timing.submit_ms,
+                timing.wall_ms);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    int iters = 200;
+    if (argc > 1) iters = std::atoi(argv[1]);
+    if (iters <= 0) {
+        std::fprintf(stderr, "usage: bench_qwen_transaction_copy [iters]\n");
+        return 1;
+    }
+
+    Buffers buffers;
+    std::vector<dsv4::QwenCopyRegion> host_descriptors;
+    host_descriptors.reserve(kLayers * 2);
+    uint64_t packed_bytes = 0;
+    uint64_t total_blocks = 0;
+    for (int layer = 0; layer < kLayers; ++layer) {
+        check(cudaMalloc(&buffers.state[layer], kStateBytes), "malloc state");
+        check(cudaMalloc(&buffers.tail[layer], kTailBytes), "malloc tail");
+        check(cudaMalloc(&buffers.state_copy[layer], kStateBytes),
+              "malloc state copy");
+        check(cudaMalloc(&buffers.tail_copy[layer], kTailBytes),
+              "malloc tail copy");
+        check(cudaMemset(buffers.state[layer], layer + 1, kStateBytes),
+              "init state");
+        check(cudaMemset(buffers.tail[layer], layer + 17, kTailBytes),
+              "init tail");
+        for (auto item : {
+                 std::pair<uint8_t*, size_t>{buffers.state[layer], kStateBytes},
+                 std::pair<uint8_t*, size_t>{buffers.tail[layer], kTailBytes}}) {
+            dsv4::QwenCopyRegion descriptor;
+            descriptor.device_address = reinterpret_cast<uint64_t>(item.first);
+            descriptor.packed_offset = packed_bytes;
+            descriptor.bytes = item.second;
+            descriptor.first_block = total_blocks;
+            host_descriptors.push_back(descriptor);
+            packed_bytes += item.second;
+            total_blocks += dsv4::qwen_copy_region_blocks(item.second);
+        }
+    }
+    check(cudaMalloc(&buffers.packed, packed_bytes), "malloc packed");
+    check(cudaMalloc(&buffers.descriptors,
+                     host_descriptors.size() * sizeof(host_descriptors[0])),
+          "malloc descriptors");
+    check(cudaMemcpy(buffers.descriptors, host_descriptors.data(),
+                     host_descriptors.size() * sizeof(host_descriptors[0]),
+                     cudaMemcpyHostToDevice),
+          "copy descriptors");
+
+    auto sync_copies = [&]() {
+        for (int layer = 0; layer < kLayers; ++layer) {
+            if (cudaMemcpy(buffers.state_copy[layer], buffers.state[layer],
+                           kStateBytes, cudaMemcpyDeviceToDevice) != cudaSuccess ||
+                cudaMemcpy(buffers.tail_copy[layer], buffers.tail[layer],
+                           kTailBytes, cudaMemcpyDeviceToDevice) != cudaSuccess) {
+                return false;
+            }
+        }
+        return true;
+    };
+    auto async_copies = [&]() {
+        for (int layer = 0; layer < kLayers; ++layer) {
+            if (cudaMemcpyAsync(buffers.state_copy[layer], buffers.state[layer],
+                                kStateBytes, cudaMemcpyDeviceToDevice) !=
+                    cudaSuccess ||
+                cudaMemcpyAsync(buffers.tail_copy[layer], buffers.tail[layer],
+                                kTailBytes, cudaMemcpyDeviceToDevice) !=
+                    cudaSuccess) {
+                return false;
+            }
+        }
+        return true;
+    };
+    auto gather = [&]() {
+        return dsv4::qwen_gather_copy_regions_cuda(
+            buffers.descriptors, static_cast<int>(host_descriptors.size()),
+            buffers.packed, total_blocks);
+    };
+    auto scatter = [&]() {
+        return dsv4::qwen_scatter_copy_regions_cuda(
+            buffers.descriptors, static_cast<int>(host_descriptors.size()),
+            buffers.packed, total_blocks);
+    };
+
+    const Timing sync = time_launch(sync_copies, iters);
+    const Timing async = time_launch(async_copies, iters);
+    const Timing gather_timing = time_launch(gather, iters);
+    const Timing scatter_timing = time_launch(scatter, iters);
+    std::printf("qwen_transaction_copy regions=%zu bytes=%llu blocks=%llu "
+                "iters=%d\n",
+                host_descriptors.size(),
+                static_cast<unsigned long long>(packed_bytes),
+                static_cast<unsigned long long>(total_blocks), iters);
+    print_timing("sync_96", sync, packed_bytes);
+    print_timing("async_96", async, packed_bytes);
+    print_timing("gather", gather_timing, packed_bytes);
+    print_timing("scatter", scatter_timing, packed_bytes);
+    std::printf("  gather_speedup event=%.3f submit=%.3f wall=%.3f\n",
+                sync.event_ms / gather_timing.event_ms,
+                sync.submit_ms / gather_timing.submit_ms,
+                sync.wall_ms / gather_timing.wall_ms);
+    return 0;
+}

--- a/cpp_engine/tests/bench_qwen_verify_batch.cpp
+++ b/cpp_engine/tests/bench_qwen_verify_batch.cpp
@@ -9,6 +9,9 @@
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 
+#include <algorithm>
+#include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -63,14 +66,40 @@ struct DeviceBuffers {
     uint16_t* x = nullptr;
     uint8_t* weight = nullptr;
     uint16_t* scale = nullptr;
+    uint16_t* weight_f16 = nullptr;
     uint16_t* y = nullptr;
     ~DeviceBuffers() {
         cudaFree(x);
         cudaFree(weight);
         cudaFree(scale);
+        cudaFree(weight_f16);
         cudaFree(y);
     }
 };
+
+template <typename Launch>
+double time_launch(Launch launch, const char* what, int iters) {
+    if (!launch()) {
+        std::fprintf(stderr, "%s launch failed\n", what);
+        std::exit(1);
+    }
+    check(cudaDeviceSynchronize(), "warmup sync");
+    cudaEvent_t start = nullptr;
+    cudaEvent_t stop = nullptr;
+    check(cudaEventCreate(&start), "event create");
+    check(cudaEventCreate(&stop), "event create");
+    check(cudaEventRecord(start), "event record");
+    for (int i = 0; i < iters; ++i) {
+        if (!launch()) std::exit(1);
+    }
+    check(cudaEventRecord(stop), "event record");
+    check(cudaEventSynchronize(stop), "event sync");
+    float ms = 0.0f;
+    check(cudaEventElapsedTime(&ms, start, stop), "event elapsed");
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+    return static_cast<double>(ms) / iters;
+}
 
 double time_rows(const DeviceBuffers& buffers, int batch, int out_rows,
                  int cols, int scale_stride, int iters) {
@@ -84,12 +113,258 @@ double time_rows(const DeviceBuffers& buffers, int batch, int out_rows,
             buffers.x, buffers.weight, buffers.scale, buffers.y, batch, out_rows,
             cols, cols, out_rows, cols, scale_stride);
     };
+    return time_launch(launch, "online FP8 projection", iters);
+}
+
+double time_resident_rows(const DeviceBuffers& buffers, int batch, int out_rows,
+                          int cols, int iters) {
+    auto launch = [&]() {
+        return dsv4::qwen_fp16_matmul_rows_f16_cublas_cuda(
+            buffers.x, buffers.weight_f16, buffers.y, batch, out_rows, cols,
+            cols, out_rows, cols);
+    };
+    return time_launch(launch, "resident FP16 projection", iters);
+}
+
+// Full-attention K and V have the same TP4 shape and consume the same normalized
+// activation.  This measures the verify-only candidate that replaces two
+// [256, 5120] GEMMs with one [512, 5120] GEMM followed by a row-pair split.
+// The caller uses rows 2..8, matching target speculative verification; prefill
+// remains on the established separate-projection path.
+void bench_full_kv_projection(int iters, std::mt19937& rng) {
+    constexpr int kRows = 256;
+    constexpr int kCols = 5120;
+    const int row_counts[] = {2, 3, 4, 5, 8};
+    const size_t weight_elements = static_cast<size_t>(kRows) * kCols;
+    const size_t fused_weight_elements = 2 * weight_elements;
+    uint16_t* x = nullptr;
+    uint16_t* k_weight = nullptr;
+    uint16_t* v_weight = nullptr;
+    uint16_t* kv_weight = nullptr;
+    uint16_t* k_separate = nullptr;
+    uint16_t* v_separate = nullptr;
+    uint16_t* k_fused = nullptr;
+    uint16_t* v_fused = nullptr;
+    uint16_t* kv_packed = nullptr;
+    check(cudaMalloc(&x, static_cast<size_t>(8) * kCols * sizeof(uint16_t)),
+          "malloc full K/V x");
+    check(cudaMalloc(&k_weight, weight_elements * sizeof(uint16_t)),
+          "malloc full K weight");
+    check(cudaMalloc(&v_weight, weight_elements * sizeof(uint16_t)),
+          "malloc full V weight");
+    check(cudaMalloc(&kv_weight, fused_weight_elements * sizeof(uint16_t)),
+          "malloc fused full K/V weight");
+    check(cudaMalloc(&k_separate, static_cast<size_t>(8) * kRows * sizeof(uint16_t)),
+          "malloc separate K output");
+    check(cudaMalloc(&v_separate, static_cast<size_t>(8) * kRows * sizeof(uint16_t)),
+          "malloc separate V output");
+    check(cudaMalloc(&k_fused, static_cast<size_t>(8) * kRows * sizeof(uint16_t)),
+          "malloc fused K output");
+    check(cudaMalloc(&v_fused, static_cast<size_t>(8) * kRows * sizeof(uint16_t)),
+          "malloc fused V output");
+    check(cudaMalloc(&kv_packed, static_cast<size_t>(8) * 2 * kRows * sizeof(uint16_t)),
+          "malloc fused K/V output");
+
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<uint16_t> host_x(static_cast<size_t>(8) * kCols);
+    std::vector<uint16_t> host_k(weight_elements);
+    std::vector<uint16_t> host_v(weight_elements);
+    for (uint16_t& value : host_x) value = to_half(dist(rng) * 0.1f);
+    for (uint16_t& value : host_k) value = to_half(dist(rng) * 0.05f);
+    for (uint16_t& value : host_v) value = to_half(dist(rng) * 0.05f);
+    check(cudaMemcpy(x, host_x.data(), host_x.size() * sizeof(uint16_t),
+                     cudaMemcpyHostToDevice), "copy full K/V x");
+    check(cudaMemcpy(k_weight, host_k.data(), host_k.size() * sizeof(uint16_t),
+                     cudaMemcpyHostToDevice), "copy full K weight");
+    check(cudaMemcpy(v_weight, host_v.data(), host_v.size() * sizeof(uint16_t),
+                     cudaMemcpyHostToDevice), "copy full V weight");
+    std::vector<uint16_t> host_kv(fused_weight_elements);
+    std::copy(host_k.begin(), host_k.end(), host_kv.begin());
+    std::copy(host_v.begin(), host_v.end(), host_kv.begin() + weight_elements);
+    check(cudaMemcpy(kv_weight, host_kv.data(), host_kv.size() * sizeof(uint16_t),
+                     cudaMemcpyHostToDevice), "copy fused full K/V weight");
+
+    std::printf("qwen_verify_full_kv rows=2,3,4,5,8 k_rows=%d cols=%d iters=%d\n",
+                kRows, kCols, iters);
+    for (int rows : row_counts) {
+        auto separate = [&]() {
+            return dsv4::qwen_fp16_matmul_rows_f16_cublas_cuda(
+                       x, k_weight, k_separate, rows, kRows, kCols, kCols,
+                       kRows, kCols) &&
+                   dsv4::qwen_fp16_matmul_rows_f16_cublas_cuda(
+                       x, v_weight, v_separate, rows, kRows, kCols, kCols,
+                       kRows, kCols);
+        };
+        auto fused = [&]() {
+            return dsv4::qwen_fp16_matmul_rows_f16_cublas_cuda(
+                       x, kv_weight, kv_packed, rows, 2 * kRows, kCols, kCols,
+                       2 * kRows, kCols) &&
+                   dsv4::qwen_split_rows_pair_f16_cuda(
+                       kv_packed, k_fused, v_fused, rows, kRows);
+        };
+        const double separate_ms = time_launch(
+            separate, "separate full K/V projection", iters);
+        const double fused_ms = time_launch(
+            fused, "fused full K/V projection", iters);
+        if (!separate() || !fused()) std::exit(1);
+        check(cudaDeviceSynchronize(), "full K/V correctness sync");
+        std::vector<uint16_t> host_k_separate(static_cast<size_t>(rows) * kRows);
+        std::vector<uint16_t> host_v_separate(static_cast<size_t>(rows) * kRows);
+        std::vector<uint16_t> host_k_fused(static_cast<size_t>(rows) * kRows);
+        std::vector<uint16_t> host_v_fused(static_cast<size_t>(rows) * kRows);
+        check(cudaMemcpy(host_k_separate.data(), k_separate,
+                         host_k_separate.size() * sizeof(uint16_t),
+                         cudaMemcpyDeviceToHost), "copy separate K result");
+        check(cudaMemcpy(host_v_separate.data(), v_separate,
+                         host_v_separate.size() * sizeof(uint16_t),
+                         cudaMemcpyDeviceToHost), "copy separate V result");
+        check(cudaMemcpy(host_k_fused.data(), k_fused,
+                         host_k_fused.size() * sizeof(uint16_t),
+                         cudaMemcpyDeviceToHost), "copy fused K result");
+        check(cudaMemcpy(host_v_fused.data(), v_fused,
+                         host_v_fused.size() * sizeof(uint16_t),
+                         cudaMemcpyDeviceToHost), "copy fused V result");
+        double max_abs = 0.0;
+        for (size_t index = 0; index < host_k_separate.size(); ++index) {
+            max_abs = std::max(max_abs, static_cast<double>(std::fabs(
+                __half2float(__ushort_as_half(host_k_separate[index])) -
+                __half2float(__ushort_as_half(host_k_fused[index])))));
+            max_abs = std::max(max_abs, static_cast<double>(std::fabs(
+                __half2float(__ushort_as_half(host_v_separate[index])) -
+                __half2float(__ushort_as_half(host_v_fused[index])))));
+        }
+        std::printf("  rows=%d separate=%.4f ms fused_split=%.4f ms speedup=%.3f "
+                    "max_abs=%.3e\n", rows, separate_ms, fused_ms,
+                    fused_ms > 0.0 ? separate_ms / fused_ms : 0.0, max_abs);
+    }
+    cudaFree(x);
+    cudaFree(k_weight);
+    cudaFree(v_weight);
+    cudaFree(kv_weight);
+    cudaFree(k_separate);
+    cudaFree(v_separate);
+    cudaFree(k_fused);
+    cudaFree(v_fused);
+    cudaFree(kv_packed);
+}
+
+// Linear-attention a/b are BF16 checkpoint matrices converted to FP16 at load:
+// two 12x5120 weights are row-concatenated into one 24x5120 projection. This
+// exact target shape is intentionally much shorter than the resident FP8
+// projections above, so benchmark the generic small-batch reduction and tensor-
+// core GEMM separately instead of inferring their crossover from large matrices.
+void bench_linear_ab(int batch, int iters, std::mt19937& rng) {
+    constexpr int kRows = 24;
+    constexpr int kCols = 5120;
+    const size_t x_elements = static_cast<size_t>(batch) * kCols;
+    const size_t weight_elements = static_cast<size_t>(kRows) * kCols;
+    const size_t y_elements = static_cast<size_t>(batch) * kRows;
+    uint16_t* x = nullptr;
+    uint16_t* weight = nullptr;
+    uint16_t* generic_y = nullptr;
+    uint16_t* cublas_y = nullptr;
+    check(cudaMalloc(&x, x_elements * sizeof(uint16_t)), "malloc linear.ab x");
+    check(cudaMalloc(&weight, weight_elements * sizeof(uint16_t)),
+          "malloc linear.ab weight");
+    check(cudaMalloc(&generic_y, y_elements * sizeof(uint16_t)),
+          "malloc linear.ab generic output");
+    check(cudaMalloc(&cublas_y, y_elements * sizeof(uint16_t)),
+          "malloc linear.ab cublas output");
+
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<uint16_t> host_x(x_elements);
+    std::vector<uint16_t> host_weight(weight_elements);
+    for (uint16_t& value : host_x) value = to_half(dist(rng) * 0.1f);
+    for (uint16_t& value : host_weight) value = to_half(dist(rng) * 0.05f);
+    check(cudaMemcpy(x, host_x.data(), host_x.size() * sizeof(uint16_t),
+                     cudaMemcpyHostToDevice), "copy linear.ab x");
+    check(cudaMemcpy(weight, host_weight.data(),
+                     host_weight.size() * sizeof(uint16_t),
+                     cudaMemcpyHostToDevice), "copy linear.ab weight");
+
+    auto generic = [&]() {
+        return dsv4::qwen_fp16_matmul_rows_f16_cuda(
+            x, weight, generic_y, batch, kRows, kCols, kCols, kRows, kCols);
+    };
+    auto cublas = [&]() {
+        return dsv4::qwen_fp16_matmul_rows_f16_cublas_cuda(
+            x, weight, cublas_y, batch, kRows, kCols, kCols, kRows, kCols);
+    };
+    const double generic_ms = time_launch(generic, "linear.ab generic", iters);
+    const double cublas_ms = time_launch(cublas, "linear.ab cuBLAS", iters);
+
+    if (!generic() || !cublas()) std::exit(1);
+    check(cudaDeviceSynchronize(), "linear.ab correctness sync");
+    std::vector<uint16_t> host_generic(y_elements);
+    std::vector<uint16_t> host_cublas(y_elements);
+    check(cudaMemcpy(host_generic.data(), generic_y,
+                     host_generic.size() * sizeof(uint16_t),
+                     cudaMemcpyDeviceToHost), "copy linear.ab generic result");
+    check(cudaMemcpy(host_cublas.data(), cublas_y,
+                     host_cublas.size() * sizeof(uint16_t),
+                     cudaMemcpyDeviceToHost), "copy linear.ab cublas result");
+    double max_abs = 0.0;
+    for (size_t index = 0; index < y_elements; ++index) {
+        const float generic_value = __half2float(
+            __ushort_as_half(host_generic[index]));
+        const float cublas_value = __half2float(
+            __ushort_as_half(host_cublas[index]));
+        max_abs = std::max(max_abs, static_cast<double>(
+            std::fabs(generic_value - cublas_value)));
+    }
+    std::printf("qwen_verify_linear_ab rows=%d out=%d cols=%d iters=%d "
+                "generic=%.4f ms cublas=%.4f ms speedup=%.3f max_abs=%.3e\n",
+                batch, kRows, kCols, iters, generic_ms, cublas_ms,
+                cublas_ms > 0.0 ? generic_ms / cublas_ms : 0.0, max_abs);
+
+    cudaFree(x);
+    cudaFree(weight);
+    cudaFree(generic_y);
+    cudaFree(cublas_y);
+}
+
+double time_resident_swiglu(const DeviceBuffers& gate, const DeviceBuffers& up,
+                            int batch, int out_rows, int cols, int iters) {
+    uint16_t* gate_output = nullptr;
+    uint16_t* up_output = nullptr;
+    const size_t elements = static_cast<size_t>(batch) * out_rows;
+    check(cudaMalloc(&gate_output, elements * sizeof(uint16_t)),
+          "malloc resident gate output");
+    check(cudaMalloc(&up_output, elements * sizeof(uint16_t)),
+          "malloc resident up output");
+    auto launch = [&]() {
+        return dsv4::qwen_fp16_matmul_rows_f16_cublas_cuda(
+                   gate.x, gate.weight_f16, gate_output, batch, out_rows, cols,
+                   cols, out_rows, cols) &&
+               dsv4::qwen_fp16_matmul_rows_f16_cublas_cuda(
+                   gate.x, up.weight_f16, up_output, batch, out_rows, cols,
+                   cols, out_rows, cols) &&
+               dsv4::qwen_silu_mul_rows_f16_cuda(
+                   gate_output, up_output, gate.y, batch, out_rows);
+    };
+    const double result = time_launch(launch, "resident FP16 SwiGLU", iters);
+    cudaFree(gate_output);
+    cudaFree(up_output);
+    return result;
+}
+
+// The fused SwiGLU is the single largest verify phase after attention, so time it
+// at the real TP4 MLP shard shape. QWEN_FP8_SWIGLU_TILE selects the K-tile; this
+// harness is far less noisy than the end-to-end bench (~1% run to run versus
+// +-4 ms/step), so it is the right place to pick that default.
+double time_swiglu(const DeviceBuffers& gate, const DeviceBuffers& up, int batch,
+                   int out_rows, int cols, int scale_stride, int iters) {
+    auto launch = [&]() {
+        return dsv4::qwen_fp8_e4m3_fp16scale_swiglu_small_batch_f16_cuda(
+            gate.x, gate.weight, gate.scale, up.weight, up.scale, gate.y, batch,
+            out_rows, cols, cols, out_rows, cols, scale_stride, nullptr);
+    };
     if (!launch()) {
-        std::fprintf(stderr, "launch failed batch=%d rows=%d cols=%d\n", batch,
-                     out_rows, cols);
+        std::fprintf(stderr, "swiglu launch failed batch=%d rows=%d\n", batch,
+                     out_rows);
         std::exit(1);
     }
-    check(cudaDeviceSynchronize(), "warmup sync");
+    check(cudaDeviceSynchronize(), "swiglu warmup sync");
     cudaEvent_t start = nullptr;
     cudaEvent_t stop = nullptr;
     check(cudaEventCreate(&start), "event create");
@@ -103,6 +378,98 @@ double time_rows(const DeviceBuffers& buffers, int batch, int out_rows,
     cudaEventDestroy(start);
     cudaEventDestroy(stop);
     return static_cast<double>(ms) / iters;
+}
+
+void bench_residual_rmsnorm(int rows, int iters, std::mt19937& rng) {
+    constexpr int kCols = 5120;
+    constexpr float kEps = 1.0e-6f;
+    const size_t elements = static_cast<size_t>(rows) * kCols;
+    uint16_t* hidden = nullptr;
+    uint16_t* delta = nullptr;
+    uint16_t* gamma = nullptr;
+    uint16_t* residual = nullptr;
+    uint16_t* normalized = nullptr;
+    check(cudaMalloc(&hidden, elements * sizeof(uint16_t)), "malloc hidden");
+    check(cudaMalloc(&delta, elements * sizeof(uint16_t)), "malloc delta");
+    check(cudaMalloc(&gamma, kCols * sizeof(uint16_t)), "malloc gamma");
+    check(cudaMalloc(&residual, elements * sizeof(uint16_t)), "malloc residual");
+    check(cudaMalloc(&normalized, elements * sizeof(uint16_t)), "malloc norm");
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<uint16_t> host(elements);
+    for (uint16_t& value : host) value = to_half(dist(rng));
+    check(cudaMemcpy(hidden, host.data(), elements * sizeof(uint16_t),
+                     cudaMemcpyHostToDevice), "copy hidden");
+    for (uint16_t& value : host) value = to_half(dist(rng) * 0.2f);
+    check(cudaMemcpy(delta, host.data(), elements * sizeof(uint16_t),
+                     cudaMemcpyHostToDevice), "copy delta");
+    host.resize(kCols);
+    for (uint16_t& value : host) value = to_half(dist(rng) * 0.1f);
+    check(cudaMemcpy(gamma, host.data(), kCols * sizeof(uint16_t),
+                     cudaMemcpyHostToDevice), "copy gamma");
+
+    auto reference = [&]() {
+        if (cudaMemcpy(residual, hidden, elements * sizeof(uint16_t),
+                       cudaMemcpyDeviceToDevice) != cudaSuccess) return false;
+        return dsv4::qwen_add_inplace_f16_cuda(
+                   residual, delta, static_cast<int>(elements)) &&
+               dsv4::qwen_rmsnorm_fp16_gamma_rows_f16_cuda(
+                   residual, gamma, normalized, rows, kCols, kEps);
+    };
+    auto fused = [&]() {
+        return dsv4::qwen_residual_add_rmsnorm_fp16_gamma_rows_f16_cuda(
+            hidden, delta, gamma, residual, normalized, rows, kCols, kEps);
+    };
+    auto event_time = [&](auto launch) {
+        if (!launch()) std::exit(1);
+        check(cudaDeviceSynchronize(), "residual norm warmup sync");
+        cudaEvent_t start = nullptr;
+        cudaEvent_t stop = nullptr;
+        check(cudaEventCreate(&start), "event create");
+        check(cudaEventCreate(&stop), "event create");
+        check(cudaEventRecord(start), "event record");
+        for (int i = 0; i < iters; ++i) {
+            if (!launch()) std::exit(1);
+        }
+        check(cudaEventRecord(stop), "event record");
+        check(cudaEventSynchronize(stop), "event sync");
+        float elapsed = 0.0f;
+        check(cudaEventElapsedTime(&elapsed, start, stop), "event elapsed");
+        cudaEventDestroy(start);
+        cudaEventDestroy(stop);
+        return static_cast<double>(elapsed) / iters;
+    };
+    auto host_time = [&](auto launch) {
+        if (!launch()) std::exit(1);
+        check(cudaDeviceSynchronize(), "residual norm host warmup sync");
+        const auto start = std::chrono::steady_clock::now();
+        for (int i = 0; i < iters; ++i) {
+            if (!launch()) std::exit(1);
+        }
+        const auto submitted = std::chrono::steady_clock::now();
+        check(cudaDeviceSynchronize(), "residual norm host final sync");
+        const auto completed = std::chrono::steady_clock::now();
+        const double submit_ms = std::chrono::duration<double, std::milli>(
+            submitted - start).count() / iters;
+        const double wall_ms = std::chrono::duration<double, std::milli>(
+            completed - start).count() / iters;
+        return std::pair<double, double>{submit_ms, wall_ms};
+    };
+    const double reference_event = event_time(reference);
+    const double fused_event = event_time(fused);
+    const auto reference_host = host_time(reference);
+    const auto fused_host = host_time(fused);
+    std::printf("qwen_residual_rmsnorm rows=%d cols=%d iters=%d "
+                "reference_event=%.4f ms fused_event=%.4f ms speedup=%.3f "
+                "reference_submit=%.4f ms fused_submit=%.4f ms "
+                "reference_wall=%.4f ms fused_wall=%.4f ms\n",
+                rows, kCols, iters, reference_event, fused_event,
+                reference_event / fused_event, reference_host.first,
+                fused_host.first, reference_host.second, fused_host.second);
+    cudaFree(hidden);
+    cudaFree(delta);
+    cudaFree(gamma);
+    cudaFree(residual);
+    cudaFree(normalized);
 }
 
 // The DFlash2 drafter runs FP16 weights with FP32 output. Its LM head is a tall
@@ -302,10 +669,12 @@ int main(int argc, char** argv) {
     using namespace dsv4;
     int iters = 50;
     int verify_rows = 8;
+    bool mlp_only = false;
     for (int i = 1; i < argc; ++i) {
         const std::string arg = argv[i];
         if (arg == "--iters" && i + 1 < argc) iters = std::atoi(argv[++i]);
         else if (arg == "--rows" && i + 1 < argc) verify_rows = std::atoi(argv[++i]);
+        else if (arg == "--mlp-only") mlp_only = true;
     }
     if (iters <= 0 || verify_rows <= 1) {
         std::fprintf(stderr, "usage: bench_qwen_verify_batch [--iters N] [--rows R>=2]\n");
@@ -316,10 +685,90 @@ int main(int argc, char** argv) {
     std::mt19937 rng(1234);
     std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
 
+    bench_residual_rmsnorm(verify_rows, std::max(iters, 1000), rng);
+    bench_linear_ab(verify_rows, std::max(iters, 1000), rng);
+    bench_full_kv_projection(std::max(iters, 1000), rng);
+
     double serial_total = 0.0;
     double verify_total = 0.0;
-    std::printf("qwen_verify_batch rows=%d iters=%d\n", verify_rows, iters);
+    double resident_total = 0.0;
+    // Fills one FP8 weight/scale set plus activations at the requested shape.
+    auto fill_buffers = [&](DeviceBuffers& buffers, int out_rows, int cols,
+                            int scale_stride) {
+        const size_t x_elements = static_cast<size_t>(verify_rows) * cols;
+        const size_t weight_elements = static_cast<size_t>(out_rows) * cols;
+        const size_t scale_elements =
+            static_cast<size_t>(out_rows) * scale_stride;
+        const size_t y_elements = static_cast<size_t>(verify_rows) * out_rows;
+        check(cudaMalloc(&buffers.x, x_elements * sizeof(uint16_t)), "malloc x");
+        check(cudaMalloc(&buffers.weight, weight_elements), "malloc weight");
+        check(cudaMalloc(&buffers.scale, scale_elements * sizeof(uint16_t)),
+              "malloc scale");
+        check(cudaMalloc(&buffers.weight_f16,
+                         weight_elements * sizeof(uint16_t)),
+              "malloc resident weight");
+        check(cudaMalloc(&buffers.y, y_elements * sizeof(uint16_t)), "malloc y");
+        std::vector<uint16_t> host_x(x_elements);
+        for (uint16_t& value : host_x) value = to_half(dist(rng) * 0.1f);
+        std::vector<uint8_t> host_weight(weight_elements);
+        for (uint8_t& code : host_weight) {
+            code = static_cast<uint8_t>(32 + (rng() % 192));
+        }
+        std::vector<uint16_t> host_scale(scale_elements);
+        for (uint16_t& value : host_scale) value = to_half(0.02f);
+        check(cudaMemcpy(buffers.x, host_x.data(),
+                         host_x.size() * sizeof(uint16_t),
+                         cudaMemcpyHostToDevice), "copy x");
+        check(cudaMemcpy(buffers.weight, host_weight.data(), host_weight.size(),
+                         cudaMemcpyHostToDevice), "copy weight");
+        check(cudaMemcpy(buffers.scale, host_scale.data(),
+                         host_scale.size() * sizeof(uint16_t),
+                         cudaMemcpyHostToDevice), "copy scale");
+        if (!dsv4::qwen_fp8_e4m3_fp16scale_dequantize_f16_cuda(
+                buffers.weight, buffers.scale, buffers.weight_f16, out_rows,
+                cols, cols, scale_stride)) {
+            std::fprintf(stderr, "resident weight dequantization failed\n");
+            std::exit(1);
+        }
+        check(cudaDeviceSynchronize(), "resident weight dequantization sync");
+    };
+
+    {
+        // Real TP4 MLP shard: intermediate 17408 / 4 ranks = 4352 rows.
+        constexpr int kSwigluRows = 4352;
+        constexpr int kSwigluCols = 5120;
+        const int scale_stride = (kSwigluCols + kFp8Block - 1) / kFp8Block;
+        DeviceBuffers gate;
+        DeviceBuffers up;
+        fill_buffers(gate, kSwigluRows, kSwigluCols, scale_stride);
+        fill_buffers(up, kSwigluRows, kSwigluCols, scale_stride);
+        const char* tile = std::getenv("QWEN_FP8_SWIGLU_TILE");
+        const char* warps = std::getenv("QWEN_FP8_SWIGLU_WARPS");
+        const double fused = time_swiglu(gate, up, verify_rows, kSwigluRows,
+                                         kSwigluCols, scale_stride, iters);
+        // Two separate online matmuls are the non-fused raw-FP8 alternative.
+        const double separate =
+            time_rows(gate, verify_rows, kSwigluRows, kSwigluCols, scale_stride,
+                      iters) +
+            time_rows(up, verify_rows, kSwigluRows, kSwigluCols, scale_stride,
+                      iters);
+        const double resident = time_resident_swiglu(
+            gate, up, verify_rows, kSwigluRows, kSwigluCols, iters);
+        std::printf("qwen_verify_swiglu rows=%d out=%d cols=%d tile=%s warps=%s "
+                    "fused=%.4f ms separate=%.4f ms resident=%.4f ms "
+                    "resident_speedup=%.3f\n",
+                    verify_rows, kSwigluRows, kSwigluCols,
+                    tile == nullptr ? "default" : tile,
+                    warps == nullptr ? "default" : warps, fused, separate,
+                    resident, resident > 0.0 ? fused / resident : 0.0);
+    }
+
+    const char* projection_warps =
+        std::getenv("QWEN_FP8_F16_SMALL_BATCH_WARPS");
+    std::printf("qwen_verify_batch rows=%d iters=%d warps=%s\n", verify_rows,
+                iters, projection_warps == nullptr ? "default" : projection_warps);
     for (const Shape& shape : kShapes) {
+        if (mlp_only && std::strncmp(shape.name, "mlp.", 4) != 0) continue;
         const int scale_stride = (shape.cols + kFp8Block - 1) / kFp8Block;
         DeviceBuffers buffers;
         const size_t x_elements =
@@ -334,6 +783,9 @@ int main(int argc, char** argv) {
         check(cudaMalloc(&buffers.weight, weight_elements), "malloc weight");
         check(cudaMalloc(&buffers.scale, scale_elements * sizeof(uint16_t)),
               "malloc scale");
+        check(cudaMalloc(&buffers.weight_f16,
+                         weight_elements * sizeof(uint16_t)),
+              "malloc resident weight");
         check(cudaMalloc(&buffers.y, y_elements * sizeof(uint16_t)), "malloc y");
 
         std::vector<uint16_t> host_x(x_elements);
@@ -353,27 +805,41 @@ int main(int argc, char** argv) {
         check(cudaMemcpy(buffers.scale, host_scale.data(),
                          host_scale.size() * sizeof(uint16_t),
                          cudaMemcpyHostToDevice), "copy scale");
+        if (!dsv4::qwen_fp8_e4m3_fp16scale_dequantize_f16_cuda(
+                buffers.weight, buffers.scale, buffers.weight_f16,
+                shape.out_rows, shape.cols, shape.cols, scale_stride)) {
+            std::fprintf(stderr, "resident weight dequantization failed\n");
+            std::exit(1);
+        }
+        check(cudaDeviceSynchronize(), "resident weight dequantization sync");
 
         const double one_row = time_rows(buffers, 1, shape.out_rows, shape.cols,
                                          scale_stride, iters);
         const double batched = time_rows(buffers, verify_rows, shape.out_rows,
                                          shape.cols, scale_stride, iters);
+        const double resident = time_resident_rows(
+            buffers, verify_rows, shape.out_rows, shape.cols, iters);
         const double serial = one_row * verify_rows;
         serial_total += serial;
         verify_total += batched;
+        resident_total += resident;
         std::printf(
             "  %-12s out=%5d cols=%5d row1=%.4f ms serial%d=%.4f ms "
-            "batch%d=%.4f ms ratio=%.3f\n",
+            "batch%d=%.4f ms resident=%.4f ms resident_speedup=%.3f\n",
             shape.name, shape.out_rows, shape.cols, one_row, verify_rows,
-            serial, verify_rows, batched,
-            batched > 0.0 ? serial / batched : 0.0);
+            serial, verify_rows, batched, resident,
+            resident > 0.0 ? batched / resident : 0.0);
     }
     std::printf(
-        "  total serial%d=%.4f ms batch%d=%.4f ms projection_speedup=%.3f\n",
-        verify_rows, serial_total, verify_rows, verify_total,
-        verify_total > 0.0 ? serial_total / verify_total : 0.0);
-    // DFlash2 proposes verify_rows - 1 draft rows per block.
-    bench_f16_draft(verify_rows - 1, iters, rng);
-    bench_context_projection(iters, rng);
+        "  total serial%d=%.4f ms batch%d=%.4f ms resident=%.4f ms "
+        "projection_speedup=%.3f resident_speedup=%.3f\n",
+        verify_rows, serial_total, verify_rows, verify_total, resident_total,
+        verify_total > 0.0 ? serial_total / verify_total : 0.0,
+        resident_total > 0.0 ? verify_total / resident_total : 0.0);
+    if (!mlp_only) {
+        // DFlash2 proposes verify_rows - 1 draft rows per block.
+        bench_f16_draft(verify_rows - 1, iters, rng);
+        bench_context_projection(iters, rng);
+    }
     return 0;
 }

--- a/cpp_engine/tests/test_qwen_dflash2_ops.cpp
+++ b/cpp_engine/tests/test_qwen_dflash2_ops.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstdint>
 #include <iostream>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <random>
@@ -356,6 +357,186 @@ void test_selector_viterbi_beats_greedy() {
     cudaFree(d_predecessor); cudaFree(d_successor);
 }
 
+void test_device_global_top1_merge() {
+    // This is the exact world-major layout produced by the NCCL all-gather
+    // wrapper: [rank][row]. Keep the test independent of NCCL so it also checks
+    // the merge kernel on a single GPU, including stream ordering.
+    const int world = 4;
+    const int rows = 5;
+    const int top_k = 1;
+    const int invalid_token = std::numeric_limits<int>::max();
+    const float negative_infinity = -std::numeric_limits<float>::infinity();
+    const std::vector<int> gathered_tokens = {
+        40, 700, 2, 99, 3,
+        41, 100, 1, 98, 4,
+        42, 50, 7, 97, 5,
+        43, 200, 8, 96, 6,
+    };
+    const std::vector<float> gathered_logits = {
+        1.0f, 5.0f, NAN, 4.0f, -1.0f,
+        3.0f, 5.0f, NAN, 4.0f, -1.0f,
+        2.0f, 4.9f, NAN, 4.0f, -1.0f,
+        NAN, 5.0f, NAN, NAN, -2.0f,
+    };
+    const std::vector<int> expected_tokens = {41, 100, invalid_token, 97, 3};
+    const std::vector<float> expected_logits = {3.0f, 5.0f, negative_infinity,
+                                                4.0f, -1.0f};
+
+    int* d_gathered_tokens = upload(gathered_tokens);
+    float* d_gathered_logits = upload(gathered_logits);
+    int* d_output_tokens = nullptr;
+    float* d_output_logits = nullptr;
+    check_cuda(cudaMalloc(&d_output_tokens, rows * sizeof(int)),
+               "global top-1 output tokens");
+    check_cuda(cudaMalloc(&d_output_logits, rows * sizeof(float)),
+               "global top-1 output logits");
+    cudaStream_t stream = nullptr;
+    check_cuda(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking),
+               "global top-1 stream");
+    require(dsv4::qwen_dflash2_merge_topk_f32_cuda(
+                d_gathered_tokens, d_gathered_logits, d_output_tokens,
+                d_output_logits, world, rows, top_k, stream),
+            "device global top-1 merge launch failed");
+    std::vector<int> output_tokens(rows);
+    std::vector<float> output_logits(rows);
+    check_cuda(cudaMemcpyAsync(output_tokens.data(), d_output_tokens,
+                               rows * sizeof(int), cudaMemcpyDeviceToHost,
+                               stream),
+               "copy global top-1 tokens");
+    check_cuda(cudaMemcpyAsync(output_logits.data(), d_output_logits,
+                               rows * sizeof(float), cudaMemcpyDeviceToHost,
+                               stream),
+               "copy global top-1 logits");
+    check_cuda(cudaStreamSynchronize(stream), "sync global top-1 merge");
+    for (int row = 0; row < rows; ++row) {
+        require(output_tokens[static_cast<size_t>(row)] == expected_tokens[row],
+                "device global top-1 token mismatch row=" + std::to_string(row));
+        const float actual = output_logits[static_cast<size_t>(row)];
+        const float expected = expected_logits[row];
+        if (std::isinf(expected)) {
+            require(std::isinf(actual) && actual < 0.0f,
+                    "device global top-1 empty logit mismatch row=" +
+                        std::to_string(row));
+        } else {
+            require(actual == expected,
+                    "device global top-1 logit mismatch row=" +
+                        std::to_string(row));
+        }
+    }
+    check_cuda(cudaStreamDestroy(stream), "destroy global top-1 stream");
+    cudaFree(d_gathered_tokens);
+    cudaFree(d_gathered_logits);
+    cudaFree(d_output_tokens);
+    cudaFree(d_output_logits);
+}
+
+void test_packed_top1_key() {
+    // Simulate the NCCL uint64 Max reduction on one GPU. Each rank packs one
+    // local candidate per row; the host-side max below is exactly the ordering
+    // used by ncclMax for the production packed path.
+    const int world = 4;
+    const int rows = 8;
+    const int invalid_token = std::numeric_limits<int>::max();
+    const float negative_infinity = -std::numeric_limits<float>::infinity();
+    const std::vector<std::vector<int>> tokens = {
+        {40, 700, 2, 99, 3, 8, 10, 20},
+        {41, 100, 1, 98, 4, 7, 11, 21},
+        {42, 50, 7, 97, 5, 6, 12, 22},
+        {43, 200, 8, 96, 6, 5, 13, 23},
+    };
+    const std::vector<std::vector<float>> logits = {
+        {1.0f, 5.0f, NAN, 4.0f, -1.0f, -0.0f, negative_infinity, NAN},
+        {3.0f, 5.0f, NAN, 4.0f, -1.0f, +0.0f, negative_infinity, NAN},
+        {2.0f, 4.9f, NAN, 4.0f, -1.0f, -0.0f, negative_infinity, NAN},
+        {NAN, 5.0f, NAN, NAN, -2.0f, +0.0f, negative_infinity, NAN},
+    };
+    const std::vector<int> expected_tokens = {
+        41, 100, invalid_token, 97, 3, 5, 10, invalid_token};
+    const std::vector<float> expected_logits = {
+        3.0f, 5.0f, negative_infinity, 4.0f, -1.0f, 0.0f,
+        negative_infinity, negative_infinity};
+
+    std::vector<int*> d_tokens(world, nullptr);
+    std::vector<float*> d_logits(world, nullptr);
+    std::vector<uint64_t*> d_keys(world, nullptr);
+    std::vector<std::vector<uint64_t>> packed(
+        world, std::vector<uint64_t>(rows));
+    for (int rank = 0; rank < world; ++rank) {
+        d_tokens[rank] = upload(tokens[rank]);
+        d_logits[rank] = upload(logits[rank]);
+        check_cuda(cudaMalloc(&d_keys[rank], rows * sizeof(uint64_t)),
+                   "packed top-1 keys");
+    }
+
+    cudaStream_t stream = nullptr;
+    check_cuda(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking),
+               "packed top-1 stream");
+    for (int rank = 0; rank < world; ++rank) {
+        require(dsv4::qwen_dflash2_pack_top1_key_f32_cuda(
+                    d_tokens[rank], d_logits[rank], d_keys[rank], rows, stream),
+                "packed top-1 pack launch failed");
+        check_cuda(cudaMemcpyAsync(packed[rank].data(), d_keys[rank],
+                                   rows * sizeof(uint64_t),
+                                   cudaMemcpyDeviceToHost, stream),
+                   "copy packed top-1 keys");
+    }
+    check_cuda(cudaStreamSynchronize(stream), "sync packed top-1 pack");
+
+    std::vector<uint64_t> reduced(rows, 0ull);
+    for (int row = 0; row < rows; ++row) {
+        for (int rank = 0; rank < world; ++rank) {
+            reduced[row] = std::max(reduced[row], packed[rank][row]);
+        }
+    }
+    uint64_t* d_reduced = upload(reduced);
+    int* d_output_tokens = nullptr;
+    float* d_output_logits = nullptr;
+    check_cuda(cudaMalloc(&d_output_tokens, rows * sizeof(int)),
+               "packed top-1 output tokens");
+    check_cuda(cudaMalloc(&d_output_logits, rows * sizeof(float)),
+               "packed top-1 output logits");
+    require(dsv4::qwen_dflash2_unpack_top1_key_f32_cuda(
+                d_reduced, d_output_tokens, d_output_logits, rows, stream),
+            "packed top-1 unpack launch failed");
+    std::vector<int> output_tokens(rows);
+    std::vector<float> output_logits(rows);
+    check_cuda(cudaMemcpyAsync(output_tokens.data(), d_output_tokens,
+                               rows * sizeof(int), cudaMemcpyDeviceToHost,
+                               stream),
+               "copy unpacked top-1 tokens");
+    check_cuda(cudaMemcpyAsync(output_logits.data(), d_output_logits,
+                               rows * sizeof(float), cudaMemcpyDeviceToHost,
+                               stream),
+               "copy unpacked top-1 logits");
+    check_cuda(cudaStreamSynchronize(stream), "sync packed top-1 unpack");
+
+    for (int row = 0; row < rows; ++row) {
+        require(output_tokens[row] == expected_tokens[row],
+                "packed top-1 token mismatch row=" + std::to_string(row));
+        if (std::isinf(expected_logits[row])) {
+            require(std::isinf(output_logits[row]) && output_logits[row] < 0.0f,
+                    "packed top-1 -inf mismatch row=" + std::to_string(row));
+        } else {
+            require(output_logits[row] == expected_logits[row],
+                    "packed top-1 logit mismatch row=" + std::to_string(row));
+        }
+    }
+    // Signed zero is canonicalized before packing so it has the same ordering
+    // as the host comparator and decodes to the canonical +0 representation.
+    require(!std::signbit(output_logits[5]),
+            "packed top-1 failed to canonicalize signed zero");
+
+    check_cuda(cudaStreamDestroy(stream), "destroy packed top-1 stream");
+    for (int rank = 0; rank < world; ++rank) {
+        cudaFree(d_tokens[rank]);
+        cudaFree(d_logits[rank]);
+        cudaFree(d_keys[rank]);
+    }
+    cudaFree(d_reduced);
+    cudaFree(d_output_tokens);
+    cudaFree(d_output_logits);
+}
+
 void test_selector_path() {
     const int rows = 3;
     const int vocab = 8;
@@ -535,6 +716,8 @@ int main() {
         test_strided_dynamic_conv();
         test_local_topk();
         test_local_topk_split_matches_reference();
+        test_device_global_top1_merge();
+        test_packed_top1_key();
         test_selector_viterbi_beats_greedy();
         test_selector_path();
         test_grouped_attention();

--- a/cpp_engine/tests/test_qwen_gqa_attention.cpp
+++ b/cpp_engine/tests/test_qwen_gqa_attention.cpp
@@ -301,6 +301,103 @@ bool run_prefill_tiled(int rows, int q_heads, int kv_heads, int head_dim,
     return true;
 }
 
+bool run_verify_crossover(int context_len) {
+    constexpr int rows = 8;
+    constexpr int q_heads = 6;
+    constexpr int kv_heads = 1;
+    constexpr int head_dim = 256;
+    constexpr int splits = 64;
+    const int position_offset = context_len - rows;
+    const size_t q_elements = static_cast<size_t>(rows) * q_heads * head_dim;
+    const size_t kv_elements = static_cast<size_t>(context_len) * kv_heads * head_dim;
+    const size_t score_elements = static_cast<size_t>(rows) * q_heads * context_len;
+    const size_t partial_elements = static_cast<size_t>(rows) * q_heads * splits *
+        static_cast<size_t>(head_dim + 2);
+    std::mt19937 rng(97531 + context_len);
+    std::uniform_real_distribution<float> dist(-0.1f, 0.1f);
+    std::vector<uint16_t> q(q_elements), k(kv_elements), v(kv_elements);
+    for (uint16_t& value : q) value = to_half(dist(rng));
+    for (uint16_t& value : k) value = to_half(dist(rng));
+    for (uint16_t& value : v) value = to_half(dist(rng));
+
+    uint16_t* d_q = nullptr;
+    uint16_t* d_k = nullptr;
+    uint16_t* d_v = nullptr;
+    uint16_t* d_exact = nullptr;
+    uint16_t* d_split = nullptr;
+    uint16_t* d_cublas = nullptr;
+    float* d_scores = nullptr;
+    float* d_partials = nullptr;
+    auto release = [&]() {
+        cudaFree(d_q); cudaFree(d_k); cudaFree(d_v);
+        cudaFree(d_exact); cudaFree(d_split); cudaFree(d_cublas);
+        cudaFree(d_scores); cudaFree(d_partials);
+    };
+    if (cudaMalloc(&d_q, q.size() * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_k, k.size() * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_v, v.size() * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_exact, q.size() * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_split, q.size() * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_cublas, q.size() * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_scores, score_elements * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&d_partials, partial_elements * sizeof(float)) != cudaSuccess) {
+        release();
+        return false;
+    }
+    if (cudaMemcpy(d_q, q.data(), q.size() * sizeof(uint16_t),
+                   cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_k, k.data(), k.size() * sizeof(uint16_t),
+                   cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_v, v.data(), v.size() * sizeof(uint16_t),
+                   cudaMemcpyHostToDevice) != cudaSuccess ||
+        !dsv4::qwen_gqa_verify_attention_f16_exact_cuda(
+            d_q, d_k, d_v, d_exact, d_scores, rows, q_heads, kv_heads,
+            head_dim, position_offset, context_len) ||
+        !dsv4::qwen_gqa_verify_attention_f16_cuda(
+            d_q, d_k, d_v, d_split, d_partials, rows, q_heads, kv_heads,
+            head_dim, position_offset, context_len, splits) ||
+        !dsv4::qwen_gqa_verify_attention_f16_cublas_qk_cuda(
+            d_q, d_k, d_v, d_cublas, d_scores, rows, q_heads, kv_heads,
+            head_dim, position_offset, context_len) ||
+        cudaDeviceSynchronize() != cudaSuccess) {
+        fail("gqa verify crossover launch ctx=" + std::to_string(context_len));
+        release();
+        return true;
+    }
+    std::vector<uint16_t> exact(q_elements), split(q_elements), cublas(q_elements);
+    if (cudaMemcpy(exact.data(), d_exact, exact.size() * sizeof(uint16_t),
+                   cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(split.data(), d_split, split.size() * sizeof(uint16_t),
+                   cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(cublas.data(), d_cublas, cublas.size() * sizeof(uint16_t),
+                   cudaMemcpyDeviceToHost) != cudaSuccess) {
+        fail("gqa verify crossover copy ctx=" + std::to_string(context_len));
+        release();
+        return true;
+    }
+    release();
+    double split_worst = 0.0;
+    double cublas_worst = 0.0;
+    for (size_t index = 0; index < exact.size(); ++index) {
+        const double reference = from_half(exact[index]);
+        split_worst = std::max(split_worst, std::fabs(
+            reference - from_half(split[index])));
+        cublas_worst = std::max(cublas_worst, std::fabs(
+            reference - from_half(cublas[index])));
+    }
+    if (split_worst > 2.0e-3 || cublas_worst > 2.0e-3) {
+        fail("gqa verify crossover ctx=" + std::to_string(context_len) +
+             " split=" + std::to_string(split_worst) +
+             " cublas=" + std::to_string(cublas_worst));
+    } else {
+        const char* production_default = context_len <= 1024 ? "exact" : "split";
+        std::printf("  gqa verify crossover ctx=%5d default=%s "
+                    "exact_vs_split=%.3e exact_vs_cublas=%.3e\n",
+                    context_len, production_default, split_worst, cublas_worst);
+    }
+    return true;
+}
+
 }  // namespace
 
 int main() {
@@ -332,6 +429,16 @@ int main() {
     const int grouping_shapes[][2] = {{12, 6}, {8, 8}, {24, 8}};
     for (const auto& shape : grouping_shapes) {
         if (!run_prefill_tiled(64, shape[0], shape[1], 128, 512, 8192)) {
+            std::printf("[SKIP] device allocation failed\n");
+            return 0;
+        }
+    }
+    // Production currently uses exact through 1K context and split-K above it;
+    // cuBLAS-QK is opt-in while its real-model crossover is validated. Cover
+    // both sides of the current boundary and representative mid/long contexts.
+    const int verify_contexts[] = {1024, 1025, 4096, 8192};
+    for (int context : verify_contexts) {
+        if (!run_verify_crossover(context)) {
             std::printf("[SKIP] device allocation failed\n");
             return 0;
         }

--- a/cpp_engine/tests/test_qwen_half_ops.cpp
+++ b/cpp_engine/tests/test_qwen_half_ops.cpp
@@ -146,6 +146,95 @@ double max_half_difference(const std::vector<uint16_t>& lhs,
     return worst;
 }
 
+bool check_residual_add_rmsnorm_fused() {
+    constexpr int cols = 5120;
+    constexpr float eps = 1.0e-6f;
+    const int row_cases[] = {2, 3, 5, 8};
+    std::mt19937 rng(26391);
+    std::uniform_real_distribution<float> hidden_dist(-2.0f, 2.0f);
+    std::uniform_real_distribution<float> delta_dist(-0.5f, 0.5f);
+    std::uniform_real_distribution<float> gamma_dist(-0.2f, 0.2f);
+    for (int rows : row_cases) {
+        const size_t elements = static_cast<size_t>(rows) * cols;
+        std::vector<uint16_t> hidden(elements);
+        std::vector<uint16_t> delta(elements);
+        std::vector<uint16_t> gamma(cols);
+        for (uint16_t& value : hidden) value = to_half(hidden_dist(rng));
+        for (uint16_t& value : delta) value = to_half(delta_dist(rng));
+        for (uint16_t& value : gamma) value = to_half(gamma_dist(rng));
+
+        DeviceBuffer dhidden, ddelta, dgamma, dref_residual, dref_normalized,
+            dfused_residual, dfused_normalized;
+        uint16_t* d_hidden = dhidden.allocate<uint16_t>(elements);
+        uint16_t* d_delta = ddelta.allocate<uint16_t>(elements);
+        uint16_t* d_gamma = dgamma.allocate<uint16_t>(gamma.size());
+        uint16_t* d_ref_residual = dref_residual.allocate<uint16_t>(elements);
+        uint16_t* d_ref_normalized = dref_normalized.allocate<uint16_t>(elements);
+        uint16_t* d_fused_residual = dfused_residual.allocate<uint16_t>(elements);
+        uint16_t* d_fused_normalized = dfused_normalized.allocate<uint16_t>(elements);
+        if (!d_hidden || !d_delta || !d_gamma || !d_ref_residual ||
+            !d_ref_normalized || !d_fused_residual || !d_fused_normalized ||
+            cudaMemcpy(d_hidden, hidden.data(), elements * sizeof(uint16_t),
+                       cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(d_delta, delta.data(), elements * sizeof(uint16_t),
+                       cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(d_gamma, gamma.data(), gamma.size() * sizeof(uint16_t),
+                       cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(d_ref_residual, d_hidden, elements * sizeof(uint16_t),
+                       cudaMemcpyDeviceToDevice) != cudaSuccess ||
+            !dsv4::qwen_add_inplace_f16_cuda(
+                d_ref_residual, d_delta, static_cast<int>(elements)) ||
+            !dsv4::qwen_rmsnorm_fp16_gamma_rows_f16_cuda(
+                d_ref_residual, d_gamma, d_ref_normalized, rows, cols, eps) ||
+            !dsv4::qwen_residual_add_rmsnorm_fp16_gamma_rows_f16_cuda(
+                d_hidden, d_delta, d_gamma, d_fused_residual,
+                d_fused_normalized, rows, cols, eps) ||
+            cudaDeviceSynchronize() != cudaSuccess) {
+            fail("FP16 fused residual RMSNorm launch");
+            return true;
+        }
+
+        std::vector<uint16_t> ref_residual(elements);
+        std::vector<uint16_t> ref_normalized(elements);
+        std::vector<uint16_t> fused_residual(elements);
+        std::vector<uint16_t> fused_normalized(elements);
+        if (cudaMemcpy(ref_residual.data(), d_ref_residual,
+                       elements * sizeof(uint16_t), cudaMemcpyDeviceToHost) !=
+                cudaSuccess ||
+            cudaMemcpy(ref_normalized.data(), d_ref_normalized,
+                       elements * sizeof(uint16_t), cudaMemcpyDeviceToHost) !=
+                cudaSuccess ||
+            cudaMemcpy(fused_residual.data(), d_fused_residual,
+                       elements * sizeof(uint16_t), cudaMemcpyDeviceToHost) !=
+                cudaSuccess ||
+            cudaMemcpy(fused_normalized.data(), d_fused_normalized,
+                       elements * sizeof(uint16_t), cudaMemcpyDeviceToHost) !=
+                cudaSuccess) {
+            fail("FP16 fused residual RMSNorm copy");
+            return true;
+        }
+        int residual_mismatches = 0;
+        int normalized_mismatches = 0;
+        for (size_t index = 0; index < elements; ++index) {
+            residual_mismatches +=
+                ref_residual[index] != fused_residual[index] ? 1 : 0;
+            normalized_mismatches +=
+                ref_normalized[index] != fused_normalized[index] ? 1 : 0;
+        }
+        if (residual_mismatches != 0 || normalized_mismatches != 0) {
+            std::printf("  FP16 fused residual RMSNorm rows=%d cols=%d "
+                        "residual_mismatch=%d normalized_mismatch=%d\n",
+                        rows, cols, residual_mismatches,
+                        normalized_mismatches);
+            fail("FP16 fused residual RMSNorm bit exactness");
+            return true;
+        }
+    }
+    std::printf("  FP16 fused residual RMSNorm bit exact rows=2,3,5,8 "
+                "cols=%d\n", cols);
+    return true;
+}
+
 bool check_prefill_tiled(int seq_len, int head_dim, int position_offset,
                          int q_heads = 6, int kv_heads = 1) {
 
@@ -674,12 +763,9 @@ bool check_fp8_f16_projection() {
         };
         bool shared_ok = true;
         double worst = 0.0;
-        // Both shared-activation variants are checked against the register-only
-        // kernel. The packed-conversion variant fuses two strided steps per
-        // iteration but keeps each lane's columns and their addition order, so it
-        // must also be bit exact.
-        const char* const shared_variants[] = {"0", "1"};
-        for (const char* fshared : shared_variants)
+        // The paired shared kernel fuses two strided steps while keeping each
+        // lane's columns and addition order, so it must match the register-only
+        // path bit for bit.
         for (const SharedCase& item : cases) {
             const int x_stride = item.cols;
             const int y_stride = item.rows;
@@ -717,20 +803,17 @@ bool check_fp8_f16_projection() {
             }
             setenv("QWEN_FP8_F16_SMALL_BATCH", "1", 1);
             setenv("QWEN_FP8_F16_SMALL_BATCH_SHARED", "1", 1);
-            setenv("QWEN_FP8_F16_SMALL_BATCH_FSHARED", fshared, 1);
             const bool shared_launched =
                 dsv4::qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
                     px, pw, ps, py_shared, item.batch, item.rows, item.cols,
                     x_stride, y_stride, weight_stride, scale_stride) &&
                 cudaDeviceSynchronize() == cudaSuccess;
             setenv("QWEN_FP8_F16_SMALL_BATCH_SHARED", "0", 1);
-            setenv("QWEN_FP8_F16_SMALL_BATCH_FSHARED", "0", 1);
             const bool plain_launched =
                 dsv4::qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
                     px, pw, ps, py_plain, item.batch, item.rows, item.cols,
                     x_stride, y_stride, weight_stride, scale_stride) &&
                 cudaDeviceSynchronize() == cudaSuccess;
-            unsetenv("QWEN_FP8_F16_SMALL_BATCH_FSHARED");
             unsetenv("QWEN_FP8_F16_SMALL_BATCH_SHARED");
             unsetenv("QWEN_FP8_F16_SMALL_BATCH");
             if (!shared_launched || !plain_launched) {
@@ -759,9 +842,8 @@ bool check_fp8_f16_projection() {
             }
             if (mismatches != 0) {
                 std::printf("  FP16 FP8 shared small-batch mismatch batch=%d "
-                            "rows=%d cols=%d fshared=%s count=%d worst=%.3e\n",
-                            item.batch, item.rows, item.cols, fshared,
-                            mismatches, worst);
+                            "rows=%d cols=%d count=%d worst=%.3e\n",
+                            item.batch, item.rows, item.cols, mismatches, worst);
                 fail("FP16 FP8 shared small-batch bit exactness");
                 shared_ok = false;
                 break;
@@ -769,9 +851,8 @@ bool check_fp8_f16_projection() {
         }
         if (shared_ok) {
             std::printf("  FP16 FP8 shared small-batch bit exact over %zu "
-                        "shard shapes x %zu variants\n",
-                        sizeof(cases) / sizeof(cases[0]),
-                        sizeof(shared_variants) / sizeof(shared_variants[0]));
+                        "shard shapes\n",
+                        sizeof(cases) / sizeof(cases[0]));
         }
     }
 
@@ -891,6 +972,154 @@ bool check_fp8_f16_projection() {
                     "dispatch=%.3e cublas=%.3e\n",
                     batch, rows, cols, prefill_error, prefill_dispatch_error,
                     prefill_cublas_error);
+    }
+    return true;
+}
+
+bool check_resident_fp16_projection() {
+    constexpr int batch = 8;
+    constexpr int rows = 136;
+    constexpr int cols = 512;
+    constexpr int x_stride = 520;
+    constexpr int y_stride = 144;
+    constexpr int weight_stride = 520;
+    constexpr int scale_stride = 5;
+    const uint8_t finite_codes[] = {
+        0x01, 0x03, 0x08, 0x18, 0x20, 0x28, 0x30, 0x38,
+        0x40, 0x48, 0x81, 0x83, 0x88, 0x98, 0xa0, 0xa8,
+        0xb0, 0xb8, 0xc0, 0xc8,
+    };
+    std::mt19937 rng(52081);
+    std::uniform_real_distribution<float> x_dist(-0.5f, 0.5f);
+    std::uniform_real_distribution<float> scale_dist(0.005f, 0.02f);
+    std::vector<uint16_t> x(static_cast<size_t>(batch) * x_stride);
+    std::vector<uint8_t> weight(static_cast<size_t>(rows) * weight_stride);
+    std::vector<uint16_t> scale(
+        static_cast<size_t>((rows + 127) / 128) * scale_stride);
+    for (uint16_t& value : x) value = to_half(x_dist(rng));
+    for (uint8_t& value : weight) {
+        value = finite_codes[rng() % (sizeof(finite_codes) / sizeof(finite_codes[0]))];
+    }
+    for (uint16_t& value : scale) value = to_half(scale_dist(rng));
+
+    std::vector<uint16_t> expected_weight(static_cast<size_t>(rows) * cols);
+    for (int row = 0; row < rows; ++row) {
+        for (int col = 0; col < cols; ++col) {
+            expected_weight[static_cast<size_t>(row) * cols + col] = to_half(
+                from_fp8_e4m3(weight[static_cast<size_t>(row) * weight_stride + col]) *
+                from_half(scale[static_cast<size_t>(row / 128) * scale_stride +
+                                      col / 128]));
+        }
+    }
+
+    DeviceBuffer dx, dw, ds, d_resident_weight, d_online, d_resident;
+    uint16_t* d_x = dx.allocate<uint16_t>(x.size());
+    uint8_t* d_weight = dw.allocate<uint8_t>(weight.size());
+    uint16_t* d_scale = ds.allocate<uint16_t>(scale.size());
+    uint16_t* d_dense = d_resident_weight.allocate<uint16_t>(
+        expected_weight.size());
+    uint16_t* d_online_y = d_online.allocate<uint16_t>(
+        static_cast<size_t>(batch) * y_stride);
+    uint16_t* d_resident_y = d_resident.allocate<uint16_t>(
+        static_cast<size_t>(batch) * y_stride);
+    if (!d_x || !d_weight || !d_scale || !d_dense || !d_online_y ||
+        !d_resident_y ||
+        cudaMemcpy(d_x, x.data(), x.size() * sizeof(uint16_t),
+                   cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_weight, weight.data(), weight.size(),
+                   cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemcpy(d_scale, scale.data(), scale.size() * sizeof(uint16_t),
+                   cudaMemcpyHostToDevice) != cudaSuccess) {
+        fail("resident FP16 projection allocation/copy");
+        return false;
+    }
+
+    setenv("QWEN_FP8_F16_SMALL_BATCH", "1", 1);
+    setenv("QWEN_FP8_F16_SMALL_BATCH_SHARED", "1", 1);
+    const bool launched =
+        dsv4::qwen_fp8_e4m3_fp16scale_dequantize_f16_cuda(
+            d_weight, d_scale, d_dense, rows, cols, weight_stride,
+            scale_stride) &&
+        dsv4::qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
+            d_x, d_weight, d_scale, d_online_y, batch, rows, cols, x_stride,
+            y_stride, weight_stride, scale_stride) &&
+        dsv4::qwen_fp16_matmul_rows_f16_cublas_cuda(
+            d_x, d_dense, d_resident_y, batch, rows, cols, x_stride, y_stride,
+            cols) &&
+        cudaDeviceSynchronize() == cudaSuccess;
+    unsetenv("QWEN_FP8_F16_SMALL_BATCH_SHARED");
+    unsetenv("QWEN_FP8_F16_SMALL_BATCH");
+    if (!launched) {
+        fail("resident FP16 projection launch");
+        return false;
+    }
+
+    std::vector<uint16_t> dense(expected_weight.size());
+    std::vector<uint16_t> online(static_cast<size_t>(batch) * y_stride);
+    std::vector<uint16_t> resident(online.size());
+    if (cudaMemcpy(dense.data(), d_dense, dense.size() * sizeof(uint16_t),
+                   cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(online.data(), d_online_y, online.size() * sizeof(uint16_t),
+                   cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(resident.data(), d_resident_y,
+                   resident.size() * sizeof(uint16_t),
+                   cudaMemcpyDeviceToHost) != cudaSuccess) {
+        fail("resident FP16 projection copy");
+        return false;
+    }
+    if (dense != expected_weight) {
+        fail("resident FP16 weight expansion layout");
+        return true;
+    }
+
+    double direct_abs = 0.0;
+    double direct_rel = 0.0;
+    double online_reference = 0.0;
+    double resident_reference = 0.0;
+    for (int sample = 0; sample < batch; ++sample) {
+        for (int row = 0; row < rows; ++row) {
+            float raw_sum = 0.0f;
+            float rounded_sum = 0.0f;
+            for (int col = 0; col < cols; ++col) {
+                const float activation = from_half(
+                    x[static_cast<size_t>(sample) * x_stride + col]);
+                const float block_scale = from_half(
+                    scale[static_cast<size_t>(row / 128) * scale_stride +
+                          col / 128]);
+                raw_sum += activation *
+                    from_fp8_e4m3(weight[static_cast<size_t>(row) *
+                                               weight_stride + col]) *
+                    block_scale;
+                rounded_sum += activation * from_half(
+                    expected_weight[static_cast<size_t>(row) * cols + col]);
+            }
+            const size_t at = static_cast<size_t>(sample) * y_stride + row;
+            const double online_value = from_half(online[at]);
+            const double resident_value = from_half(resident[at]);
+            const double difference = std::fabs(online_value - resident_value);
+            direct_abs = std::max(direct_abs, difference);
+            const double magnitude = std::max(
+                std::fabs(online_value), std::fabs(resident_value));
+            if (magnitude >= 0.25) {
+                direct_rel = std::max(direct_rel, difference / magnitude);
+            }
+            online_reference = std::max(
+                online_reference,
+                std::fabs(online_value - static_cast<double>(raw_sum)));
+            resident_reference = std::max(
+                resident_reference,
+                std::fabs(resident_value - static_cast<double>(rounded_sum)));
+        }
+    }
+    if (direct_abs > 3.0e-2 || online_reference > 3.0e-2 ||
+        resident_reference > 3.0e-2) {
+        fail("resident FP16 projection numerical check");
+    } else {
+        std::printf("  resident FP16 projection batch=%d rows=%d cols=%d "
+                    "online_vs_resident_abs=%.3e rel=%.3e "
+                    "online_ref=%.3e resident_ref=%.3e\n",
+                    batch, rows, cols, direct_abs, direct_rel,
+                    online_reference, resident_reference);
     }
     return true;
 }
@@ -1019,6 +1248,126 @@ bool check_batched_argmax() {
         std::printf("  batched argmax rows=%d count=%d tie=lower-token\n",
                     rows, count);
     }
+    return true;
+}
+
+bool check_region_copy() {
+    constexpr uint8_t kGuard = 0xa7;
+    std::vector<size_t> sizes;
+    sizes.reserve(97);
+    for (int index = 0; index < 48; ++index) {
+        sizes.push_back(index == 17 ? 786432 + 13 : 786432);
+        sizes.push_back(index == 9 ? 15360 + 7 : 15360);
+    }
+    sizes.push_back(10240 + 5);
+
+    std::vector<DeviceBuffer> buffers(sizes.size());
+    std::vector<uint8_t*> device_regions(sizes.size());
+    std::vector<std::vector<uint8_t>> expected(sizes.size());
+    std::vector<dsv4::QwenCopyRegion> descriptors;
+    descriptors.reserve(sizes.size());
+    uint64_t packed_bytes = 0;
+    uint64_t total_blocks = 0;
+    for (size_t region = 0; region < sizes.size(); ++region) {
+        const size_t bytes = sizes[region];
+        device_regions[region] = buffers[region].allocate<uint8_t>(bytes + 32);
+        if (device_regions[region] == nullptr) return false;
+        expected[region].resize(bytes);
+        for (size_t index = 0; index < bytes; ++index) {
+            expected[region][index] = static_cast<uint8_t>(
+                (region * 131 + index * 17 + (index >> 8)) & 0xffu);
+        }
+        std::vector<uint8_t> initial(bytes + 32, kGuard);
+        std::copy(expected[region].begin(), expected[region].end(),
+                  initial.begin() + 16);
+        if (cudaMemcpy(device_regions[region], initial.data(), initial.size(),
+                       cudaMemcpyHostToDevice) != cudaSuccess) {
+            fail("region copy source upload");
+            return true;
+        }
+        device_regions[region] += 16;
+        dsv4::QwenCopyRegion descriptor;
+        descriptor.device_address = reinterpret_cast<uint64_t>(
+            device_regions[region]);
+        descriptor.packed_offset = packed_bytes;
+        descriptor.bytes = bytes;
+        descriptor.first_block = total_blocks;
+        descriptors.push_back(descriptor);
+        packed_bytes += bytes;
+        total_blocks += dsv4::qwen_copy_region_blocks(bytes);
+    }
+
+    DeviceBuffer ddescriptors, dpacked;
+    auto* d_regions = ddescriptors.allocate<dsv4::QwenCopyRegion>(
+        descriptors.size());
+    uint8_t* d_packed = dpacked.allocate<uint8_t>(packed_bytes + 32);
+    if (!d_regions || !d_packed ||
+        cudaMemcpy(d_regions, descriptors.data(),
+                   descriptors.size() * sizeof(descriptors[0]),
+                   cudaMemcpyHostToDevice) != cudaSuccess ||
+        cudaMemset(d_packed, kGuard, packed_bytes + 32) != cudaSuccess ||
+        !dsv4::qwen_gather_copy_regions_cuda(
+            d_regions, static_cast<int>(descriptors.size()), d_packed + 16,
+            total_blocks) ||
+        cudaDeviceSynchronize() != cudaSuccess) {
+        fail("region gather launch");
+        return true;
+    }
+
+    std::vector<uint8_t> packed(packed_bytes + 32);
+    if (cudaMemcpy(packed.data(), d_packed, packed.size(),
+                   cudaMemcpyDeviceToHost) != cudaSuccess) {
+        fail("region gather copy");
+        return true;
+    }
+    for (size_t index = 0; index < 16; ++index) {
+        if (packed[index] != kGuard || packed[16 + packed_bytes + index] != kGuard) {
+            fail("region gather guard check");
+            return true;
+        }
+    }
+    for (size_t region = 0; region < descriptors.size(); ++region) {
+        const uint8_t* got = packed.data() + 16 +
+            descriptors[region].packed_offset;
+        if (!std::equal(expected[region].begin(), expected[region].end(), got)) {
+            fail("region gather numerical check");
+            return true;
+        }
+    }
+
+    for (size_t region = 0; region < descriptors.size(); ++region) {
+        if (cudaMemset(device_regions[region], 0, sizes[region]) != cudaSuccess) {
+            fail("region scatter reset");
+            return true;
+        }
+    }
+    if (!dsv4::qwen_scatter_copy_regions_cuda(
+            d_regions, static_cast<int>(descriptors.size()), d_packed + 16,
+            total_blocks) ||
+        cudaDeviceSynchronize() != cudaSuccess) {
+        fail("region scatter launch");
+        return true;
+    }
+    for (size_t region = 0; region < descriptors.size(); ++region) {
+        std::vector<uint8_t> got(sizes[region] + 32);
+        if (cudaMemcpy(got.data(), device_regions[region] - 16, got.size(),
+                       cudaMemcpyDeviceToHost) != cudaSuccess) {
+            fail("region scatter copy");
+            return true;
+        }
+        if (!std::all_of(got.begin(), got.begin() + 16,
+                         [](uint8_t value) { return value == kGuard; }) ||
+            !std::all_of(got.end() - 16, got.end(),
+                         [](uint8_t value) { return value == kGuard; }) ||
+            !std::equal(expected[region].begin(), expected[region].end(),
+                        got.begin() + 16)) {
+            fail("region scatter numerical check");
+            return true;
+        }
+    }
+    std::printf("  region gather/scatter regions=%zu bytes=%llu bit exact\n",
+                descriptors.size(),
+                static_cast<unsigned long long>(packed_bytes));
     return true;
 }
 
@@ -1238,6 +1587,158 @@ bool check_fused_swiglu() {
     return true;
 }
 
+bool check_gated_delta_prenormalized(int rows = 8, int heads = 12,
+                                     int key_heads = 4, int passes = 1,
+                                     float scale = 0.2f) {
+    constexpr int dim = 128;
+    const size_t state_elements = static_cast<size_t>(heads) * dim * dim;
+    const size_t key_elements = static_cast<size_t>(rows) * key_heads * dim;
+    const size_t value_elements = static_cast<size_t>(rows) * heads * dim;
+    const size_t gate_elements = static_cast<size_t>(rows) * heads;
+    std::mt19937 rng(17001 + rows * 31 + heads * 7 + key_heads);
+    std::uniform_real_distribution<float> dist(-scale, scale);
+    std::vector<float> state(state_elements);
+    for (float& value : state) value = dist(rng);
+    std::vector<uint16_t> q(key_elements), k(key_elements), v(value_elements);
+    std::vector<uint16_t> g(gate_elements), beta(gate_elements);
+    for (uint16_t& value : q) value = to_half(dist(rng));
+    for (uint16_t& value : k) value = to_half(dist(rng));
+    for (uint16_t& value : v) value = to_half(dist(rng));
+    for (uint16_t& value : g) value = to_half(dist(rng) - 0.3f);
+    for (uint16_t& value : beta) value = to_half(dist(rng) + 0.5f);
+
+    float* d_state_reference = nullptr;
+    float* d_state_normalized = nullptr;
+    float* d_state_shared = nullptr;
+    uint16_t* d_shared = nullptr;
+    uint16_t* d_q = nullptr;
+    uint16_t* d_k = nullptr;
+    uint16_t* d_v = nullptr;
+    uint16_t* d_g = nullptr;
+    uint16_t* d_beta = nullptr;
+    uint16_t* d_reference = nullptr;
+    uint16_t* d_normalized = nullptr;
+    float* d_q_normalized = nullptr;
+    float* d_k_normalized = nullptr;
+    auto malloc_copy = [](void** device, const void* host, size_t bytes) {
+        return cudaMalloc(device, bytes) == cudaSuccess &&
+               cudaMemcpy(*device, host, bytes, cudaMemcpyHostToDevice) == cudaSuccess;
+    };
+    if (!malloc_copy(reinterpret_cast<void**>(&d_state_reference), state.data(),
+                     state.size() * sizeof(float)) ||
+        !malloc_copy(reinterpret_cast<void**>(&d_state_normalized), state.data(),
+                     state.size() * sizeof(float)) ||
+        !malloc_copy(reinterpret_cast<void**>(&d_state_shared), state.data(),
+                     state.size() * sizeof(float)) ||
+        !malloc_copy(reinterpret_cast<void**>(&d_q), q.data(),
+                     q.size() * sizeof(uint16_t)) ||
+        !malloc_copy(reinterpret_cast<void**>(&d_k), k.data(),
+                     k.size() * sizeof(uint16_t)) ||
+        !malloc_copy(reinterpret_cast<void**>(&d_v), v.data(),
+                     v.size() * sizeof(uint16_t)) ||
+        !malloc_copy(reinterpret_cast<void**>(&d_g), g.data(),
+                     g.size() * sizeof(uint16_t)) ||
+        !malloc_copy(reinterpret_cast<void**>(&d_beta), beta.data(),
+                     beta.size() * sizeof(uint16_t)) ||
+        cudaMalloc(&d_reference, value_elements * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_normalized, value_elements * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_shared, value_elements * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_q_normalized, key_elements * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&d_k_normalized, key_elements * sizeof(float)) != cudaSuccess) {
+        fail("gated delta prenormalized allocation");
+        return false;
+    }
+    const float q_scale = 1.0f / std::sqrt(static_cast<float>(dim));
+    // Repeated passes reuse the evolving state, which is what a multi-round
+    // speculative verify does. A kernel that mishandles the state load/store
+    // shows up on the second pass even if the first one looks right.
+    for (int pass = 0; pass < passes; ++pass) {
+        if (!dsv4::qwen_gated_delta_sequence_f16_cuda(
+                d_state_reference, d_q, d_k, d_v, d_g, d_beta, d_reference,
+                rows, heads, key_heads, dim, dim, q_scale) ||
+            !dsv4::qwen_normalize_gated_delta_qk_f16_cuda(
+                d_q, d_k, d_q_normalized, d_k_normalized, rows, key_heads, dim) ||
+            !dsv4::qwen_gated_delta_sequence_normalized_f16_cuda(
+                d_state_normalized, d_q_normalized, d_k_normalized, d_v, d_g,
+                d_beta, d_normalized, rows, heads, key_heads, dim, dim, q_scale) ||
+            !dsv4::qwen_gated_delta_sequence_normalized_shared_f16_cuda(
+                d_state_shared, d_q_normalized, d_k_normalized, d_v, d_g,
+                d_beta, d_shared, rows, heads, key_heads, dim, dim, q_scale) ||
+            cudaDeviceSynchronize() != cudaSuccess) {
+            fail("gated delta prenormalized launch");
+            return false;
+        }
+    }
+    std::vector<uint16_t> reference(value_elements), normalized(value_elements);
+    std::vector<uint16_t> shared(value_elements);
+    std::vector<float> reference_state(state_elements), normalized_state(state_elements);
+    std::vector<float> shared_state(state_elements);
+    cudaMemcpy(reference.data(), d_reference,
+               reference.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    cudaMemcpy(normalized.data(), d_normalized,
+               normalized.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    cudaMemcpy(shared.data(), d_shared,
+               shared.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    cudaMemcpy(reference_state.data(), d_state_reference,
+               reference_state.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(normalized_state.data(), d_state_normalized,
+               normalized_state.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(shared_state.data(), d_state_shared,
+               shared_state.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    double output_worst = 0.0;
+    double shared_output_worst = 0.0;
+    bool finite = true;
+    for (size_t i = 0; i < reference.size(); ++i) {
+        const double base = from_half(reference[i]);
+        const double candidate = from_half(shared[i]);
+        if (!std::isfinite(candidate)) finite = false;
+        output_worst = std::max(
+            output_worst, std::fabs(base - from_half(normalized[i])));
+        shared_output_worst = std::max(shared_output_worst,
+                                       std::fabs(base - candidate));
+    }
+    double state_worst = 0.0;
+    double shared_state_worst = 0.0;
+    for (size_t i = 0; i < reference_state.size(); ++i) {
+        if (!std::isfinite(shared_state[i])) finite = false;
+        state_worst = std::max(
+            state_worst,
+            std::fabs(static_cast<double>(reference_state[i]) -
+                      normalized_state[i]));
+        shared_state_worst = std::max(
+            shared_state_worst,
+            std::fabs(static_cast<double>(reference_state[i]) -
+                      shared_state[i]));
+    }
+    if (output_worst != 0.0 || state_worst != 0.0) {
+        fail("gated delta prenormalized bit exact");
+    } else if (!finite) {
+        fail("gated delta shared-state finite");
+    } else if (shared_output_worst != 0.0 || shared_state_worst != 0.0) {
+        fail("gated delta shared-state bit exact");
+    } else {
+        std::printf("  gated delta prenormalized rows=%d heads=%d key_heads=%d "
+                    "passes=%d output=%.3e state=%.3e shared_output=%.3e "
+                    "shared_state=%.3e\n",
+                    rows, heads, key_heads, passes, output_worst, state_worst,
+                    shared_output_worst, shared_state_worst);
+    }
+    cudaFree(d_state_reference);
+    cudaFree(d_state_normalized);
+    cudaFree(d_state_shared);
+    cudaFree(d_shared);
+    cudaFree(d_q);
+    cudaFree(d_k);
+    cudaFree(d_v);
+    cudaFree(d_g);
+    cudaFree(d_beta);
+    cudaFree(d_reference);
+    cudaFree(d_normalized);
+    cudaFree(d_q_normalized);
+    cudaFree(d_k_normalized);
+    return true;
+}
+
 bool check_fp8_cache() {
     constexpr int q_heads = 6;
     constexpr int kv_heads = 1;
@@ -1346,6 +1847,7 @@ int main() {
     check_fp16_cache(1);
     check_fp16_cache(17);
     check_fp16_cache(333);
+    check_residual_add_rmsnorm_fused();
     check_prefill_tiled(1, 64, 0);
     check_prefill_tiled(2, 256, 0);
     check_prefill_tiled(7, 64, 3);
@@ -1367,11 +1869,23 @@ int main() {
     check_decode_window_reference();
     check_decode_grid_256k();
     check_fp8_f16_projection();
+    check_resident_fp16_projection();
     check_batched_argmax();
+    check_region_copy();
     check_strided_row_copy(1);
     check_strided_row_copy(8);
     check_fused_swiglu();
     check_fp8_fused_swiglu_shared();
+    check_gated_delta_prenormalized();
+    check_gated_delta_prenormalized(2);
+    check_gated_delta_prenormalized(3);
+    check_gated_delta_prenormalized(5);
+    check_gated_delta_prenormalized(7);
+    check_gated_delta_prenormalized(8, 12, 2);
+    check_gated_delta_prenormalized(8, 12, 12);
+    check_gated_delta_prenormalized(8, 4, 1);
+    check_gated_delta_prenormalized(8, 12, 4, 3);
+    check_gated_delta_prenormalized(8, 12, 4, 3, 2.0f);
     check_fp8_cache();
     if (failures != 0) {
         std::printf("test_qwen_half_ops failures=%d\n", failures);

--- a/scripts/bench_qwen_drafters.py
+++ b/scripts/bench_qwen_drafters.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Compare Qwen speculative drafters across upstream datasets.
+
+Runs plain decode plus any of native MTP, external DSpark, and external
+DFlash2 over the same real chat-template prompts, at concurrency one, and
+reports per-dataset acceptance and speedup for each drafter.
+
+Every drafter is verified against the plain token stream for exact greedy
+parity, so a speedup here is never bought with a different output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import re
+import subprocess
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+# Each entry yields the raw prompt strings for a dataset. Fetching goes through
+# plain HTTP rather than the datasets package so the bench has no extra
+# dependency in the inference environment.
+DATASETS: dict[str, dict[str, Any]] = {
+    "gsm8k": {
+        "url": "https://raw.githubusercontent.com/openai/grade-school-math/"
+               "master/grade_school_math/data/test.jsonl",
+        "suffix": "\nPlease reason step by step, and put your final answer "
+                  "within \\boxed{}.",
+        "field": "question",
+    },
+    "math500": {
+        "url": "https://huggingface.co/datasets/HuggingFaceH4/MATH-500/"
+               "resolve/main/test.jsonl",
+        "suffix": "\nPlease reason step by step, and put your final answer "
+                  "within \\boxed{}.",
+        "field": "problem",
+    },
+    "humaneval": {
+        "url": "https://github.com/openai/human-eval/raw/master/data/"
+               "HumanEval.jsonl.gz",
+        "prefix": "Complete the following Python function. Return the full "
+                  "function including the signature.\n\n```python\n",
+        "suffix": "\n```",
+        "field": "prompt",
+        "gzip": True,
+    },
+    "mbpp": {
+        "url": "https://raw.githubusercontent.com/google-research/"
+               "google-research/master/mbpp/mbpp.jsonl",
+        "suffix": "\nWrite the solution in Python.",
+        "field": "text",
+    },
+    "mt-bench": {
+        "url": "https://raw.githubusercontent.com/lm-sys/FastChat/main/"
+               "fastchat/llm_judge/data/mt_bench/question.jsonl",
+        # mt-bench rows carry a multi-turn list; the first turn is the prompt.
+        "field": "turns",
+        "first_of_list": True,
+    },
+}
+
+DRAFTERS = ("mtp", "dspark", "dflash2")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt", required=True)
+    parser.add_argument("--dspark", help="external DSpark checkpoint directory")
+    parser.add_argument("--dflash2", help="external DFlash2 checkpoint directory")
+    parser.add_argument("--binary", default="cpp_engine/build/dsv4_cpp_engine")
+    parser.add_argument(
+        "--drafters", default="mtp,dspark,dflash2",
+        help="comma-separated subset of mtp,dspark,dflash2")
+    parser.add_argument(
+        "--datasets", default="gsm8k,math500,humaneval,mbpp,mt-bench",
+        help=f"comma-separated subset of {','.join(sorted(DATASETS))}")
+    parser.add_argument("--num-prompts", type=int, default=8)
+    parser.add_argument("--max-new-tokens", type=int, default=256)
+    parser.add_argument("--prefill-chunk-tokens", type=int, default=512)
+    parser.add_argument("--kv-cache-dtype", choices=("fp16", "fp8"), default="fp16")
+    parser.add_argument("--tp-world", type=int, default=4)
+    parser.add_argument("--devices", default="0,1,2,3")
+    parser.add_argument("--work-dir", default=".tmp/qwen_drafters")
+    parser.add_argument(
+        "--tokenizer-python",
+        default="/home/lvyufeng/miniconda3/envs/deepseek/bin/python")
+    parser.add_argument("--max-context", type=int, default=32768)
+    parser.add_argument("--mtp-tokens", type=int, default=1)
+    parser.add_argument("--mtp-adaptive", action="store_true")
+    parser.add_argument(
+        "--keep-going", action="store_true",
+        help="record a failed request and continue instead of aborting the run")
+    parser.add_argument("--temperature", type=float, default=0.0,
+                        help="sampling temperature (0 = greedy)")
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--top-k", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=0)
+    return parser.parse_args()
+
+
+def fetch_raw(name: str, count: int, cache: Path) -> list[str]:
+    """Return `count` raw prompt strings, caching the decoded rows on disk."""
+    if cache.exists():
+        saved = json.loads(cache.read_text(encoding="utf-8"))
+        # A short cache must be refetched rather than silently shrinking the run.
+        if len(saved) >= count:
+            return [str(item) for item in saved[:count]]
+
+    spec = DATASETS[name]
+    with urllib.request.urlopen(spec["url"], timeout=120) as response:
+        payload = response.read()
+    if spec.get("gzip"):
+        payload = gzip.decompress(payload)
+
+    rows: list[str] = []
+    for line in payload.decode("utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        row = json.loads(line)
+        value = row[spec["field"]]
+        if spec.get("first_of_list"):
+            value = value[0]
+        rows.append(f"{spec.get('prefix', '')}{value}{spec.get('suffix', '')}")
+        if len(rows) >= count:
+            break
+    if len(rows) < count:
+        raise RuntimeError(
+            f"{name} yielded {len(rows)} prompts but {count} were requested")
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps(rows), encoding="utf-8")
+    return rows
+
+
+CHAT_CODE = r'''
+import json, sys
+from transformers import AutoTokenizer
+ckpt = sys.argv[1]
+prompts = json.loads(sys.stdin.read())
+tok = AutoTokenizer.from_pretrained(ckpt, local_files_only=True)
+rows = [tok.apply_chat_template([{"role": "user", "content": item}],
+                                tokenize=True, add_generation_prompt=True,
+                                reasoning_effort="xhigh")
+        for item in prompts]
+print(json.dumps(rows))
+'''
+
+
+def tokenize_chat(args: argparse.Namespace, prompts: list[str]) -> list[list[int]]:
+    """Apply the real chat template; benchmark protocol depends on it."""
+    result = subprocess.run(
+        [args.tokenizer_python, "-c", CHAT_CODE, args.ckpt],
+        input=json.dumps(prompts), capture_output=True, text=True, check=True)
+    return [[int(x) for x in row] for row in json.loads(result.stdout)]
+
+
+def build_fixture(args: argparse.Namespace, name: str, root: Path) -> list[list[int]]:
+    token_cache = root / f"{name}_prompts.json"
+    if token_cache.exists():
+        saved = json.loads(token_cache.read_text(encoding="utf-8"))
+        if isinstance(saved, list) and len(saved) >= args.num_prompts:
+            return [[int(x) for x in row] for row in saved[:args.num_prompts]]
+    raw = fetch_raw(name, args.num_prompts, root / f"{name}_prompts.raw.json")
+    rows = tokenize_chat(args, raw)
+    token_cache.parent.mkdir(parents=True, exist_ok=True)
+    token_cache.write_text(json.dumps(rows), encoding="utf-8")
+    return rows
+
+
+def parse_log(path: Path) -> tuple[dict[str, Any], list[int]]:
+    runtime: dict[str, Any] | None = None
+    tokens: list[int] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if line.startswith("qwen_runtime=1 "):
+            runtime = {}
+            for key, value in re.findall(r"(\w+)=([^\s]+)", line):
+                try:
+                    runtime[key] = int(value)
+                except ValueError:
+                    try:
+                        runtime[key] = float(value)
+                    except ValueError:
+                        runtime[key] = value
+        match = re.match(r"generate_step=(\d+) token=(-?\d+)", line)
+        if match:
+            tokens.append(int(match.group(2)))
+    if runtime is None:
+        raise RuntimeError(f"missing runtime telemetry in {path}")
+    return runtime, tokens
+
+
+def mode_command(args: argparse.Namespace, mode: str) -> list[str]:
+    if mode == "plain":
+        return []
+    if mode == "mtp":
+        command = ["--qwen-mtp-tokens", str(args.mtp_tokens)]
+        if args.mtp_adaptive:
+            command.append("--qwen-mtp-adaptive")
+        return command
+    if mode == "dspark":
+        return ["--qwen-dspark", str(args.dspark)]
+    if mode == "dflash2":
+        return ["--qwen-dflash2", str(args.dflash2)]
+    raise RuntimeError(f"unknown mode {mode}")
+
+
+def run_request(args: argparse.Namespace, prompt: list[int], mode: str,
+                dataset: str, index: int, root: Path) -> dict[str, Any]:
+    case_dir = root / dataset / mode / f"request_{index:03d}"
+    case_dir.mkdir(parents=True, exist_ok=True)
+    token_path = case_dir / "prompt.txt"
+    token_path.write_text(",".join(str(x) for x in prompt), encoding="ascii")
+    id_path = case_dir / "nccl.id"
+    if id_path.exists():
+        id_path.unlink()
+
+    processes: list[subprocess.Popen[bytes]] = []
+    logs = []
+    started = time.monotonic()
+    try:
+        for rank in range(args.tp_world):
+            command = [
+                str(Path(args.binary).resolve()), "--ckpt", str(args.ckpt),
+                "--tp-world", str(args.tp_world), "--tp-rank", str(rank),
+                "--device", "0", "--nccl-id-path", str(id_path),
+                "--token-ids-file", str(token_path), "--generate-token", "123",
+                "--max-new-tokens", str(args.max_new_tokens),
+                "--max-context",
+                str(max(args.max_context, len(prompt) + args.max_new_tokens)),
+                "--prefill-chunk-tokens", str(args.prefill_chunk_tokens),
+                "--kv-cache-dtype", args.kv_cache_dtype,
+                "--smoke-layers", "0", "--resident-bench",
+                "--qwen-temperature", str(args.temperature),
+                "--qwen-top-p", str(args.top_p),
+                "--qwen-top-k", str(args.top_k),
+                "--qwen-seed", str(args.seed),
+            ] + mode_command(args, mode)
+            env = os.environ.copy()
+            env["CUDA_VISIBLE_DEVICES"] = args.devices.split(",")[rank]
+            log = (case_dir / f"rank{rank}.log").open("wb")
+            logs.append(log)
+            processes.append(subprocess.Popen(
+                command, stdout=log, stderr=subprocess.STDOUT, env=env))
+        statuses = [process.wait() for process in processes]
+    finally:
+        for process in processes:
+            if process.poll() is None:
+                process.terminate()
+        for log in logs:
+            log.close()
+    if any(status != 0 for status in statuses):
+        raise RuntimeError(f"{dataset}/{mode} request {index} failed: {statuses}")
+
+    parsed = [parse_log(case_dir / f"rank{rank}.log")
+              for rank in range(args.tp_world)]
+    if any(parsed[0][1] != item[1] for item in parsed[1:]):
+        raise RuntimeError(f"{dataset}/{mode} rank parity failed at request {index}")
+    return {"mode": mode, "index": index, "prompt_tokens": len(prompt),
+            "runtime": parsed[0][0], "tokens": parsed[0][1],
+            "elapsed_process_wall_seconds": time.monotonic() - started,
+            "rank_runtime": [item[0] for item in parsed]}
+
+
+def acceptance(runtime: dict[str, Any]) -> dict[str, Any]:
+    """Speculative telemetry shares the mtp_* field names across drafters."""
+    proposed = runtime.get("mtp_proposed_drafts", 0) or 0
+    correct = runtime.get("mtp_correct_drafts", 0) or 0
+    return {
+        "accept_length": runtime.get("spec_accept_length", 0),
+        "draft_match_rate": (correct / proposed) if proposed else 0.0,
+        "proposed_drafts": proposed,
+        "correct_drafts": correct,
+        "verify_count": runtime.get("mtp_verify_count", 0),
+        "rollback_count": runtime.get("mtp_rollback_count", 0),
+        "draft_seconds": runtime.get("mtp_draft_seconds", 0.0),
+        "verify_seconds": runtime.get("mtp_verify_seconds", 0.0),
+        "replay_seconds": runtime.get("mtp_replay_seconds", 0.0),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    if args.tp_world != len(args.devices.split(",")):
+        raise SystemExit("--devices must contain one device per TP rank")
+
+    drafters = [item for item in args.drafters.split(",") if item]
+    for item in drafters:
+        if item not in DRAFTERS:
+            raise SystemExit(f"unknown drafter {item}; choose from {DRAFTERS}")
+    if "dspark" in drafters and not args.dspark:
+        raise SystemExit("--dspark is required to benchmark the dspark drafter")
+    if "dflash2" in drafters and not args.dflash2:
+        raise SystemExit("--dflash2 is required to benchmark the dflash2 drafter")
+
+    datasets = [item for item in args.datasets.split(",") if item]
+    for item in datasets:
+        if item not in DATASETS:
+            raise SystemExit(f"unknown dataset {item}; choose from {sorted(DATASETS)}")
+
+    root = Path(args.work_dir).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    output: dict[str, Any] = {
+        "num_prompts": args.num_prompts, "max_new_tokens": args.max_new_tokens,
+        "drafters": drafters, "datasets": datasets, "results": [],
+    }
+
+    for dataset in datasets:
+        prompts = build_fixture(args, dataset, root)
+        for index, prompt in enumerate(prompts):
+            entry: dict[str, Any] = {"dataset": dataset, "index": index,
+                                     "prompt_tokens": len(prompt)}
+            try:
+                plain = run_request(args, prompt, "plain", dataset, index, root)
+            except RuntimeError as error:
+                if not args.keep_going:
+                    raise
+                print(f"dataset={dataset} request={index + 1}/{len(prompts)} "
+                      f"plain FAILED: {error}", flush=True)
+                entry["plain_error"] = str(error)
+                output["results"].append(entry)
+                continue
+            entry["plain"] = plain
+            plain_wall = plain["runtime"]["wall"]
+            plain_decode = plain["runtime"]["decode_seconds"]
+
+            for mode in drafters:
+                try:
+                    run = run_request(args, prompt, mode, dataset, index, root)
+                except RuntimeError as error:
+                    if not args.keep_going:
+                        raise
+                    print(f"dataset={dataset} request={index + 1}/{len(prompts)} "
+                          f"{mode} FAILED: {error}", flush=True)
+                    entry[mode] = {"error": str(error)}
+                    continue
+                # Greedy parity is the precondition for reporting any speedup:
+                # a drafter that changes the output is not a faster decoder.
+                # In sampled mode (temperature > 0), every step draws a fresh
+                # uniform, so drafter and plain paths diverge by design.
+                parity = (run["tokens"] == plain["tokens"]
+                          if args.temperature <= 1e-5 else None)
+                stats = acceptance(run["runtime"])
+                wall = run["runtime"]["wall"]
+                decode = run["runtime"]["decode_seconds"]
+                entry[mode] = {
+                    "run": run, "parity": parity, "acceptance": stats,
+                    "wall_speedup": plain_wall / wall if wall else 0.0,
+                    "decode_speedup": plain_decode / decode if decode else 0.0,
+                }
+                parity_str = ("PASS" if parity else "FAIL") if parity is not None else "N/A"
+                print(f"dataset={dataset} request={index + 1}/{len(prompts)} "
+                      f"mode={mode} wall={wall:.4f}s "
+                      f"speedup={plain_wall / wall:.4f} "
+                      f"decode_speedup={plain_decode / decode if decode else 0:.4f} "
+                      f"accept_length={stats['accept_length']} "
+                      f"match_rate={stats['draft_match_rate']:.4f} "
+                      f"parity={parity_str}", flush=True)
+            output["results"].append(entry)
+            (root / "results.json").write_text(
+                json.dumps(output, indent=2), encoding="utf-8")
+
+    print()
+    print(f"{'dataset':<10} {'drafter':<8} {'wall':>7} {'decode':>7} "
+          f"{'acc_len':>8} {'match':>7} {'parity':>7}")
+    summary: dict[str, Any] = {}
+    for dataset in datasets:
+        rows = [item for item in output["results"] if item["dataset"] == dataset]
+        for mode in drafters:
+            runs = [item[mode] for item in rows
+                    if mode in item and "error" not in item[mode]]
+            if not runs:
+                print(f"{dataset:<10} {mode:<8} {'n/a':>7}")
+                continue
+            plains = [item["plain"] for item in rows
+                      if mode in item and "error" not in item[mode]]
+            plain_wall = sum(item["runtime"]["wall"] for item in plains)
+            plain_decode = sum(item["runtime"]["decode_seconds"] for item in plains)
+            mode_wall = sum(item["run"]["runtime"]["wall"] for item in runs)
+            mode_decode = sum(
+                item["run"]["runtime"]["decode_seconds"] for item in runs)
+            # Aggregate acceptance is draft-weighted, not a mean of per-request
+            # rates, so long requests are not down-weighted to match short ones.
+            proposed = sum(item["acceptance"]["proposed_drafts"] for item in runs)
+            correct = sum(item["acceptance"]["correct_drafts"] for item in runs)
+            accept_len = sum(
+                item["acceptance"]["accept_length"] for item in runs) / len(runs)
+            passes = sum(1 for item in runs if item["parity"] is True)
+            parity_checked = sum(1 for item in runs if item["parity"] is not None)
+            entry = {
+                "requests": len(runs),
+                "wall_speedup": plain_wall / mode_wall if mode_wall else 0.0,
+                "decode_speedup": plain_decode / mode_decode if mode_decode else 0.0,
+                "mean_accept_length": accept_len,
+                "draft_match_rate": (correct / proposed) if proposed else 0.0,
+                "parity_pass": passes, "parity_total": parity_checked,
+            }
+            summary.setdefault(dataset, {})[mode] = entry
+            parity_display = (f"{passes}/{parity_checked}" if parity_checked > 0
+                            else "N/A")
+            print(f"{dataset:<10} {mode:<8} {entry['wall_speedup']:>7.4f} "
+                  f"{entry['decode_speedup']:>7.4f} {accept_len:>8.3f} "
+                  f"{entry['draft_match_rate']:>7.4f} "
+                  f"{parity_display:>7}")
+    output["summary"] = summary
+    (root / "results.json").write_text(json.dumps(output, indent=2), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR moves the Qwen TP4 speculative target verify work into concrete CUDA hot-path optimizations and adds focused regression/benchmark coverage. It is intentionally separate from the existing drafter-acceptance documentation PR #79.

### Runtime changes

- Keep selected FP8 target matrices as resident FP16 verify weights and use cuBLAS tensor-core GEMMs for the narrow verify batch.
- Fuse DeltaNet `linear.a`/`linear.b` projections and add shared-activation FP8 small-batch SwiGLU kernels.
- Batch target verification, use cuBLAS FP32 LM-head GEMM for multi-row draft logits, and add Q/K prenormalization for DeltaNet recurrence.
- Pack recurrent transaction regions and perform device-resident gather/scatter for rollback/replay.
- Add exact/split-K GQA verify dispatch, deterministic device top-1 merge, packed uint64 top-1 support, and stream-aware NCCL wrappers.
- Expose focused CUDA benchmarks for projection, DeltaNet, transaction copies, and GQA verify.

The existing decode/prefill raw-quantized paths remain available. Candidates that did not show stable end-to-end gains remain opt-in/default-off, including:

- `QWEN_GATED_DELTA_SHARED_STATE=0`
- `QWEN_GQA_VERIFY_CUBLAS_QK=0`
- `QWEN_FUSE_KV_PROJECTION=0`
- `QWEN_NCCL_COMM_STREAM=0`
- `QWEN_VERIFY_DEVICE_TOP1=0`
- `QWEN_VERIFY_DEVICE_TOP1_PACKED=0`

The focused fused K/V kernel was 1.61--1.66x faster than two separate projections, but strict TP4 end-to-end A/B showed no stable gain, so it is deliberately not enabled by default.

## Real TP4 serial measurements

All measurements used the real Qwen3.8-27B FP8 target, real drafter checkpoints/tokenizer where applicable, TP4 on four RTX 2080 Ti GPUs, greedy parity, and strictly serial plain-then-speculative runs. Full-request and decode-only speedups are separate metrics.

8K prompt with 121 generated tokens:

| Mode | Plain wall (s) | Spec wall (s) | Full-request speedup | Decode speedup |
| --- | ---: | ---: | ---: | ---: |
| MTP K=1 | 23.2051 | 24.0315 | 0.966x | 2.386x |
| MTP K=2 | 23.2051 | 24.0729 | 0.964x | 2.953x |
| MTP K=4 | 23.2051 | 23.8815 | 0.972x | 3.866x |
| DSpark | 24.4165 | 20.9834 | 1.164x | 3.086x |
| DFlash2 | 24.4702 | 20.5880 | 1.189x | 4.192x |

The MTP and DSpark/DFlash2 rows use their respective serial baselines; small baseline differences reflect separate process invocations. Plain/spec greedy token streams and TP rank outputs matched, including rollback/replay checks.

Additional long-context observations already validated on the prior fixed binary: DSpark full-request speedup was about 1.032x at 8K, 0.987x at 32K, and 1.002x at 64K; decode-only speedup remained positive while prefill increasingly dominated wall time. A complete final-binary 128K/256K matrix is not included in this PR.

## Validation

Passed:

- `cmake --build cpp_engine/build --target dsv4_cpp_engine test_qwen_dflash2_ops test_qwen_gqa_attention test_qwen_half_ops test_qwen_engine -j2`
- `test_qwen_dflash2_ops`
- `test_qwen_gqa_attention`
- `test_qwen_half_ops`
- `test_qwen_engine`
- `git diff --cached --check`
- Strict TP rank parity and greedy plain/spec parity in the real TP4 measurements

This PR does not claim that verify is theoretically exhausted. CUDA Graph feasibility and a complete final-binary 8K/32K/64K/128K/256K matrix remain follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
