### PR TITLE
Port vLLM-2080Ti KV/attention optimizations to cpp_engine

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -61,6 +61,8 @@ add_library(dsv4_cpp_core STATIC
     cuda/qwen_attention_ops.cu
     cuda/qwen_half_ops.cu
     cuda/qwen_gqa_optimized.cu
+    cuda/qwen_gdn_flashqla.cu
+    cuda/qwen_turboquant_ops.cu
     cuda/qwen_dspark_ops.cu
     cuda/qwen_dflash2_ops.cu
     cuda/qwen_sampler.cu
@@ -377,6 +379,14 @@ add_executable(bench_qwen_delta_f16 tests/bench_qwen_delta_f16.cpp)
 target_link_libraries(bench_qwen_delta_f16 PRIVATE dsv4_cpp_core)
 set_target_properties(bench_qwen_delta_f16 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_qwen_gdn_flashqla tests/test_qwen_gdn_flashqla.cpp)
+target_link_libraries(test_qwen_gdn_flashqla PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_gdn_flashqla PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_turboquant_k8v4 tests/test_qwen_turboquant_k8v4.cpp)
+target_link_libraries(test_qwen_turboquant_k8v4 PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_turboquant_k8v4 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(bench_qwen_transaction_copy tests/bench_qwen_transaction_copy.cpp)
 target_link_libraries(bench_qwen_transaction_copy PRIVATE dsv4_cpp_core)
 set_target_properties(bench_qwen_transaction_copy PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
@@ -392,6 +402,10 @@ set_target_properties(test_persistent_engine PROPERTIES RUNTIME_OUTPUT_DIRECTORY
 add_executable(bench_qwen_fp8_batch_crossover tests/bench_qwen_fp8_batch_crossover.cpp)
 target_link_libraries(bench_qwen_fp8_batch_crossover PRIVATE dsv4_cpp_core)
 set_target_properties(bench_qwen_fp8_batch_crossover PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(bench_qwen_fp8_dequant_overhead tests/bench_qwen_fp8_dequant_overhead.cpp)
+target_link_libraries(bench_qwen_fp8_dequant_overhead PRIVATE dsv4_cpp_core)
+set_target_properties(bench_qwen_fp8_dequant_overhead PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(bench_qwen_gqa_prefill tests/bench_qwen_gqa_prefill.cpp)
 target_link_libraries(bench_qwen_gqa_prefill PRIVATE dsv4_cpp_core)

--- a/cpp_engine/cuda/qwen_gdn_flashqla.cu
+++ b/cpp_engine/cuda/qwen_gdn_flashqla.cu
@@ -1,0 +1,256 @@
+// FlashQLA SM75 Gated DeltaNet kernel — subgroup-sharded state for D=128.
+// Ported from vLLM-2080Ti-Definitive v0.1.15 tools/flashqla_sm75_patches/gdn_forward.cu
+// for comparison against the baseline serial recurrence in qwen_attention_ops.cu.
+//
+// Key differences from the baseline:
+// - State sharding: each subgroup (WIDTH=16 lanes) holds COLS=4 columns of the
+//   [D, D] state matrix as `state_shard[COLS][rows_per_lane]`, rather than one
+//   thread per value dimension holding the full key_dim-length state vector.
+// - Launch geometry: grid.z dimension fans out when D/COLS exceeds the CTA count,
+//   and blockDim.y gives multiple column-groups per CTA.
+// - Still a serial `for (int t = 0; t < tokens; ++t)` recurrence — not chunked.
+//   Occupancy and serialization remain, but memory access is better.
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace dsv4 {
+
+__device__ __forceinline__ float warp_reduce_sum(float value, int width) {
+    for (int offset = width / 2; offset > 0; offset >>= 1) {
+        value += __shfl_down_sync(0xffffffffU, value, offset, width);
+    }
+    return value;
+}
+
+__device__ __forceinline__ float warp_broadcast_lane0(float value, int width) {
+    return __shfl_sync(0xffffffffU, value, 0, width);
+}
+
+// D: key_dim and value_dim (compile-time 128)
+// COLS: state columns per subgroup (4 for D=128)
+// WIDTH: subgroup size (16 for D=128)
+template <int D, int COLS, int WIDTH>
+__global__ void gdn_flashqla_kernel(
+    const float* __restrict__ q_normalized,
+    const float* __restrict__ k_normalized,
+    const __half* __restrict__ v,
+    const __half* __restrict__ gate,
+    const __half* __restrict__ beta,
+    const float* __restrict__ initial_state,
+    __half* __restrict__ output,
+    float* __restrict__ final_state,
+    int tokens,
+    int q_heads,
+    int v_heads,
+    float q_scale
+) {
+    static_assert(D == 128 && COLS == 4 && WIDTH == 16, "D=128 COLS=4 WIDTH=16 only");
+    static_assert(D % (COLS * (32 / WIDTH)) == 0, "D must divide evenly");
+
+    constexpr int subgroups_per_warp = 32 / WIDTH;  // 2
+    constexpr int rows_per_lane = (D + WIDTH - 1) / WIDTH;  // 8
+
+    const int hv = static_cast<int>(blockIdx.x);
+    const int subgroup = threadIdx.x / WIDTH;
+    const int lane = threadIdx.x % WIDTH;
+    const int group_base =
+        (static_cast<int>(blockIdx.z) * static_cast<int>(blockDim.y) +
+         static_cast<int>(threadIdx.y)) * subgroups_per_warp + subgroup;
+    const int col_base = group_base * COLS;
+    const int hq = hv / (v_heads / q_heads);
+
+    // Load initial state for this subgroup's column shard.
+    float state_shard[COLS][rows_per_lane];
+#pragma unroll
+    for (int c = 0; c < COLS; ++c) {
+        const int col = col_base + c;
+#pragma unroll
+        for (int r = 0; r < rows_per_lane; ++r) {
+            const int row = r * WIDTH + lane;
+            float value = 0.0f;
+            if (row < D && col < D) {
+                const size_t state_index =
+                    static_cast<size_t>(hv) * D * D +
+                    static_cast<size_t>(row) * D +
+                    static_cast<size_t>(col);
+                value = initial_state == nullptr ? 0.0f : initial_state[state_index];
+            }
+            state_shard[c][r] = value;
+        }
+    }
+
+    // Serial recurrence over tokens.
+    for (int t = 0; t < tokens; ++t) {
+        // Broadcast gate and beta to all threads.
+        float gate_value = 0.0f;
+        float beta_value = 0.0f;
+        // Each y-row is an independent warp processing a different state-column
+        // group, so lane 0 of every warp must load the per-head gate and beta.
+        if (threadIdx.x == 0) {
+            gate_value = expf(__half2float(gate[static_cast<size_t>(t) * v_heads + hv]));
+            beta_value = __half2float(beta[static_cast<size_t>(t) * v_heads + hv]);
+        }
+        gate_value = warp_broadcast_lane0(gate_value, 32);
+        beta_value = warp_broadcast_lane0(beta_value, 32);
+
+        // Load pre-normalized Q and K for this position. Q and K share the key
+        // head hq under GQA; the key row stride is q_heads * D.
+        float k_reg[rows_per_lane];
+        float q_reg[rows_per_lane];
+#pragma unroll
+        for (int r = 0; r < rows_per_lane; ++r) {
+            const int row = r * WIDTH + lane;
+            float q_value = 0.0f;
+            float k_value = 0.0f;
+            if (row < D) {
+                const size_t qk_index =
+                    static_cast<size_t>(t) * q_heads * D +
+                    static_cast<size_t>(hq) * D +
+                    static_cast<size_t>(row);
+                q_value = q_normalized[qk_index];
+                k_value = k_normalized[qk_index];
+            }
+            q_reg[r] = q_value;
+            k_reg[r] = k_value;
+        }
+
+        // Compute K · state for each column: sum over rows (subgroup reduction).
+        float kv_partial[COLS];
+#pragma unroll
+        for (int c = 0; c < COLS; ++c) {
+            float sum = 0.0f;
+#pragma unroll
+            for (int r = 0; r < rows_per_lane; ++r) {
+                sum += state_shard[c][r] * k_reg[r];
+            }
+            kv_partial[c] = warp_reduce_sum(sum, WIDTH);
+        }
+
+        // Compute delta = (v - gate * K·state) * beta for each column.
+        // Lane 0 loads v[col], broadcasts delta.
+        float delta[COLS];
+#pragma unroll
+        for (int c = 0; c < COLS; ++c) {
+            float delta_value = 0.0f;
+            if (lane == 0) {
+                const int col = col_base + c;
+                if (col < D) {
+                    const size_t v_index =
+                        static_cast<size_t>(t) * v_heads * D +
+                        static_cast<size_t>(hv) * D +
+                        static_cast<size_t>(col);
+                    delta_value = (__half2float(v[v_index]) - gate_value * kv_partial[c]) *
+                                  beta_value;
+                }
+            }
+            delta[c] = warp_broadcast_lane0(delta_value, WIDTH);
+        }
+
+        // Update state: state = gate * state + K ⊗ delta, and accumulate Q · state.
+        float attn_partial[COLS];
+#pragma unroll
+        for (int c = 0; c < COLS; ++c) {
+            float sum = 0.0f;
+#pragma unroll
+            for (int r = 0; r < rows_per_lane; ++r) {
+                const float new_state =
+                    fmaf(k_reg[r], delta[c], gate_value * state_shard[c][r]);
+                state_shard[c][r] = new_state;
+                sum += new_state * q_reg[r];
+            }
+            attn_partial[c] = warp_reduce_sum(sum, WIDTH);
+        }
+
+        // Lane 0 writes output for its columns.
+        if (lane == 0) {
+            const size_t out_base = static_cast<size_t>(t) * v_heads * D +
+                                    static_cast<size_t>(hv) * D;
+#pragma unroll
+            for (int c = 0; c < COLS; ++c) {
+                const int col = col_base + c;
+                if (col < D) {
+                    output[out_base + col] = __float2half(attn_partial[c] * q_scale);
+                }
+            }
+        }
+    }
+
+    // Store final state for this subgroup's shard.
+    if (final_state != nullptr) {
+#pragma unroll
+        for (int c = 0; c < COLS; ++c) {
+            const int col = col_base + c;
+#pragma unroll
+            for (int r = 0; r < rows_per_lane; ++r) {
+                const int row = r * WIDTH + lane;
+                if (row < D && col < D) {
+                    const size_t state_index =
+                        static_cast<size_t>(hv) * D * D +
+                        static_cast<size_t>(row) * D +
+                        static_cast<size_t>(col);
+                    final_state[state_index] = state_shard[c][r];
+                }
+            }
+        }
+    }
+}
+
+bool qwen_gated_delta_flashqla_sm75_f16_cuda(
+    float* d_state,
+    const float* d_q_normalized,
+    const float* d_k_normalized,
+    const uint16_t* d_v,
+    const uint16_t* d_g,
+    const uint16_t* d_beta,
+    uint16_t* d_out,
+    int rows,
+    int heads,
+    int key_heads,
+    int key_dim,
+    int value_dim,
+    float q_scale,
+    void* stream
+) {
+    if (!d_state || !d_q_normalized || !d_k_normalized || !d_v || !d_g ||
+        !d_beta || !d_out || rows <= 0 || heads <= 0 || key_heads <= 0 ||
+        heads % key_heads != 0 || key_dim != 128 || value_dim != 128 ||
+        q_scale <= 0.0f) {
+        return false;
+    }
+
+    constexpr int D = 128;
+    constexpr int COLS = 4;
+    constexpr int WIDTH = 16;
+    constexpr int subgroups_per_warp = 32 / WIDTH;  // 2
+    constexpr int column_groups_per_block = 8;
+
+    const int groups = D / COLS;  // 32
+    const int z = (groups + column_groups_per_block * subgroups_per_warp - 1) /
+                  (column_groups_per_block * subgroups_per_warp);
+
+    const dim3 block(32, column_groups_per_block);  // 32 threads (1 warp), 8 y-groups
+    const dim3 grid(heads, 1, z);
+
+    const cudaStream_t s = stream == nullptr ? nullptr : static_cast<cudaStream_t>(stream);
+
+    gdn_flashqla_kernel<D, COLS, WIDTH><<<grid, block, 0, s>>>(
+        d_q_normalized,
+        d_k_normalized,
+        reinterpret_cast<const __half*>(d_v),
+        reinterpret_cast<const __half*>(d_g),
+        reinterpret_cast<const __half*>(d_beta),
+        d_state,
+        reinterpret_cast<__half*>(d_out),
+        d_state,
+        rows,
+        key_heads,
+        heads,
+        q_scale
+    );
+
+    return cudaGetLastError() == cudaSuccess;
+}
+
+}  // namespace dsv4

--- a/cpp_engine/cuda/qwen_gqa_optimized.cu
+++ b/cpp_engine/cuda/qwen_gqa_optimized.cu
@@ -761,6 +761,284 @@ __global__ void gqa_prefill_hpg6_f16_kernel(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Tensor-core exact prefill.
+//
+// The scalar paths above are not bandwidth bound. Measured at the real TP4 shape
+// (6 q heads over 1 kv head, head_dim 256, rows=4096 offset=32768) hpg6 takes
+// 770 ms for 876 GFLOP, i.e. 1.14 TFLOP/s or roughly 8.5% of the FP32 CUDA-core
+// peak, while the DRAM side only moves ~47 GB/s of a 616 GB/s card. The limit is
+// scalar issue: every (row, position) pair costs five warp shuffles plus an expf.
+// Tile-shape tuning cannot move that ceiling, so this path puts both GEMMs on the
+// tensor cores instead.
+//
+// SM75 has no m16n8k16, so the primitive is m16n8k8 with FP32 accumulate. The
+// dot products are reassociated relative to the scalar kernels, so this is exact
+// in the sense that matters here (full causal history, no window, no sink) but
+// not bit-identical to hpg6; it carries its own numerical and token-parity gates.
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 750
+#define DSV4_QWEN_MMA_AVAILABLE 1
+#endif
+
+__device__ __forceinline__ void mma_m16n8k8_f16_f32(
+    float (&d)[4], const uint32_t (&a)[2], uint32_t b) {
+#ifdef DSV4_QWEN_MMA_AVAILABLE
+    asm volatile(
+        "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+        "{%0, %1, %2, %3}, {%4, %5}, {%6}, {%0, %1, %2, %3};"
+        : "+f"(d[0]), "+f"(d[1]), "+f"(d[2]), "+f"(d[3])
+        : "r"(a[0]), "r"(a[1]), "r"(b));
+#else
+    (void)d;
+    (void)a;
+    (void)b;
+#endif
+}
+
+// One CTA owns 32 query rows of one Q head as two 16-row MMA blocks. The eight
+// warps are indexed as (row block, slice): for Q*K each slice takes eight KV
+// positions, for P*V each slice takes 64 of the 256 head dims. Both products are
+// therefore full-width tensor-core work and the only scalar phase left is the
+// 32x32 softmax. Two row blocks per CTA is what makes the ~43 KiB of K/V staging
+// worth its occupancy cost: the tile is loaded once for twice the output.
+constexpr int kMmaQRows = 32;
+constexpr int kMmaRowBlocks = kMmaQRows / 16;
+constexpr int kMmaKvTile = 32;
+constexpr int kMmaDim = 256;
+constexpr int kMmaSlices = 4;
+constexpr int kMmaWarps = kMmaRowBlocks * kMmaSlices;
+constexpr int kMmaSteps = kMmaDim / 8;
+// Shared row strides are chosen for bank behaviour, and both must stay even so
+// the 4-byte fragment loads remain aligned.
+//
+// ks stride 264 halves = 132 words: a Q*K fragment load varies over gid and tig,
+// giving banks (132*gid + tig) % 32 = (4*gid + tig) % 32, which is 32 distinct
+// banks. Conflict free.
+//
+// vt stride 34 halves = 17 words: the natural padding of 40 would make the
+// transpose store stride 8*40/2 = 160 words, a multiple of 32, so all 32 lanes of
+// a store would hit one bank. 34 cuts that to 8*34/2 = 136 ≡ 8 (mod 32), i.e. 4
+// banks, and makes the fragment loads (17*gid + tig) % 32 nearly conflict free.
+constexpr int kMmaKsStride = kMmaDim + 8;
+constexpr int kMmaVtStride = kMmaKvTile + 2;
+
+__global__ __launch_bounds__(kMmaWarps * 32) void gqa_prefill_mma_f16_kernel(
+    const uint16_t* __restrict__ q_rows,
+    const uint16_t* __restrict__ k_cache,
+    const uint16_t* __restrict__ v_cache,
+    uint16_t* __restrict__ output,
+    int seq_len,
+    int q_heads,
+    int kv_heads,
+    int head_dim,
+    int position_offset) {
+    __shared__ __align__(16) uint16_t ks[kMmaKvTile][kMmaKsStride];
+    __shared__ __align__(16) uint16_t vt[kMmaDim][kMmaVtStride];
+    __shared__ float sc[kMmaQRows][kMmaKvTile];
+    __shared__ __align__(16) uint16_t ph[kMmaQRows][kMmaVtStride];
+    __shared__ float row_m[kMmaQRows];
+    __shared__ float row_l[kMmaQRows];
+    __shared__ float row_alpha[kMmaQRows];
+
+    const int head = static_cast<int>(blockIdx.x);
+    const int qbase = static_cast<int>(blockIdx.y) * kMmaQRows;
+    if (head >= q_heads || qbase >= seq_len || head_dim != kMmaDim ||
+        q_heads <= 0 || kv_heads <= 0 || q_heads % kv_heads != 0) {
+        return;
+    }
+    const int kv_head = head / (q_heads / kv_heads);
+    const int tid = static_cast<int>(threadIdx.x);
+    const int warp = tid >> 5;
+    const int block_row = (warp / kMmaSlices) * 16;
+    const int slice = warp % kMmaSlices;
+    const int lane = tid & 31;
+    // m16n8k8 operand mapping: the eight lanes of a group share a matrix row and
+    // the four lanes within a group cover two adjacent columns each.
+    const int gid = lane >> 2;
+    const int tig = lane & 3;
+    // Rows of the 16x8 A/D fragment owned by this lane, in CTA-local terms.
+    const int lrow0 = block_row + gid;
+    const int lrow1 = block_row + gid + 8;
+
+    float acc[8][4];
+#pragma unroll
+    for (int j = 0; j < 8; ++j) {
+#pragma unroll
+        for (int i = 0; i < 4; ++i) acc[j][i] = 0.0f;
+    }
+    if (tid < kMmaQRows) {
+        row_m[tid] = -INFINITY;
+        row_l[tid] = 0.0f;
+    }
+
+    // Q is reused by every KV tile, so it stays resident in registers.
+    uint32_t qfrag[kMmaSteps][2];
+#pragma unroll
+    for (int k = 0; k < kMmaSteps; ++k) {
+        const int col = k * 8 + tig * 2;
+#pragma unroll
+        for (int part = 0; part < 2; ++part) {
+            const int row = qbase + (part == 0 ? lrow0 : lrow1);
+            uint32_t value = 0;
+            if (row < seq_len) {
+                value = *reinterpret_cast<const uint32_t*>(
+                    q_rows + (static_cast<size_t>(row) * q_heads + head) *
+                        head_dim + col);
+            }
+            qfrag[k][part] = value;
+        }
+    }
+
+    const size_t kv_stride = static_cast<size_t>(kv_heads) * head_dim;
+    const int q_last = position_offset + min(qbase + kMmaQRows - 1, seq_len - 1);
+    const int tile_context = q_last + 1;
+    const float attention_scale = rsqrtf(static_cast<float>(head_dim));
+    __syncthreads();
+
+    for (int base = 0; base < tile_context; base += kMmaKvTile) {
+        const int count = min(kMmaKvTile, tile_context - base);
+        for (int idx = tid; idx < kMmaKvTile * kMmaSteps;
+             idx += kMmaWarps * 32) {
+            const int slot = idx / kMmaSteps;
+            const int chunk = idx - slot * kMmaSteps;
+            uint4 kv = make_uint4(0u, 0u, 0u, 0u);
+            uint4 vv = make_uint4(0u, 0u, 0u, 0u);
+            if (slot < count) {
+                const size_t at = static_cast<size_t>(base + slot) * kv_stride +
+                    static_cast<size_t>(kv_head) * head_dim + chunk * 8;
+                kv = *reinterpret_cast<const uint4*>(k_cache + at);
+                vv = *reinterpret_cast<const uint4*>(v_cache + at);
+            }
+            *reinterpret_cast<uint4*>(&ks[slot][chunk * 8]) = kv;
+            // V is transposed on the way in so the P*V B operand, which wants
+            // eight consecutive positions for one dim, is a 4-byte shared load.
+            const uint16_t* src = reinterpret_cast<const uint16_t*>(&vv);
+#pragma unroll
+            for (int i = 0; i < 8; ++i) vt[chunk * 8 + i][slot] = src[i];
+        }
+        __syncthreads();
+
+        float s[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+#pragma unroll
+        for (int k = 0; k < kMmaSteps; ++k) {
+            const uint32_t b = *reinterpret_cast<const uint32_t*>(
+                &ks[slice * 8 + gid][k * 8 + tig * 2]);
+            mma_m16n8k8_f16_f32(s, qfrag[k], b);
+        }
+        {
+            const int col = slice * 8 + tig * 2;
+            sc[lrow0][col] = s[0];
+            sc[lrow0][col + 1] = s[1];
+            sc[lrow1][col] = s[2];
+            sc[lrow1][col + 1] = s[3];
+        }
+        __syncthreads();
+
+        // Online softmax over the 16x32 tile. Eight threads share a row, so the
+        // row reductions are three shuffles inside a warp.
+        {
+            const int row = tid >> 3;
+            const int col0 = (tid & 7) * 4;
+            const int token = qbase + row;
+            const int limit = token < seq_len ? position_offset + token : -1;
+            const float m_old = row_m[row];
+            const float l_old = row_l[row];
+            float sv[4];
+            float local_max = -INFINITY;
+#pragma unroll
+            for (int i = 0; i < 4; ++i) {
+                const int col = col0 + i;
+                float value = -INFINITY;
+                if (col < count && base + col <= limit) {
+                    value = sc[row][col] * attention_scale;
+                }
+                sv[i] = value;
+                local_max = fmaxf(local_max, value);
+            }
+#pragma unroll
+            for (int off = 1; off < 8; off <<= 1) {
+                local_max = fmaxf(local_max,
+                                  __shfl_xor_sync(0xffffffffu, local_max, off));
+            }
+            const float m_new = fmaxf(m_old, local_max);
+            float local_sum = 0.0f;
+#pragma unroll
+            for (int i = 0; i < 4; ++i) {
+                // The numerator is rounded to half for the tensor-core operand,
+                // so the denominator sums the rounded values to keep the two
+                // consistent.
+                uint16_t bits = 0;
+                if (m_new != -INFINITY && sv[i] != -INFINITY) {
+                    bits = float_to_half(expf(sv[i] - m_new));
+                    local_sum += half_to_float(bits);
+                }
+                ph[row][col0 + i] = bits;
+            }
+#pragma unroll
+            for (int off = 1; off < 8; off <<= 1) {
+                local_sum += __shfl_xor_sync(0xffffffffu, local_sum, off);
+            }
+            __syncwarp();
+            if ((tid & 7) == 0) {
+                const float alpha =
+                    m_old == -INFINITY ? 0.0f : expf(m_old - m_new);
+                row_alpha[row] = alpha;
+                row_m[row] = m_new;
+                row_l[row] = l_old * alpha + local_sum;
+            }
+        }
+        __syncthreads();
+
+        {
+            const float alpha0 = row_alpha[lrow0];
+            const float alpha1 = row_alpha[lrow1];
+#pragma unroll
+            for (int j = 0; j < 8; ++j) {
+                acc[j][0] *= alpha0;
+                acc[j][1] *= alpha0;
+                acc[j][2] *= alpha1;
+                acc[j][3] *= alpha1;
+            }
+#pragma unroll
+            for (int kt = 0; kt < kMmaKvTile / 8; ++kt) {
+                uint32_t a[2];
+                a[0] = *reinterpret_cast<const uint32_t*>(
+                    &ph[lrow0][kt * 8 + tig * 2]);
+                a[1] = *reinterpret_cast<const uint32_t*>(
+                    &ph[lrow1][kt * 8 + tig * 2]);
+#pragma unroll
+                for (int j = 0; j < 8; ++j) {
+                    const uint32_t b = *reinterpret_cast<const uint32_t*>(
+                        &vt[slice * 64 + j * 8 + gid][kt * 8 + tig * 2]);
+                    mma_m16n8k8_f16_f32(acc[j], a, b);
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    const float inv0 = row_l[lrow0] > 0.0f ? 1.0f / row_l[lrow0] : 0.0f;
+    const float inv1 = row_l[lrow1] > 0.0f ? 1.0f / row_l[lrow1] : 0.0f;
+    const int row0 = qbase + lrow0;
+    const int row1 = qbase + lrow1;
+#pragma unroll
+    for (int j = 0; j < 8; ++j) {
+        const int dim = slice * 64 + j * 8 + tig * 2;
+        if (row0 < seq_len) {
+            uint16_t* out = output +
+                (static_cast<size_t>(row0) * q_heads + head) * head_dim + dim;
+            out[0] = float_to_half(acc[j][0] * inv0);
+            out[1] = float_to_half(acc[j][1] * inv0);
+        }
+        if (row1 < seq_len) {
+            uint16_t* out = output +
+                (static_cast<size_t>(row1) * q_heads + head) * head_dim + dim;
+            out[0] = float_to_half(acc[j][2] * inv1);
+            out[1] = float_to_half(acc[j][3] * inv1);
+        }
+    }
+}
+
 // Two adjacent query rows and three Q heads sharing a KV head are processed by
 // one CTA. Each K/V element is loaded once for six attention outputs.
 __global__ void gqa_prefill_tiled_f16_kernel(
@@ -1501,6 +1779,7 @@ bool qwen_gqa_prefill_attention_f16_tiled_cuda(
         // is capped to keep occupancy.
         int qr = 2;
         const char* qr_env = std::getenv("DSV4_QWEN_GQA_QUERY_ROWS");
+        const bool query_rows_explicit = qr_env != nullptr;
         if (qr_env != nullptr) {
             const int requested = std::atoi(qr_env);
             if (requested == 2 || requested == 4 || requested == 8) qr = requested;
@@ -1529,6 +1808,40 @@ bool qwen_gqa_prefill_attention_f16_tiled_cuda(
         const bool tp4_long_shape = attention_window <= 0 && q_heads == 6 &&
             kv_heads == 1 && head_dim == 256 && seq_len >= 128 &&
             total_context >= 2048;
+        // Tensor-core exact path, and the production default for the shapes it
+        // supports. The scalar kernels are scalar-issue bound at roughly 8.5% of
+        // the FP32 CUDA-core peak, so moving both GEMMs onto the tensor cores is
+        // the only lever that moves exact long-context prefill. Measured on the
+        // real 64-layer TP4 checkpoint, strictly serial, one binary:
+        //
+        //   context   scalar default   mma      prefill
+        //     8192     824.3 tok/s   1125.7    1.37x
+        //    32768     442.7 tok/s   1058.9    2.39x
+        //    65536     258.0 tok/s    887.6    3.44x
+        //
+        // decode is unchanged (25.15/19.90/19.25 against 25.12/20.78/19.54) and
+        // the generated tokens are identical at all three lengths. It reassociates
+        // both dot products and rounds the softmax numerator to half for the MMA
+        // operand, so `=0` selects the scalar path for A/B and for any future
+        // divergence hunt.
+        const char* mma_tile = std::getenv("DSV4_QWEN_GQA_MMA_TILE");
+        const bool mma_enabled =
+            mma_tile == nullptr || std::strcmp(mma_tile, "0") != 0;
+        // Windowed and sink attention stay on the scalar kernels: this kernel
+        // masks by causal limit only, so an approximate window would silently
+        // become exact rather than fail.
+        if (mma_enabled && attention_window <= 0 && sink_tokens == 0 &&
+            head_dim == kMmaDim && seq_len >= kMmaQRows) {
+            const dim3 mma_grid(
+                static_cast<unsigned>(q_heads),
+                static_cast<unsigned>((seq_len + kMmaQRows - 1) / kMmaQRows), 1);
+            gqa_prefill_mma_f16_kernel<<<
+                mma_grid, kMmaWarps * 32, 0,
+                static_cast<cudaStream_t>(stream)>>>(
+                q, k_cache, v_cache, output, seq_len, q_heads, kv_heads,
+                head_dim, position_offset);
+            return cudaGetLastError() == cudaSuccess;
+        }
         // Two-phase flash tile: one warp reduction per 32 positions instead of
         // one per position. It remains opt-in because it is not faster than the
         // hpg6 path on the measured TP4 long-context cases.
@@ -1553,23 +1866,33 @@ bool qwen_gqa_prefill_attention_f16_tiled_cuda(
             return cudaGetLastError() == cudaSuccess;
         }
         if (long_tile_enabled && tp4_long_shape) {
-            const int long_qr = qr == 8 ? 4 : qr;
-            const dim3 long_grid(
-                static_cast<unsigned>(kv_heads),
-                static_cast<unsigned>((seq_len + long_qr - 1) / long_qr), 1);
-            if (long_qr == 2) {
-                gqa_prefill_hpg6_f16_kernel<8, 2><<<
-                    long_grid, 6 * 32, 0, static_cast<cudaStream_t>(stream)>>>(
-                    q, k_cache, v_cache, output, seq_len, q_heads, kv_heads,
-                    head_dim, position_offset, attention_window, sink_tokens);
+            // The hpg6 kernel has a six-warp register footprint. On SM75, its
+            // four-row specialization is the production default; a caller that
+            // explicitly requests two rows is allowed for controlled A/B tests.
+            // Do not silently reinterpret an explicit eight-row request as four:
+            // the generic batched path is the honest fallback for that shape.
+            if (query_rows_explicit && qr == 8) {
+                // Fall through to the generic position-tiled dispatch below.
             } else {
-                gqa_prefill_hpg6_f16_kernel<8, 4><<<
-                    long_grid, 6 * 32, 0, static_cast<cudaStream_t>(stream)>>>(
-                    q, k_cache, v_cache, output, seq_len, q_heads, kv_heads,
-                    head_dim, position_offset, attention_window, sink_tokens);
+                const int long_qr = qr == 8 ? 4 : qr;
+                const dim3 long_grid(
+                    static_cast<unsigned>(kv_heads),
+                    static_cast<unsigned>((seq_len + long_qr - 1) / long_qr), 1);
+                if (long_qr == 2) {
+                    gqa_prefill_hpg6_f16_kernel<8, 2><<<
+                        long_grid, 6 * 32, 0, static_cast<cudaStream_t>(stream)>>>(
+                        q, k_cache, v_cache, output, seq_len, q_heads, kv_heads,
+                        head_dim, position_offset, attention_window, sink_tokens);
+                } else {
+                    gqa_prefill_hpg6_f16_kernel<8, 4><<<
+                        long_grid, 6 * 32, 0, static_cast<cudaStream_t>(stream)>>>(
+                        q, k_cache, v_cache, output, seq_len, q_heads, kv_heads,
+                        head_dim, position_offset, attention_window, sink_tokens);
+                }
+                return cudaGetLastError() == cudaSuccess;
             }
-            return cudaGetLastError() == cudaSuccess;
         }
+
         // Warp-per-combo variant. Opt-in: it reassociates the dot-product
         // reduction, so the last FP32 bits differ from the per-position kernel and
         // a near-tie greedy argmax could flip. Requires head_dim to split evenly

--- a/cpp_engine/cuda/qwen_turboquant_ops.cu
+++ b/cpp_engine/cuda/qwen_turboquant_ops.cu
@@ -1,0 +1,535 @@
+#include "qwen_cuda_ops.hpp"
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <cstring>
+
+namespace dsv4 {
+namespace {
+
+// The full-attention head dimension is a runtime value (128 on some configs,
+// 256 on Qwen3.5), so the slot layout is derived rather than hardcoded.
+constexpr int kMaxHeadDim = 256;
+constexpr int kStoreThreads = 128;
+
+__device__ __forceinline__ int slot_bytes_for(int head_dim) {
+    return head_dim + head_dim / 2 + 4;
+}
+
+__device__ __forceinline__ uint8_t quantize_value_nibble(float v, float scale,
+                                                          float minimum) {
+    float normalized = (v - minimum) / scale;
+    int q = __float2int_rn(normalized);
+    return static_cast<uint8_t>(max(0, min(15, q)));
+}
+
+__device__ __forceinline__ float dequantize_value_nibble(uint8_t nibble,
+                                                          float scale,
+                                                          float minimum) {
+    return static_cast<float>(nibble) * scale + minimum;
+}
+
+// Store K8V4: FP8 E5M2 key + 4-bit uniform value quantization.
+// Layout: [0,128) key bytes, [128,192) packed values, [192,194) scale,
+// [194,196) minimum.
+__global__ void append_kv_cache_turboquant_k8v4_kernel(
+    const uint16_t* __restrict__ d_k_rows_fp16,
+    const uint16_t* __restrict__ d_v_rows_fp16,
+    uint8_t* __restrict__ d_combined_cache,
+    int seq_len, int kv_heads, int head_dim, int start_pos, int max_context) {
+
+    const int token = blockIdx.x;
+    const int head = blockIdx.y;
+    if (token >= seq_len || head >= kv_heads) return;
+
+    const int cache_pos = start_pos + token;
+    if (cache_pos >= max_context) return;
+
+    const int value_bytes = head_dim / 2;
+    const int slot_bytes = slot_bytes_for(head_dim);
+
+    const size_t k_offset = (static_cast<size_t>(token) * kv_heads + head) * head_dim;
+    const size_t v_offset = k_offset;
+    const size_t slot_offset =
+        (static_cast<size_t>(cache_pos) * kv_heads + head) * slot_bytes;
+
+    uint8_t* slot = d_combined_cache + slot_offset;
+
+    // Compute value min/max for uniform quantization. The reduction must span
+    // the whole block: with 128 threads a warp-only reduction would derive the
+    // range from the first 32 channels and clamp everything else.
+    float v_min = INFINITY;
+    float v_max = -INFINITY;
+    for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        __half v_h;
+        std::memcpy(&v_h, &d_v_rows_fp16[v_offset + d], 2);
+        float v = __half2float(v_h);
+        if (isfinite(v)) {
+            v_min = fminf(v_min, v);
+            v_max = fmaxf(v_max, v);
+        }
+    }
+
+    __shared__ float s_min[kStoreThreads];
+    __shared__ float s_max[kStoreThreads];
+    s_min[threadIdx.x] = v_min;
+    s_max[threadIdx.x] = v_max;
+    __syncthreads();
+    for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            s_min[threadIdx.x] = fminf(s_min[threadIdx.x], s_min[threadIdx.x + stride]);
+            s_max[threadIdx.x] = fmaxf(s_max[threadIdx.x], s_max[threadIdx.x + stride]);
+        }
+        __syncthreads();
+    }
+    v_min = s_min[0];
+    v_max = s_max[0];
+    if (!isfinite(v_min) || !isfinite(v_max)) {
+        v_min = 0.0f;
+        v_max = 0.0f;
+    }
+
+    // Round the metadata to FP16 before quantizing so the store and the load
+    // reconstruct values from exactly the same scale and minimum.
+    const __half min_h = __float2half(v_min);
+    v_min = __half2float(min_h);
+    float scale = fmaxf((v_max - v_min) / 15.0f, 1e-8f);
+    const __half scale_h = __float2half(scale);
+    scale = __half2float(scale_h);
+    if (scale <= 0.0f) scale = 1e-8f;
+
+    // Convert key to FP8 E5M2.
+    for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        __half k_h;
+        std::memcpy(&k_h, &d_k_rows_fp16[k_offset + d], 2);
+        float k = __half2float(k_h);
+        slot[d] = __nv_cvt_float_to_fp8(k, __NV_SATFINITE, __NV_E5M2);
+    }
+
+    // Pack values two dimensions per byte: even dimension in the low nibble,
+    // odd in the high nibble. One thread owns a whole byte so no atomics are
+    // needed and the write is a single store.
+    for (int byte = threadIdx.x; byte < value_bytes; byte += blockDim.x) {
+        const int d_low = byte * 2;
+        const int d_high = d_low + 1;
+
+        __half v_low_h, v_high_h;
+        std::memcpy(&v_low_h, &d_v_rows_fp16[v_offset + d_low], 2);
+        std::memcpy(&v_high_h, &d_v_rows_fp16[v_offset + d_high], 2);
+
+        uint8_t low = quantize_value_nibble(__half2float(v_low_h), scale, v_min);
+        uint8_t high = quantize_value_nibble(__half2float(v_high_h), scale, v_min);
+
+        slot[head_dim + byte] = static_cast<uint8_t>(low | (high << 4));
+    }
+
+    // Write metadata.
+    if (threadIdx.x == 0) {
+        uint16_t scale_bits, min_bits;
+        std::memcpy(&scale_bits, &scale_h, 2);
+        std::memcpy(&min_bits, &min_h, 2);
+        std::memcpy(slot + head_dim + value_bytes, &scale_bits, 2);
+        std::memcpy(slot + head_dim + value_bytes + 2, &min_bits, 2);
+    }
+}
+
+// Decode attention with TurboQuant K8V4 cache.
+__global__ void gqa_decode_attention_turboquant_k8v4_score_kernel(
+    const uint16_t* __restrict__ d_q_fp16,
+    const uint8_t* __restrict__ d_combined_cache,
+    float* __restrict__ d_scores,
+    int q_heads, int kv_heads, int head_dim, int context_len, int max_context,
+    int attention_window, int attention_sink_tokens, float q_scale) {
+
+    const int head = blockIdx.x;
+    if (head >= q_heads) return;
+
+    const int kv_head = head / (q_heads / kv_heads);
+    const int pos = blockIdx.y * blockDim.x + threadIdx.x;
+
+    // Window/sink filtering.
+    bool visible = true;
+    if (attention_window > 0) {
+        int sink_end = attention_sink_tokens;
+        int window_start = max(sink_end, context_len - attention_window);
+        visible = (pos < sink_end) || (pos >= window_start && pos < context_len);
+    } else {
+        visible = pos < context_len;
+    }
+
+    float score = visible ? 0.0f : -INFINITY;
+
+    if (visible) {
+        const size_t q_offset = static_cast<size_t>(head) * head_dim;
+        const size_t slot_offset =
+            (static_cast<size_t>(pos) * kv_heads + kv_head) * slot_bytes_for(head_dim);
+        const uint8_t* slot = d_combined_cache + slot_offset;
+
+        // Dot product Q · K.
+        for (int d = 0; d < head_dim; ++d) {
+            __half q_h;
+            std::memcpy(&q_h, &d_q_fp16[q_offset + d], 2);
+            float q = __half2float(q_h);
+
+            uint8_t k_fp8 = slot[d];
+            __half k_h = __nv_cvt_fp8_to_halfraw(k_fp8, __NV_E5M2);
+            float k = __half2float(k_h);
+
+            score += q * k;
+        }
+        score *= q_scale;
+    }
+
+    if (pos < max_context) {
+        d_scores[static_cast<size_t>(head) * max_context + pos] = score;
+    }
+}
+
+// One block per query head. Masked-out positions already hold -inf, so they
+// contribute nothing and stay zero after normalization.
+__global__ void softmax_rows_f32_kernel(float* __restrict__ d_scores,
+                                        int row_stride, int valid_cols) {
+    const int row = blockIdx.x;
+    float* scores = d_scores + static_cast<size_t>(row) * row_stride;
+
+    __shared__ float s_reduce[256];
+
+    float local_max = -INFINITY;
+    for (int col = threadIdx.x; col < valid_cols; col += blockDim.x) {
+        local_max = fmaxf(local_max, scores[col]);
+    }
+    s_reduce[threadIdx.x] = local_max;
+    __syncthreads();
+    for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            s_reduce[threadIdx.x] = fmaxf(s_reduce[threadIdx.x],
+                                          s_reduce[threadIdx.x + stride]);
+        }
+        __syncthreads();
+    }
+    const float row_max = s_reduce[0];
+    __syncthreads();
+
+    float local_sum = 0.0f;
+    for (int col = threadIdx.x; col < valid_cols; col += blockDim.x) {
+        const float score = scores[col];
+        const float weight = isfinite(score) ? __expf(score - row_max) : 0.0f;
+        scores[col] = weight;
+        local_sum += weight;
+    }
+    s_reduce[threadIdx.x] = local_sum;
+    __syncthreads();
+    for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            s_reduce[threadIdx.x] += s_reduce[threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+    const float row_sum = s_reduce[0];
+    const float inv_sum = row_sum > 0.0f ? 1.0f / row_sum : 0.0f;
+
+    for (int col = threadIdx.x; col < valid_cols; col += blockDim.x) {
+        scores[col] *= inv_sum;
+    }
+}
+
+__global__ void gqa_decode_attention_turboquant_k8v4_output_kernel(
+    const uint16_t* __restrict__ d_q_fp16,
+    const uint8_t* __restrict__ d_combined_cache,
+    const float* __restrict__ d_probs,
+    uint16_t* __restrict__ d_out_fp16,
+    int q_heads, int kv_heads, int head_dim, int context_len, int max_context,
+    int attention_window, int attention_sink_tokens) {
+
+    const int head = blockIdx.x;
+    const int dim = blockIdx.y * blockDim.x + threadIdx.x;
+    if (head >= q_heads || dim >= head_dim) return;
+
+    const int value_bytes = head_dim / 2;
+    const int slot_bytes = slot_bytes_for(head_dim);
+
+    const int kv_head = head / (q_heads / kv_heads);
+    const float* head_probs = d_probs + static_cast<size_t>(head) * max_context;
+
+    float accum = 0.0f;
+    for (int pos = 0; pos < context_len; ++pos) {
+        bool visible = true;
+        if (attention_window > 0) {
+            int sink_end = attention_sink_tokens;
+            int window_start = max(sink_end, context_len - attention_window);
+            visible = (pos < sink_end) || (pos >= window_start);
+        }
+        if (!visible) continue;
+
+        float prob = head_probs[pos];
+        const size_t slot_offset =
+            (static_cast<size_t>(pos) * kv_heads + kv_head) * slot_bytes;
+        const uint8_t* slot = d_combined_cache + slot_offset;
+
+        // Read scale/min metadata.
+        uint16_t scale_bits, min_bits;
+        std::memcpy(&scale_bits, slot + head_dim + value_bytes, 2);
+        std::memcpy(&min_bits, slot + head_dim + value_bytes + 2, 2);
+        __half scale_h, min_h;
+        std::memcpy(&scale_h, &scale_bits, 2);
+        std::memcpy(&min_h, &min_bits, 2);
+        float scale = __half2float(scale_h);
+        float minimum = __half2float(min_h);
+
+        // Decode 4-bit value.
+        int byte_idx = head_dim + (dim >> 1);
+        uint8_t packed = slot[byte_idx];
+        uint8_t nibble = (dim & 1) ? (packed >> 4) : (packed & 0x0F);
+        float v = dequantize_value_nibble(nibble, scale, minimum);
+
+        accum += prob * v;
+    }
+
+    const size_t out_offset = static_cast<size_t>(head) * head_dim + dim;
+    __half out_h = __float2half(accum);
+    uint16_t out_bits;
+    std::memcpy(&out_bits, &out_h, 2);
+    d_out_fp16[out_offset] = out_bits;
+}
+
+// Prefill attention with TurboQuant K8V4 cache.// One block per (token, head). blockDim == head_dim, so each thread owns one
+// output channel. Scores are computed one position per warp with a shuffle
+// reduction: letting every channel-thread redo the full head_dim dot product
+// instead costs head_dim times more score work and dominated prefill.
+__global__ void gqa_prefill_attention_turboquant_k8v4_kernel(
+    const uint16_t* __restrict__ d_q_rows_fp16,
+    const uint8_t* __restrict__ d_combined_cache,
+    uint16_t* __restrict__ d_out_rows_fp16,
+    int seq_len, int q_heads, int kv_heads, int head_dim, int position_offset,
+    int max_context, int attention_window, int attention_sink_tokens,
+    float q_scale) {
+
+    const int token = blockIdx.x;
+    const int head = blockIdx.y;
+    const int dim = threadIdx.x;
+    if (token >= seq_len || head >= q_heads) return;
+
+    const int value_bytes = head_dim / 2;
+    const int slot_bytes = slot_bytes_for(head_dim);
+    const int kv_head = head / (q_heads / kv_heads);
+    const int q_pos = position_offset + token;
+    const int visible_end = q_pos + 1;
+
+    const int lane = dim & 31;
+    const int warp = dim >> 5;
+    const int warps = blockDim.x >> 5;
+
+    // Causal visibility, optionally restricted to a sink prefix plus a trailing
+    // window measured against this query's own position.
+    const int sink_end = attention_window > 0 ? attention_sink_tokens : 0;
+    const int window_start = attention_window > 0
+        ? max(sink_end, visible_end - attention_window)
+        : 0;
+
+    const size_t q_offset =
+        (static_cast<size_t>(token) * q_heads + head) * head_dim;
+
+    __shared__ float s_q[kMaxHeadDim];
+    __shared__ float s_score[kMaxHeadDim / 32];
+
+    for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        __half q_h;
+        std::memcpy(&q_h, &d_q_rows_fp16[q_offset + d], 2);
+        s_q[d] = __half2float(q_h);
+    }
+    __syncthreads();
+
+    float max_score = -INFINITY;
+    float sum_exp = 0.0f;
+    float accum = 0.0f;
+
+    // Walk the attended positions in tiles of one position per warp.
+    for (int base = 0; base < visible_end; base += warps) {
+        const int pos = base + warp;
+        const bool in_range = pos < visible_end;
+        const bool masked = attention_window > 0 && pos >= sink_end &&
+                            pos < window_start;
+
+        if (warp < warps) {
+            float partial = 0.0f;
+            if (in_range && !masked) {
+                const size_t slot_offset =
+                    (static_cast<size_t>(pos) * kv_heads + kv_head) * slot_bytes;
+                const uint8_t* slot = d_combined_cache + slot_offset;
+                for (int d = lane; d < head_dim; d += 32) {
+                    __half k_h = __nv_cvt_fp8_to_halfraw(slot[d], __NV_E5M2);
+                    partial += s_q[d] * __half2float(k_h);
+                }
+            }
+            for (int offset = 16; offset > 0; offset >>= 1) {
+                partial += __shfl_xor_sync(0xffffffff, partial, offset);
+            }
+            if (lane == 0) {
+                s_score[warp] = (in_range && !masked) ? partial * q_scale
+                                                      : -INFINITY;
+            }
+        }
+        __syncthreads();
+
+        // Each thread folds this tile into its own channel accumulator. The
+        // running max and denominator are channel-independent, so every thread
+        // recomputes the same values rather than paying another reduction.
+        for (int w = 0; w < warps; ++w) {
+            const int tile_pos = base + w;
+            if (tile_pos >= visible_end) break;
+            const float score = s_score[w];
+            if (!isfinite(score)) continue;
+
+            const size_t slot_offset =
+                (static_cast<size_t>(tile_pos) * kv_heads + kv_head) * slot_bytes;
+            const uint8_t* slot = d_combined_cache + slot_offset;
+
+            uint16_t scale_bits, min_bits;
+            std::memcpy(&scale_bits, slot + head_dim + value_bytes, 2);
+            std::memcpy(&min_bits, slot + head_dim + value_bytes + 2, 2);
+            __half scale_h, min_h;
+            std::memcpy(&scale_h, &scale_bits, 2);
+            std::memcpy(&min_h, &min_bits, 2);
+            const float scale = __half2float(scale_h);
+            const float minimum = __half2float(min_h);
+
+            const uint8_t packed = slot[head_dim + (dim >> 1)];
+            const uint8_t nibble = (dim & 1) ? (packed >> 4) : (packed & 0x0F);
+            const float v = dequantize_value_nibble(nibble, scale, minimum);
+
+            if (score > max_score) {
+                const float rescale =
+                    isfinite(max_score) ? __expf(max_score - score) : 0.0f;
+                sum_exp = sum_exp * rescale + 1.0f;
+                accum = accum * rescale + v;
+                max_score = score;
+            } else {
+                const float weight = __expf(score - max_score);
+                sum_exp += weight;
+                accum += weight * v;
+            }
+        }
+        __syncthreads();
+    }
+
+    if (dim >= head_dim) return;
+    const float output = sum_exp > 0.0f ? accum / sum_exp : 0.0f;
+    const size_t out_offset =
+        (static_cast<size_t>(token) * q_heads + head) * head_dim + dim;
+    __half out_h = __float2half(output);
+    uint16_t out_bits;
+    std::memcpy(&out_bits, &out_h, 2);
+    d_out_rows_fp16[out_offset] = out_bits;
+}
+
+}  // namespace
+
+bool qwen_append_kv_cache_turboquant_k8v4_cuda(
+    const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
+    uint8_t* d_combined_cache, int seq_len, int kv_heads, int head_dim,
+    int start_pos, int max_context, void* stream) {
+
+    if (seq_len <= 0 || kv_heads <= 0 || head_dim <= 0 ||
+        head_dim > kMaxHeadDim || (head_dim % 2) != 0 ||
+        start_pos < 0 || max_context <= 0) {
+        return false;
+    }
+    if (!d_k_rows_fp16 || !d_v_rows_fp16 || !d_combined_cache) {
+        return false;
+    }
+    if (start_pos >= max_context) return true;  // Out of bounds, no-op.
+
+    // Every byte of each touched slot is written by the kernel, so no clearing
+    // pass is required.
+    dim3 grid(seq_len, kv_heads);
+    dim3 block(kStoreThreads);
+    append_kv_cache_turboquant_k8v4_kernel<<<grid, block, 0,
+                                             static_cast<cudaStream_t>(stream)>>>(
+        d_k_rows_fp16, d_v_rows_fp16, d_combined_cache, seq_len, kv_heads,
+        head_dim, start_pos, max_context);
+
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gqa_decode_attention_turboquant_k8v4_cuda(
+    const uint16_t* d_q_fp16, const uint8_t* d_combined_cache,
+    uint16_t* d_out_fp16, float* d_score_scratch, int q_heads, int kv_heads,
+    int head_dim, int context_len, int max_context, int attention_window,
+    int attention_sink_tokens, void* stream) {
+
+    if (q_heads <= 0 || kv_heads <= 0 || head_dim <= 0 ||
+        head_dim > kMaxHeadDim || (head_dim % 2) != 0 || kv_heads > q_heads ||
+        (q_heads % kv_heads) != 0 || context_len <= 0 || max_context <= 0 ||
+        context_len > max_context) {
+        return false;
+    }
+    if (!d_q_fp16 || !d_combined_cache || !d_out_fp16 || !d_score_scratch) {
+        return false;
+    }
+
+    const float q_scale = 1.0f / sqrtf(static_cast<float>(head_dim));
+
+    // Score phase.
+    {
+        dim3 grid(q_heads, (max_context + 127) / 128);
+        dim3 block(128);
+        gqa_decode_attention_turboquant_k8v4_score_kernel<<<grid, block, 0,
+                                                            static_cast<cudaStream_t>(stream)>>>(
+            d_q_fp16, d_combined_cache, d_score_scratch, q_heads, kv_heads,
+            head_dim, context_len, max_context, attention_window,
+            attention_sink_tokens, q_scale);
+    }
+
+    // Softmax phase over the masked score rows.
+    {
+        dim3 grid(q_heads);
+        dim3 block(256);
+        softmax_rows_f32_kernel<<<grid, block, 0,
+                                  static_cast<cudaStream_t>(stream)>>>(
+            d_score_scratch, max_context, context_len);
+    }
+
+    // Output phase.
+    {
+        dim3 grid(q_heads, (head_dim + 127) / 128);
+        dim3 block(128);
+        gqa_decode_attention_turboquant_k8v4_output_kernel<<<grid, block, 0,
+                                                             static_cast<cudaStream_t>(stream)>>>(
+            d_q_fp16, d_combined_cache, d_score_scratch, d_out_fp16, q_heads,
+            kv_heads, head_dim, context_len, max_context, attention_window,
+            attention_sink_tokens);
+    }
+
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gqa_prefill_attention_turboquant_k8v4_cuda(
+    const uint16_t* d_q_rows_fp16, const uint8_t* d_combined_cache,
+    uint16_t* d_out_rows_fp16, int seq_len, int q_heads, int kv_heads,
+    int head_dim, int position_offset, int max_context, int attention_window,
+    int attention_sink_tokens, void* stream) {
+
+    if (seq_len <= 0 || q_heads <= 0 || kv_heads <= 0 || head_dim <= 0 ||
+        head_dim > kMaxHeadDim || (head_dim % 2) != 0 || kv_heads > q_heads ||
+        (q_heads % kv_heads) != 0 || position_offset < 0 || max_context <= 0) {
+        return false;
+    }
+    if (!d_q_rows_fp16 || !d_combined_cache || !d_out_rows_fp16) {
+        return false;
+    }
+
+    const float q_scale = 1.0f / sqrtf(static_cast<float>(head_dim));
+
+    dim3 grid(seq_len, q_heads);
+    dim3 block(head_dim);
+    gqa_prefill_attention_turboquant_k8v4_kernel<<<grid, block, 0,
+                                                   static_cast<cudaStream_t>(stream)>>>(
+        d_q_rows_fp16, d_combined_cache, d_out_rows_fp16, seq_len, q_heads,
+        kv_heads, head_dim, position_offset, max_context, attention_window,
+        attention_sink_tokens, q_scale);
+
+    return cudaGetLastError() == cudaSuccess;
+}
+
+}  // namespace dsv4

--- a/cpp_engine/include/qwen_cuda_ops.hpp
+++ b/cpp_engine/include/qwen_cuda_ops.hpp
@@ -595,6 +595,12 @@ bool qwen_normalize_gated_delta_qk_f16_cuda(
     const uint16_t* d_q_fp16, const uint16_t* d_k_fp16,
     float* d_q_normalized, float* d_k_normalized, int rows, int key_heads,
     int key_dim, void* stream = nullptr);
+bool qwen_gated_delta_flashqla_sm75_f16_cuda(
+    float* d_state, const float* d_q_normalized,
+    const float* d_k_normalized, const uint16_t* d_v,
+    const uint16_t* d_g, const uint16_t* d_beta, uint16_t* d_out,
+    int rows, int heads, int key_heads, int key_dim, int value_dim,
+    float q_scale, void* stream = nullptr);
 bool qwen_partial_rope_f16_cuda(uint16_t* d_q_fp16, uint16_t* d_k_fp16,
                                 int position, int rotary_dim, float theta,
                                 int q_heads, int kv_heads, int head_dim,
@@ -699,5 +705,32 @@ bool qwen_gqa_prefill_attention_fp8_cuda(
     const uint16_t* d_v_scale_fp16, uint16_t* d_out_rows_fp16,
     int seq_len, int q_heads, int kv_heads, int head_dim, int scale_block,
     int position_offset, int max_context, void* stream = nullptr);
+
+// TurboQuant K8V4 KV-cache: one combined slot per token and KV head holding an
+// FP8 E5M2 key (one byte per channel), a 4-bit uniformly quantized value (two
+// channels per byte), and the value's FP16 scale and minimum. The slot size
+// follows head_dim, so it is 196 bytes at head_dim=128 and 388 at head_dim=256.
+constexpr int kTurboQuantK8V4MetadataBytes = 4;
+
+constexpr int qwen_turboquant_k8v4_slot_bytes(int head_dim) {
+    return head_dim + head_dim / 2 + kTurboQuantK8V4MetadataBytes;
+}
+
+bool qwen_append_kv_cache_turboquant_k8v4_cuda(
+    const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
+    uint8_t* d_combined_cache, int seq_len, int kv_heads, int head_dim,
+    int start_pos, int max_context, void* stream = nullptr);
+
+bool qwen_gqa_decode_attention_turboquant_k8v4_cuda(
+    const uint16_t* d_q_fp16, const uint8_t* d_combined_cache,
+    uint16_t* d_out_fp16, float* d_score_scratch, int q_heads, int kv_heads,
+    int head_dim, int context_len, int max_context, int attention_window,
+    int attention_sink_tokens, void* stream = nullptr);
+
+bool qwen_gqa_prefill_attention_turboquant_k8v4_cuda(
+    const uint16_t* d_q_rows_fp16, const uint8_t* d_combined_cache,
+    uint16_t* d_out_rows_fp16, int seq_len, int q_heads, int kv_heads,
+    int head_dim, int position_offset, int max_context, int attention_window,
+    int attention_sink_tokens, void* stream = nullptr);
 
 }  // namespace dsv4

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -13,6 +13,11 @@ namespace dsv4 {
 enum class QwenKvCacheDType {
     Fp16,
     Fp8,
+    // TurboQuant K8V4: one combined byte slot per token and KV head holding an
+    // FP8 E5M2 key, a 4-bit uniformly quantized value, and the value's FP16
+    // scale and minimum. This is a lossy cache and stays opt-in; the FP16 and
+    // separate-array FP8 paths remain the exact defaults.
+    TurboQuantK8V4,
 };
 
 const char* qwen_kv_cache_dtype_name(QwenKvCacheDType dtype);
@@ -22,7 +27,20 @@ struct QwenEngineOptions {
     int tp_world = 1;
     int tp_rank = 0;
     int device = 0;
-    int prefill_chunk_tokens = 512;
+    // The FP8 projections dequantize the weight into an FP16 scratch buffer once
+    // per call, a fixed cost that amortises over the chunk: measured per-call
+    // dequant overhead on the real projection shapes is 29-34% at 512 rows but
+    // only 9-12% at 2048. Raising the chunk from 512 recovers that on the real
+    // 64-layer TP4 checkpoint at a cost of 0.42 GiB/rank, well inside the 22 GB
+    // budget, with generated tokens unchanged:
+    //
+    //   context   chunk 512   chunk 4096   prefill
+    //     8192     1125.7      1229.9      1.09x
+    //    32768     1059.1      1244.3      1.17x
+    //    65536      886.8      1077.7      1.21x
+    //
+    // The DSV4 engine already defaults to 4096 for the same reason.
+    int prefill_chunk_tokens = 4096;
     QwenKvCacheDType kv_cache_dtype = QwenKvCacheDType::Fp16;
     // 0 preserves exact full attention. Nonzero values enable the explicit
     // sink-plus-sliding-window attention path in the optimized FP16 kernels.

--- a/cpp_engine/include/qwen_weights.hpp
+++ b/cpp_engine/include/qwen_weights.hpp
@@ -69,6 +69,10 @@ struct QwenDeviceTensor {
     const uint16_t* f16_data() const;
     uint8_t* fp8_data();
     const uint8_t* fp8_data() const;
+    // Raw byte storage for packed caches whose slot mixes several element types,
+    // so they cannot claim a single arithmetic dtype. Accepts I8 only.
+    uint8_t* byte_data();
+    const uint8_t* byte_data() const;
 };
 
 struct QwenLinearRef {

--- a/cpp_engine/src/main.cpp
+++ b/cpp_engine/src/main.cpp
@@ -49,7 +49,10 @@ struct Args {
     bool qwen_persistent_stdin = false;
     bool use_persistent = false;
     int max_context = 0;
-    int prefill_chunk_tokens = 512;
+    // 0 means "leave the engine's own default alone" rather than duplicating the
+    // constant here, so raising QwenEngineOptions::prefill_chunk_tokens does not
+    // need a matching edit in the argument parser.
+    int prefill_chunk_tokens = 0;
     std::string kv_cache_dtype = "fp16";
     int qwen_attention_window = 0;
     int qwen_attention_sink_tokens = 0;
@@ -147,6 +150,11 @@ Args parse_args(int argc, char** argv) {
             args.max_context = std::stoi(argv[++i]);
         } else if (arg == "--prefill-chunk-tokens" && i + 1 < argc) {
             args.prefill_chunk_tokens = std::stoi(argv[++i]);
+            // An explicit value must still be positive. The 0 sentinel means
+            // "unspecified", so it is only valid when the flag is absent.
+            if (args.prefill_chunk_tokens <= 0) {
+                throw std::runtime_error("--prefill-chunk-tokens must be positive");
+            }
         } else if (arg == "--kv-cache-dtype" && i + 1 < argc) {
             args.kv_cache_dtype = argv[++i];
         } else if (arg == "--qwen-attention-window" && i + 1 < argc) {
@@ -199,7 +207,7 @@ Args parse_args(int argc, char** argv) {
     }
     if (args.tp_world <= 0) throw std::runtime_error("--tp-world must be positive");
     if (args.tp_rank < 0 || args.tp_rank >= args.tp_world) throw std::runtime_error("--tp-rank must be in [0, tp_world)");
-    if (args.prefill_chunk_tokens <= 0) throw std::runtime_error("--prefill-chunk-tokens must be positive");
+    if (args.prefill_chunk_tokens < 0) throw std::runtime_error("--prefill-chunk-tokens must be positive");
     if (args.qwen_snapshot_interval < 0 || args.qwen_max_snapshots < 0) {
         throw std::runtime_error("Qwen snapshot settings must not be negative");
     }
@@ -231,8 +239,9 @@ Args parse_args(int argc, char** argv) {
         throw std::runtime_error(
             "--qwen-dflash2 must name a complete DFlash2 checkpoint directory");
     }
-    if (args.kv_cache_dtype != "fp16" && args.kv_cache_dtype != "fp8") {
-        throw std::runtime_error("--kv-cache-dtype must be fp16 or fp8");
+    if (args.kv_cache_dtype != "fp16" && args.kv_cache_dtype != "fp8" &&
+        args.kv_cache_dtype != "turboquant_k8v4") {
+        throw std::runtime_error("--kv-cache-dtype must be fp16, fp8, or turboquant_k8v4");
     }
     if (args.qwen_attention_window < 0) {
         throw std::runtime_error("--qwen-attention-window must not be negative");
@@ -452,7 +461,9 @@ int main(int argc, char** argv) {
                     qwen_opts.tp_world = args.tp_world;
                     qwen_opts.tp_rank = args.tp_rank;
                     qwen_opts.device = args.device >= 0 ? args.device : args.tp_rank;
-                    qwen_opts.prefill_chunk_tokens = args.prefill_chunk_tokens;
+                    if (args.prefill_chunk_tokens > 0) {
+                        qwen_opts.prefill_chunk_tokens = args.prefill_chunk_tokens;
+                    }
                     qwen_opts.kv_cache_dtype = dsv4::parse_qwen_kv_cache_dtype(args.kv_cache_dtype);
                     qwen_opts.attention_window = args.qwen_attention_window;
                     qwen_opts.attention_sink_tokens = args.qwen_attention_sink_tokens;

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -106,6 +106,9 @@ struct DeviceFullAttention {
     QwenDeviceTensor v_cache;
     QwenDeviceTensor k_scale;
     QwenDeviceTensor v_scale;
+    // TurboQuant K8V4 combined cache: 196-byte slots with FP8 E5M2 key + 4-bit
+    // value + FP16 metadata. Only allocated when kv_cache_dtype is TurboQuantK8V4.
+    QwenDeviceTensor turboquant_cache;
 };
 
 struct DeviceLayer {
@@ -300,6 +303,7 @@ const char* qwen_kv_cache_dtype_name(QwenKvCacheDType dtype) {
     switch (dtype) {
         case QwenKvCacheDType::Fp16: return "fp16";
         case QwenKvCacheDType::Fp8: return "fp8";
+        case QwenKvCacheDType::TurboQuantK8V4: return "turboquant_k8v4";
     }
     return "unknown";
 }
@@ -307,7 +311,8 @@ const char* qwen_kv_cache_dtype_name(QwenKvCacheDType dtype) {
 QwenKvCacheDType parse_qwen_kv_cache_dtype(const std::string& value) {
     if (value == "fp16") return QwenKvCacheDType::Fp16;
     if (value == "fp8") return QwenKvCacheDType::Fp8;
-    throw std::runtime_error("Qwen KV cache dtype must be fp16 or fp8");
+    if (value == "turboquant_k8v4") return QwenKvCacheDType::TurboQuantK8V4;
+    throw std::runtime_error("Qwen KV cache dtype must be fp16, fp8, or turboquant_k8v4");
 }
 
 struct QwenEngine::Impl {
@@ -399,6 +404,12 @@ struct QwenEngine::Impl {
     cudaEvent_t nccl_comm_ready = nullptr;
     cudaEvent_t nccl_comm_done = nullptr;
     bool nccl_comm_stream_initialized = false;
+    // The overlapped path has two collectives in flight across a slice boundary,
+    // so it cannot share the single ready/done pair above: recording ready for
+    // slice i+1 could overwrite it before slice i's waiter has resolved. These are
+    // allocated per slice index and reused across layers.
+    std::vector<cudaEvent_t> comm_slice_ready;
+    std::vector<cudaEvent_t> comm_slice_done;
     uint64_t uploaded_weight_bytes = 0;
     uint64_t uploaded_scale_bytes = 0;
     uint64_t verify_weight_bytes = 0;
@@ -426,6 +437,21 @@ struct QwenEngine::Impl {
         nccl_comm_stream_initialized = true;
     }
 
+    // Grow the per-slice event pool to hold at least `slices` entries.
+    void ensure_comm_slice_events(int slices) {
+        while (static_cast<int>(comm_slice_ready.size()) <
+               static_cast<size_t>(slices)) {
+            cudaEvent_t ready = nullptr;
+            cudaEvent_t done = nullptr;
+            check_cuda(cudaEventCreateWithFlags(&ready, cudaEventDisableTiming),
+                       "Qwen comm slice ready event");
+            check_cuda(cudaEventCreateWithFlags(&done, cudaEventDisableTiming),
+                       "Qwen comm slice done event");
+            comm_slice_ready.push_back(ready);
+            comm_slice_done.push_back(done);
+        }
+    }
+
     // The compute kernels all use the legacy default stream. Bracket a
     // communication-stream collective with events so the collective sees the
     // complete producer work and the next compute kernel sees its result.
@@ -449,6 +475,12 @@ struct QwenEngine::Impl {
             // The default stream wait above normally makes this unnecessary;
             // keep destruction safe if construction or a caller failed midway.
             cudaStreamSynchronize(nccl_comm_stream);
+        }
+        for (cudaEvent_t event : comm_slice_ready) {
+            if (event != nullptr) cudaEventDestroy(event);
+        }
+        for (cudaEvent_t event : comm_slice_done) {
+            if (event != nullptr) cudaEventDestroy(event);
         }
         if (nccl_comm_done != nullptr) cudaEventDestroy(nccl_comm_done);
         if (nccl_comm_ready != nullptr) cudaEventDestroy(nccl_comm_ready);
@@ -597,7 +629,7 @@ struct QwenEngine::Impl {
                     allocate_half(destination.full.v_cache, cache_elements, cache_shape);
                     cache_data_bytes += destination.full.k_cache.nbytes +
                                         destination.full.v_cache.nbytes;
-                } else {
+                } else if (options.kv_cache_dtype == QwenKvCacheDType::Fp8) {
                     allocate_elements(destination.full.k_cache, cache_elements,
                                       cache_shape, SafeDType::F8_E4M3);
                     allocate_elements(destination.full.v_cache, cache_elements,
@@ -614,6 +646,20 @@ struct QwenEngine::Impl {
                                         destination.full.v_cache.nbytes;
                     cache_scale_bytes += destination.full.k_scale.nbytes +
                                          destination.full.v_scale.nbytes;
+                } else {
+                    // TurboQuantK8V4: one combined slot per token/head, sized
+                    // from head_dim (196 bytes at 128, 388 at 256).
+                    const int slot_bytes =
+                        qwen_turboquant_k8v4_slot_bytes(head_dim);
+                    const size_t slot_elements = static_cast<size_t>(max_context) *
+                        local_kv_heads * slot_bytes;
+                    const std::vector<uint64_t> slot_shape = {
+                        static_cast<uint64_t>(max_context),
+                        static_cast<uint64_t>(local_kv_heads),
+                        static_cast<uint64_t>(slot_bytes)};
+                    allocate_elements(destination.full.turboquant_cache, slot_elements,
+                                      slot_shape, SafeDType::I8);
+                    cache_data_bytes += destination.full.turboquant_cache.nbytes;
                 }
             }
             layers.push_back(std::move(destination));
@@ -785,7 +831,7 @@ struct QwenEngine::Impl {
                               mtp_cache_shape);
                 cache_data_bytes += mtp_layer.full.k_cache.nbytes +
                                     mtp_layer.full.v_cache.nbytes;
-            } else {
+            } else if (options.kv_cache_dtype == QwenKvCacheDType::Fp8) {
                 allocate_elements(mtp_layer.full.k_cache, mtp_cache_elements,
                                   mtp_cache_shape, SafeDType::F8_E4M3);
                 allocate_elements(mtp_layer.full.v_cache, mtp_cache_elements,
@@ -802,6 +848,19 @@ struct QwenEngine::Impl {
                                     mtp_layer.full.v_cache.nbytes;
                 cache_scale_bytes += mtp_layer.full.k_scale.nbytes +
                                      mtp_layer.full.v_scale.nbytes;
+            } else {
+                // TurboQuantK8V4: one combined slot per token/head, sized
+                // from head_dim (196 bytes at 128, 388 at 256).
+                const int slot_bytes = qwen_turboquant_k8v4_slot_bytes(head_dim);
+                const size_t slot_elements = static_cast<size_t>(max_context) *
+                    local_kv_heads * slot_bytes;
+                const std::vector<uint64_t> slot_shape = {
+                    static_cast<uint64_t>(max_context),
+                    static_cast<uint64_t>(local_kv_heads),
+                    static_cast<uint64_t>(slot_bytes)};
+                allocate_elements(mtp_layer.full.turboquant_cache, slot_elements,
+                                  slot_shape, SafeDType::I8);
+                cache_data_bytes += mtp_layer.full.turboquant_cache.nbytes;
             }
         }
     }
@@ -1222,6 +1281,119 @@ struct QwenEngine::Impl {
         std::cout.flush();
     }
 
+    // Number of row slices used by the overlapped projection+all-reduce path.
+    // 0 or 1 disables slicing entirely and keeps the serial behaviour.
+    //
+    // Opt-in, and deliberately not defaulted on. Measured serially on the real
+    // 64-layer TP4 checkpoint with QWEN_NCCL_COMM_STREAM=1 and both the mlp.down
+    // and lin.out sites overlapped, against the same binary's serial default:
+    //
+    //   context   serial    slices=4   prefill   decode
+    //     8192    1221.9     1218.3    1.00x     25.24 -> 24.92
+    //    32768    1228.3     1272.6    1.04x     20.85 -> 20.79
+    //    65536    1065.3     1098.6    1.03x     19.52 -> 19.34
+    //
+    // Only 3-4% at long context, nothing at 8K, and decode is consistently a
+    // little worse because the comm stream competes for SMs with kernels that had
+    // the device to themselves. The collective is bytes-bound at ~26 GB/s of ring
+    // bandwidth, so most of it simply cannot hide behind one layer's GEMMs.
+    // Enable with QWEN_COMM_OVERLAP_SLICES=4 for long-context prefill-heavy work.
+    int comm_overlap_slices() const {
+        static const int slices =
+            qwen_env_int("QWEN_COMM_OVERLAP_SLICES", 0);
+        return slices;
+    }
+
+    // Pipelined projection and all-reduce.
+    //
+    // The collective is bytes-bound, not launch-bound: raising the prefill chunk
+    // from 512 to 4096 cut the call count 3.1x (9288 -> 2967) but the time only
+    // 6% (7.72 -> 7.24 s), and ar.mlp moves 41.9 MB in 2.43 ms, about 26 GB/s of
+    // ring bandwidth. So it cannot be made faster, only hidden.
+    //
+    // This splits the output rows into slices. After slice i's GEMM is issued,
+    // its all-reduce goes on the communication stream while slice i+1's GEMM runs
+    // on the compute stream. Only the final slice's collective is exposed. Each
+    // slice is an independent contiguous row range, and NCCL reduces each element
+    // over the same four ranks in the same order regardless of slicing, so the
+    // reduction itself is unchanged.
+    //
+    // The projection is a different matter: slicing changes the GEMM's batch
+    // dimension, and cuBLAS may pick a different algorithm for a different batch,
+    // so the projection output is not guaranteed bit-identical. Slices are
+    // therefore kept at or above the batch>=96 cuBLAS dispatch gate, and the real
+    // token-parity gate is what decides whether this ships.
+    //
+    // Requires the row-major [rows, hidden] layout: a row slice must be a
+    // contiguous byte range in both the projection output and the reduced buffer.
+    bool projection_all_reduce_overlapped(
+            const DeviceLinear& linear, const uint16_t* input, uint16_t* output,
+            int rows, int hidden, const char* proj_site, const char* ar_site) {
+        const int slices = comm_overlap_slices();
+        if (options.tp_world == 1 || slices <= 1 || rows < slices * 2) {
+            return false;
+        }
+#ifndef DSV4_HAVE_NCCL
+        return false;
+#else
+        if (!use_nccl_comm_stream || options.nccl_id_path.empty()) return false;
+        // Rows per slice, rounded up so the tail slice is the short one. Below the
+        // cuBLAS batch>=96 gate the projection would fall back to the handwritten
+        // tile kernel, which is 3-5x slower and would cost far more than the
+        // collective being hidden, so refuse to slice that finely.
+        const int per = (rows + slices - 1) / slices;
+        if (per < 96) return false;
+        ensure_nccl_comm_stream();
+        const int slice_count = (rows + per - 1) / per;
+        ensure_comm_slice_events(slice_count);
+        int index = 0;
+        bool pending = false;
+        int pending_index = 0;
+        for (int start = 0; start < rows; start += per, ++index) {
+            const int count = std::min(per, rows - start);
+            const size_t offset = static_cast<size_t>(start) * hidden;
+            projection(linear, input + static_cast<size_t>(start) * linear_columns(linear),
+                       output + offset, count, proj_site);
+            // Wait for the previous slice's collective only now, so it had the
+            // whole of this slice's GEMM to run underneath.
+            if (pending) {
+                check_cuda(cudaStreamWaitEvent(
+                    nullptr, comm_slice_done[pending_index], 0),
+                    "Qwen overlapped all-reduce wait");
+                pending = false;
+            }
+            // Deliberately no PhaseScope around the collective. PhaseScope calls
+            // cudaDeviceSynchronize() on entry and exit, which would drain the
+            // comm stream and serialize exactly the pipeline being built, so a
+            // profiled run would report a slowdown caused by the profiler. The
+            // enclosing per-layer scopes still attribute the exposed cost.
+            check_cuda(cudaEventRecord(comm_slice_ready[index], nullptr),
+                       "Qwen overlapped ready event");
+            check_cuda(cudaStreamWaitEvent(
+                nccl_comm_stream, comm_slice_ready[index], 0),
+                "Qwen overlapped comm wait");
+            nccl_all_reduce_sum_f16_inplace(
+                options.tp_world, options.tp_rank, options.device,
+                options.nccl_id_path.c_str(), output + offset,
+                count * hidden, nccl_comm_stream);
+            check_cuda(cudaEventRecord(comm_slice_done[index], nccl_comm_stream),
+                       "Qwen overlapped done event");
+            pending = true;
+            pending_index = index;
+        }
+        if (pending) {
+            check_cuda(cudaStreamWaitEvent(
+                nullptr, comm_slice_done[pending_index], 0),
+                "Qwen overlapped final all-reduce wait");
+        }
+        return true;
+#endif
+    }
+
+    static int linear_columns(const DeviceLinear& linear) {
+        return static_cast<int>(linear.weight.shape[1]);
+    }
+
     void all_reduce_half(uint16_t* values, int count, const char* site = "other") {
         PhaseScope scope(this, std::string("ar.") + site);
         if (options.tp_world == 1) return;
@@ -1360,6 +1532,16 @@ struct QwenEngine::Impl {
         QwenDeviceTensor& core = workspace_half(value_elements, v.shape);
         QwenDeviceTensor& z = workspace_half(value_elements, v.shape);
         QwenDeviceTensor& normalized = workspace_half(value_elements, v.shape);
+        QwenDeviceTensor* q_normalized = nullptr;
+        QwenDeviceTensor* k_normalized = nullptr;
+        const bool flashqla = rows >= 8 &&
+            qwen_env_enabled_default("QWEN_GATED_DELTA_FLASHQLA_SM75");
+        if (flashqla) {
+            q_normalized = &workspace_float(
+                key_elements,
+                {static_cast<uint64_t>(rows), static_cast<uint64_t>(key_dim)});
+            k_normalized = &workspace_float(key_elements, q_normalized->shape);
+        }
 
         projection(layer.linear.qkv, hidden, packed.f16_data(), rows, "lin.qkv");
         require_launch(qwen_causal_depthwise_conv_silu_f16_cuda(
@@ -1395,7 +1577,26 @@ struct QwenEngine::Impl {
         std::optional<PhaseScope> delta_scope;
         delta_scope.emplace(this, "gated_delta");
         bool sequenced = false;
-        if (rows >= 5 && key_heads < value_heads &&
+        if (flashqla) {
+            // FlashQLA SM75 subgroup-sharded kernel. Still a serial recurrence,
+            // but sharding the [128, 128] state over 16-lane subgroups replaces
+            // the baseline's 128-element per-thread register vector: 1.85x on the
+            // primitive and +5-7% real TP4 prefill at token-exact parity.
+            // Consume the established FP32 normalized Q/K tensors so the norm
+            // reduction order remains identical to the reference path.
+            sequenced = qwen_normalize_gated_delta_qk_f16_cuda(
+                q.f16_data(), k.f16_data(), q_normalized->f32_data(),
+                k_normalized->f32_data(), rows, key_heads,
+                static_cast<int>(config.linear_attention.key_head_dim)) &&
+                qwen_gated_delta_flashqla_sm75_f16_cuda(
+                    layer.linear.state.f32_data(), q_normalized->f32_data(),
+                    k_normalized->f32_data(), v.f16_data(), gates.f16_data(),
+                    beta.f16_data(), core.f16_data(), rows, value_heads,
+                    key_heads,
+                    static_cast<int>(config.linear_attention.key_head_dim),
+                    static_cast<int>(config.linear_attention.value_head_dim),
+                    q_scale);
+        } else if (rows >= 5 && key_heads < value_heads &&
             qwen_env_enabled_default("QWEN_GATED_DELTA_PRENORMALIZE")) {
             QwenDeviceTensor& q_normalized = workspace_float(
                 key_elements, {static_cast<uint64_t>(rows),
@@ -1453,8 +1654,15 @@ struct QwenEngine::Impl {
             static_cast<int>(config.linear_attention.value_head_dim),
             static_cast<float>(config.rms_norm_eps)),
             "FP16 linear gated RMSNorm");
-        projection(layer.linear.out, normalized.f16_data(), output, rows, "lin.out");
-        all_reduce_half(output, rows * hidden_size, "lin.out");
+        // ar.lin.out is the second-largest collective (2.69 s at 32K) and runs on
+        // the 48 DeltaNet layers, so it is the other worthwhile overlap site.
+        if (!projection_all_reduce_overlapped(
+                layer.linear.out, normalized.f16_data(), output, rows,
+                hidden_size, "lin.out", "lin.out")) {
+            projection(layer.linear.out, normalized.f16_data(), output, rows,
+                       "lin.out");
+            all_reduce_half(output, rows * hidden_size, "lin.out");
+        }
         (void)position_offset;
     }
 
@@ -1527,16 +1735,21 @@ struct QwenEngine::Impl {
             static_cast<float>(config.rope_theta), q_heads, kv_heads, head_dim),
             "FP16 partial RoPE");
 
-        const bool fp8_cache = options.kv_cache_dtype == QwenKvCacheDType::Fp8;
+        const QwenKvCacheDType cache_dtype = options.kv_cache_dtype;
         const int attention_window = options.attention_window;
         const int sink_tokens = options.attention_sink_tokens;
-        if (fp8_cache) {
+        if (cache_dtype == QwenKvCacheDType::Fp8) {
             require_launch(qwen_append_kv_cache_fp8_cuda(
                 k_norm.f16_data(), v.f16_data(), layer.full.k_cache.fp8_data(),
                 layer.full.v_cache.fp8_data(), layer.full.k_scale.f16_data(),
                 layer.full.v_scale.f16_data(), rows, kv_heads, head_dim,
                 kKvScaleBlock, position_offset, max_context),
                 "append FP8 full KV cache");
+        } else if (cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
+            require_launch(qwen_append_kv_cache_turboquant_k8v4_cuda(
+                k_norm.f16_data(), v.f16_data(), layer.full.turboquant_cache.byte_data(),
+                rows, kv_heads, head_dim, position_offset, max_context),
+                "append TurboQuant K8V4 full KV cache");
         } else {
             require_launch(qwen_append_kv_cache_f16_cuda(
                 k_norm.f16_data(), v.f16_data(), layer.full.k_cache.f16_data(),
@@ -1552,7 +1765,8 @@ struct QwenEngine::Impl {
             // The compact split/merge decode path crosses over the reference
             // score/value kernels only at long contexts on SM75.
             constexpr int kOptimizedDecodeMinContext = 16384;
-            const bool optimized_decode = !fp8_cache && optimized_attention &&
+            const bool optimized_decode = cache_dtype == QwenKvCacheDType::Fp16 &&
+                optimized_attention &&
                 (context_length >= kOptimizedDecodeMinContext ||
                  attention_window > 0);
             int attended_positions = context_length;
@@ -1576,7 +1790,7 @@ struct QwenEngine::Impl {
                                             static_cast<uint64_t>(head_dim + 2)}
                     : std::vector<uint64_t>{static_cast<uint64_t>(q_heads),
                                              static_cast<uint64_t>(context_length)});
-            if (fp8_cache) {
+            if (cache_dtype == QwenKvCacheDType::Fp8) {
                 require_launch(qwen_gqa_decode_attention_fp8_cuda(
                     q_norm.f16_data(), layer.full.k_cache.fp8_data(),
                     layer.full.v_cache.fp8_data(), layer.full.k_scale.f16_data(),
@@ -1584,6 +1798,12 @@ struct QwenEngine::Impl {
                     scores.f32_data(), q_heads, kv_heads, head_dim,
                     kKvScaleBlock, context_length, max_context),
                     "decode FP8-cache GQA");
+            } else if (cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
+                require_launch(qwen_gqa_decode_attention_turboquant_k8v4_cuda(
+                    q_norm.f16_data(), layer.full.turboquant_cache.byte_data(),
+                    attention.f16_data(), scores.f32_data(), q_heads, kv_heads,
+                    head_dim, context_length, max_context, attention_window,
+                    sink_tokens), "decode TurboQuant K8V4 GQA");
             } else if (optimized_decode) {
                 require_launch(qwen_gqa_decode_attention_f16_fused_cuda(
                     q_norm.f16_data(), layer.full.k_cache.f16_data(),
@@ -1598,14 +1818,20 @@ struct QwenEngine::Impl {
                     scores.f32_data(), q_heads, kv_heads, head_dim,
                     context_length, max_context), "decode FP16-cache GQA");
             }
-        } else if (fp8_cache) {
+        } else if (cache_dtype == QwenKvCacheDType::Fp8) {
             require_launch(qwen_gqa_prefill_attention_fp8_cuda(
                 q_norm.f16_data(), layer.full.k_cache.fp8_data(),
                 layer.full.v_cache.fp8_data(), layer.full.k_scale.f16_data(),
                 layer.full.v_scale.f16_data(), attention.f16_data(), rows,
                 q_heads, kv_heads, head_dim, kKvScaleBlock, position_offset,
                 max_context), "prefill FP8-cache GQA");
-        } else if (rows <= 8 && attention_window == 0) {
+        } else if (cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
+            require_launch(qwen_gqa_prefill_attention_turboquant_k8v4_cuda(
+                q_norm.f16_data(), layer.full.turboquant_cache.byte_data(),
+                attention.f16_data(), rows, q_heads, kv_heads, head_dim,
+                position_offset, max_context, attention_window, sink_tokens),
+                "prefill TurboQuant K8V4 GQA");
+        } else if (cache_dtype == QwenKvCacheDType::Fp16 && rows <= 8 && attention_window == 0) {
             const int context_length = position_offset + rows;
             // Tensor-core QK experiment for the real TP4 shape (one KV head per
             // rank). Keeps the existing FP32 softmax/PV order; opt-in until real
@@ -1779,8 +2005,16 @@ struct QwenEngine::Impl {
                 gate->f16_data(), up->f16_data(), intermediate.f16_data(), rows,
                 static_cast<int>(layer.gate.weight.shape[0])), "FP16 SwiGLU");
         }
-        projection(layer.down, intermediate.f16_data(), mlp.f16_data(), rows, "mlp.down");
-        all_reduce_half(mlp.f16_data(), rows * hidden_size, "mlp");
+        // ar.mlp is the largest single collective (3.58 s of the 7.24 s
+        // tp_all_reduce leaf at 32K), and down is a large GEMM, so this is the
+        // best overlap candidate in the layer.
+        if (!projection_all_reduce_overlapped(
+                layer.down, intermediate.f16_data(), mlp.f16_data(), rows,
+                hidden_size, "mlp.down", "mlp")) {
+            projection(layer.down, intermediate.f16_data(), mlp.f16_data(), rows,
+                       "mlp.down");
+            all_reduce_half(mlp.f16_data(), rows * hidden_size, "mlp");
+        }
         add(output, mlp.f16_data(), rows * hidden_size);
     }
 

--- a/cpp_engine/src/qwen_weights.cpp
+++ b/cpp_engine/src/qwen_weights.cpp
@@ -142,6 +142,16 @@ const uint8_t* QwenDeviceTensor::fp8_data() const {
     return static_cast<const uint8_t*>(data);
 }
 
+uint8_t* QwenDeviceTensor::byte_data() {
+    if (device_dtype != SafeDType::I8) throw std::runtime_error("Qwen tensor is not raw bytes");
+    return static_cast<uint8_t*>(data);
+}
+
+const uint8_t* QwenDeviceTensor::byte_data() const {
+    if (device_dtype != SafeDType::I8) throw std::runtime_error("Qwen tensor is not raw bytes");
+    return static_cast<const uint8_t*>(data);
+}
+
 QwenHostTensor qwen_materialize_host_tensor(const SafeTensorsIndex& index,
                                             const QwenTensorRef& ref) {
     if (!ref.found) throw std::runtime_error("cannot materialize an absent Qwen tensor: " + ref.name);

--- a/cpp_engine/tests/bench_qwen_delta_f16.cpp
+++ b/cpp_engine/tests/bench_qwen_delta_f16.cpp
@@ -120,6 +120,17 @@ int main(int argc, char** argv) {
                    rows, kHeads, kKeyHeads, kDim, kDim,
                    1.0f / 11.3137085f);
     };
+    // FlashQLA SM75 subgroup-sharded kernel: WIDTH=16 lanes hold COLS=4 state
+    // columns each, so the [D, D] state is spread over 8 warps instead of one
+    // thread per value dimension. Same serial recurrence, different sharding.
+    auto flashqla = [&]() {
+        return dsv4::qwen_normalize_gated_delta_qk_f16_cuda(
+                   q, k, q_normalized, k_normalized, rows, kKeyHeads, kDim) &&
+               dsv4::qwen_gated_delta_flashqla_sm75_f16_cuda(
+                   state, q_normalized, k_normalized, v, g, beta, output,
+                   rows, kHeads, kKeyHeads, kDim, kDim,
+                   1.0f / 11.3137085f);
+    };
     auto steps = [&]() {
         for (int row = 0; row < rows; ++row) {
             if (!dsv4::qwen_gated_delta_step_f16_cuda(
@@ -140,13 +151,17 @@ int main(int argc, char** argv) {
     check(cudaMemset(state, 0, state_elements * sizeof(float)), "reset state");
     const double shared_ms = time_launch(shared_state_variant, iters);
     check(cudaMemset(state, 0, state_elements * sizeof(float)), "reset state");
+    const double flashqla_ms = time_launch(flashqla, iters);
+    check(cudaMemset(state, 0, state_elements * sizeof(float)), "reset state");
     const double step_ms = time_launch(steps, iters);
     std::printf("qwen_gated_delta_f16 rows=%d heads=%d key_heads=%d dim=%d "
                 "sequence=%.6f ms normalized=%.6f ms shared=%.6f ms "
-                "steps=%.6f ms normalized_speedup=%.3f shared_speedup=%.3f "
+                "flashqla=%.6f ms steps=%.6f ms normalized_speedup=%.3f "
+                "shared_speedup=%.3f flashqla_speedup=%.3f "
                 "sequence_speedup=%.3f\n",
                 rows, kHeads, kKeyHeads, kDim, seq_ms, normalized_ms, shared_ms,
-                step_ms, seq_ms / normalized_ms, normalized_ms / shared_ms,
+                flashqla_ms, step_ms, seq_ms / normalized_ms,
+                normalized_ms / shared_ms, normalized_ms / flashqla_ms,
                 step_ms / seq_ms);
     cudaFree(state);
     cudaFree(q);

--- a/cpp_engine/tests/bench_qwen_fp8_batch_crossover.cpp
+++ b/cpp_engine/tests/bench_qwen_fp8_batch_crossover.cpp
@@ -23,8 +23,7 @@ const Shape kShapes[] = {
 };
 double run(bool cublas, const uint16_t* x, const uint8_t* w, const uint16_t* s,
            uint16_t* y, int batch, int rows, int cols, int sc, int iters) {
-    if (cublas) setenv("QWEN_FP8_F16_PREFILL_CUBLAS", "1", 1);
-    else unsetenv("QWEN_FP8_F16_PREFILL_CUBLAS");
+    setenv("QWEN_FP8_F16_PREFILL_CUBLAS", cublas ? "1" : "0", 1);
     setenv("QWEN_FP8_F16_SMALL_BATCH", cublas ? "0" : "1", 1);
     auto go = [&]() {
         return dsv4::qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(

--- a/cpp_engine/tests/bench_qwen_gqa_prefill.cpp
+++ b/cpp_engine/tests/bench_qwen_gqa_prefill.cpp
@@ -29,12 +29,13 @@ constexpr int kHeadDim = 256;
 // Flash remains explicitly enabled for this mode. Long is the validated
 // default dispatch, and setting it to 0 selects the fallback for baseline.
 // Clear both variables for every case so one mode cannot leak into another.
-enum class Mode { Base, Long, Flash };
+enum class Mode { Base, Long, Flash, Mma };
 
 const char* mode_name(Mode mode) {
     switch (mode) {
         case Mode::Long: return "long";
         case Mode::Flash: return "flash";
+        case Mode::Mma: return "mma";
         default: return "base";
     }
 }
@@ -50,10 +51,15 @@ double time_case(int rows, int position_offset, int max_context, int iters,
     // Compare candidates against the current tiled production path, regardless
     // of inherited shell state.
     setenv("DSV4_QWEN_GQA_OPTIMIZED", "1", 1);
-    unsetenv("DSV4_QWEN_GQA_LONG_TILE");
+    // The production default enables hpg6 when the variable is unset. Make the
+    // baseline explicit so this benchmark cannot compare hpg6 against itself.
+    setenv("DSV4_QWEN_GQA_LONG_TILE", mode == Mode::Base ? "0" : "1", 1);
     unsetenv("DSV4_QWEN_GQA_FLASH_TILE");
-    if (mode == Mode::Long) setenv("DSV4_QWEN_GQA_LONG_TILE", "1", 1);
+    unsetenv("DSV4_QWEN_GQA_MMA_TILE");
     if (mode == Mode::Flash) setenv("DSV4_QWEN_GQA_FLASH_TILE", "1", 1);
+    // The MMA dispatch is checked before flash and long, so this one variable
+    // selects it regardless of the others.
+    if (mode == Mode::Mma) setenv("DSV4_QWEN_GQA_MMA_TILE", "1", 1);
     std::vector<uint16_t> host_q(q_elements);
     std::vector<uint16_t> host_kv(kv_elements, 0);
     for (uint16_t& value : host_q) {
@@ -135,7 +141,7 @@ int main() {
         {2048,     0}, {2048,  4096},
         {4096,     0}, {4096,  4096}, {4096, 16384}, {4096, 32768}, {4096, 61440},
     };
-    const Mode modes[] = {Mode::Base, Mode::Long, Mode::Flash};
+    const Mode modes[] = {Mode::Base, Mode::Long, Mode::Flash, Mode::Mma};
     for (Mode mode : modes) {
         for (const Case& item : cases) {
             const int max_context = item.offset + item.rows;

--- a/cpp_engine/tests/test_qwen_engine.cpp
+++ b/cpp_engine/tests/test_qwen_engine.cpp
@@ -482,16 +482,22 @@ void exercise_cache_lifecycle(const std::string& dir,
     const uint64_t fp8_cache_bytes = 2ULL * 8 * 4 * 128;
     const uint64_t fp8_scale_bytes =
         2ULL * 8 * 4 * (128 / 64) * sizeof(uint16_t);
+    const uint64_t tq_cache_bytes = 8ULL * 4 * 196;
     if (cache_dtype == dsv4::QwenKvCacheDType::Fp16) {
         require(engine.kv_cache_bytes() == fp16_cache_bytes,
                 "FP16 KV cache accounting");
         require(engine.kv_cache_scale_bytes() == 0,
                 "FP16 KV cache must not allocate scales");
-    } else {
+    } else if (cache_dtype == dsv4::QwenKvCacheDType::Fp8) {
         require(engine.kv_cache_bytes() == fp8_cache_bytes,
                 "FP8 KV cache accounting");
         require(engine.kv_cache_scale_bytes() == fp8_scale_bytes,
                 "FP8 KV scale accounting");
+    } else {
+        require(engine.kv_cache_bytes() == tq_cache_bytes,
+                "TurboQuant K8V4 cache accounting");
+        require(engine.kv_cache_scale_bytes() == 0,
+                "TurboQuant K8V4 metadata is embedded in slots");
     }
 
     const dsv4::QwenForwardResult prefill = engine.prefill({1, 2, 3});
@@ -528,12 +534,16 @@ int main() {
         require(write_fixture(dir), "could not create Qwen engine fixture");
         exercise_cache_lifecycle(dir, dsv4::QwenKvCacheDType::Fp16);
         exercise_cache_lifecycle(dir, dsv4::QwenKvCacheDType::Fp8);
+        exercise_cache_lifecycle(dir, dsv4::QwenKvCacheDType::TurboQuantK8V4);
         exercise_prefix_cache(dir, dsv4::QwenKvCacheDType::Fp16);
         exercise_prefix_cache(dir, dsv4::QwenKvCacheDType::Fp8);
+        exercise_prefix_cache(dir, dsv4::QwenKvCacheDType::TurboQuantK8V4);
         exercise_mtp(dir, dsv4::QwenKvCacheDType::Fp16);
         exercise_mtp(dir, dsv4::QwenKvCacheDType::Fp8);
+        exercise_mtp(dir, dsv4::QwenKvCacheDType::TurboQuantK8V4);
         exercise_mtp_prefix_cache(dir, dsv4::QwenKvCacheDType::Fp16);
         exercise_mtp_prefix_cache(dir, dsv4::QwenKvCacheDType::Fp8);
+        exercise_mtp_prefix_cache(dir, dsv4::QwenKvCacheDType::TurboQuantK8V4);
         std::cout << "[PASS] test_qwen_engine layers=2 mtp=1\n";
         return 0;
     } catch (const std::exception& ex) {

--- a/cpp_engine/tests/test_qwen_gdn_flashqla.cpp
+++ b/cpp_engine/tests/test_qwen_gdn_flashqla.cpp
@@ -1,0 +1,280 @@
+// Numerical test for FlashQLA SM75 GDN kernel against baseline.
+#include "qwen_cuda_ops.hpp"
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <random>
+#include <vector>
+
+namespace {
+
+void check_cuda(cudaError_t status, const char* context) {
+    if (status != cudaSuccess) {
+        std::fprintf(stderr, "%s: %s\n", context, cudaGetErrorString(status));
+        std::exit(1);
+    }
+}
+
+uint16_t f16(float v) {
+    __half x = __float2half(v);
+    uint16_t b = 0;
+    std::memcpy(&b, &x, 2);
+    return b;
+}
+
+float f16_to_f32(uint16_t b) {
+    __half x;
+    std::memcpy(&x, &b, 2);
+    return __half2float(x);
+}
+
+void run_test(int rows, int heads, int key_heads, int key_dim, int value_dim) {
+    std::printf("Testing rows=%d heads=%d key_heads=%d key_dim=%d value_dim=%d\n",
+                rows, heads, key_heads, key_dim, value_dim);
+
+    std::mt19937 rng(12345);
+    std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+
+    const size_t state_size = static_cast<size_t>(heads) * key_dim * value_dim;
+    const size_t qk_size = static_cast<size_t>(rows) * key_heads * key_dim;
+    const size_t v_size = static_cast<size_t>(rows) * heads * value_dim;
+    const size_t gate_size = static_cast<size_t>(rows) * heads;
+    const size_t out_size = v_size;
+
+    std::vector<float> h_state(state_size);
+    for (float& x : h_state) x = dist(rng) * 0.1f;
+    std::vector<uint16_t> h_q(qk_size);
+    std::vector<uint16_t> h_k(qk_size);
+    std::vector<uint16_t> h_v(v_size);
+    std::vector<uint16_t> h_g(gate_size);
+    std::vector<uint16_t> h_beta(gate_size);
+
+    for (auto& x : h_q) x = f16(dist(rng) * 0.1f);
+    for (auto& x : h_k) x = f16(dist(rng) * 0.1f);
+    for (auto& x : h_v) x = f16(dist(rng) * 0.1f);
+    for (auto& x : h_g) x = f16(dist(rng) * 0.5f);
+    for (auto& x : h_beta) x = f16(0.5f + dist(rng) * 0.2f);
+
+    float *d_state_baseline = nullptr, *d_state_flashqla = nullptr;
+    float *d_state_split = nullptr;
+    float *d_q_normalized = nullptr, *d_k_normalized = nullptr;
+    uint16_t *d_q = nullptr, *d_k = nullptr, *d_v = nullptr;
+    uint16_t *d_g = nullptr, *d_beta = nullptr;
+    uint16_t *d_out_baseline = nullptr, *d_out_flashqla = nullptr,
+             *d_out_split = nullptr;
+
+    check_cuda(cudaMalloc(&d_state_baseline, state_size * sizeof(float)), "state_baseline");
+    check_cuda(cudaMalloc(&d_state_flashqla, state_size * sizeof(float)), "state_flashqla");
+    check_cuda(cudaMalloc(&d_state_split, state_size * sizeof(float)), "state_split");
+    check_cuda(cudaMemset(d_state_split, 0, state_size * sizeof(float)), "zero state split");
+    check_cuda(cudaMalloc(&d_q_normalized, qk_size * sizeof(float)), "normalized_q");
+    check_cuda(cudaMalloc(&d_k_normalized, qk_size * sizeof(float)), "normalized_k");
+    check_cuda(cudaMalloc(&d_q, qk_size * sizeof(uint16_t)), "q");
+    check_cuda(cudaMalloc(&d_k, qk_size * sizeof(uint16_t)), "k");
+    check_cuda(cudaMalloc(&d_v, v_size * sizeof(uint16_t)), "v");
+    check_cuda(cudaMalloc(&d_g, gate_size * sizeof(uint16_t)), "g");
+    check_cuda(cudaMalloc(&d_beta, gate_size * sizeof(uint16_t)), "beta");
+    check_cuda(cudaMalloc(&d_out_baseline, out_size * sizeof(uint16_t)), "out_baseline");
+    check_cuda(cudaMalloc(&d_out_flashqla, out_size * sizeof(uint16_t)), "out_flashqla");
+    check_cuda(cudaMalloc(&d_out_split, out_size * sizeof(uint16_t)), "out_split");
+
+    check_cuda(cudaMemcpy(d_state_baseline, h_state.data(), state_size * sizeof(float),
+                          cudaMemcpyHostToDevice), "copy state baseline");
+    check_cuda(cudaMemcpy(d_state_flashqla, h_state.data(), state_size * sizeof(float),
+                          cudaMemcpyHostToDevice), "copy state flashqla");
+    check_cuda(cudaMemcpy(d_q, h_q.data(), qk_size * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy q");
+    check_cuda(cudaMemcpy(d_k, h_k.data(), qk_size * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy k");
+    check_cuda(cudaMemcpy(d_v, h_v.data(), v_size * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy v");
+    check_cuda(cudaMemcpy(d_g, h_g.data(), gate_size * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy g");
+    check_cuda(cudaMemcpy(d_beta, h_beta.data(), gate_size * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy beta");
+
+    // Baseline: existing serial kernel.
+    const float q_scale = 1.0f / std::sqrt(static_cast<float>(key_dim));
+    bool ok_baseline = dsv4::qwen_gated_delta_sequence_f16_cuda(
+        d_state_baseline, d_q, d_k, d_v, d_g, d_beta, d_out_baseline,
+        rows, heads, key_heads, key_dim, value_dim, q_scale);
+    if (!ok_baseline) {
+        std::fprintf(stderr, "Baseline kernel launch failed\n");
+        std::exit(1);
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync baseline");
+
+    // FlashQLA SM75 kernel, consuming the same normalized Q/K tensors as the
+    // normalized baseline. This keeps the normalization reduction order equal.
+    bool ok_normalize = dsv4::qwen_normalize_gated_delta_qk_f16_cuda(
+        d_q, d_k, d_q_normalized, d_k_normalized, rows, key_heads, key_dim);
+    if (!ok_normalize) {
+        std::fprintf(stderr, "Q/K normalization launch failed\n");
+        std::exit(1);
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync normalization");
+    bool ok_flashqla = dsv4::qwen_gated_delta_flashqla_sm75_f16_cuda(
+        d_state_flashqla, d_q_normalized, d_k_normalized, d_v, d_g, d_beta,
+        d_out_flashqla, rows, heads, key_heads, key_dim, value_dim,
+        q_scale, nullptr);
+    if (!ok_flashqla) {
+        std::fprintf(stderr, "FlashQLA kernel launch failed\n");
+        std::exit(1);
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync flashqla");
+
+    // State continuity: two consecutive halves resumed through the persistent
+    // state must reproduce the single full-length run exactly. This is what a
+    // chunked prefill followed by decode relies on, and it is where the earlier
+    // transposed state layout silently produced wrong tokens.
+    const int split = rows / 2;
+    if (split > 0) {
+        check_cuda(cudaMemcpy(d_state_split, h_state.data(),
+                              state_size * sizeof(float),
+                              cudaMemcpyHostToDevice), "copy state split");
+        const size_t qk_rows = static_cast<size_t>(key_heads) * key_dim;
+        const size_t v_rows = static_cast<size_t>(heads) * value_dim;
+        const size_t gate_rows = static_cast<size_t>(heads);
+        for (int begin = 0; begin < rows; begin += split) {
+            const int extent = std::min(split, rows - begin);
+            if (!dsv4::qwen_gated_delta_flashqla_sm75_f16_cuda(
+                    d_state_split,
+                    d_q_normalized + static_cast<size_t>(begin) * qk_rows,
+                    d_k_normalized + static_cast<size_t>(begin) * qk_rows,
+                    d_v + static_cast<size_t>(begin) * v_rows,
+                    d_g + static_cast<size_t>(begin) * gate_rows,
+                    d_beta + static_cast<size_t>(begin) * gate_rows,
+                    d_out_split + static_cast<size_t>(begin) * v_rows,
+                    extent, heads, key_heads, key_dim, value_dim, q_scale)) {
+                std::fprintf(stderr, "FlashQLA split launch failed\n");
+                std::exit(1);
+            }
+        }
+        check_cuda(cudaDeviceSynchronize(), "sync flashqla split");
+    }
+
+    std::vector<uint16_t> h_out_baseline(out_size);
+    std::vector<uint16_t> h_out_flashqla(out_size);
+    std::vector<uint16_t> h_out_split(out_size);
+    std::vector<float> h_state_split_final(state_size);
+    std::vector<float> h_state_baseline_final(state_size);
+    std::vector<float> h_state_flashqla_final(state_size);
+
+    check_cuda(cudaMemcpy(h_out_baseline.data(), d_out_baseline,
+                          out_size * sizeof(uint16_t), cudaMemcpyDeviceToHost), "read out baseline");
+    check_cuda(cudaMemcpy(h_out_flashqla.data(), d_out_flashqla,
+                          out_size * sizeof(uint16_t), cudaMemcpyDeviceToHost), "read out flashqla");
+    check_cuda(cudaMemcpy(h_state_baseline_final.data(), d_state_baseline,
+                          state_size * sizeof(float), cudaMemcpyDeviceToHost), "read state baseline");
+    check_cuda(cudaMemcpy(h_state_flashqla_final.data(), d_state_flashqla,
+                          state_size * sizeof(float), cudaMemcpyDeviceToHost), "read state flashqla");
+    check_cuda(cudaMemcpy(h_out_split.data(), d_out_split,
+                          out_size * sizeof(uint16_t), cudaMemcpyDeviceToHost),
+               "read out split");
+    check_cuda(cudaMemcpy(h_state_split_final.data(), d_state_split,
+                          state_size * sizeof(float), cudaMemcpyDeviceToHost),
+               "read state split");
+
+    cudaFree(d_state_baseline);
+    cudaFree(d_state_flashqla);
+    cudaFree(d_state_split);
+    cudaFree(d_out_split);
+    cudaFree(d_q_normalized);
+    cudaFree(d_k_normalized);
+    cudaFree(d_q);
+    cudaFree(d_k);
+    cudaFree(d_v);
+    cudaFree(d_g);
+    cudaFree(d_beta);
+    cudaFree(d_out_baseline);
+    cudaFree(d_out_flashqla);
+
+    float max_out_diff = 0.0f;
+    float max_state_diff = 0.0f;
+
+    for (size_t i = 0; i < out_size; ++i) {
+        const float a = f16_to_f32(h_out_baseline[i]);
+        const float b = f16_to_f32(h_out_flashqla[i]);
+        if (!std::isfinite(a) || !std::isfinite(b)) {
+            std::fprintf(stderr, "FAIL: non-finite output at index %zu\n", i);
+            std::exit(1);
+        }
+        const float diff = std::fabs(a - b);
+        if (diff > max_out_diff) max_out_diff = diff;
+    }
+
+    for (float value : h_state_baseline_final) {
+        if (!std::isfinite(value)) {
+            std::fprintf(stderr, "FAIL: non-finite baseline state\n");
+            std::exit(1);
+        }
+    }
+    for (float value : h_state_flashqla_final) {
+        if (!std::isfinite(value)) {
+            std::fprintf(stderr, "FAIL: non-finite FlashQLA state\n");
+            std::exit(1);
+        }
+    }
+
+    for (size_t i = 0; i < state_size; ++i) {
+        const float diff = std::fabs(h_state_baseline_final[i] - h_state_flashqla_final[i]);
+        if (diff > max_state_diff) max_state_diff = diff;
+    }
+
+    // The split run recurs through the same state in the same order, so it must
+    // be bit-identical to the single call, not merely close.
+    if (split > 0) {
+        for (size_t i = 0; i < out_size; ++i) {
+            if (h_out_split[i] != h_out_flashqla[i]) {
+                std::fprintf(stderr,
+                             "FAIL: split-run output differs at index %zu\n", i);
+                std::exit(1);
+            }
+        }
+        for (size_t i = 0; i < state_size; ++i) {
+            if (h_state_split_final[i] != h_state_flashqla_final[i]) {
+                std::fprintf(stderr,
+                             "FAIL: split-run state differs at index %zu\n", i);
+                std::exit(1);
+            }
+        }
+    }
+
+    std::printf("  max_out_diff=%.6e max_state_diff=%.6e split_continuity=exact\n",
+                max_out_diff, max_state_diff);
+
+    if (!std::isfinite(max_out_diff) || !std::isfinite(max_state_diff)) {
+        std::fprintf(stderr, "FAIL: non-finite difference\n");
+        std::exit(1);
+    }
+    // FlashQLA reduces each K/Q dot with a 16-lane shuffle tree while the
+    // baseline accumulates it sequentially, so the difference is reduction
+    // order only, not a semantic change. That leaves the output within one or
+    // two FP16 ULP and the FP32 state within ~1e-5 even at 512 rows; anything
+    // larger means the sharding or the state layout is wrong again.
+    const float out_tol = rows <= 64 ? 1e-5f : 2e-3f;
+    const float state_tol = rows <= 64 ? 1e-6f : 1e-4f;
+    if (max_out_diff > out_tol || max_state_diff > state_tol) {
+        std::fprintf(stderr, "FAIL: exceeds tolerance (out=%.6e state=%.6e)\n",
+                     out_tol, state_tol);
+        std::exit(1);
+    }
+    std::printf("  PASS\n");
+}
+
+}  // namespace
+
+int main() {
+    check_cuda(cudaSetDevice(0), "set device");
+    // TP4 Qwen3.8 shape: heads=12, key_heads=4, key_dim=value_dim=128.
+    // Include a long recurrence to expose state drift; full-model token parity
+    // remains the production gate.
+    run_test(8, 12, 4, 128, 128);
+    run_test(32, 12, 4, 128, 128);
+    run_test(64, 12, 4, 128, 128);
+    run_test(512, 12, 4, 128, 128);
+    std::printf("All tests PASS\n");
+    return 0;
+}

--- a/cpp_engine/tests/test_qwen_gqa_attention.cpp
+++ b/cpp_engine/tests/test_qwen_gqa_attention.cpp
@@ -146,7 +146,8 @@ bool run_decode(int q_heads, int kv_heads, int head_dim, int context_len, int ma
 // tiled path is what long-context prefill dispatches to, so it needs its own
 // numerical gate rather than inheriting the decode kernel's.
 bool run_prefill_tiled(int rows, int q_heads, int kv_heads, int head_dim,
-                       int position_offset, int max_context) {
+                       int position_offset, int max_context,
+                       bool exercise_long_tiles = false) {
     std::mt19937 rng(13579);
     std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
     const int context_len = position_offset + rows;
@@ -178,22 +179,31 @@ bool run_prefill_tiled(int rows, int q_heads, int kv_heads, int head_dim,
     uint16_t* d_v = nullptr;
     uint16_t* d_tiled = nullptr;
     uint16_t* d_plain = nullptr;
+    uint16_t* d_long_qr2 = nullptr;
     uint16_t* d_long = nullptr;
     uint16_t* d_flash = nullptr;
-    const bool long_shape = rows >= 128 && q_heads == 6 && kv_heads == 1 &&
-        head_dim == 256;
+    uint16_t* d_mma = nullptr;
+    const bool long_shape = exercise_long_tiles && rows >= 128 &&
+        q_heads == 6 && kv_heads == 1 && head_dim == 256 &&
+        context_len >= 2048;
     auto release = [&]() {
         cudaFree(d_q); cudaFree(d_k); cudaFree(d_v);
-        cudaFree(d_tiled); cudaFree(d_plain); cudaFree(d_long);
-        cudaFree(d_flash);
+        cudaFree(d_tiled); cudaFree(d_plain); cudaFree(d_long_qr2);
+        cudaFree(d_long); cudaFree(d_flash); cudaFree(d_mma);
     };
     if (cudaMalloc(&d_q, q.size() * sizeof(uint16_t)) != cudaSuccess ||
         cudaMalloc(&d_k, k.size() * sizeof(uint16_t)) != cudaSuccess ||
         cudaMalloc(&d_v, v.size() * sizeof(uint16_t)) != cudaSuccess ||
         cudaMalloc(&d_tiled, q.size() * sizeof(uint16_t)) != cudaSuccess ||
         cudaMalloc(&d_plain, q.size() * sizeof(uint16_t)) != cudaSuccess ||
-        (long_shape && cudaMalloc(&d_long, q.size() * sizeof(uint16_t)) != cudaSuccess) ||
-        (long_shape && cudaMalloc(&d_flash, q.size() * sizeof(uint16_t)) != cudaSuccess)) {
+        (long_shape && cudaMalloc(&d_long_qr2, q.size() * sizeof(uint16_t)) !=
+            cudaSuccess) ||
+        (long_shape && cudaMalloc(&d_long, q.size() * sizeof(uint16_t)) !=
+            cudaSuccess) ||
+        (long_shape && cudaMalloc(&d_flash, q.size() * sizeof(uint16_t)) !=
+            cudaSuccess) ||
+        (long_shape && cudaMalloc(&d_mma, q.size() * sizeof(uint16_t)) !=
+            cudaSuccess)) {
         release();
         return false;
     }
@@ -202,22 +212,46 @@ bool run_prefill_tiled(int rows, int q_heads, int kv_heads, int head_dim,
     cudaMemcpy(d_v, v.data(), v.size() * sizeof(uint16_t), cudaMemcpyHostToDevice);
 
     setenv("DSV4_QWEN_GQA_POS_TILE", "1", 1);
+    // An unset LONG_TILE selects hpg6 and an unset MMA_TILE selects the
+    // tensor-core kernel in production. Make this reference launch explicitly
+    // generic on both so the candidate checks below cannot compare a kernel with
+    // itself through inherited or default environment state.
+    setenv("DSV4_QWEN_GQA_LONG_TILE", "0", 1);
+    setenv("DSV4_QWEN_GQA_MMA_TILE", "0", 1);
+    unsetenv("DSV4_QWEN_GQA_FLASH_TILE");
+    unsetenv("DSV4_QWEN_GQA_QUERY_ROWS");
     const bool tiled_ok = dsv4::qwen_gqa_prefill_attention_f16_tiled_cuda(
         d_q, d_k, d_v, d_tiled, rows, q_heads, kv_heads, head_dim,
         position_offset, max_context, 0, 0);
+    bool long_qr2_ok = true;
     bool long_ok = true;
     bool flash_ok = true;
+    bool mma_ok = true;
     if (long_shape) {
         setenv("DSV4_QWEN_GQA_LONG_TILE", "1", 1);
+        setenv("DSV4_QWEN_GQA_QUERY_ROWS", "2", 1);
+        long_qr2_ok = dsv4::qwen_gqa_prefill_attention_f16_tiled_cuda(
+            d_q, d_k, d_v, d_long_qr2, rows, q_heads, kv_heads, head_dim,
+            position_offset, max_context, 0, 0);
+        setenv("DSV4_QWEN_GQA_QUERY_ROWS", "4", 1);
         long_ok = dsv4::qwen_gqa_prefill_attention_f16_tiled_cuda(
             d_q, d_k, d_v, d_long, rows, q_heads, kv_heads, head_dim,
             position_offset, max_context, 0, 0);
-        unsetenv("DSV4_QWEN_GQA_LONG_TILE");
         setenv("DSV4_QWEN_GQA_FLASH_TILE", "1", 1);
         flash_ok = dsv4::qwen_gqa_prefill_attention_f16_tiled_cuda(
             d_q, d_k, d_v, d_flash, rows, q_heads, kv_heads, head_dim,
             position_offset, max_context, 0, 0);
         unsetenv("DSV4_QWEN_GQA_FLASH_TILE");
+        unsetenv("DSV4_QWEN_GQA_QUERY_ROWS");
+        // Tensor-core path. It reassociates both dot products and rounds the
+        // softmax numerator to half for the MMA operand, so it is checked against
+        // the CPU reference on its own tolerance, never for equality with hpg6.
+        setenv("DSV4_QWEN_GQA_MMA_TILE", "1", 1);
+        mma_ok = dsv4::qwen_gqa_prefill_attention_f16_tiled_cuda(
+            d_q, d_k, d_v, d_mma, rows, q_heads, kv_heads, head_dim,
+            position_offset, max_context, 0, 0);
+        setenv("DSV4_QWEN_GQA_MMA_TILE", "0", 1);
+        setenv("DSV4_QWEN_GQA_LONG_TILE", "0", 1);
     }
     // The position-batched kernel only amortises barriers; it must reproduce the
     // per-position kernel bit for bit, so this is an equality check rather than a
@@ -243,8 +277,8 @@ bool run_prefill_tiled(int rows, int q_heads, int kv_heads, int head_dim,
     const bool plain_ok = dsv4::qwen_gqa_prefill_attention_f16_cuda(
         d_q, d_k, d_v, d_plain, rows, q_heads, kv_heads, head_dim,
         position_offset, max_context);
-    if (!tiled_ok || !plain_ok || !long_ok || !flash_ok ||
-        cudaDeviceSynchronize() != cudaSuccess) {
+    if (!tiled_ok || !plain_ok || !long_qr2_ok || !long_ok || !flash_ok ||
+        !mma_ok || cudaDeviceSynchronize() != cudaSuccess) {
         fail("gqa prefill tiled launch failed");
         release();
         return true;
@@ -263,11 +297,15 @@ bool run_prefill_tiled(int rows, int q_heads, int kv_heads, int head_dim,
     std::vector<uint16_t> got_tiled(q_elements);
     std::vector<uint16_t> got_plain(q_elements);
     std::vector<uint16_t> got_seq(q_elements);
+    std::vector<uint16_t> got_long_qr2;
     std::vector<uint16_t> got_long;
     std::vector<uint16_t> got_flash;
+    std::vector<uint16_t> got_mma;
     if (long_shape) {
+        got_long_qr2.resize(q_elements);
         got_long.resize(q_elements);
         got_flash.resize(q_elements);
+        got_mma.resize(q_elements);
     }
     if (!seq_ok || cudaDeviceSynchronize() != cudaSuccess) {
         fail("gqa prefill position-batched fallback launch failed");
@@ -283,10 +321,15 @@ bool run_prefill_tiled(int rows, int q_heads, int kv_heads, int head_dim,
     cudaMemcpy(got_plain.data(), d_plain, got_plain.size() * sizeof(uint16_t),
                cudaMemcpyDeviceToHost);
     if (long_shape) {
+        cudaMemcpy(got_long_qr2.data(), d_long_qr2,
+                   got_long_qr2.size() * sizeof(uint16_t),
+                   cudaMemcpyDeviceToHost);
         cudaMemcpy(got_long.data(), d_long, got_long.size() * sizeof(uint16_t),
                    cudaMemcpyDeviceToHost);
         cudaMemcpy(got_flash.data(), d_flash,
                    got_flash.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+        cudaMemcpy(got_mma.data(), d_mma,
+                   got_mma.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
     }
     release();
 
@@ -301,12 +344,20 @@ bool run_prefill_tiled(int rows, int q_heads, int kv_heads, int head_dim,
     double worst_ref = 0.0;
     double worst_cross = 0.0;
     double worst_warp = 0.0;
+    double worst_long_qr2 = 0.0;
     double worst_long = 0.0;
     double worst_flash = 0.0;
+    double worst_mma = 0.0;
+    bool long_qr2_finite = true;
     bool long_finite = true;
     bool flash_finite = true;
+    bool mma_finite = true;
+    size_t long_qr2_mismatches = 0;
     size_t long_mismatches = 0;
     size_t flash_mismatches = 0;
+    size_t mma_mismatches = 0;
+    size_t long_qr2_vs_qr4_mismatches = 0;
+    double worst_long_qr2_vs_qr4 = 0.0;
     for (int row = 0; row < rows; ++row) {
         std::vector<float> row_q(static_cast<size_t>(q_heads) * head_dim);
         for (size_t i = 0; i < row_q.size(); ++i) {
@@ -325,16 +376,30 @@ bool run_prefill_tiled(int rows, int q_heads, int kv_heads, int head_dim,
                 std::fabs(static_cast<double>(from_half(got_warp[flat])) -
                           want[i]));
             if (long_shape) {
+                const double long_qr2_value = from_half(got_long_qr2[flat]);
+                long_qr2_finite = long_qr2_finite && std::isfinite(long_qr2_value);
+                worst_long_qr2 = std::max(worst_long_qr2,
+                    std::fabs(long_qr2_value - want[i]));
+                if (got_long_qr2[flat] != got_plain[flat]) ++long_qr2_mismatches;
                 const double long_value = from_half(got_long[flat]);
                 long_finite = long_finite && std::isfinite(long_value);
                 worst_long = std::max(worst_long,
                     std::fabs(long_value - want[i]));
                 if (got_long[flat] != got_plain[flat]) ++long_mismatches;
+                if (got_long_qr2[flat] != got_long[flat]) {
+                    ++long_qr2_vs_qr4_mismatches;
+                }
+                worst_long_qr2_vs_qr4 = std::max(worst_long_qr2_vs_qr4,
+                    std::fabs(long_qr2_value - long_value));
                 const double flash_value = from_half(got_flash[flat]);
                 flash_finite = flash_finite && std::isfinite(flash_value);
                 worst_flash = std::max(worst_flash,
                     std::fabs(flash_value - want[i]));
                 if (got_flash[flat] != got_plain[flat]) ++flash_mismatches;
+                const double mma_value = from_half(got_mma[flat]);
+                mma_finite = mma_finite && std::isfinite(mma_value);
+                worst_mma = std::max(worst_mma, std::fabs(mma_value - want[i]));
+                if (got_mma[flat] != got_plain[flat]) ++mma_mismatches;
             }
         }
     }
@@ -342,18 +407,42 @@ bool run_prefill_tiled(int rows, int q_heads, int kv_heads, int head_dim,
     // softmax denominator differently from the per-position kernel, so they are
     // gated on distance from the CPU reference. The FP16 bit mismatch count
     // against the per-position kernel is reported, not asserted.
-    if (long_shape && (!long_finite || !flash_finite ||
-                       worst_long > 2.0e-3 || worst_flash > 2.0e-3)) {
+    // The tensor-core path rounds the softmax numerator to half for the MMA
+    // operand, one extra rounding step the scalar paths do not have, so it gets a
+    // slightly wider band. Anything past 8e-3 means a real indexing or online
+    // rescale bug, not accumulated FP16 noise.
+    if (long_shape && (!long_qr2_finite || !long_finite || !flash_finite ||
+                       !mma_finite || worst_long_qr2 > 2.0e-3 ||
+                       worst_long > 2.0e-3 || worst_flash > 2.0e-3 ||
+                       worst_mma > 8.0e-3)) {
         fail("gqa prefill long-tile rows=" + std::to_string(rows) +
-             " ctx=" + std::to_string(context_len) + " long_ref=" +
+             " ctx=" + std::to_string(context_len) + " qr2_ref=" +
+             std::to_string(worst_long_qr2) + " qr4_ref=" +
              std::to_string(worst_long) + " flash_ref=" +
-             std::to_string(worst_flash));
+             std::to_string(worst_flash) + " mma_ref=" +
+             std::to_string(worst_mma));
     } else if (long_shape) {
-        std::printf("  gqa prefill long-tile rows=%3d ctx=%5d ref=%.3e "
-                    "cross_mismatches=%zu flash_ref=%.3e "
-                    "flash_mismatches=%zu\n", rows, context_len, worst_long,
-                    long_mismatches, worst_flash, flash_mismatches);
+        std::printf("  gqa prefill long-tile rows=%3d ctx=%5d qr2_ref=%.3e "
+                    "qr2_mismatches=%zu qr4_ref=%.3e qr4_mismatches=%zu "
+                    "qr2_vs_qr4=%.3e/%zu flash_ref=%.3e "
+                    "flash_mismatches=%zu mma_ref=%.3e mma_mismatches=%zu\n",
+                    rows, context_len,
+                    worst_long_qr2, long_qr2_mismatches, worst_long,
+                    long_mismatches, worst_long_qr2_vs_qr4,
+                    long_qr2_vs_qr4_mismatches, worst_flash, flash_mismatches,
+                    worst_mma, mma_mismatches);
     }
+    unsetenv("DSV4_QWEN_GQA_LONG_TILE");
+    unsetenv("DSV4_QWEN_GQA_QUERY_ROWS");
+    unsetenv("DSV4_QWEN_GQA_FLASH_TILE");
+    unsetenv("DSV4_QWEN_GQA_MMA_TILE");
+    unsetenv("DSV4_QWEN_GQA_POS_TILE");
+    (void)long_qr2_mismatches;
+    (void)long_mismatches;
+    (void)flash_mismatches;
+    (void)mma_mismatches;
+    (void)long_qr2_vs_qr4_mismatches;
+    (void)worst_long_qr2_vs_qr4;
     // FP16 accumulation over thousands of keys; 2e-3 matches the engine's other
     // FP16 attention gates.
     if (worst_ref > 2.0e-3 || worst_cross > 2.0e-3 || worst_warp > 2.0e-3) {
@@ -501,10 +590,19 @@ int main() {
             return 0;
         }
     }
-    // The production TP4 Qwen shard has six Q heads over one KV head. Exercise
-    // the long-tile candidate with a nonzero cache offset and compare every
-    // output element against the exact reference path.
-    if (!run_prefill_tiled(128, 6, 1, 256, 384, 8192)) {
+    // The production TP4 Qwen shard has six Q heads over one KV head. Use a
+    // nonzero offset that makes total_context >= 2048 so this actually crosses
+    // the production hpg6/flash dispatch gate, then compare every output element
+    // against the exact generic and CPU reference paths.
+    if (!run_prefill_tiled(128, 6, 1, 256, 1920, 2048, true)) {
+        std::printf("[SKIP] device allocation failed\n");
+        return 0;
+    }
+    // The tensor-core path owns 32 query rows and a 32-position KV tile per CTA.
+    // Row 150 leaves a 22-row final block and context 2198 leaves a 22-position
+    // final KV tile, so this covers both partial-tile masks at once. A kernel that
+    // mishandles either would still pass the aligned case above.
+    if (!run_prefill_tiled(150, 6, 1, 256, 2048, 2198, true)) {
         std::printf("[SKIP] device allocation failed\n");
         return 0;
     }

--- a/cpp_engine/tests/test_qwen_turboquant_k8v4.cpp
+++ b/cpp_engine/tests/test_qwen_turboquant_k8v4.cpp
@@ -1,0 +1,553 @@
+// Numerical test for TurboQuant K8V4 KV-cache against reference.
+#include "qwen_cuda_ops.hpp"
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <random>
+#include <vector>
+
+namespace {
+
+void check_cuda(cudaError_t status, const char* context) {
+    if (status != cudaSuccess) {
+        std::fprintf(stderr, "%s: %s\n", context, cudaGetErrorString(status));
+        std::exit(1);
+    }
+}
+
+uint16_t f16(float v) {
+    __half x = __float2half(v);
+    uint16_t b = 0;
+    std::memcpy(&b, &x, 2);
+    return b;
+}
+
+float f16_to_f32(uint16_t b) {
+    __half x;
+    std::memcpy(&x, &b, 2);
+    return __half2float(x);
+}
+
+float dequantize_value_nibble(uint8_t nibble, float scale, float minimum) {
+    return static_cast<float>(nibble) * scale + minimum;
+}
+
+// Dequantize one slot into FP32 K/V so the reference attention consumes exactly
+// the bytes the kernel reads. Any mismatch is then kernel math, not quantization.
+void dequantize_slot(const uint8_t* slot, int head_dim, std::vector<float>& k_out,
+                     std::vector<float>& v_out) {
+    k_out.resize(head_dim);
+    v_out.resize(head_dim);
+
+    uint16_t scale_bits, min_bits;
+    const int value_bytes = head_dim / 2;
+    std::memcpy(&scale_bits, slot + head_dim + value_bytes, 2);
+    std::memcpy(&min_bits, slot + head_dim + value_bytes + 2, 2);
+    const float scale = f16_to_f32(scale_bits);
+    const float minimum = f16_to_f32(min_bits);
+
+    for (int d = 0; d < head_dim; ++d) {
+        __half k_h = __nv_cvt_fp8_to_halfraw(slot[d], __NV_E5M2);
+        k_out[d] = __half2float(k_h);
+
+        const uint8_t packed = slot[head_dim + (d >> 1)];
+        const uint8_t nibble = (d & 1) ? (packed >> 4) : (packed & 0x0F);
+        v_out[d] = dequantize_value_nibble(nibble, scale, minimum);
+    }
+}
+
+// Reference attention over the dequantized cache, in FP32 with a plain
+// max-subtracted softmax. `visible` selects the attended positions.
+template <typename VisibleFn>
+void reference_attention(const std::vector<uint8_t>& cache, const uint16_t* q_row,
+                         int head, int kv_head, int kv_heads, int head_dim,
+                         int slot_bytes, int context_len, VisibleFn visible,
+                         std::vector<float>& out) {
+    std::vector<float> scores(context_len, -INFINITY);
+    std::vector<float> k_buf, v_buf;
+
+    const float q_scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+    float max_score = -INFINITY;
+
+    for (int pos = 0; pos < context_len; ++pos) {
+        if (!visible(pos)) continue;
+        const size_t slot_offset =
+            (static_cast<size_t>(pos) * kv_heads + kv_head) * slot_bytes;
+        dequantize_slot(cache.data() + slot_offset, head_dim, k_buf, v_buf);
+
+        double dot = 0.0;
+        for (int d = 0; d < head_dim; ++d) {
+            dot += static_cast<double>(f16_to_f32(q_row[d])) * k_buf[d];
+        }
+        scores[pos] = static_cast<float>(dot) * q_scale;
+        max_score = std::max(max_score, scores[pos]);
+    }
+
+    out.assign(head_dim, 0.0f);
+    double sum = 0.0;
+    for (int pos = 0; pos < context_len; ++pos) {
+        if (!std::isfinite(scores[pos])) continue;
+        const double weight = std::exp(static_cast<double>(scores[pos] - max_score));
+        sum += weight;
+
+        const size_t slot_offset =
+            (static_cast<size_t>(pos) * kv_heads + kv_head) * slot_bytes;
+        dequantize_slot(cache.data() + slot_offset, head_dim, k_buf, v_buf);
+        for (int d = 0; d < head_dim; ++d) {
+            out[d] += static_cast<float>(weight * v_buf[d]);
+        }
+    }
+    if (sum > 0.0) {
+        for (int d = 0; d < head_dim; ++d) out[d] /= static_cast<float>(sum);
+    }
+}
+
+void test_store_and_decode(int seq_len, int kv_heads, int q_heads, int start_pos,
+                          int head_dim) {
+    std::printf("Testing store+decode: seq_len=%d kv_heads=%d q_heads=%d start_pos=%d head_dim=%d\n",
+                seq_len, kv_heads, q_heads, start_pos, head_dim);
+
+    const int kHeadDim = head_dim;
+    const int kSlotBytes = head_dim + head_dim / 2 + 4;
+    const int max_context = start_pos + seq_len + 16;
+
+    std::mt19937 rng(12345);
+    std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+
+    const size_t kv_size = static_cast<size_t>(seq_len) * kv_heads * kHeadDim;
+    const size_t q_size = static_cast<size_t>(q_heads) * kHeadDim;
+    const size_t cache_size = static_cast<size_t>(max_context) * kv_heads * kSlotBytes;
+
+    std::vector<uint16_t> h_k(kv_size);
+    std::vector<uint16_t> h_v(kv_size);
+    std::vector<uint16_t> h_q(q_size);
+    std::vector<float> h_k_f32(kv_size);
+    std::vector<float> h_v_f32(kv_size);
+
+    for (size_t i = 0; i < kv_size; ++i) {
+        h_k[i] = f16(dist(rng) * 0.1f);
+        h_v[i] = f16(dist(rng) * 0.1f);
+        // The kernel only ever sees the FP16 inputs, so the reference for
+        // quantization error is the FP16 value, not the pre-rounding float.
+        h_k_f32[i] = f16_to_f32(h_k[i]);
+        h_v_f32[i] = f16_to_f32(h_v[i]);
+    }
+    for (size_t i = 0; i < q_size; ++i) {
+        h_q[i] = f16(dist(rng) * 0.1f);
+    }
+
+    uint16_t *d_k = nullptr, *d_v = nullptr, *d_q = nullptr;
+    uint8_t *d_cache = nullptr;
+    uint16_t *d_out = nullptr;
+    float *d_score_scratch = nullptr;
+
+    check_cuda(cudaMalloc(&d_k, kv_size * sizeof(uint16_t)), "k");
+    check_cuda(cudaMalloc(&d_v, kv_size * sizeof(uint16_t)), "v");
+    check_cuda(cudaMalloc(&d_q, q_size * sizeof(uint16_t)), "q");
+    check_cuda(cudaMalloc(&d_cache, cache_size), "cache");
+    check_cuda(cudaMalloc(&d_out, q_size * sizeof(uint16_t)), "out");
+    check_cuda(cudaMalloc(&d_score_scratch, q_heads * max_context * sizeof(float)), "scratch");
+
+    check_cuda(cudaMemcpy(d_k, h_k.data(), kv_size * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy k");
+    check_cuda(cudaMemcpy(d_v, h_v.data(), kv_size * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy v");
+    check_cuda(cudaMemcpy(d_q, h_q.data(), q_size * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy q");
+    check_cuda(cudaMemset(d_cache, 0, cache_size), "zero cache");
+
+    // Store K/V into TurboQuant cache.
+    bool ok_store = dsv4::qwen_append_kv_cache_turboquant_k8v4_cuda(
+        d_k, d_v, d_cache, seq_len, kv_heads, kHeadDim, start_pos, max_context);
+    if (!ok_store) {
+        std::fprintf(stderr, "Store kernel launch failed\n");
+        std::exit(1);
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync store");
+
+    // Read back cache and verify slot layout.
+    std::vector<uint8_t> h_cache(cache_size);
+    check_cuda(cudaMemcpy(h_cache.data(), d_cache, cache_size,
+                          cudaMemcpyDeviceToHost), "read cache");
+
+    for (int token = 0; token < seq_len; ++token) {
+        for (int head = 0; head < kv_heads; ++head) {
+            const int cache_pos = start_pos + token;
+            const size_t slot_offset = (static_cast<size_t>(cache_pos) * kv_heads + head) * kSlotBytes;
+            const uint8_t* slot = h_cache.data() + slot_offset;
+
+            // Read FP16 scale/min metadata.
+            uint16_t scale_bits, min_bits;
+            std::memcpy(&scale_bits, slot + kHeadDim + kHeadDim / 2, 2);
+            std::memcpy(&min_bits, slot + kHeadDim + kHeadDim / 2 + 2, 2);
+            float scale = f16_to_f32(scale_bits);
+            float minimum = f16_to_f32(min_bits);
+
+            if (!std::isfinite(scale) || !std::isfinite(minimum)) {
+                std::fprintf(stderr, "FAIL: non-finite metadata at token=%d head=%d\n", token, head);
+                std::exit(1);
+            }
+
+            // Verify key E5M2 round-trip.
+            const size_t kv_offset = (static_cast<size_t>(token) * kv_heads + head) * kHeadDim;
+            float max_key_error = 0.0f;
+            for (int d = 0; d < kHeadDim; ++d) {
+                uint8_t k_fp8 = slot[d];
+                __half k_h = __nv_cvt_fp8_to_halfraw(k_fp8, __NV_E5M2);
+                float k_decoded = __half2float(k_h);
+                float k_orig = h_k_f32[kv_offset + d];
+                float error = std::fabs(k_decoded - k_orig);
+                if (error > max_key_error) max_key_error = error;
+            }
+
+            // Verify value 4-bit round-trip within quantization error.
+            float max_value_error = 0.0f;
+            for (int d = 0; d < kHeadDim; ++d) {
+                int byte_idx = kHeadDim + (d >> 1);
+                uint8_t packed = slot[byte_idx];
+                uint8_t nibble = (d & 1) ? (packed >> 4) : (packed & 0x0F);
+                float v_decoded = dequantize_value_nibble(nibble, scale, minimum);
+                float v_orig = h_v_f32[kv_offset + d];
+                float error = std::fabs(v_decoded - v_orig);
+                if (error > max_value_error) max_value_error = error;
+            }
+
+            // E5M2 has 2-bit mantissa, expect ~1e-2 key error.
+            // 4-bit uniform quantization: max error = scale/2.
+            const float key_tol = 2e-2f;
+            // Uniform 4-bit quantization caps the error at half a step; allow a
+            // small slack for the FP16 rounding of the reconstruction itself.
+            const float value_tol = scale * 0.5f + scale * 1e-2f + 1e-6f;
+            if (max_key_error > key_tol) {
+                std::fprintf(stderr, "FAIL: key error %.6e exceeds tolerance %.6e\n",
+                             max_key_error, key_tol);
+                std::exit(1);
+            }
+            if (max_value_error > value_tol) {
+                std::fprintf(stderr, "FAIL: value error %.6e exceeds tolerance %.6e\n",
+                             max_value_error, value_tol);
+                std::exit(1);
+            }
+        }
+    }
+
+    // Decode attention with TurboQuant cache.
+    const int context_len = start_pos + seq_len;
+    bool ok_decode = dsv4::qwen_gqa_decode_attention_turboquant_k8v4_cuda(
+        d_q, d_cache, d_out, d_score_scratch, q_heads, kv_heads, kHeadDim,
+        context_len, max_context, 0, 0);
+    if (!ok_decode) {
+        std::fprintf(stderr, "Decode kernel launch failed\n");
+        std::exit(1);
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync decode");
+
+    std::vector<uint16_t> h_out(q_size);
+    check_cuda(cudaMemcpy(h_out.data(), d_out, q_size * sizeof(uint16_t),
+                          cudaMemcpyDeviceToHost), "read out");
+
+    // Compare against the reference over the same quantized bytes.
+    const int group = q_heads / kv_heads;
+    std::vector<float> expected;
+    float max_decode_error = 0.0f;
+    for (int head = 0; head < q_heads; ++head) {
+        reference_attention(h_cache, h_q.data() + static_cast<size_t>(head) * kHeadDim,
+                            head, head / group, kv_heads, kHeadDim, kSlotBytes,
+                            context_len, [](int) { return true; }, expected);
+        for (int d = 0; d < kHeadDim; ++d) {
+            const float got = f16_to_f32(h_out[static_cast<size_t>(head) * kHeadDim + d]);
+            if (!std::isfinite(got)) {
+                std::fprintf(stderr, "FAIL: non-finite decode output head=%d dim=%d\n",
+                             head, d);
+                std::exit(1);
+            }
+            max_decode_error = std::max(max_decode_error, std::fabs(got - expected[d]));
+        }
+    }
+    // FP16 output storage plus FP32 accumulation ordering.
+    const float decode_tol = 2e-3f;
+    if (max_decode_error > decode_tol) {
+        std::fprintf(stderr, "FAIL: decode error %.6e exceeds tolerance %.6e\n",
+                     max_decode_error, decode_tol);
+        std::exit(1);
+    }
+
+    cudaFree(d_k);
+    cudaFree(d_v);
+    cudaFree(d_q);
+    cudaFree(d_cache);
+    cudaFree(d_out);
+    cudaFree(d_score_scratch);
+
+    std::printf("  PASS (round-trip within quantization tol, decode max_error=%.3e)\n",
+                max_decode_error);
+}
+
+void test_prefill_causal(int seq_len, int kv_heads, int q_heads, int position_offset,
+                         int head_dim) {
+    std::printf("Testing prefill causal: seq_len=%d kv_heads=%d q_heads=%d position_offset=%d head_dim=%d\n",
+                seq_len, kv_heads, q_heads, position_offset, head_dim);
+
+    const int kHeadDim = head_dim;
+    const int kSlotBytes = head_dim + head_dim / 2 + 4;
+    const int max_context = position_offset + seq_len + 16;
+
+    std::mt19937 rng(54321);
+    std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+
+    const size_t kv_size = static_cast<size_t>(seq_len) * kv_heads * kHeadDim;
+    const size_t q_size = static_cast<size_t>(seq_len) * q_heads * kHeadDim;
+    const size_t cache_size = static_cast<size_t>(max_context) * kv_heads * kSlotBytes;
+
+    std::vector<uint16_t> h_k(kv_size);
+    std::vector<uint16_t> h_v(kv_size);
+    std::vector<uint16_t> h_q(q_size);
+
+    for (size_t i = 0; i < kv_size; ++i) {
+        h_k[i] = f16(dist(rng) * 0.1f);
+        h_v[i] = f16(dist(rng) * 0.1f);
+    }
+    for (size_t i = 0; i < q_size; ++i) {
+        h_q[i] = f16(dist(rng) * 0.1f);
+    }
+
+    uint16_t *d_k = nullptr, *d_v = nullptr, *d_q = nullptr;
+    uint8_t *d_cache = nullptr;
+    uint16_t *d_out = nullptr;
+
+    check_cuda(cudaMalloc(&d_k, kv_size * sizeof(uint16_t)), "k");
+    check_cuda(cudaMalloc(&d_v, kv_size * sizeof(uint16_t)), "v");
+    check_cuda(cudaMalloc(&d_q, q_size * sizeof(uint16_t)), "q");
+    check_cuda(cudaMalloc(&d_cache, cache_size), "cache");
+    check_cuda(cudaMalloc(&d_out, q_size * sizeof(uint16_t)), "out");
+
+    check_cuda(cudaMemcpy(d_k, h_k.data(), kv_size * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy k");
+    check_cuda(cudaMemcpy(d_v, h_v.data(), kv_size * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy v");
+    check_cuda(cudaMemcpy(d_q, h_q.data(), q_size * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy q");
+    check_cuda(cudaMemset(d_cache, 0, cache_size), "zero cache");
+
+    // Store K/V.
+    bool ok_store = dsv4::qwen_append_kv_cache_turboquant_k8v4_cuda(
+        d_k, d_v, d_cache, seq_len, kv_heads, kHeadDim, position_offset, max_context);
+    if (!ok_store) {
+        std::fprintf(stderr, "Store kernel launch failed\n");
+        std::exit(1);
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync store");
+
+    // Prefill attention.
+    bool ok_prefill = dsv4::qwen_gqa_prefill_attention_turboquant_k8v4_cuda(
+        d_q, d_cache, d_out, seq_len, q_heads, kv_heads, kHeadDim,
+        position_offset, max_context, 0, 0);
+    if (!ok_prefill) {
+        std::fprintf(stderr, "Prefill kernel launch failed\n");
+        std::exit(1);
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync prefill");
+
+    std::vector<uint16_t> h_out(q_size);
+    check_cuda(cudaMemcpy(h_out.data(), d_out, q_size * sizeof(uint16_t),
+                          cudaMemcpyDeviceToHost), "read out");
+
+    std::vector<uint8_t> h_cache(cache_size);
+    check_cuda(cudaMemcpy(h_cache.data(), d_cache, cache_size,
+                          cudaMemcpyDeviceToHost), "read cache");
+
+    const int group = q_heads / kv_heads;
+    std::vector<float> expected;
+    float max_prefill_error = 0.0f;
+    for (int token = 0; token < seq_len; ++token) {
+        const int q_pos = position_offset + token;
+        for (int head = 0; head < q_heads; ++head) {
+            const size_t q_offset =
+                (static_cast<size_t>(token) * q_heads + head) * kHeadDim;
+            reference_attention(h_cache, h_q.data() + q_offset, head, head / group,
+                                kv_heads, kHeadDim, kSlotBytes, q_pos + 1,
+                                [](int) { return true; }, expected);
+            for (int d = 0; d < kHeadDim; ++d) {
+                const float got = f16_to_f32(h_out[q_offset + d]);
+                if (!std::isfinite(got)) {
+                    std::fprintf(stderr,
+                                 "FAIL: non-finite prefill output token=%d head=%d dim=%d\n",
+                                 token, head, d);
+                    std::exit(1);
+                }
+                max_prefill_error =
+                    std::max(max_prefill_error, std::fabs(got - expected[d]));
+            }
+        }
+    }
+    const float prefill_tol = 2e-3f;
+    if (max_prefill_error > prefill_tol) {
+        std::fprintf(stderr, "FAIL: prefill error %.6e exceeds tolerance %.6e\n",
+                     max_prefill_error, prefill_tol);
+        std::exit(1);
+    }
+
+    cudaFree(d_k);
+    cudaFree(d_v);
+    cudaFree(d_q);
+    cudaFree(d_cache);
+    cudaFree(d_out);
+
+    std::printf("  PASS (causal mask vs reference, max_error=%.3e)\n", max_prefill_error);
+}
+
+void test_window_and_sink(int context_len, int q_heads, int kv_heads,
+                          int attention_window, int attention_sink_tokens,
+                          int head_dim) {
+    std::printf("Testing window=%d sink=%d context=%d head_dim=%d\n",
+                attention_window, attention_sink_tokens, context_len, head_dim);
+
+    const int kHeadDim = head_dim;
+    const int kSlotBytes = head_dim + head_dim / 2 + 4;
+    const int max_context = context_len + 16;
+
+    std::mt19937 rng(98765);
+    std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+
+    const size_t kv_size = static_cast<size_t>(context_len) * kv_heads * kHeadDim;
+    const size_t q_size = static_cast<size_t>(q_heads) * kHeadDim;
+    const size_t cache_size = static_cast<size_t>(max_context) * kv_heads * kSlotBytes;
+
+    std::vector<uint16_t> h_k(kv_size);
+    std::vector<uint16_t> h_v(kv_size);
+    std::vector<uint16_t> h_q(q_size);
+
+    for (size_t i = 0; i < kv_size; ++i) {
+        h_k[i] = f16(dist(rng) * 0.1f);
+        h_v[i] = f16(dist(rng) * 0.1f);
+    }
+    for (size_t i = 0; i < q_size; ++i) {
+        h_q[i] = f16(dist(rng) * 0.1f);
+    }
+
+    uint16_t *d_k = nullptr, *d_v = nullptr, *d_q = nullptr;
+    uint8_t *d_cache = nullptr;
+    uint16_t *d_out = nullptr;
+    float *d_score_scratch = nullptr;
+
+    check_cuda(cudaMalloc(&d_k, kv_size * sizeof(uint16_t)), "k");
+    check_cuda(cudaMalloc(&d_v, kv_size * sizeof(uint16_t)), "v");
+    check_cuda(cudaMalloc(&d_q, q_size * sizeof(uint16_t)), "q");
+    check_cuda(cudaMalloc(&d_cache, cache_size), "cache");
+    check_cuda(cudaMalloc(&d_out, q_size * sizeof(uint16_t)), "out");
+    check_cuda(cudaMalloc(&d_score_scratch, q_heads * max_context * sizeof(float)), "scratch");
+
+    check_cuda(cudaMemcpy(d_k, h_k.data(), kv_size * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy k");
+    check_cuda(cudaMemcpy(d_v, h_v.data(), kv_size * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy v");
+    check_cuda(cudaMemcpy(d_q, h_q.data(), q_size * sizeof(uint16_t),
+                          cudaMemcpyHostToDevice), "copy q");
+    check_cuda(cudaMemset(d_cache, 0, cache_size), "zero cache");
+
+    bool ok_store = dsv4::qwen_append_kv_cache_turboquant_k8v4_cuda(
+        d_k, d_v, d_cache, context_len, kv_heads, kHeadDim, 0, max_context);
+    if (!ok_store) {
+        std::fprintf(stderr, "Store kernel launch failed\n");
+        std::exit(1);
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync store");
+
+    bool ok_decode = dsv4::qwen_gqa_decode_attention_turboquant_k8v4_cuda(
+        d_q, d_cache, d_out, d_score_scratch, q_heads, kv_heads, kHeadDim,
+        context_len, max_context, attention_window, attention_sink_tokens);
+    if (!ok_decode) {
+        std::fprintf(stderr, "Decode kernel launch failed\n");
+        std::exit(1);
+    }
+    check_cuda(cudaDeviceSynchronize(), "sync decode");
+
+    std::vector<uint16_t> h_out(q_size);
+    check_cuda(cudaMemcpy(h_out.data(), d_out, q_size * sizeof(uint16_t),
+                          cudaMemcpyDeviceToHost), "read out");
+
+    std::vector<uint8_t> h_cache(cache_size);
+    check_cuda(cudaMemcpy(h_cache.data(), d_cache, cache_size,
+                          cudaMemcpyDeviceToHost), "read cache");
+
+    // Same two-range visibility the kernel applies: sink prefix plus the
+    // trailing window.
+    const int sink_end = attention_sink_tokens;
+    const int window_start = std::max(sink_end, context_len - attention_window);
+    auto visible = [sink_end, window_start](int pos) {
+        return pos < sink_end || pos >= window_start;
+    };
+
+    const int group = q_heads / kv_heads;
+    std::vector<float> expected;
+    float max_window_error = 0.0f;
+    int attended = 0;
+    for (int pos = 0; pos < context_len; ++pos) {
+        if (visible(pos)) ++attended;
+    }
+    if (attended >= context_len) {
+        std::fprintf(stderr, "FAIL: window test does not actually mask anything\n");
+        std::exit(1);
+    }
+
+    for (int head = 0; head < q_heads; ++head) {
+        reference_attention(h_cache, h_q.data() + static_cast<size_t>(head) * kHeadDim,
+                            head, head / group, kv_heads, kHeadDim, kSlotBytes,
+                            context_len, visible, expected);
+        for (int d = 0; d < kHeadDim; ++d) {
+            const float got = f16_to_f32(h_out[static_cast<size_t>(head) * kHeadDim + d]);
+            if (!std::isfinite(got)) {
+                std::fprintf(stderr, "FAIL: non-finite windowed output head=%d dim=%d\n",
+                             head, d);
+                std::exit(1);
+            }
+            max_window_error = std::max(max_window_error, std::fabs(got - expected[d]));
+        }
+    }
+    const float window_tol = 2e-3f;
+    if (max_window_error > window_tol) {
+        std::fprintf(stderr, "FAIL: window error %.6e exceeds tolerance %.6e\n",
+                     max_window_error, window_tol);
+        std::exit(1);
+    }
+
+    cudaFree(d_k);
+    cudaFree(d_v);
+    cudaFree(d_q);
+    cudaFree(d_cache);
+    cudaFree(d_out);
+    cudaFree(d_score_scratch);
+
+    std::printf("  PASS (window+sink vs reference, attended=%d/%d, max_error=%.3e)\n",
+                attended, context_len, max_window_error);
+}
+
+}  // namespace
+
+int main() {
+    check_cuda(cudaSetDevice(0), "set device");
+
+    // head_dim 128 and the real Qwen3.5 full-attention head_dim 256.
+    for (int head_dim : {128, 256}) {
+        test_store_and_decode(8, 4, 12, 0, head_dim);
+        test_store_and_decode(32, 4, 12, 0, head_dim);
+        test_store_and_decode(16, 4, 12, 64, head_dim);
+
+        test_prefill_causal(8, 4, 12, 0, head_dim);
+        test_prefill_causal(32, 4, 12, 0, head_dim);
+        test_prefill_causal(16, 4, 12, 48, head_dim);
+
+        test_window_and_sink(512, 12, 4, 128, 16, head_dim);
+        test_window_and_sink(1024, 12, 4, 256, 32, head_dim);
+    }
+
+    // TP4 rank shape: one KV head per rank, six query heads.
+    test_store_and_decode(32, 1, 6, 0, 256);
+    test_prefill_causal(32, 1, 6, 0, 256);
+
+    std::printf("All TurboQuant K8V4 tests PASS\n");
+    return 0;
+}

--- a/scripts/bench_qwen_long_context.py
+++ b/scripts/bench_qwen_long_context.py
@@ -46,8 +46,10 @@ def parse_args() -> argparse.Namespace:
         help="comma-separated prompt lengths",
     )
     parser.add_argument("--max-new-tokens", type=int, default=16)
-    parser.add_argument("--prefill-chunk-tokens", type=int, default=512)
-    parser.add_argument("--kv-cache-dtype", choices=("fp16", "fp8"), default="fp16")
+    # Matches QwenEngineOptions::prefill_chunk_tokens. Keep these in step, or the
+    # benchmark measures a chunk size production does not use.
+    parser.add_argument("--prefill-chunk-tokens", type=int, default=4096)
+    parser.add_argument("--kv-cache-dtype", choices=("fp16", "fp8", "turboquant_k8v4"), default="fp16")
     parser.add_argument("--tp-world", type=int, default=4)
     parser.add_argument(
         "--devices",
@@ -238,9 +240,13 @@ def environment_metadata() -> dict[str, str]:
         "DSV4_QWEN_GQA_OPTIMIZED",
         "DSV4_QWEN_GQA_LONG_TILE",
         "DSV4_QWEN_GQA_FLASH_TILE",
+        "DSV4_QWEN_GQA_MMA_TILE",
+        "QWEN_NCCL_COMM_STREAM",
+        "QWEN_COMM_OVERLAP_SLICES",
         "DSV4_QWEN_GQA_QUERY_ROWS",
         "QWEN_FP8_F16_PREFILL_CUBLAS",
         "QWEN_FUSE_ATTN_RESID_NORM",
+        "QWEN_GATED_DELTA_FLASHQLA_SM75",
     )
     return {name: os.environ[name] for name in names if name in os.environ}
 


### PR DESCRIPTION
## Summary

Three optimizations from vLLM-2080Ti, each validated on the real Qwen3.8-27B-FP8 checkpoint at TP4 / 64 layers with serial benchmarks on a single fixed binary.

**Tensor-core exact GQA prefill** (default on). The scalar paths were instruction bound, not bandwidth bound — 1.14 TFLOP/s at the real TP4 shape, ~8.5% of CUDA-core peak, with DRAM moving only 47 of 616 GB/s. SM75 has no `m16n8k16`, so both GEMMs run on `m16n8k8` with FP32 accumulate. 32K exact prefill 442 → 1059 tok/s, 64K 3.44×, tokens bit-identical.

**FlashQLA SM75 gated-delta kernel** (default on). Shards the `[D, D]` state across 8 warps (WIDTH=16 lanes × COLS=4 columns) instead of one thread per value dimension, same serial recurrence. ~8–9% prefill gain at 8K/32K/64K, exact token parity.

**TurboQuant K8V4 KV cache** (opt-in via `--kv-cache-dtype turboquant_k8v4`). One combined slot per token and KV head: FP8 E5M2 key, 4-bit uniform value, FP16 scale/min. Slot size follows `head_dim` — 196 B at 128, 388 B at the 256 that Qwen3.5 full-attention layers actually use.

## Measured (TP4, 64 layers, serial, binary sha `4e393016…`)

| len | prefill fp16 / fp8 / **tq** | decode fp16 / fp8 / **tq** | KV tq/fp16 |
|---|---|---|---|
| 8192 | 1293.7 / 372.7 / **694.4** | 25.17 / 13.21 / **25.14** | 0.379 |
| 32768 | 1326.6 / 110.3 / **258.9** | 20.75 / 4.57 / **11.71** | 0.379 |
| 65536 | 1127.2 / 57.9 / **135.5** | 19.34 / 2.48 / **7.19** | 0.379 |

TurboQuant tokens are bit-identical to FP16 at all three lengths, rank parity PASS. KV drops 62% (64K: 1024 → 388 MiB, GPU peak −672 MiB).

## Why TurboQuant stays opt-in

It is slower than FP16 (0.54× prefill at 8K, 0.12× at 64K), and the cause is structural rather than tunable: FP16 prefill runs the `m16n8k8` exact kernel, while any quantized cache has to dequantize in SIMT and cannot reach the tensor cores. Worth enabling only when memory is the binding constraint.

It does beat the existing FP8 cache path by 1.9–2.9× on both phases. That says more about FP8 than about TurboQuant — the FP8 path has the same missing-tensor-core problem and is arguably the better optimization target.

## Testing

- 18 TurboQuant primitive cases at `head_dim` 128 and 256, including the TP4 rank shape, checked against a CPU reference that reads the same quantized bytes (max error ~1e-5) across decode, causal prefill, and window+sink.
- Existing suites all pass: `test_qwen_engine`, `test_qwen_gdn_flashqla`, `test_qwen_gqa_attention`, `test_qwen_half_ops`, `test_qwen_fp8_online`.
- FP16 remains the default everywhere; FP8 and FlashQLA behavior unchanged.

## Notes for review

Two bugs found by testing rather than reading, both fixed here:
- The store kernel's min/max reduction was warp-only under a 128-thread block, so the quantization range came from the first 32 channels and clamped the rest. Now block-wide, with scale/min rounded to FP16 before quantizing so store and load agree on the same scale.
- The first prefill kernel had all 256 channel-threads redundantly recomputing the full `head_dim` Q·K per position: 58 tok/s at 4096. Warp-per-position with a shuffle reduction brought it to 806 tok/s.