### PR TITLE
Fix bench_qwen_gqa_prefill comparing every mode against itself

### DIFF
--- a/cpp_engine/tests/bench_qwen_gqa_prefill.cpp
+++ b/cpp_engine/tests/bench_qwen_gqa_prefill.cpp
@@ -55,11 +55,11 @@ double time_case(int rows, int position_offset, int max_context, int iters,
     // baseline explicit so this benchmark cannot compare hpg6 against itself.
     setenv("DSV4_QWEN_GQA_LONG_TILE", mode == Mode::Base ? "0" : "1", 1);
     unsetenv("DSV4_QWEN_GQA_FLASH_TILE");
-    unsetenv("DSV4_QWEN_GQA_MMA_TILE");
     if (mode == Mode::Flash) setenv("DSV4_QWEN_GQA_FLASH_TILE", "1", 1);
-    // The MMA dispatch is checked before flash and long, so this one variable
-    // selects it regardless of the others.
-    if (mode == Mode::Mma) setenv("DSV4_QWEN_GQA_MMA_TILE", "1", 1);
+    // MMA is the production default and is dispatched before flash and long, so
+    // unsetting its variable would silently run MMA for every mode and make all
+    // four rows identical. It has to be switched off explicitly instead.
+    setenv("DSV4_QWEN_GQA_MMA_TILE", mode == Mode::Mma ? "1" : "0", 1);
     std::vector<uint16_t> host_q(q_elements);
     std::vector<uint16_t> host_kv(kv_elements, 0);
     for (uint16_t& value : host_q) {


### PR DESCRIPTION
## Bug

The bench unset `DSV4_QWEN_GQA_MMA_TILE` for the `base`/`long`/`flash` modes, but in the dispatcher an unset variable means **enabled**:

```cpp
const bool mma_enabled = mma_tile == nullptr || std::strcmp(mma_tile, "0") != 0;
```

MMA is also checked before flash and long, so all four modes ran the MMA kernel and the bench printed four identical rows. Any comparison drawn from it was a kernel against itself.

## Fix

Set the variable to `"0"` for the other modes rather than unsetting it. The modes now separate, and the production default turns out to be 10.7x faster than the fallbacks it was silently being compared against:

| mode | rows=4096 offset=16384 | offset=32768 | offset=61440 |
|---|---|---|---|
| base | 532.9 ms | 1011.9 ms | 1846.7 ms |
| long | 407.0 ms | 770.5 ms | 1405.5 ms |
| flash | 400.5 ms | 761.1 ms | 1389.1 ms |
| mma | 38.4 ms | 71.1 ms | 129.5 ms |

## Test plan

`CUDA_VISIBLE_DEVICES=0 build/tests/bench_qwen_gqa_prefill` — before the fix all four mode rows were identical to within noise; after it they differ as above. Bench-only change, no engine code touched.