### PR TITLE
Add Qwen4-Exp heterogeneous TP4 inference

### DIFF
--- a/scripts/run_qwen4_exp_tp4.sh
+++ b/scripts/run_qwen4_exp_tp4.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# TP4 heterogeneous inference for Qwen3.8-Flash-Next.
+#
+# Dense weights are sharded across the four 2080 Ti cards; the 225 GiB routed
+# experts and 95 GiB PLE table stay in host RAM and are read through the shared
+# page cache, so the four ranks pay for one copy between them.
+#
+# Usage: scripts/run_qwen4_exp_tp4.sh [prompt] [max_new_tokens]
+set -euo pipefail
+
+MODEL="${QWEN4EXP_MODEL:-/mnt/data1/modelscope/Qwen/Qwen3.8-Flash-Next}"
+PROMPT="${1:-用一句话介绍你自己。}"
+MAX_NEW="${2:-16}"
+CHUNK="${QWEN4EXP_CHUNK:-512}"
+PYTHON="${QWEN4EXP_PYTHON:-/home/lvyufeng/miniconda3/envs/deepseek/bin/python}"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$REPO"
+export PYTHONPATH="$REPO:${PYTHONPATH:-}"
+# The 2080 Ti has no NVLink between all pairs here; P2P over PCIe is fine for
+# the per-layer all-reduce but must not fall back to a broken path silently.
+export NCCL_P2P_DISABLE="${NCCL_P2P_DISABLE:-0}"
+export NCCL_DEBUG="${NCCL_DEBUG:-WARN}"
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-16}"
+
+exec "$PYTHON" -m torch.distributed.run \
+  --nproc_per_node=4 \
+  --master_port="${MASTER_PORT:-29571}" \
+  -m src.models.qwen4_exp.runtime \
+  --model "$MODEL" \
+  --prompt "$PROMPT" \
+  --max-new-tokens "$MAX_NEW" \
+  --chunk-size "$CHUNK"

--- a/src/models/qwen4_exp/__init__.py
+++ b/src/models/qwen4_exp/__init__.py
@@ -1,0 +1,15 @@
+"""Qwen4-Exp (Qwen3.8-Flash-Next) inference support.
+
+The checkpoint is a 335 GiB BF16 hybrid model: 48 decoder layers alternating
+GatedDeltaNet linear attention (36x) with QSA sparse full attention (12x), a
+4-stream hyper-connection residual, 512 routed experts at top-10, and a 95 GiB
+hashed n-gram Per-Layer-Embedding table on layer 2.
+
+Sizes drive the placement plan: routed experts (225 GiB) and the PLE table
+(95 GiB) live in host RAM, everything else (~10 GiB) is tensor-parallel across
+the four 2080 Ti cards.  See `placement.py`.
+"""
+
+from src.models.qwen4_exp.config import Qwen4ExpConfig, Qwen4ExpTextConfig
+
+__all__ = ["Qwen4ExpConfig", "Qwen4ExpTextConfig"]

--- a/src/models/qwen4_exp/attention.py
+++ b/src/models/qwen4_exp/attention.py
@@ -1,0 +1,483 @@
+"""Qwen4-Exp attention paths: GatedDeltaNet linear attention and QSA attention.
+
+Both keep their own cache state. GatedDeltaNet carries a depthwise conv window
+plus a (num_v_heads, head_k_dim, head_v_dim) recurrent matrix; QSA layers carry
+a regular KV cache plus the indexer's raw pre-pool key cache.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+
+from src.models.qwen4_exp.config import Qwen4ExpTextConfig
+from src.models.qwen4_exp.layers import RMSNorm, RMSNormGated, apply_rotary_pos_emb
+
+
+def l2norm(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    """FLA-compatible L2 norm: eps is added to the squared sum, not to the norm."""
+    return x * torch.rsqrt((x * x).sum(dim=-1, keepdim=True) + eps)
+
+
+# ---------------------------------------------------------------------------
+# Gated delta rule
+# ---------------------------------------------------------------------------
+
+
+def recurrent_gated_delta_rule(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Sequential delta-rule scan in float32.
+
+    query/key: (batch, seq, heads, k_dim); value: (batch, seq, heads, v_dim);
+    g/beta: (batch, seq, heads); state: (batch, heads, k_dim, v_dim).
+
+    This is O(seq) launches, which is fine for decode (seq==1) but slow for
+    prefill; `chunk_gated_delta_rule` is the prefill path.
+    """
+    initial_dtype = query.dtype
+    query = l2norm(query)
+    key = l2norm(key)
+    query, key, value, beta, g = (
+        x.transpose(1, 2).contiguous().to(torch.float32) for x in (query, key, value, beta, g)
+    )
+
+    batch_size, num_heads, seq_len, k_dim = key.shape
+    v_dim = value.shape[-1]
+    query = query * (1 / (k_dim**0.5))
+
+    out = torch.zeros(batch_size, num_heads, seq_len, v_dim, dtype=torch.float32, device=value.device)
+    state = (
+        torch.zeros(batch_size, num_heads, k_dim, v_dim, dtype=torch.float32, device=value.device)
+        if initial_state is None
+        else initial_state.to(torch.float32)
+    )
+
+    for i in range(seq_len):
+        q_t, k_t, v_t = query[:, :, i], key[:, :, i], value[:, :, i]
+        g_t = g[:, :, i].exp().unsqueeze(-1).unsqueeze(-1)
+        beta_t = beta[:, :, i].unsqueeze(-1)
+        state = state * g_t
+        kv_mem = (state * k_t.unsqueeze(-1)).sum(dim=-2)
+        delta = (v_t - kv_mem) * beta_t
+        state = state + k_t.unsqueeze(-1) * delta.unsqueeze(-2)
+        out[:, :, i] = (state * q_t.unsqueeze(-1)).sum(dim=-2)
+
+    return out.transpose(1, 2).contiguous().to(initial_dtype), state
+
+
+def chunk_gated_delta_rule(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    chunk_size: int = 64,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Chunked (WY-representation) delta rule for prefill.
+
+    Ports upstream's `torch_chunk_gated_delta_rule`: within a chunk the
+    interactions are resolved by a forward substitution on the strictly-lower
+    triangular attention matrix, then chunks are chained through the recurrent
+    state.  Mathematically identical to the sequential scan, ~chunk_size fewer
+    kernel launches.
+    """
+    initial_dtype = query.dtype
+    query = l2norm(query)
+    key = l2norm(key)
+    query, key, value, beta, g = (
+        x.transpose(1, 2).contiguous().to(torch.float32) for x in (query, key, value, beta, g)
+    )
+
+    batch_size, num_heads, seq_len, k_dim = key.shape
+    v_dim = value.shape[-1]
+    pad_size = (chunk_size - seq_len % chunk_size) % chunk_size
+    query = F.pad(query, (0, 0, 0, pad_size))
+    key = F.pad(key, (0, 0, 0, pad_size))
+    value = F.pad(value, (0, 0, 0, pad_size))
+    beta = F.pad(beta, (0, pad_size))
+    g = F.pad(g, (0, pad_size))
+    total_len = seq_len + pad_size
+
+    query = query * (1 / (k_dim**0.5))
+    v_beta = value * beta.unsqueeze(-1)
+    k_beta = key * beta.unsqueeze(-1)
+
+    # Reshape into chunks: (batch, heads, n_chunks, chunk_size, dim)
+    def to_chunks(x: torch.Tensor) -> torch.Tensor:
+        return x.reshape(batch_size, num_heads, total_len // chunk_size, chunk_size, -1)
+
+    query, key, value, k_beta, v_beta = (to_chunks(x) for x in (query, key, value, k_beta, v_beta))
+    g = g.reshape(batch_size, num_heads, total_len // chunk_size, chunk_size)
+    g_cum = g.cumsum(dim=-1)
+
+    mask = torch.triu(
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=0
+    )
+    decay_mask = ((g_cum.unsqueeze(-1) - g_cum.unsqueeze(-2)).tril().exp().float()).tril()
+    attn = -((k_beta @ key.transpose(-1, -2)) * decay_mask).masked_fill(mask, 0)
+    # Forward substitution to invert (I + strictly-lower-triangular).
+    for i in range(1, chunk_size):
+        row = attn[..., i, :i].clone()
+        sub = attn[..., :i, :i].clone()
+        attn[..., i, :i] = row + (row.unsqueeze(-1) * sub).sum(-2)
+    attn = attn + torch.eye(chunk_size, dtype=attn.dtype, device=attn.device)
+
+    value = attn @ v_beta
+    k_cumdecay = attn @ (k_beta * g_cum.exp().unsqueeze(-1))
+
+    last_recurrent_state = (
+        torch.zeros(batch_size, num_heads, k_dim, v_dim, dtype=torch.float32, device=value.device)
+        if initial_state is None
+        else initial_state.to(torch.float32)
+    )
+    core_attn_out = torch.zeros_like(value)
+    mask_strict = torch.triu(
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=1
+    )
+
+    for i in range(0, total_len // chunk_size):
+        q_i, k_i, v_i = query[:, :, i], key[:, :, i], value[:, :, i]
+        attn_i = (q_i @ k_i.transpose(-1, -2) * decay_mask[:, :, i]).masked_fill_(mask_strict, 0)
+        v_prime = k_cumdecay[:, :, i] @ last_recurrent_state
+        v_new = v_i - v_prime
+        attn_inter = (q_i * g_cum[:, :, i, :, None].exp()) @ last_recurrent_state
+        core_attn_out[:, :, i] = attn_inter + attn_i @ v_new
+        g_last = g_cum[:, :, i, -1, None, None].exp()
+        decay_k = (g_cum[:, :, i, -1, None] - g_cum[:, :, i]).exp()
+        last_recurrent_state = (
+            last_recurrent_state * g_last + (k_i * decay_k[..., None]).transpose(-1, -2) @ v_new
+        )
+
+    core_attn_out = core_attn_out.reshape(batch_size, num_heads, total_len, v_dim)
+    core_attn_out = core_attn_out[:, :, :seq_len]
+    return core_attn_out.transpose(1, 2).contiguous().to(initial_dtype), last_recurrent_state
+
+
+# ---------------------------------------------------------------------------
+# GatedDeltaNet layer
+# ---------------------------------------------------------------------------
+
+
+class GatedDeltaNetCache:
+    """Depthwise conv window + recurrent state for one linear-attention layer.
+
+    Sized from the *shard's* head counts, not the config's, so a TP rank only
+    allocates the slice of the conv/recurrent state it actually owns.
+    """
+
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        batch_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+        *,
+        num_v_heads: int | None = None,
+        num_k_heads: int | None = None,
+    ) -> None:
+        v_heads = config.linear_num_value_heads if num_v_heads is None else num_v_heads
+        k_heads = config.linear_num_key_heads if num_k_heads is None else num_k_heads
+        conv_dim = 2 * k_heads * config.linear_key_head_dim + v_heads * config.linear_value_head_dim
+        self.conv_state = torch.zeros(
+            batch_size, conv_dim, config.linear_conv_kernel_dim - 1, device=device, dtype=dtype
+        )
+        self.recurrent_state = torch.zeros(
+            batch_size,
+            v_heads,
+            config.linear_key_head_dim,
+            config.linear_value_head_dim,
+            device=device,
+            dtype=torch.float32,
+        )
+        self.initialized = False
+
+
+class GatedDeltaNet:
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        weights: dict[str, torch.Tensor],
+        *,
+        num_v_heads: int | None = None,
+        num_k_heads: int | None = None,
+    ) -> None:
+        self.config = config
+        # TP shards the head dimension; the shard's head counts override config.
+        self.num_v_heads = config.linear_num_value_heads if num_v_heads is None else num_v_heads
+        self.num_k_heads = config.linear_num_key_heads if num_k_heads is None else num_k_heads
+        self.head_k_dim = config.linear_key_head_dim
+        self.head_v_dim = config.linear_value_head_dim
+        self.key_dim = self.head_k_dim * self.num_k_heads
+        self.value_dim = self.head_v_dim * self.num_v_heads
+        self.conv_kernel_size = config.linear_conv_kernel_dim
+
+        self.in_proj_qkv = weights["in_proj_qkv"]
+        self.in_proj_z = weights["in_proj_z"]
+        self.in_proj_b = weights["in_proj_b"]
+        self.in_proj_a = weights["in_proj_a"]
+        self.conv1d_weight = weights["conv1d"]  # (conv_dim, 1, kernel)
+        self.dt_bias = weights["dt_bias"]
+        self.A_log = weights["A_log"]
+        self.out_proj = weights["out_proj"]
+        self.norm = RMSNormGated(
+            weights["norm"], config.rms_norm_eps, activation=config.output_gate_type or config.hidden_act
+        )
+
+    def __call__(self, hidden_states: torch.Tensor, cache: GatedDeltaNetCache | None) -> torch.Tensor:
+        batch_size, seq_len, _ = hidden_states.shape
+
+        mixed_qkv = F.linear(hidden_states, self.in_proj_qkv).transpose(1, 2)  # (b, conv_dim, seq)
+        z = F.linear(hidden_states, self.in_proj_z).reshape(batch_size, seq_len, -1, self.head_v_dim)
+        b = F.linear(hidden_states, self.in_proj_b)
+        a = F.linear(hidden_states, self.in_proj_a)
+
+        conv_weight = self.conv1d_weight.squeeze(1)
+        channels = conv_weight.shape[0]
+        if cache is not None:
+            # Prepend the cached window so the causal conv sees real history, then
+            # keep only the new positions and refresh the window.
+            padded = torch.cat([cache.conv_state.to(mixed_qkv.dtype), mixed_qkv], dim=-1)
+            cache.conv_state = padded[:, :, -(self.conv_kernel_size - 1) :].clone()
+            conv_in = padded
+        else:
+            conv_in = F.pad(mixed_qkv, (self.conv_kernel_size - 1, 0))
+        conv_out = F.conv1d(conv_in, conv_weight.unsqueeze(1), None, padding=0, groups=channels)
+        mixed_qkv = F.silu(conv_out[:, :, -seq_len:])
+
+        mixed_qkv = mixed_qkv.transpose(1, 2)
+        query, key, value = torch.split(
+            mixed_qkv, [self.key_dim, self.key_dim, self.value_dim], dim=-1
+        )
+        query = query.reshape(batch_size, seq_len, -1, self.head_k_dim)
+        key = key.reshape(batch_size, seq_len, -1, self.head_k_dim)
+        value = value.reshape(batch_size, seq_len, -1, self.head_v_dim)
+
+        beta = b.sigmoid()
+        # float32 on A_log: in bf16 exp() of a large magnitude saturates to inf.
+        g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias.float())
+
+        repeat = self.num_v_heads // self.num_k_heads
+        if repeat > 1:
+            query = query.repeat_interleave(repeat, dim=2)
+            key = key.repeat_interleave(repeat, dim=2)
+
+        initial_state = cache.recurrent_state if (cache is not None and cache.initialized) else None
+        rule = recurrent_gated_delta_rule if seq_len == 1 else chunk_gated_delta_rule
+        core_attn_out, last_state = rule(query, key, value, g, beta, initial_state)
+        if cache is not None:
+            cache.recurrent_state = last_state
+            cache.initialized = True
+
+        core_attn_out = self.norm(
+            core_attn_out.reshape(-1, self.head_v_dim), z.reshape(-1, self.head_v_dim)
+        ).reshape(batch_size, seq_len, -1)
+        return F.linear(core_attn_out, self.out_proj)
+
+
+# ---------------------------------------------------------------------------
+# QSA sparse attention
+# ---------------------------------------------------------------------------
+
+
+class QSAAttentionCache:
+    """KV cache plus the indexer's pre-pool raw key cache for one QSA layer."""
+
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        batch_size: int,
+        max_seq_len: int,
+        device: torch.device,
+        dtype: torch.dtype,
+        *,
+        num_kv_heads: int | None = None,
+    ) -> None:
+        kv_heads = config.num_key_value_heads if num_kv_heads is None else num_kv_heads
+        self.k = torch.zeros(batch_size, kv_heads, max_seq_len, config.head_dim, device=device, dtype=dtype)
+        self.v = torch.zeros(batch_size, kv_heads, max_seq_len, config.head_dim, device=device, dtype=dtype)
+        self.index_k = torch.zeros(
+            batch_size, max_seq_len, config.indexer_head_dim, device=device, dtype=dtype
+        )
+        self.length = 0
+
+
+class QSAIndexer:
+    """Picks a token budget per query from mean-pooled key blocks.
+
+    Keys are averaged in groups of `compress_ratio`, RoPE'd at the group start
+    position, then scored against the (multi-head, ReLU-summed) index queries.
+    The top `budget / compress_ratio` blocks expand back to token indices; the
+    ragged tail beyond the last complete block is always visible.
+    """
+
+    def __init__(self, config: Qwen4ExpTextConfig, weights: dict[str, torch.Tensor], *, n_heads: int | None = None) -> None:
+        self.n_heads = config.indexer_n_heads if n_heads is None else n_heads
+        self.kv_heads = config.indexer_kv_heads
+        self.head_dim = config.indexer_head_dim
+        self.budget = config.indexer_budget
+        self.compress_ratio = config.indexer_compress_ratio
+        self.block_topk = self.budget // self.compress_ratio
+        self.qk_proj = weights["index_qk_proj"]
+        self.q_layernorm = RMSNorm(weights["q_layernorm"], config.rms_norm_eps)
+        self.k_layernorm = RMSNorm(weights["k_layernorm"], config.rms_norm_eps)
+
+    def __call__(
+        self,
+        hidden_states: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        cache: QSAAttentionCache | None,
+        *,
+        past_len: int,
+        raw_keys_override: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Returns a bool mask (batch, 1, seq, kv_len): True where a token is selected."""
+        batch_size, seq_len, _ = hidden_states.shape
+        qk = F.linear(hidden_states, self.qk_proj)
+        q, token_k = torch.split(
+            qk, [self.n_heads * self.head_dim, self.kv_heads * self.head_dim], dim=-1
+        )
+        q = self.q_layernorm(q.reshape(batch_size, seq_len, -1, self.head_dim))
+        q = apply_rotary_pos_emb(q, cos[:, -seq_len:], sin[:, -seq_len:], unsqueeze_dim=2)
+        new_raw_keys = token_k.reshape(batch_size, seq_len, self.head_dim)
+
+        if cache is not None:
+            cache.index_k[:, past_len : past_len + seq_len] = new_raw_keys
+            raw_keys = cache.index_k[:, : past_len + seq_len]
+        elif raw_keys_override is not None:
+            raw_keys = torch.cat([raw_keys_override, new_raw_keys], dim=1)
+        else:
+            raw_keys = new_raw_keys
+
+        kv_len = raw_keys.shape[1]
+        # Every query at absolute position p sees keys [0, p]; block boundaries
+        # are therefore query-dependent only through how many keys are visible.
+        num_blocks_total = kv_len // self.compress_ratio
+        if num_blocks_total == 0:
+            return torch.ones(batch_size, 1, seq_len, kv_len, dtype=torch.bool, device=hidden_states.device)
+
+        # Pool + RoPE all complete blocks once (shared across queries).
+        block_tokens = torch.arange(
+            num_blocks_total * self.compress_ratio, device=hidden_states.device
+        ).view(num_blocks_total, self.compress_ratio)
+        pooled = raw_keys[:, : num_blocks_total * self.compress_ratio].reshape(
+            batch_size, num_blocks_total, self.compress_ratio, self.head_dim
+        )
+        pooled = pooled.float().mean(dim=2).to(raw_keys.dtype)
+        pooled = self.k_layernorm(pooled)
+        # cos/sin cover every absolute position in the cache, so a block's RoPE
+        # phase comes from its first token's position.
+        group_starts = block_tokens[:, 0]
+        block_keys = apply_rotary_pos_emb(
+            pooled.unsqueeze(2), cos[:, group_starts], sin[:, group_starts], unsqueeze_dim=2
+        ).squeeze(2)  # (batch, blocks, head_dim)
+
+        # scores: (batch, seq, blocks) = sum over index heads of relu(q . k)
+        scores = torch.einsum("bqhd,bkd->bqhk", q.float(), block_keys.float())
+        scores = torch.relu(scores).sum(dim=2) / math.sqrt(self.head_dim)
+
+        query_abs = past_len + torch.arange(seq_len, device=hidden_states.device)
+        visible_keys = query_abs + 1  # causal: keys [0, p] inclusive
+        blocks_visible = visible_keys // self.compress_ratio  # per-query complete-block count
+        block_ids = torch.arange(num_blocks_total, device=hidden_states.device)
+        block_ok = block_ids.view(1, -1) < blocks_visible.view(-1, 1)  # (seq, blocks)
+        scores = scores.masked_fill(~block_ok.unsqueeze(0), float("-inf"))
+
+        topk = min(self.block_topk, num_blocks_total)
+        selected_blocks = scores.topk(topk, dim=-1).indices  # (batch, seq, topk)
+        # -inf rows mean "fewer visible blocks than topk"; drop those picks.
+        selected_valid = torch.gather(block_ok.unsqueeze(0).expand(batch_size, -1, -1), 2, selected_blocks)
+
+        mask = torch.zeros(batch_size, seq_len, kv_len, dtype=torch.bool, device=hidden_states.device)
+        block_expand = block_tokens[selected_blocks]  # (batch, seq, topk, compress_ratio)
+        valid_expand = selected_valid.unsqueeze(-1).expand_as(block_expand)
+        flat_idx = block_expand.reshape(batch_size, seq_len, -1)
+        flat_valid = valid_expand.reshape(batch_size, seq_len, -1)
+        mask.scatter_(2, flat_idx, flat_valid)
+
+        # The tail past the last complete visible block is always attendable.
+        key_ids = torch.arange(kv_len, device=hidden_states.device)
+        tail_start = (blocks_visible * self.compress_ratio).view(-1, 1)
+        tail = (key_ids.view(1, -1) >= tail_start) & (key_ids.view(1, -1) < visible_keys.view(-1, 1))
+        mask |= tail.unsqueeze(0)
+        return mask.unsqueeze(1)
+
+
+class QSAAttention:
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        weights: dict[str, torch.Tensor],
+        *,
+        num_heads: int | None = None,
+        num_kv_heads: int | None = None,
+        indexer_heads: int | None = None,
+    ) -> None:
+        self.config = config
+        self.num_heads = config.num_attention_heads if num_heads is None else num_heads
+        self.num_kv_heads = config.num_key_value_heads if num_kv_heads is None else num_kv_heads
+        self.head_dim = config.head_dim
+        self.num_kv_groups = self.num_heads // self.num_kv_heads
+        self.scaling = self.head_dim**-0.5
+        self.q_proj = weights["q_proj"]  # (heads * head_dim * 2, hidden): value+gate packed
+        self.k_proj = weights["k_proj"]
+        self.v_proj = weights["v_proj"]
+        self.o_proj = weights["o_proj"]
+        self.q_norm = RMSNorm(weights["q_norm"], config.rms_norm_eps)
+        self.k_norm = RMSNorm(weights["k_norm"], config.rms_norm_eps)
+        self.indexer = QSAIndexer(config, weights, n_heads=indexer_heads)
+
+    def __call__(
+        self,
+        hidden_states: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        cache: QSAAttentionCache | None,
+        *,
+        past_len: int,
+    ) -> torch.Tensor:
+        batch_size, seq_len, _ = hidden_states.shape
+        selected = self.indexer(hidden_states, cos, sin, cache, past_len=past_len)
+
+        qg = F.linear(hidden_states, self.q_proj).view(batch_size, seq_len, -1, self.head_dim * 2)
+        query, gate = torch.chunk(qg, 2, dim=-1)
+        gate = gate.reshape(batch_size, seq_len, -1)
+        query = self.q_norm(query).transpose(1, 2)
+        key = self.k_norm(
+            F.linear(hidden_states, self.k_proj).view(batch_size, seq_len, -1, self.head_dim)
+        ).transpose(1, 2)
+        value = F.linear(hidden_states, self.v_proj).view(batch_size, seq_len, -1, self.head_dim).transpose(1, 2)
+
+        cur_cos, cur_sin = cos[:, -seq_len:], sin[:, -seq_len:]
+        query, key = apply_rotary_pos_emb(query, cur_cos, cur_sin, k=key, unsqueeze_dim=1)
+
+        if cache is not None:
+            cache.k[:, :, past_len : past_len + seq_len] = key
+            cache.v[:, :, past_len : past_len + seq_len] = value
+            cache.length = past_len + seq_len
+            key = cache.k[:, :, : cache.length]
+            value = cache.v[:, :, : cache.length]
+
+        kv_len = key.shape[2]
+        query_abs = past_len + torch.arange(seq_len, device=hidden_states.device)
+        causal = torch.arange(kv_len, device=hidden_states.device).view(1, -1) <= query_abs.view(-1, 1)
+        allow = causal.view(1, 1, seq_len, kv_len) & selected
+
+        key = key.repeat_interleave(self.num_kv_groups, dim=1)
+        value = value.repeat_interleave(self.num_kv_groups, dim=1)
+        attn_weights = torch.matmul(query, key.transpose(2, 3)) * self.scaling
+        attn_weights = attn_weights.masked_fill(~allow, torch.finfo(attn_weights.dtype).min)
+        attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+        attn_out = torch.matmul(attn_weights, value).transpose(1, 2).reshape(batch_size, seq_len, -1)
+
+        attn_out = attn_out * torch.sigmoid(gate)
+        return F.linear(attn_out, self.o_proj)

--- a/src/models/qwen4_exp/builder.py
+++ b/src/models/qwen4_exp/builder.py
@@ -1,0 +1,425 @@
+"""Assemble a `Qwen4ExpModel` from checkpoint tensors.
+
+Two entry points:
+
+* `build_from_state_dict` — everything resident on one device. Used by the
+  parity tests against upstream `transformers` goldens.
+* `build_heterogeneous` — dense weights sharded across GPUs, routed experts and
+  the PLE table left in host RAM. This is the TP4 path for the real 335 GiB
+  checkpoint.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from src.models.qwen4_exp.config import Qwen4ExpTextConfig
+from src.models.qwen4_exp.layers import GatedResidual
+from src.models.qwen4_exp.model import (
+    PLELayer,
+    Qwen4ExpDecoderLayer,
+    Qwen4ExpModel,
+    TPShard,
+)
+from src.models.qwen4_exp.moe import HostExpertMoE, InMemoryMoE, ShardedMoE
+from src.models.qwen4_exp.weights import (
+    DeviceEmbedding,
+    HostEmbedding,
+    HostNGramTable,
+    Qwen4ExpCheckpoint,
+)
+
+LM = "model.language_model"
+
+# Layer-local tensor suffixes, grouped by the sub-module that consumes them.
+_HC_SUFFIXES = ("hc_norm", "input_mix_weight_down", "input_mix_weight_up", "block_inject_weight")
+_LINEAR_ATTN_SUFFIXES = (
+    "in_proj_qkv.weight",
+    "in_proj_z.weight",
+    "in_proj_b.weight",
+    "in_proj_a.weight",
+    "conv1d.weight",
+    "dt_bias",
+    "A_log",
+    "out_proj.weight",
+    "norm.weight",
+)
+_QSA_SUFFIXES = (
+    "q_proj.weight",
+    "k_proj.weight",
+    "v_proj.weight",
+    "o_proj.weight",
+    "q_norm.weight",
+    "k_norm.weight",
+    "indexer.index_qk_proj.weight",
+    "indexer.q_layernorm.weight",
+    "indexer.k_layernorm.weight",
+)
+_PLE_SUFFIXES = (
+    "key_proj.weight",
+    "value_proj.weight",
+    "norm_key.weight",
+    "norm_query.weight",
+    "norm_conv.weight",
+    "conv1d.weight",
+)
+
+
+def _strip_weight(name: str) -> str:
+    return name[: -len(".weight")] if name.endswith(".weight") else name
+
+
+def collect_layer_weights(
+    getter,
+    config: Qwen4ExpTextConfig,
+    layer_idx: int,
+    *,
+    prefix: str = LM,
+) -> dict[str, torch.Tensor]:
+    """Gather one decoder layer's non-expert tensors into short keys.
+
+    `getter(full_name)` returns a tensor already on the target device/dtype.
+    Keys come back as e.g. `linear_attn.in_proj_qkv`, `self_attn.q_norm`,
+    `attn_hyper_connection.hc_norm`, `mlp.gate`.
+    """
+    base = f"{prefix}.layers.{layer_idx}"
+    out: dict[str, torch.Tensor] = {}
+
+    for hc in ("attn_hyper_connection", "mlp_hyper_connection"):
+        for suffix in _HC_SUFFIXES:
+            out[f"{hc}.{suffix}"] = getter(f"{base}.{hc}.{suffix}.weight")
+
+    if config.is_linear_layer(layer_idx):
+        for suffix in _LINEAR_ATTN_SUFFIXES:
+            out[f"linear_attn.{_strip_weight(suffix)}"] = getter(f"{base}.linear_attn.{suffix}")
+    else:
+        for suffix in _QSA_SUFFIXES:
+            short = _strip_weight(suffix)
+            # The indexer's tensors are consumed by QSAAttention's weight dict
+            # under their bare names.
+            short = short[len("indexer.") :] if short.startswith("indexer.") else short
+            out[f"self_attn.{short}"] = getter(f"{base}.self_attn.{suffix}")
+
+    out["mlp.gate"] = getter(f"{base}.mlp.gate.weight")
+    out["mlp.shared_expert_gate"] = getter(f"{base}.mlp.shared_expert_gate.weight")
+    for proj in ("gate_proj", "up_proj", "down_proj"):
+        out[f"mlp.shared_expert.{proj}"] = getter(f"{base}.mlp.shared_expert.{proj}.weight")
+    return out
+
+
+def _ple_weights(getter, layer_idx: int, *, prefix: str = LM) -> dict[str, torch.Tensor]:
+    base = f"{prefix}.layers.{layer_idx}.ple"
+    return {_strip_weight(s): getter(f"{base}.{s}") for s in _PLE_SUFFIXES}
+
+
+def _final_mixer(getter, config: Qwen4ExpTextConfig, *, prefix: str = LM) -> GatedResidual:
+    base = f"{prefix}.hyper_connection_mixer"
+    return GatedResidual(
+        config,
+        getter(f"{base}.hc_norm.weight"),
+        getter(f"{base}.input_mix_weight_down.weight"),
+        getter(f"{base}.input_mix_weight_up.weight"),
+        None,
+    )
+
+
+class _TensorStore:
+    """Adapts a plain dict of tensors to the `getter` protocol."""
+
+    def __init__(self, tensors: dict[str, torch.Tensor], device, dtype) -> None:
+        self.tensors = tensors
+        self.device = device
+        self.dtype = dtype
+
+    def __call__(self, name: str) -> torch.Tensor:
+        t = self.tensors[name]
+        # Integer buffers (n-gram multipliers, vocab sizes) must keep their dtype.
+        if t.is_floating_point():
+            return t.to(self.device, dtype=self.dtype)
+        return t.to(self.device)
+
+
+def build_from_state_dict(
+    config: Qwen4ExpTextConfig,
+    state_dict: dict[str, torch.Tensor],
+    *,
+    device: torch.device | str = "cpu",
+    dtype: torch.dtype = torch.float32,
+    prefix: str = LM,
+) -> Qwen4ExpModel:
+    """Single-device model with every expert resident. Small models / tests only."""
+    device = torch.device(device)
+    getter = _TensorStore(state_dict, device, dtype)
+
+    gate_up = {}
+    down = {}
+    for layer_idx in range(config.num_hidden_layers):
+        gate_up[layer_idx] = getter(f"{prefix}.layers.{layer_idx}.mlp.experts.gate_up_proj")
+        down[layer_idx] = getter(f"{prefix}.layers.{layer_idx}.mlp.experts.down_proj")
+    moe = InMemoryMoE(config.num_experts, gate_up, down)
+
+    layers = []
+    for layer_idx in range(config.num_hidden_layers):
+        ple = None
+        ple_index = config.ple_layer_index(layer_idx)
+        if ple_index is not None:
+            table_key = f"{prefix}.layers.{layer_idx}.ple.ple_embedding.ngram_embedding.weight"
+            shards = [state_dict[table_key]] if table_key in state_dict else _gather_shards(
+                state_dict, f"{prefix}.layers.{layer_idx}.ple.ple_embedding.ngram_embedding"
+            )
+            table = HostNGramTable(shards, device=device, dtype=dtype)
+            ple = PLELayer(
+                config,
+                _ple_weights(getter, layer_idx, prefix=prefix),
+                ple_index,
+                device,
+                ngram_table=table,
+            )
+        layers.append(
+            Qwen4ExpDecoderLayer(
+                config,
+                layer_idx,
+                collect_layer_weights(getter, config, layer_idx, prefix=prefix),
+                moe,
+                device=device,
+                ple=ple,
+            )
+        )
+
+    embed_weight = getter(f"{prefix}.embed_tokens.weight")
+    return Qwen4ExpModel(
+        config,
+        layers,
+        embed_tokens=DeviceEmbedding(embed_weight),
+        lm_head=getter("lm_head.weight"),
+        final_mixer=_final_mixer(getter, config, prefix=prefix),
+        device=device,
+        dtype=dtype,
+    )
+
+
+def _gather_shards(state_dict: dict[str, torch.Tensor], base: str) -> list[torch.Tensor]:
+    keys = [k for k in state_dict if k.startswith(f"{base}.shard_")]
+    keys.sort(key=lambda k: int(k.split("shard_")[1].split(".")[0]))
+    if not keys:
+        raise KeyError(f"no n-gram embedding shards under {base}")
+    return [state_dict[k] for k in keys]
+
+
+def build_heterogeneous(
+    config: Qwen4ExpTextConfig,
+    checkpoint: Qwen4ExpCheckpoint,
+    *,
+    device: torch.device | str,
+    dtype: torch.dtype = torch.bfloat16,
+    rank: int = 0,
+    world_size: int = 1,
+    all_reduce=None,
+    expert_cache_capacity: int = 0,
+    prefix: str = LM,
+) -> Qwen4ExpModel:
+    """TP-sharded dense weights on GPU, routed experts + PLE table in host RAM.
+
+    Sharding plan (heads divide evenly by 4 for this config):
+      * QSA: 24 q-heads / 2 kv-heads / 4 indexer heads -> per rank 6 / 2 / 1.
+        kv heads (2) do not divide by 4, so KV is replicated and only q/o are
+        split; that costs a little duplicate KV cache but keeps the reduce simple.
+      * GatedDeltaNet: 48 v-heads / 16 k-heads -> 12 / 4 per rank.
+      * Shared expert and hyper-connections: replicated (they are tiny).
+      * Routed experts: round-robin by expert id across ranks.
+      * lm_head: column-sharded, gathered by the caller.
+    """
+    device = torch.device(device)
+    store = checkpoint.store
+
+    def dense(name: str) -> torch.Tensor:
+        return store.load(name, device=device, dtype=dtype)
+
+    def shard_rows(name: str, groups: int, group_size: int) -> torch.Tensor:
+        """Split a [out, in] weight's output rows into `groups` head-groups and
+        keep this rank's contiguous slice."""
+        full = store.view(name)
+        per_rank = groups // world_size
+        start = rank * per_rank * group_size
+        end = start + per_rank * group_size
+        return full[start:end].to(device, dtype=dtype)
+
+    def shard_cols(name: str, groups: int, group_size: int) -> torch.Tensor:
+        """Split a [out, in] weight's input columns to match a row-sharded input."""
+        full = store.view(name)
+        per_rank = groups // world_size
+        start = rank * per_rank * group_size
+        end = start + per_rank * group_size
+        return full[:, start:end].to(device, dtype=dtype)
+
+    # GQA: a q head is bound to the kv head `q // num_kv_groups`, so slicing q
+    # heads dictates which kv heads this rank needs.  With 24 q / 2 kv on 4
+    # ranks each rank owns 6 q heads that all share one kv head, so kv is
+    # sliced (not replicated) and the group count stays consistent.
+    q_per_rank = config.num_attention_heads // world_size
+    global_groups = config.num_attention_heads // config.num_key_value_heads
+    kv_start = (rank * q_per_rank) // global_groups
+    kv_end = ((rank + 1) * q_per_rank - 1) // global_groups + 1
+    kv_per_rank = kv_end - kv_start
+    if q_per_rank % kv_per_rank != 0:
+        raise ValueError(
+            f"TP world_size={world_size} splits {config.num_attention_heads} q heads into "
+            f"{q_per_rank} per rank, which does not group evenly onto {kv_per_rank} kv heads"
+        )
+
+    shard = TPShard(
+        attn_heads=q_per_rank,
+        attn_kv_heads=kv_per_rank,
+        # The indexer's score is a sum over its heads and its mask must be
+        # identical on every rank, so it is replicated rather than sharded.
+        indexer_heads=config.indexer_n_heads or 0,
+        linear_v_heads=config.linear_num_value_heads // world_size,
+        linear_k_heads=config.linear_num_key_heads // world_size,
+    )
+
+    inner_moe = HostExpertMoE(
+        checkpoint,
+        config.num_experts,
+        device,
+        dtype,
+        cache_capacity=expert_cache_capacity,
+    )
+    moe = ShardedMoE(inner_moe, rank, world_size) if world_size > 1 else inner_moe
+
+    layers: list[Qwen4ExpDecoderLayer] = []
+    for layer_idx in range(config.num_hidden_layers):
+        base = f"{prefix}.layers.{layer_idx}"
+        weights: dict[str, torch.Tensor] = {}
+
+        for hc in ("attn_hyper_connection", "mlp_hyper_connection"):
+            for suffix in _HC_SUFFIXES:
+                weights[f"{hc}.{suffix}"] = dense(f"{base}.{hc}.{suffix}.weight")
+
+        if config.is_linear_layer(layer_idx):
+            # qkv is packed [k_dim, k_dim, v_dim]; shard each section by heads.
+            qkv = store.view(f"{base}.linear_attn.in_proj_qkv.weight")
+            k_dim, v_dim = config.key_dim, config.value_dim
+            k_per = k_dim // world_size
+            v_per = v_dim // world_size
+            weights["linear_attn.in_proj_qkv"] = torch.cat(
+                [
+                    qkv[rank * k_per : (rank + 1) * k_per],
+                    qkv[k_dim + rank * k_per : k_dim + (rank + 1) * k_per],
+                    qkv[2 * k_dim + rank * v_per : 2 * k_dim + (rank + 1) * v_per],
+                ],
+                dim=0,
+            ).to(device, dtype=dtype)
+            weights["linear_attn.in_proj_z"] = shard_rows(
+                f"{base}.linear_attn.in_proj_z.weight", config.linear_num_value_heads, config.linear_value_head_dim
+            )
+            weights["linear_attn.in_proj_b"] = shard_rows(
+                f"{base}.linear_attn.in_proj_b.weight", config.linear_num_value_heads, 1
+            )
+            weights["linear_attn.in_proj_a"] = shard_rows(
+                f"{base}.linear_attn.in_proj_a.weight", config.linear_num_value_heads, 1
+            )
+            # conv1d is depthwise over the packed conv_dim, so it shards the same
+            # way as in_proj_qkv.
+            conv = store.view(f"{base}.linear_attn.conv1d.weight")
+            weights["linear_attn.conv1d"] = torch.cat(
+                [
+                    conv[rank * k_per : (rank + 1) * k_per],
+                    conv[k_dim + rank * k_per : k_dim + (rank + 1) * k_per],
+                    conv[2 * k_dim + rank * v_per : 2 * k_dim + (rank + 1) * v_per],
+                ],
+                dim=0,
+            ).to(device, dtype=dtype)
+            v_head_per_rank = config.linear_num_value_heads // world_size
+            weights["linear_attn.dt_bias"] = store.view(f"{base}.linear_attn.dt_bias")[
+                rank * v_head_per_rank : (rank + 1) * v_head_per_rank
+            ].to(device, dtype=dtype)
+            weights["linear_attn.A_log"] = store.view(f"{base}.linear_attn.A_log")[
+                rank * v_head_per_rank : (rank + 1) * v_head_per_rank
+            ].to(device, dtype=dtype)
+            # norm is per-head-dim (shared across heads), so it stays whole.
+            weights["linear_attn.norm"] = dense(f"{base}.linear_attn.norm.weight")
+            weights["linear_attn.out_proj"] = shard_cols(
+                f"{base}.linear_attn.out_proj.weight", config.linear_num_value_heads, config.linear_value_head_dim
+            )
+        else:
+            # q_proj packs [value, gate] per head, so its head stride is 2*head_dim.
+            weights["self_attn.q_proj"] = shard_rows(
+                f"{base}.self_attn.q_proj.weight", config.num_attention_heads, config.head_dim * 2
+            )
+            # Slice the kv heads this rank's q heads actually attend to.
+            kv_lo = kv_start * config.head_dim
+            kv_hi = kv_end * config.head_dim
+            weights["self_attn.k_proj"] = store.view(f"{base}.self_attn.k_proj.weight")[
+                kv_lo:kv_hi
+            ].to(device, dtype=dtype)
+            weights["self_attn.v_proj"] = store.view(f"{base}.self_attn.v_proj.weight")[
+                kv_lo:kv_hi
+            ].to(device, dtype=dtype)
+            weights["self_attn.o_proj"] = shard_cols(
+                f"{base}.self_attn.o_proj.weight", config.num_attention_heads, config.head_dim
+            )
+            weights["self_attn.q_norm"] = dense(f"{base}.self_attn.q_norm.weight")
+            weights["self_attn.k_norm"] = dense(f"{base}.self_attn.k_norm.weight")
+            # The indexer's scores are a sum over its heads, so sharding heads
+            # would need its own reduce. Keep it replicated: 640x2560 per layer.
+            weights["self_attn.index_qk_proj"] = dense(f"{base}.self_attn.indexer.index_qk_proj.weight")
+            weights["self_attn.q_layernorm"] = dense(f"{base}.self_attn.indexer.q_layernorm.weight")
+            weights["self_attn.k_layernorm"] = dense(f"{base}.self_attn.indexer.k_layernorm.weight")
+
+        weights["mlp.gate"] = dense(f"{base}.mlp.gate.weight")
+        weights["mlp.shared_expert_gate"] = dense(f"{base}.mlp.shared_expert_gate.weight")
+        # Shared expert: column-parallel gate/up, row-parallel down, so its
+        # partial sums fold into the same all-reduce as the routed experts.
+        inter_per_rank = config.shared_expert_intermediate_size // world_size
+        gp = store.view(f"{base}.mlp.shared_expert.gate_proj.weight")
+        up = store.view(f"{base}.mlp.shared_expert.up_proj.weight")
+        dn = store.view(f"{base}.mlp.shared_expert.down_proj.weight")
+        lo, hi = rank * inter_per_rank, (rank + 1) * inter_per_rank
+        weights["mlp.shared_expert.gate_proj"] = gp[lo:hi].to(device, dtype=dtype)
+        weights["mlp.shared_expert.up_proj"] = up[lo:hi].to(device, dtype=dtype)
+        weights["mlp.shared_expert.down_proj"] = dn[:, lo:hi].to(device, dtype=dtype)
+
+        ple = None
+        ple_index = config.ple_layer_index(layer_idx)
+        if ple_index is not None:
+            shard_keys = checkpoint.ngram_shard_keys(layer_idx)
+            table = HostNGramTable(
+                [store.view(k) for k in shard_keys], device=device, dtype=dtype
+            )
+            ple = PLELayer(
+                config,
+                {_strip_weight(s): dense(f"{base}.ple.{s}") for s in _PLE_SUFFIXES},
+                ple_index,
+                device,
+                ngram_table=table,
+            )
+
+        layers.append(
+            Qwen4ExpDecoderLayer(
+                config,
+                layer_idx,
+                weights,
+                moe,
+                device=device,
+                ple=ple,
+                tp_shard=shard,
+                all_reduce=all_reduce,
+            )
+        )
+
+    # 1.18 GiB each: embedding stays in host RAM (gathered per step), lm_head is
+    # column-sharded so each rank holds 300 MiB.
+    embed_weight = store.view(f"{prefix}.embed_tokens.weight")
+    lm_head_full = store.view("lm_head.weight")
+    vocab_per_rank = lm_head_full.shape[0] // world_size
+    lm_head = lm_head_full[rank * vocab_per_rank : (rank + 1) * vocab_per_rank].to(device, dtype=dtype)
+
+    return Qwen4ExpModel(
+        config,
+        layers,
+        embed_tokens=HostEmbedding(embed_weight, device=device, dtype=dtype),
+        lm_head=lm_head,
+        final_mixer=_final_mixer(dense, config, prefix=prefix),
+        device=device,
+        dtype=dtype,
+    )

--- a/src/models/qwen4_exp/config.py
+++ b/src/models/qwen4_exp/config.py
@@ -1,0 +1,232 @@
+"""Qwen4-Exp configuration parsing.
+
+Reads the HF `config.json` shipped with Qwen3.8-Flash-Next without depending on
+a transformers version that knows the architecture.  Only the fields the runtime
+actually needs are kept; the vision tower is parsed but unused by the text path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import math
+import os
+
+
+def _is_prime(value: int) -> bool:
+    if value < 2:
+        return False
+    if value % 2 == 0:
+        return value == 2
+    for divisor in range(3, math.isqrt(value) + 1, 2):
+        if value % divisor == 0:
+            return False
+    return True
+
+
+def find_nth_prime_after(start: int, count: int) -> int:
+    """`count`-th prime strictly greater than `start` (matches upstream)."""
+    prime = start
+    for _ in range(count):
+        prime += 1
+        while not _is_prime(prime):
+            prime += 1
+    return prime
+
+
+@dataclass
+class Qwen4ExpTextConfig:
+    # Core transformer geometry
+    hidden_size: int = 2560
+    num_hidden_layers: int = 48
+    num_attention_heads: int = 24
+    num_key_value_heads: int = 2
+    head_dim: int = 256
+    vocab_size: int = 248320
+    rms_norm_eps: float = 1e-6
+    hidden_act: str = "silu"
+    attention_bias: bool = False
+    max_position_embeddings: int = 262144
+    tie_word_embeddings: bool = False
+
+    # Per-layer attention flavour: "linear_attention" or "qwen_sparse_attention".
+    layer_types: list[str] = field(default_factory=list)
+    full_attention_interval: int = 4
+
+    # GatedDeltaNet (linear attention) layers
+    linear_conv_kernel_dim: int = 4
+    linear_key_head_dim: int = 128
+    linear_value_head_dim: int = 128
+    linear_num_key_heads: int = 16
+    linear_num_value_heads: int = 48
+    output_gate_type: str | None = "sigmoid"
+
+    # Hyper-connections (4 parallel residual streams)
+    hc_count: int = 4
+    hc_lowrank: int = 320
+
+    # MoE
+    num_experts: int = 512
+    num_experts_per_tok: int = 10
+    moe_intermediate_size: int = 640
+    shared_expert_intermediate_size: int = 640
+    norm_topk_prob: bool = True
+
+    # QSA indexer on full-attention layers
+    indexer_n_heads: int | None = 4
+    indexer_kv_heads: int | None = 1
+    indexer_head_dim: int | None = 128
+    indexer_budget: int | None = 2048
+    indexer_compress_ratio: int | None = 4
+
+    # PLE hashed n-gram embeddings
+    ple_layer_ids: list[int] = field(default_factory=list)
+    ple_embed_dim: int = 2560
+    ple_conv_kernel_size: int = 4
+    ngram_size: int = 3
+    heads_per_ngram: int = 8
+    ngram_vocab_size_base: int = 20_000_000
+    make_ngram_vocab_size_divisible_by: int = 128
+    split_ngram_parts: int = 128
+    seed: int = 1234
+
+    # RoPE
+    rope_theta: float = 1e7
+    partial_rotary_factor: float = 0.25
+    mrope_section: list[int] = field(default_factory=lambda: [11, 11, 10])
+    mrope_interleaved: bool = True
+
+    # Tokens
+    bos_token_id: int = 248044
+    eos_token_id: list[int] = field(default_factory=lambda: [248044])
+    pad_token_id: int | None = None
+
+    # MTP draft head (one extra layer); unused until spec decoding lands.
+    mtp_num_hidden_layers: int = 1
+    mtp_rope_theta: float = 1e7
+
+    def __post_init__(self) -> None:
+        if not self.layer_types:
+            self.layer_types = [
+                "linear_attention" if (i + 1) % self.full_attention_interval else "qwen_sparse_attention"
+                for i in range(self.num_hidden_layers)
+            ]
+        # The shipped checkpoint labels indexer layers "full_attention"; upstream
+        # renames them so the QSA path is explicit.
+        self.layer_types = [
+            "qwen_sparse_attention" if t == "full_attention" else t for t in self.layer_types
+        ]
+        self.ple_layer_ids = sorted(set(self.ple_layer_ids))
+        if isinstance(self.eos_token_id, int):
+            self.eos_token_id = [self.eos_token_id]
+
+    # -- derived geometry -------------------------------------------------
+
+    @property
+    def rotary_dim(self) -> int:
+        return int(self.head_dim * self.partial_rotary_factor)
+
+    @property
+    def key_dim(self) -> int:
+        return self.linear_key_head_dim * self.linear_num_key_heads
+
+    @property
+    def value_dim(self) -> int:
+        return self.linear_value_head_dim * self.linear_num_value_heads
+
+    @property
+    def conv_dim(self) -> int:
+        return self.key_dim * 2 + self.value_dim
+
+    @property
+    def hc_hidden_size(self) -> int:
+        return self.hc_count * self.hidden_size
+
+    @property
+    def ngram_heads(self) -> int:
+        return (self.ngram_size - 1) * self.heads_per_ngram
+
+    @property
+    def primary_eos_token_id(self) -> int:
+        return self.eos_token_id[0]
+
+    def is_linear_layer(self, layer_idx: int) -> bool:
+        return self.layer_types[layer_idx] == "linear_attention"
+
+    def ple_layer_index(self, layer_idx: int) -> int | None:
+        """Position of `layer_idx` in the PLE layer list, or None.
+
+        `ple_layer_ids` is one-indexed in the checkpoint config.
+        """
+        one_indexed = layer_idx + 1
+        if one_indexed in self.ple_layer_ids:
+            return self.ple_layer_ids.index(one_indexed)
+        return None
+
+    def ngram_head_vocab_sizes(self, ple_layer_index: int) -> tuple[list[int], list[int], int]:
+        """Per-head hashed vocab sizes/offsets for one PLE layer.
+
+        Each head gets a distinct prime above `ngram_vocab_size_base`, indexed
+        globally across PLE layers so tables never collide.  Returns
+        (sizes, offsets, padded_total).
+        """
+        sizes: list[int] = []
+        offsets: list[int] = []
+        total = 0
+        for head_idx in range(self.ngram_heads):
+            global_head_idx = ple_layer_index * self.ngram_heads + head_idx
+            size = find_nth_prime_after(self.ngram_vocab_size_base - 1, global_head_idx + 1)
+            sizes.append(size)
+            offsets.append(total)
+            total += size
+        divisor = self.make_ngram_vocab_size_divisible_by
+        padded = math.ceil(total / divisor) * divisor
+        return sizes, offsets, padded
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "Qwen4ExpTextConfig":
+        rope = raw.get("rope_parameters") or {}
+        mtp = raw.get("mtp") or {}
+        known = {f for f in cls.__dataclass_fields__}
+        kwargs = {k: v for k, v in raw.items() if k in known}
+        kwargs["rope_theta"] = float(rope.get("rope_theta", raw.get("rope_theta", 1e7)))
+        kwargs["partial_rotary_factor"] = float(
+            rope.get("partial_rotary_factor", raw.get("partial_rotary_factor", 0.25))
+        )
+        if "mrope_section" in rope:
+            kwargs["mrope_section"] = list(rope["mrope_section"])
+        kwargs["mrope_interleaved"] = bool(rope.get("mrope_interleaved", True))
+        if "rope_theta" in mtp:
+            kwargs["mtp_rope_theta"] = float(mtp["rope_theta"])
+        return cls(**kwargs)
+
+
+@dataclass
+class Qwen4ExpConfig:
+    text_config: Qwen4ExpTextConfig
+    architecture: str = "qwen4_exp"
+    image_token_id: int | None = None
+    video_token_id: int | None = None
+    vision_start_token_id: int | None = None
+    vision_end_token_id: int | None = None
+    tie_word_embeddings: bool = False
+    raw: dict = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "Qwen4ExpConfig":
+        text_raw = raw.get("text_config", raw)
+        return cls(
+            text_config=Qwen4ExpTextConfig.from_dict(text_raw),
+            architecture=(raw.get("architectures") or ["qwen4_exp"])[0],
+            image_token_id=raw.get("image_token_id"),
+            video_token_id=raw.get("video_token_id"),
+            vision_start_token_id=raw.get("vision_start_token_id"),
+            vision_end_token_id=raw.get("vision_end_token_id"),
+            tie_word_embeddings=bool(raw.get("tie_word_embeddings", False)),
+            raw=raw,
+        )
+
+    @classmethod
+    def from_pretrained(cls, model_dir: str) -> "Qwen4ExpConfig":
+        with open(os.path.join(model_dir, "config.json")) as f:
+            return cls.from_dict(json.load(f))

--- a/src/models/qwen4_exp/layers.py
+++ b/src/models/qwen4_exp/layers.py
@@ -1,0 +1,319 @@
+"""Qwen4-Exp building blocks: norms, RoPE, hyper-connections, PLE, MoE.
+
+Numerics follow the upstream `transformers` implementation exactly (including
+where it forces float32), because the tests check bit-level agreement against
+goldens captured from it.  Nothing here is TP-aware; sharding happens in
+`runtime.py` by handing sliced weights to these modules.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+
+from src.models.qwen4_exp.config import Qwen4ExpTextConfig
+
+
+# ---------------------------------------------------------------------------
+# Norms
+# ---------------------------------------------------------------------------
+
+
+class RMSNorm:
+    """RMSNorm with upstream's `(1 + weight)` convention and optional grouping.
+
+    `group_size` normalizes each contiguous group independently, which is how
+    the hyper-connection norms treat their `hc_count * hidden_size` input: each
+    residual stream gets its own statistics.
+    """
+
+    def __init__(self, weight: torch.Tensor, eps: float, *, group_size: int | None = None) -> None:
+        self.weight = weight
+        self.eps = eps
+        self.group_size = group_size
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        in_dtype = x.dtype
+        h = x.to(torch.float32)
+        if self.group_size is not None:
+            h = h.reshape(*h.shape[:-1], -1, self.group_size)
+        h = h * torch.rsqrt(h.pow(2).mean(-1, keepdim=True) + self.eps)
+        if self.group_size is not None:
+            h = h.flatten(-2)
+        # Qwen stores the norm scale centered on zero: the effective gain is
+        # (1 + weight), and the multiply happens in float32 before the cast back.
+        return (h * (1.0 + self.weight.to(torch.float32))).to(in_dtype)
+
+
+class RMSNormGated:
+    """Per-head RMSNorm followed by a gate activation (GatedDeltaNet output).
+
+    Upstream multiplies by `weight` (not `1 + weight`) here and applies the gate
+    activation in float32.
+    """
+
+    def __init__(self, weight: torch.Tensor, eps: float, *, activation: str = "silu") -> None:
+        self.weight = weight
+        self.eps = eps
+        self.activation = activation
+
+    def __call__(self, x: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+        in_dtype = x.dtype
+        h = x.to(torch.float32)
+        h = h * torch.rsqrt(h.pow(2).mean(-1, keepdim=True) + self.eps)
+        h = self.weight * h.to(in_dtype)
+        act = torch.sigmoid if self.activation == "sigmoid" else F.silu
+        h = h * act(gate.to(torch.float32))
+        return h.to(in_dtype)
+
+
+# ---------------------------------------------------------------------------
+# RoPE
+# ---------------------------------------------------------------------------
+
+
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    half = x.shape[-1] // 2
+    return torch.cat((-x[..., half:], x[..., :half]), dim=-1)
+
+
+def apply_rotary_pos_emb(
+    q: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    k: torch.Tensor | None = None,
+    unsqueeze_dim: int = 1,
+):
+    """Partial RoPE: rotate the leading `cos.shape[-1]` dims, pass the rest."""
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    rotary_dim = cos.shape[-1]
+
+    q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
+    q_out = torch.cat([(q_rot * cos) + (rotate_half(q_rot) * sin), q_pass], dim=-1)
+    if k is None:
+        return q_out
+    k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
+    k_out = torch.cat([(k_rot * cos) + (rotate_half(k_rot) * sin), k_pass], dim=-1)
+    return q_out, k_out
+
+
+class MRoPE:
+    """Interleaved 3D (text/height/width) rotary embedding.
+
+    For text-only inference all three sections carry the same positions, so the
+    interleaving is a no-op numerically, but we keep the general path so image
+    and video position ids work later without a second code path.
+    """
+
+    def __init__(self, config: Qwen4ExpTextConfig, device: torch.device, *, rope_theta: float | None = None) -> None:
+        dim = config.rotary_dim
+        theta = config.rope_theta if rope_theta is None else rope_theta
+        self.inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim))
+        self.mrope_section = list(config.mrope_section)
+        self.attention_scaling = 1.0
+
+    def __call__(self, position_ids: torch.Tensor, dtype: torch.dtype) -> tuple[torch.Tensor, torch.Tensor]:
+        """position_ids: (3, batch, seq) or (batch, seq). Returns cos/sin (batch, seq, rotary_dim)."""
+        if position_ids.ndim == 2:
+            position_ids = position_ids[None].expand(3, -1, -1)
+        inv_freq = self.inv_freq[None, None, :, None].expand(3, position_ids.shape[1], -1, 1)
+        pos = position_ids[:, :, None, :].float()
+        freqs = (inv_freq.float() @ pos).transpose(2, 3)  # (3, batch, seq, dim/2)
+        freqs = self._interleave(freqs)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        return (emb.cos() * self.attention_scaling).to(dtype), (emb.sin() * self.attention_scaling).to(dtype)
+
+    def _interleave(self, freqs: torch.Tensor) -> torch.Tensor:
+        """Rearrange chunked [TTT..HHH..WWW] frequencies into [THWTHW..TT]."""
+        out = freqs[0].clone()
+        for dim, offset in enumerate((1, 2), start=1):
+            length = self.mrope_section[dim] * 3
+            idx = slice(offset, length, 3)
+            out[..., idx] = freqs[dim, ..., idx]
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Hyper-connections
+# ---------------------------------------------------------------------------
+
+
+class GatedResidual:
+    """Mixes the `hc_count` residual streams into one block input.
+
+    The streams stay separate across the whole network; each block reads a
+    low-rank-gated mean of them and writes its output back into every stream
+    scaled by a learned per-stream injection weight.  With `block_inject_weight`
+    absent (the final mixer) only the mixed input is returned.
+    """
+
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        hc_norm: torch.Tensor,
+        mix_down: torch.Tensor,
+        mix_up: torch.Tensor,
+        block_inject: torch.Tensor | None,
+    ) -> None:
+        self.hc_count = config.hc_count
+        self.hidden_size = config.hidden_size
+        self.hc_norm = RMSNorm(hc_norm, config.rms_norm_eps, group_size=config.hidden_size)
+        self.mix_down = mix_down
+        self.mix_up = mix_up
+        self.block_inject = block_inject
+
+    def __call__(self, hyper_input: torch.Tensor):
+        normed = self.hc_norm(hyper_input)
+        w = F.silu(F.linear(normed, self.mix_down) / self.hc_count)
+        w = torch.sigmoid(F.linear(w, self.mix_up))
+        w = w.unflatten(-1, (self.hc_count, self.hidden_size))
+        mixed = (w * normed.unflatten(-1, (self.hc_count, self.hidden_size))).mean(dim=-2)
+        if self.block_inject is None:
+            return mixed
+        inject = 2 * torch.sigmoid(F.linear(normed, self.block_inject) / self.hc_count)
+        return mixed, hyper_input, inject
+
+
+def inject_into_streams(
+    block_output: torch.Tensor, hyper_input: torch.Tensor, injection_weights: torch.Tensor
+) -> torch.Tensor:
+    """Scatter a block's output back into all hyper-connection streams."""
+    injection = block_output.unsqueeze(-2) * injection_weights.unsqueeze(-1)
+    return hyper_input + injection.flatten(-2)
+
+
+# ---------------------------------------------------------------------------
+# PLE hashed n-gram embeddings
+# ---------------------------------------------------------------------------
+
+_MASK64 = (1 << 64) - 1
+_SPLITMIX_GAMMA = 0x9E3779B97F4A7C15
+_SPLITMIX_M1 = 0xBF58476D1CE4E5B9
+_SPLITMIX_M2 = 0x94D049BB133111EB
+_PRIME_1 = 10007
+
+
+def _splitmix64(value: int) -> int:
+    value = (value + _SPLITMIX_GAMMA) & _MASK64
+    value = ((value ^ (value >> 30)) * _SPLITMIX_M1) & _MASK64
+    value = ((value ^ (value >> 27)) * _SPLITMIX_M2) & _MASK64
+    return (value ^ (value >> 31)) & _MASK64
+
+
+def build_layer_multipliers(unigram_vocab_size: int, ngram_size: int, ple_layer_index: int, seed: int) -> torch.Tensor:
+    """Odd per-position hash multipliers, derived deterministically from the seed."""
+    max_long = (1 << 63) - 1
+    multiplier_max = max_long // max(unigram_vocab_size, 1)
+    half_bound = max(1, multiplier_max // 2)
+    base_seed = seed + _PRIME_1 * ple_layer_index
+    multipliers = []
+    for index in range(ngram_size):
+        value = (base_seed + _SPLITMIX_GAMMA * (index + 1)) & _MASK64
+        multipliers.append(2 * (_splitmix64(value) % half_bound) + 1)
+    return torch.tensor(multipliers, dtype=torch.long)
+
+
+class NGramHasher:
+    """Maps token ids to hashed n-gram embedding row ids.
+
+    Rows are looked up in a table whose `total_vocab_size` is the concatenation
+    of one distinct-prime slice per (n-gram order, head).  The hash mixes the
+    shifted token ids by XOR of per-position multiples, then takes a remainder
+    per head.  Token history crossing an EOS boundary is masked to EOS so
+    n-grams never straddle documents.
+    """
+
+    def __init__(self, config: Qwen4ExpTextConfig, ple_layer_index: int, device: torch.device) -> None:
+        # The hash runs on int64 token ids and its output feeds a host-side
+        # gather, so it stays on the CPU regardless of the compute device: doing
+        # it on the GPU would only add a device round-trip.
+        device = torch.device("cpu")
+        self.ngram_size = config.ngram_size
+        self.context_len = config.ngram_size - 1
+        self.heads_per_ngram = config.heads_per_ngram
+        self.eos_token_id = config.primary_eos_token_id
+        sizes, offsets, padded = config.ngram_head_vocab_sizes(ple_layer_index)
+        self.head_vocab_sizes = torch.tensor(sizes, dtype=torch.long, device=device)
+        self.head_offsets = torch.tensor(offsets, dtype=torch.long, device=device)
+        self.padded_vocab_size = padded
+        self.layer_multipliers = build_layer_multipliers(
+            config.vocab_size, config.ngram_size, ple_layer_index, config.seed
+        ).to(device)
+
+    def _shift_right_ignore_eos(self, token_ids: torch.Tensor, shift: int) -> torch.Tensor:
+        if shift == 0:
+            return token_ids
+        batch_size, seq_len = token_ids.shape
+        positions = torch.arange(seq_len, device=token_ids.device, dtype=torch.long)
+        eos_positions = torch.where(token_ids == self.eos_token_id, positions, -1)
+        previous_eos_inclusive = torch.cummax(eos_positions, dim=1).values
+        previous_eos = torch.cat(
+            [eos_positions.new_full((batch_size, 1), -1), previous_eos_inclusive[:, :-1]], dim=1
+        )
+        position_in_segment = positions.unsqueeze(0) - (previous_eos + 1)
+        source_positions = positions - shift
+        gather_positions = source_positions.clamp_min(0).unsqueeze(0).expand(batch_size, -1)
+        shifted = token_ids.gather(dim=1, index=gather_positions)
+        valid = (position_in_segment >= shift) & (source_positions.unsqueeze(0) >= 0)
+        return torch.where(valid, shifted, token_ids.new_full((), self.eos_token_id))
+
+    def row_ids(self, token_history: torch.Tensor, out_len: int) -> torch.Tensor:
+        """token_history: (batch, context_len + out_len) -> (batch, out_len, ngram_heads)."""
+        token_history = token_history.to("cpu", dtype=torch.long)
+        shifted = [self._shift_right_ignore_eos(token_history, s) for s in range(self.ngram_size)]
+        blocks = []
+        for ngram in range(2, self.ngram_size + 1):
+            start = (ngram - 2) * self.heads_per_ngram
+            end = start + self.heads_per_ngram
+            mixed = shifted[0] * self.layer_multipliers[0]
+            for position in range(1, ngram):
+                mixed = torch.bitwise_xor(mixed, shifted[position] * self.layer_multipliers[position])
+            sizes = self.head_vocab_sizes[start:end].view(1, 1, -1)
+            offsets = self.head_offsets[start:end].view(1, 1, -1)
+            blocks.append(torch.remainder(mixed.unsqueeze(-1), sizes) + offsets)
+        return torch.cat(blocks, dim=-1)[:, -out_len:]
+
+
+# ---------------------------------------------------------------------------
+# MoE
+# ---------------------------------------------------------------------------
+
+
+class TopKRouter:
+    """Softmax-over-all-experts router with renormalized top-k weights."""
+
+    def __init__(self, weight: torch.Tensor, top_k: int, *, norm_topk_prob: bool = True) -> None:
+        self.weight = weight
+        self.top_k = top_k
+        self.norm_topk_prob = norm_topk_prob
+
+    def __call__(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        logits = F.linear(hidden_states, self.weight)
+        probs = F.softmax(logits, dim=-1, dtype=torch.float32)
+        top_value, indices = torch.topk(probs, self.top_k, dim=-1)
+        if self.norm_topk_prob:
+            top_value = top_value / top_value.sum(dim=-1, keepdim=True)
+        return top_value.to(logits.dtype), indices
+
+
+class DenseMLP:
+    """SwiGLU MLP used by the shared expert."""
+
+    def __init__(self, gate_proj: torch.Tensor, up_proj: torch.Tensor, down_proj: torch.Tensor) -> None:
+        self.gate_proj = gate_proj
+        self.up_proj = up_proj
+        self.down_proj = down_proj
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        return F.linear(F.silu(F.linear(x, self.gate_proj)) * F.linear(x, self.up_proj), self.down_proj)
+
+
+def swiglu_expert(
+    x: torch.Tensor, gate_up_proj: torch.Tensor, down_proj: torch.Tensor
+) -> torch.Tensor:
+    """One expert's fused-gate SwiGLU: gate_up is [2*inter, hidden] row-packed."""
+    gate, up = F.linear(x, gate_up_proj).chunk(2, dim=-1)
+    return F.linear(F.silu(gate) * up, down_proj)

--- a/src/models/qwen4_exp/model.py
+++ b/src/models/qwen4_exp/model.py
@@ -1,0 +1,365 @@
+"""Qwen4-Exp decoder stack.
+
+Weights arrive as plain tensors from a provider (see `weights.py`), so the same
+module code serves the single-GPU reference path and the TP4 heterogeneous path
+— the latter simply hands over sharded tensors and a host-resident MoE backend.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+import torch
+import torch.nn.functional as F
+
+from src.models.qwen4_exp.attention import (
+    GatedDeltaNet,
+    GatedDeltaNetCache,
+    QSAAttention,
+    QSAAttentionCache,
+)
+from src.models.qwen4_exp.config import Qwen4ExpTextConfig
+from src.models.qwen4_exp.layers import (
+    DenseMLP,
+    GatedResidual,
+    MRoPE,
+    NGramHasher,
+    RMSNorm,
+    TopKRouter,
+    inject_into_streams,
+)
+from src.models.qwen4_exp.moe import MoEBackend
+
+
+@dataclass
+class Qwen4ExpCache:
+    """Per-layer cache state plus the PLE token-history window.
+
+    `ple_token_history` holds the last `ngram_size - 1` token ids so decode steps
+    can hash n-grams that reach back before the current token.
+    """
+
+    layers: list[object] = field(default_factory=list)
+    ple_token_history: torch.Tensor | None = None
+    length: int = 0
+
+
+class PLELayer:
+    """Injects hashed n-gram features into every hyper-connection stream.
+
+    The n-gram embedding is projected to one value and `hc_count` keys; the
+    normalized stream activations gate the value per stream, then a dilated
+    depthwise conv adds local lexical context.  The dilation is `ngram_size`, so
+    the conv state spans `(kernel - 1) * ngram_size` positions.
+    """
+
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        weights: dict[str, torch.Tensor],
+        ple_layer_index: int,
+        device: torch.device,
+        *,
+        ngram_table: object,
+    ) -> None:
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.hc_count = config.hc_count
+        self.hasher = NGramHasher(config, ple_layer_index, device)
+        self.ngram_table = ngram_table
+        self.key_proj = weights["key_proj"]
+        self.value_proj = weights["value_proj"]
+        self.norm_key = RMSNorm(weights["norm_key"], config.rms_norm_eps, group_size=config.hidden_size)
+        self.norm_query = RMSNorm(weights["norm_query"], config.rms_norm_eps, group_size=config.hidden_size)
+        self.norm_conv = RMSNorm(weights["norm_conv"], config.rms_norm_eps, group_size=config.hidden_size)
+        self.conv1d_weight = weights["conv1d"]  # (hc_hidden, 1, kernel)
+        self.conv_dilation = config.ngram_size
+        self.conv_kernel_size = config.ple_conv_kernel_size
+        self.short_conv_state_len = (self.conv_kernel_size - 1) * self.conv_dilation
+        self.conv_state: torch.Tensor | None = None
+
+    def reset_cache(self) -> None:
+        self.conv_state = None
+
+    def _short_conv(self, hidden_states: torch.Tensor, *, use_cache: bool) -> torch.Tensor:
+        seq_len = hidden_states.shape[1]
+        x = hidden_states.transpose(1, 2)  # (b, hc_hidden, seq)
+        if use_cache and self.conv_state is not None:
+            x = torch.cat([self.conv_state.to(x.dtype), x], dim=-1)
+        if use_cache:
+            self.conv_state = x[:, :, -self.short_conv_state_len :].clone()
+        x = F.pad(x, (self.short_conv_state_len, 0))
+        x = x[..., -(self.short_conv_state_len + seq_len) :]
+        channels = self.conv1d_weight.shape[0]
+        x = F.conv1d(
+            x,
+            self.conv1d_weight,
+            None,
+            padding=0,
+            dilation=self.conv_dilation,
+            groups=channels,
+        )
+        return F.silu(x).transpose(1, 2)
+
+    def __call__(
+        self,
+        hidden_states: torch.Tensor,
+        token_history: torch.Tensor,
+        out_len: int,
+        *,
+        use_cache: bool,
+    ) -> torch.Tensor:
+        row_ids = self.hasher.row_ids(token_history, out_len)
+        embeddings = self.ngram_table(row_ids).flatten(-2).to(hidden_states.dtype)
+        key_normed = self.norm_key(F.linear(embeddings, self.key_proj)).unflatten(
+            -1, (self.hc_count, self.hidden_size)
+        )
+        value = F.linear(embeddings, self.value_proj)
+        query_normed = self.norm_query(hidden_states).unflatten(-1, (self.hc_count, self.hidden_size))
+        gate = (key_normed * query_normed).sum(dim=-1, keepdim=True) / math.sqrt(self.hidden_size)
+        # Signed sqrt keeps the gate's sign while compressing its magnitude.
+        gate = gate.abs().clamp_min(1e-6).sqrt() * gate.sign()
+        gated_value = torch.sigmoid(gate) * value.unsqueeze(-2)
+        gated_value_normed = self.norm_conv(gated_value.flatten(-2))
+        gated_value = gated_value.flatten(-2)
+        return gated_value + self._short_conv(gated_value_normed, use_cache=use_cache)
+
+
+class Qwen4ExpDecoderLayer:
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        layer_idx: int,
+        weights: dict[str, torch.Tensor],
+        moe: MoEBackend,
+        *,
+        device: torch.device,
+        ple: PLELayer | None = None,
+        tp_shard: "TPShard | None" = None,
+        all_reduce=None,
+    ) -> None:
+        self.config = config
+        self.layer_idx = layer_idx
+        self.is_linear = config.is_linear_layer(layer_idx)
+        self.ple = ple
+        self.moe = moe
+        # Row-parallel outputs (attention o_proj/out_proj and the MLP sum) are
+        # partial sums on each rank; the hyper-connection streams themselves are
+        # replicated, so the reduce must land on the block output *before* it is
+        # injected back into the streams.
+        self.all_reduce = all_reduce
+        shard = tp_shard or TPShard.single(config)
+
+        if self.is_linear:
+            self.attn = GatedDeltaNet(
+                config,
+                {k[len("linear_attn.") :]: v for k, v in weights.items() if k.startswith("linear_attn.")},
+                num_v_heads=shard.linear_v_heads,
+                num_k_heads=shard.linear_k_heads,
+            )
+        else:
+            self.attn = QSAAttention(
+                config,
+                {k[len("self_attn.") :]: v for k, v in weights.items() if k.startswith("self_attn.")},
+                num_heads=shard.attn_heads,
+                num_kv_heads=shard.attn_kv_heads,
+                indexer_heads=shard.indexer_heads,
+            )
+
+        self.attn_hc = GatedResidual(
+            config,
+            weights["attn_hyper_connection.hc_norm"],
+            weights["attn_hyper_connection.input_mix_weight_down"],
+            weights["attn_hyper_connection.input_mix_weight_up"],
+            weights["attn_hyper_connection.block_inject_weight"],
+        )
+        self.mlp_hc = GatedResidual(
+            config,
+            weights["mlp_hyper_connection.hc_norm"],
+            weights["mlp_hyper_connection.input_mix_weight_down"],
+            weights["mlp_hyper_connection.input_mix_weight_up"],
+            weights["mlp_hyper_connection.block_inject_weight"],
+        )
+
+        self.router = TopKRouter(weights["mlp.gate"], config.num_experts_per_tok, norm_topk_prob=config.norm_topk_prob)
+        self.shared_expert = DenseMLP(
+            weights["mlp.shared_expert.gate_proj"],
+            weights["mlp.shared_expert.up_proj"],
+            weights["mlp.shared_expert.down_proj"],
+        )
+        self.shared_expert_gate = weights["mlp.shared_expert_gate"]
+
+    def make_cache(self, batch_size: int, max_seq_len: int, device: torch.device, dtype: torch.dtype):
+        if self.is_linear:
+            return GatedDeltaNetCache(
+                self.config,
+                batch_size,
+                device,
+                dtype,
+                num_v_heads=self.attn.num_v_heads,
+                num_k_heads=self.attn.num_k_heads,
+            )
+        return QSAAttentionCache(
+            self.config,
+            batch_size,
+            max_seq_len,
+            device,
+            dtype,
+            num_kv_heads=self.attn.num_kv_heads,
+        )
+
+    def __call__(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        cache,
+        past_len: int,
+        token_history: torch.Tensor | None,
+        use_cache: bool,
+    ) -> torch.Tensor:
+        if self.ple is not None:
+            assert token_history is not None, "PLE layers need the token id history"
+            hidden_states = hidden_states + self.ple(
+                hidden_states, token_history, hidden_states.shape[1], use_cache=use_cache
+            )
+
+        mixed, hyper_input, inject = self.attn_hc(hidden_states)
+        if self.is_linear:
+            attn_out = self.attn(mixed, cache)
+        else:
+            attn_out = self.attn(mixed, cos, sin, cache, past_len=past_len)
+        if self.all_reduce is not None:
+            attn_out = self.all_reduce(attn_out)
+        hidden_states = inject_into_streams(attn_out, hyper_input, inject)
+
+        mixed, hyper_input, inject = self.mlp_hc(hidden_states)
+        flat = mixed.reshape(-1, mixed.shape[-1])
+        weights, indices = self.router(flat)
+        routed = self.moe(self.layer_idx, flat, indices, weights)
+        shared = self.shared_expert(flat)
+        shared = torch.sigmoid(F.linear(flat, self.shared_expert_gate)) * shared
+        mlp_out = (routed + shared).reshape(mixed.shape)
+        if self.all_reduce is not None:
+            mlp_out = self.all_reduce(mlp_out)
+        return inject_into_streams(mlp_out, hyper_input, inject)
+
+
+@dataclass
+class TPShard:
+    """Head counts owned by this rank after tensor-parallel splitting."""
+
+    attn_heads: int
+    attn_kv_heads: int
+    indexer_heads: int
+    linear_v_heads: int
+    linear_k_heads: int
+
+    @classmethod
+    def single(cls, config: Qwen4ExpTextConfig) -> "TPShard":
+        return cls(
+            attn_heads=config.num_attention_heads,
+            attn_kv_heads=config.num_key_value_heads,
+            indexer_heads=config.indexer_n_heads or 0,
+            linear_v_heads=config.linear_num_value_heads,
+            linear_k_heads=config.linear_num_key_heads,
+        )
+
+
+class Qwen4ExpModel:
+    """The 48-layer decoder stack with 4-stream hyper-connections."""
+
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        layers: list[Qwen4ExpDecoderLayer],
+        *,
+        embed_tokens,
+        lm_head: torch.Tensor,
+        final_mixer: GatedResidual,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> None:
+        self.config = config
+        self.layers = layers
+        self.embed_tokens = embed_tokens
+        self.lm_head = lm_head
+        self.final_mixer = final_mixer
+        self.device = device
+        self.dtype = dtype
+        self.rope = MRoPE(config, device)
+        self._cos: torch.Tensor | None = None
+        self._sin: torch.Tensor | None = None
+
+    def make_cache(self, batch_size: int, max_seq_len: int) -> Qwen4ExpCache:
+        cache = Qwen4ExpCache(
+            layers=[layer.make_cache(batch_size, max_seq_len, self.device, self.dtype) for layer in self.layers]
+        )
+        for layer in self.layers:
+            if layer.ple is not None:
+                layer.ple.reset_cache()
+        cache.ple_token_history = torch.full(
+            (batch_size, self.config.ngram_size - 1),
+            self.config.primary_eos_token_id,
+            dtype=torch.long,
+        )
+        return cache
+
+    def _rope_cache(self, total_len: int, batch_size: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """cos/sin for absolute positions [0, total_len). The QSA indexer needs
+        every past position, not just the current ones, so we keep the full span
+        and grow it in place."""
+        if self._cos is None or self._cos.shape[1] < total_len or self._cos.shape[0] != batch_size:
+            position_ids = torch.arange(total_len, device=self.device).view(1, 1, -1).expand(3, batch_size, -1)
+            self._cos, self._sin = self.rope(position_ids, self.dtype)
+        return self._cos[:, :total_len], self._sin[:, :total_len]
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        *,
+        cache: Qwen4ExpCache | None = None,
+        past_len: int = 0,
+    ) -> torch.Tensor:
+        batch_size, seq_len = input_ids.shape
+        total_len = past_len + seq_len
+        cos, sin = self._rope_cache(total_len, batch_size)
+
+        token_history = None
+        if any(layer.ple is not None for layer in self.layers):
+            # Token ids and the n-gram hash live on the CPU (the PLE table is
+            # host-resident), so keep the history there too.
+            ids_cpu = input_ids.to("cpu", dtype=torch.long)
+            if cache is not None and cache.ple_token_history is not None:
+                token_history = torch.cat([cache.ple_token_history, ids_cpu], dim=1)
+            else:
+                pad = torch.full(
+                    (batch_size, self.config.ngram_size - 1),
+                    self.config.primary_eos_token_id,
+                    dtype=torch.long,
+                )
+                token_history = torch.cat([pad, ids_cpu], dim=1)
+
+        hidden = self.embed_tokens(input_ids).to(self.dtype)
+        hidden = hidden.repeat(1, 1, self.config.hc_count)
+
+        for idx, layer in enumerate(self.layers):
+            hidden = layer(
+                hidden,
+                cos=cos,
+                sin=sin,
+                cache=cache.layers[idx] if cache is not None else None,
+                past_len=past_len,
+                token_history=token_history,
+                use_cache=cache is not None,
+            )
+
+        if cache is not None:
+            cache.length = total_len
+            if token_history is not None:
+                cache.ple_token_history = token_history[:, -(self.config.ngram_size - 1) :].clone()
+
+        hidden = self.final_mixer(hidden)
+        return F.linear(hidden, self.lm_head)

--- a/src/models/qwen4_exp/moe.py
+++ b/src/models/qwen4_exp/moe.py
@@ -1,0 +1,185 @@
+"""Qwen4-Exp routed-expert backends.
+
+Two implementations share one interface:
+
+* `InMemoryMoE` keeps `gate_up_proj`/`down_proj` as dense tensors on whatever
+  device they were handed.  Used by tests and small models.
+* `HostExpertMoE` reads expert rows straight out of the mmap'd safetensors on
+  demand and runs the SwiGLU on the GPU, staging only the active experts.  This
+  is what makes the 225 GiB expert set usable on 4x22 GiB cards: a decode step
+  touches at most `top_k` experts per layer (6.6 MiB each in BF16).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import torch
+
+from src.models.qwen4_exp.layers import swiglu_expert
+
+
+class MoEBackend(Protocol):
+    def __call__(
+        self,
+        layer_idx: int,
+        hidden_states: torch.Tensor,
+        indices: torch.Tensor,
+        weights: torch.Tensor,
+    ) -> torch.Tensor:
+        """hidden_states: (tokens, hidden); indices/weights: (tokens, top_k)."""
+        ...
+
+
+def _dispatch_experts(
+    hidden_states: torch.Tensor,
+    indices: torch.Tensor,
+    weights: torch.Tensor,
+    num_experts: int,
+    expert_weights,
+) -> torch.Tensor:
+    """Group tokens by expert, run each expert once, scatter-add the results.
+
+    `expert_weights(expert_id)` returns `(gate_up, down)` on the compute device.
+    Experts are visited in ascending id so the accumulation order is fixed and
+    the result is run-to-run reproducible.
+    """
+    out = torch.zeros_like(hidden_states)
+    flat_experts = indices.reshape(-1)
+    order = torch.argsort(flat_experts, stable=True)
+    sorted_experts = flat_experts[order]
+    unique, counts = torch.unique_consecutive(sorted_experts, return_counts=True)
+    top_k = indices.shape[1]
+
+    offset = 0
+    unique_list = unique.tolist()
+    counts_list = counts.tolist()
+    for expert_id, count in zip(unique_list, counts_list):
+        slot = order[offset : offset + count]
+        offset += count
+        if expert_id >= num_experts:
+            continue
+        token_idx = slot // top_k
+        k_idx = slot % top_k
+        gate_up, down = expert_weights(int(expert_id))
+        contrib = swiglu_expert(hidden_states[token_idx], gate_up, down)
+        contrib = contrib * weights[token_idx, k_idx].unsqueeze(-1).to(contrib.dtype)
+        out.index_add_(0, token_idx, contrib.to(out.dtype))
+    return out
+
+
+class InMemoryMoE:
+    """All experts resident as dense per-layer tensors."""
+
+    def __init__(self, num_experts: int, gate_up: dict[int, torch.Tensor], down: dict[int, torch.Tensor]) -> None:
+        self.num_experts = num_experts
+        self.gate_up = gate_up  # layer_idx -> (num_experts, 2*inter, hidden)
+        self.down = down  # layer_idx -> (num_experts, hidden, inter)
+
+    def __call__(
+        self,
+        layer_idx: int,
+        hidden_states: torch.Tensor,
+        indices: torch.Tensor,
+        weights: torch.Tensor,
+    ) -> torch.Tensor:
+        gu = self.gate_up[layer_idx]
+        dn = self.down[layer_idx]
+        return _dispatch_experts(
+            hidden_states,
+            indices,
+            weights,
+            self.num_experts,
+            lambda e: (gu[e], dn[e]),
+        )
+
+
+class HostExpertMoE:
+    """Experts stay in host RAM (mmap'd checkpoint); active ones are staged to GPU.
+
+    The reader must expose `expert_rows(layer_idx, expert_id)` returning CPU
+    tensors that alias the mapping.  A small LRU keeps recently used experts on
+    device, which pays off during prefill where consecutive chunks reuse the same
+    hot experts.
+    """
+
+    def __init__(
+        self,
+        reader,
+        num_experts: int,
+        device: torch.device,
+        dtype: torch.dtype,
+        *,
+        cache_capacity: int = 0,
+    ) -> None:
+        self.reader = reader
+        self.num_experts = num_experts
+        self.device = device
+        self.dtype = dtype
+        self.cache_capacity = cache_capacity
+        self._cache: dict[tuple[int, int], tuple[torch.Tensor, torch.Tensor]] = {}
+        self._order: list[tuple[int, int]] = []
+        self.stage_bytes = 0
+        self.stage_calls = 0
+
+    def _fetch(self, layer_idx: int, expert_id: int) -> tuple[torch.Tensor, torch.Tensor]:
+        key = (layer_idx, expert_id)
+        hit = self._cache.get(key)
+        if hit is not None:
+            return hit
+        gate_up_cpu, down_cpu = self.reader.expert_rows(layer_idx, expert_id)
+        gate_up = gate_up_cpu.to(self.device, dtype=self.dtype, non_blocking=True)
+        down = down_cpu.to(self.device, dtype=self.dtype, non_blocking=True)
+        self.stage_bytes += gate_up.numel() * gate_up.element_size() + down.numel() * down.element_size()
+        self.stage_calls += 1
+        if self.cache_capacity > 0:
+            self._cache[key] = (gate_up, down)
+            self._order.append(key)
+            while len(self._order) > self.cache_capacity:
+                evicted = self._order.pop(0)
+                self._cache.pop(evicted, None)
+        return gate_up, down
+
+    def __call__(
+        self,
+        layer_idx: int,
+        hidden_states: torch.Tensor,
+        indices: torch.Tensor,
+        weights: torch.Tensor,
+    ) -> torch.Tensor:
+        return _dispatch_experts(
+            hidden_states,
+            indices,
+            weights,
+            self.num_experts,
+            lambda e: self._fetch(layer_idx, e),
+        )
+
+
+class ShardedMoE:
+    """Wraps a backend so each rank only runs the experts it owns.
+
+    Experts are partitioned round-robin by id across `world_size` ranks; the
+    per-layer all-reduce that already follows the MLP block sums the partial
+    results, so no extra communication is needed.
+    """
+
+    def __init__(self, inner: MoEBackend, rank: int, world_size: int) -> None:
+        self.inner = inner
+        self.rank = rank
+        self.world_size = world_size
+
+    def __call__(
+        self,
+        layer_idx: int,
+        hidden_states: torch.Tensor,
+        indices: torch.Tensor,
+        weights: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.world_size == 1:
+            return self.inner(layer_idx, hidden_states, indices, weights)
+        # Mask out foreign experts by pointing them at an out-of-range id, which
+        # `_dispatch_experts` skips.
+        mine = (indices % self.world_size) == self.rank
+        local = torch.where(mine, indices, torch.full_like(indices, self.inner.num_experts))
+        return self.inner(layer_idx, hidden_states, local, weights)

--- a/src/models/qwen4_exp/runtime.py
+++ b/src/models/qwen4_exp/runtime.py
@@ -1,0 +1,272 @@
+"""TP4 heterogeneous runtime for Qwen4-Exp.
+
+Launch layout: one process per GPU, NCCL for the per-layer all-reduce.  Dense
+weights are sharded (see `builder.build_heterogeneous`); routed experts and the
+95 GiB PLE table stay in host RAM and are read through the shared page cache, so
+the four ranks pay for one copy between them.
+
+Memory per rank (BF16, 4 ranks):
+  dense sharded weights   ~2.6 GiB   (attn/linear-attn projections, HC mixers)
+  lm_head shard            0.30 GiB
+  KV + conv/recurrent      grows with context
+  staged experts        top_k * 6.6 MiB per layer, freed each step
+
+Entry point: `python -m src.models.qwen4_exp.runtime --model DIR --prompt ...`
+under torchrun, or `run_tp4()` from another module.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from dataclasses import dataclass
+
+import torch
+
+from src.models.qwen4_exp.builder import build_heterogeneous
+from src.models.qwen4_exp.config import Qwen4ExpConfig
+from src.models.qwen4_exp.model import Qwen4ExpModel
+from src.models.qwen4_exp.weights import MmapSafetensors, Qwen4ExpCheckpoint
+
+
+@dataclass
+class TPContext:
+    rank: int
+    world_size: int
+    device: torch.device
+    initialized: bool
+
+
+def init_distributed() -> TPContext:
+    """Join the torchrun-provided process group, or fall back to single-rank."""
+    import torch.distributed as dist
+
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", str(rank)))
+
+    if world_size > 1:
+        if not dist.is_initialized():
+            dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+        torch.cuda.set_device(local_rank)
+        return TPContext(rank, world_size, torch.device(f"cuda:{local_rank}"), True)
+
+    device = torch.device(f"cuda:{local_rank}" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        torch.cuda.set_device(local_rank)
+    return TPContext(rank, world_size, device, False)
+
+
+def make_all_reduce(ctx: TPContext):
+    """Sum a row-parallel block output across ranks. None when world_size == 1."""
+    if ctx.world_size == 1:
+        return None
+    import torch.distributed as dist
+
+    def all_reduce(tensor: torch.Tensor) -> torch.Tensor:
+        # The tensor is a fresh block output, so an in-place reduce is safe and
+        # avoids an extra allocation per layer.
+        tensor = tensor.contiguous()
+        dist.all_reduce(tensor, op=dist.ReduceOp.SUM)
+        return tensor
+
+    return all_reduce
+
+
+def gather_logits(logits: torch.Tensor, ctx: TPContext) -> torch.Tensor:
+    """Concatenate the vocab-sharded lm_head outputs into full logits."""
+    if ctx.world_size == 1:
+        return logits
+    import torch.distributed as dist
+
+    parts = [torch.empty_like(logits) for _ in range(ctx.world_size)]
+    dist.all_gather(parts, logits.contiguous())
+    return torch.cat(parts, dim=-1)
+
+
+def load_model(
+    model_dir: str,
+    ctx: TPContext,
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+    expert_cache_capacity: int = 0,
+) -> tuple[Qwen4ExpModel, Qwen4ExpConfig]:
+    config = Qwen4ExpConfig.from_pretrained(model_dir)
+    checkpoint = Qwen4ExpCheckpoint(model_dir, store=MmapSafetensors(model_dir))
+    model = build_heterogeneous(
+        config.text_config,
+        checkpoint,
+        device=ctx.device,
+        dtype=dtype,
+        rank=ctx.rank,
+        world_size=ctx.world_size,
+        all_reduce=make_all_reduce(ctx),
+        expert_cache_capacity=expert_cache_capacity,
+    )
+    return model, config
+
+
+def generate(
+    model: Qwen4ExpModel,
+    ctx: TPContext,
+    input_ids: torch.Tensor,
+    *,
+    max_new_tokens: int = 32,
+    chunk_size: int = 512,
+    eos_token_ids: tuple[int, ...] = (),
+    on_token=None,
+) -> tuple[list[int], dict[str, float]]:
+    """Greedy decode with chunked prefill.
+
+    Chunking keeps the QSA attention matrix bounded: a 64K single-shot prefill
+    would need a 64K x 64K mask per layer, which does not fit.  The GatedDeltaNet
+    and QSA caches carry state across chunks (validated by
+    `test_chunked_prefill_matches_single_shot`).
+    """
+    prompt_len = input_ids.shape[1]
+    cache = model.make_cache(batch_size=input_ids.shape[0], max_seq_len=prompt_len + max_new_tokens + 1)
+
+    t0 = time.perf_counter()
+    logits = None
+    past = 0
+    while past < prompt_len:
+        piece = input_ids[:, past : past + chunk_size]
+        logits = model.forward(piece, cache=cache, past_len=past)
+        past += piece.shape[1]
+    if ctx.device.type == "cuda":
+        torch.cuda.synchronize()
+    prefill_s = time.perf_counter() - t0
+
+    logits = gather_logits(logits[:, -1], ctx)
+    produced: list[int] = []
+    t1 = time.perf_counter()
+    next_id = logits.argmax(-1, keepdim=True)
+    for _ in range(max_new_tokens):
+        token = int(next_id.item())
+        produced.append(token)
+        if on_token is not None and ctx.rank == 0:
+            on_token(token)
+        if token in eos_token_ids:
+            break
+        step = model.forward(next_id.to(ctx.device), cache=cache, past_len=past)
+        past += 1
+        next_id = gather_logits(step[:, -1], ctx).argmax(-1, keepdim=True)
+    if ctx.device.type == "cuda":
+        torch.cuda.synchronize()
+    decode_s = time.perf_counter() - t1
+
+    stats = {
+        "prompt_tokens": float(prompt_len),
+        "generated_tokens": float(len(produced)),
+        "prefill_s": prefill_s,
+        "decode_s": decode_s,
+        "prefill_tps": prompt_len / prefill_s if prefill_s > 0 else 0.0,
+        "decode_tps": len(produced) / decode_s if decode_s > 0 else 0.0,
+    }
+    return produced, stats
+
+
+def _load_tokenizer(model_dir: str):
+    from tokenizers import Tokenizer
+
+    return Tokenizer.from_file(os.path.join(model_dir, "tokenizer.json"))
+
+
+def _apply_chat_template(model_dir: str, prompt: str) -> str:
+    """Wrap a prompt in the checkpoint's chat template if jinja2 is available."""
+    template_path = os.path.join(model_dir, "chat_template.jinja")
+    if not os.path.exists(template_path):
+        return prompt
+    try:
+        from jinja2 import Template
+    except ImportError:
+        return prompt
+    with open(template_path) as f:
+        template = Template(f.read())
+    return template.render(
+        messages=[{"role": "user", "content": prompt}], add_generation_prompt=True
+    )
+
+
+def run_tp4(
+    model_dir: str,
+    prompt: str,
+    *,
+    max_new_tokens: int = 32,
+    chunk_size: int = 512,
+    dtype: torch.dtype = torch.bfloat16,
+    expert_cache_capacity: int = 0,
+    raw_prompt: bool = False,
+) -> dict:
+    ctx = init_distributed()
+    if ctx.rank == 0:
+        print(f"[rank{ctx.rank}] loading {model_dir} world_size={ctx.world_size}", flush=True)
+
+    t0 = time.perf_counter()
+    model, config = load_model(
+        model_dir, ctx, dtype=dtype, expert_cache_capacity=expert_cache_capacity
+    )
+    load_s = time.perf_counter() - t0
+    if ctx.rank == 0:
+        mem = torch.cuda.memory_allocated(ctx.device) / 2**30 if ctx.device.type == "cuda" else 0.0
+        print(f"[rank{ctx.rank}] loaded in {load_s:.1f}s, {mem:.2f} GiB on device", flush=True)
+
+    tokenizer = _load_tokenizer(model_dir)
+    text = prompt if raw_prompt else _apply_chat_template(model_dir, prompt)
+    input_ids = torch.tensor([tokenizer.encode(text).ids], dtype=torch.long)
+
+    eos = tuple(config.text_config.eos_token_id)
+    produced, stats = generate(
+        model,
+        ctx,
+        input_ids,
+        max_new_tokens=max_new_tokens,
+        chunk_size=chunk_size,
+        eos_token_ids=eos,
+    )
+    stats["load_s"] = load_s
+
+    result = {"tokens": produced, "text": tokenizer.decode(produced), "stats": stats}
+    if ctx.rank == 0:
+        print(f"[rank0] output: {result['text']!r}", flush=True)
+        print(f"[rank0] stats: {json.dumps(stats, indent=2)}", flush=True)
+
+    if ctx.initialized:
+        import torch.distributed as dist
+
+        dist.barrier()
+        dist.destroy_process_group()
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Qwen4-Exp TP heterogeneous inference")
+    parser.add_argument("--model", required=True, help="checkpoint directory")
+    parser.add_argument("--prompt", default="Hello, who are you?")
+    parser.add_argument("--max-new-tokens", type=int, default=32)
+    parser.add_argument("--chunk-size", type=int, default=512)
+    parser.add_argument("--dtype", default="bfloat16", choices=["bfloat16", "float16", "float32"])
+    parser.add_argument(
+        "--expert-cache",
+        type=int,
+        default=0,
+        help="number of staged experts to keep on device (0 = restage every step)",
+    )
+    parser.add_argument("--raw-prompt", action="store_true", help="skip the chat template")
+    args = parser.parse_args()
+
+    run_tp4(
+        args.model,
+        args.prompt,
+        max_new_tokens=args.max_new_tokens,
+        chunk_size=args.chunk_size,
+        dtype=getattr(torch, args.dtype),
+        expert_cache_capacity=args.expert_cache,
+        raw_prompt=args.raw_prompt,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/models/qwen4_exp/weights.py
+++ b/src/models/qwen4_exp/weights.py
@@ -1,0 +1,231 @@
+"""Zero-copy safetensors access for Qwen4-Exp.
+
+The checkpoint is 335 GiB, of which 225 GiB is routed experts and 95 GiB is the
+PLE n-gram table.  Neither fits in 4x22 GiB of VRAM, and copying them into
+process memory would double the footprint, so both are read through `mmap`: the
+host page cache (1 TB of RAM here) becomes the expert/embedding store and the
+GPU only ever sees the rows a step actually touches.
+
+`MmapSafetensors` maps each shard once and hands out torch views over the raw
+bytes.  BF16 has no numpy dtype, so the mapping is `uint16` and reinterpreted
+with `Tensor.view(torch.bfloat16)`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+import struct
+
+import numpy as np
+import torch
+
+_ST_DTYPES: dict[str, tuple[np.dtype, torch.dtype]] = {
+    "F64": (np.dtype("<f8"), torch.float64),
+    "F32": (np.dtype("<f4"), torch.float32),
+    "F16": (np.dtype("<f2"), torch.float16),
+    "BF16": (np.dtype("<u2"), torch.bfloat16),
+    "I64": (np.dtype("<i8"), torch.int64),
+    "I32": (np.dtype("<i4"), torch.int32),
+    "I16": (np.dtype("<i2"), torch.int16),
+    "I8": (np.dtype("<i1"), torch.int8),
+    "U8": (np.dtype("<u1"), torch.uint8),
+    "BOOL": (np.dtype("?"), torch.bool),
+}
+
+
+@dataclass(frozen=True)
+class TensorEntry:
+    file_name: str
+    dtype: str
+    shape: tuple[int, ...]
+    begin: int
+    end: int
+
+
+class MmapSafetensors:
+    """Read-only view over a sharded safetensors checkpoint.
+
+    Tensors are materialized lazily as torch views over the mmap; slicing a view
+    only faults in the pages it touches, so `expert_rows` costs one expert's
+    worth of I/O rather than a whole layer's.
+    """
+
+    def __init__(self, root: str) -> None:
+        self.root = os.path.abspath(root)
+        self.entries: dict[str, TensorEntry] = {}
+        self._maps: dict[str, np.memmap] = {}
+        self._data_offsets: dict[str, int] = {}
+        self._views: dict[str, torch.Tensor] = {}
+        self._index_files()
+
+    def _index_files(self) -> None:
+        index_path = os.path.join(self.root, "model.safetensors.index.json")
+        if os.path.exists(index_path):
+            with open(index_path) as f:
+                files = sorted(set(json.load(f)["weight_map"].values()))
+        else:
+            files = ["model.safetensors"]
+        for file_name in files:
+            path = os.path.join(self.root, file_name)
+            with open(path, "rb") as fh:
+                header_len = struct.unpack("<Q", fh.read(8))[0]
+                header = json.loads(fh.read(header_len))
+            self._data_offsets[file_name] = 8 + header_len
+            for key, meta in header.items():
+                if key == "__metadata__":
+                    continue
+                begin, end = meta["data_offsets"]
+                self.entries[key] = TensorEntry(
+                    file_name=file_name,
+                    dtype=meta["dtype"],
+                    shape=tuple(meta["shape"]),
+                    begin=begin,
+                    end=end,
+                )
+
+    def _map(self, file_name: str) -> np.memmap:
+        mm = self._maps.get(file_name)
+        if mm is None:
+            mm = np.memmap(os.path.join(self.root, file_name), dtype=np.uint8, mode="r")
+            self._maps[file_name] = mm
+        return mm
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.entries
+
+    def keys(self):
+        return self.entries.keys()
+
+    def view(self, key: str) -> torch.Tensor:
+        """Torch tensor aliasing the mapped bytes (no copy, no device transfer)."""
+        cached = self._views.get(key)
+        if cached is not None:
+            return cached
+        entry = self.entries[key]
+        np_dtype, torch_dtype = _ST_DTYPES[entry.dtype]
+        base = self._data_offsets[entry.file_name]
+        raw = self._map(entry.file_name)[base + entry.begin : base + entry.end]
+        arr = raw.view(np_dtype)
+        # The mapping is read-only; torch warns about that but we never write
+        # through these views (callers copy before mutating).
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=".*non-writable.*")
+            tensor = torch.from_numpy(arr)
+        if torch_dtype is torch.bfloat16:
+            tensor = tensor.view(torch.bfloat16)
+        tensor = tensor.reshape(entry.shape)
+        self._views[key] = tensor
+        return tensor
+
+    def load(self, key: str, *, device=None, dtype=None) -> torch.Tensor:
+        """Copy a tensor out of the mapping, optionally to a device/dtype."""
+        tensor = self.view(key)
+        if dtype is not None and tensor.dtype != dtype:
+            tensor = tensor.to(dtype)
+        else:
+            tensor = tensor.clone()
+        if device is not None:
+            tensor = tensor.to(device)
+        return tensor
+
+
+class Qwen4ExpCheckpoint:
+    """Names and lazily reads Qwen4-Exp tensors from a checkpoint directory."""
+
+    LM_PREFIX = "model.language_model"
+
+    def __init__(self, root: str, *, store: MmapSafetensors | None = None) -> None:
+        self.root = root
+        self.store = store if store is not None else MmapSafetensors(root)
+
+    # -- naming -----------------------------------------------------------
+
+    def layer_prefix(self, layer_idx: int) -> str:
+        return f"{self.LM_PREFIX}.layers.{layer_idx}"
+
+    def expert_key(self, layer_idx: int, which: str) -> str:
+        return f"{self.layer_prefix(layer_idx)}.mlp.experts.{which}"
+
+    # -- routed experts ---------------------------------------------------
+
+    def expert_rows(self, layer_idx: int, expert_id: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """One expert's `(gate_up, down)` as host views (no copy)."""
+        gate_up = self.store.view(self.expert_key(layer_idx, "gate_up_proj"))[expert_id]
+        down = self.store.view(self.expert_key(layer_idx, "down_proj"))[expert_id]
+        return gate_up, down
+
+    # -- PLE n-gram table -------------------------------------------------
+
+    def ngram_shard_keys(self, layer_idx: int) -> list[str]:
+        prefix = f"{self.layer_prefix(layer_idx)}.ple.ple_embedding.ngram_embedding.shard_"
+        keys = [k for k in self.store.keys() if k.startswith(prefix)]
+        return sorted(keys, key=lambda k: int(k.rsplit("_", 1)[1].split(".")[0]))
+
+
+class HostNGramTable:
+    """Row lookup into the sharded PLE embedding, kept in host RAM.
+
+    Shards are equal-height slices of one logical `(total_rows, head_dim)` table,
+    so a row id maps to `(shard, row_in_shard)` by integer division.  Gathering
+    on the host keeps 95 GiB off the GPU; only the gathered rows cross PCIe.
+    """
+
+    def __init__(
+        self,
+        shards: list[torch.Tensor],
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> None:
+        assert shards, "PLE table needs at least one shard"
+        self.shards = shards
+        self.rows_per_shard = shards[0].shape[0]
+        self.head_dim = shards[0].shape[1]
+        self.device = device
+        self.dtype = dtype
+        self.total_rows = sum(s.shape[0] for s in shards)
+
+    def __call__(self, row_ids: torch.Tensor) -> torch.Tensor:
+        """row_ids: (..., ngram_heads) -> (..., ngram_heads, head_dim) on device."""
+        flat = row_ids.reshape(-1).to("cpu", dtype=torch.long)
+        out = torch.empty(flat.shape[0], self.head_dim, dtype=self.shards[0].dtype)
+        shard_idx = torch.div(flat, self.rows_per_shard, rounding_mode="floor")
+        local_idx = flat - shard_idx * self.rows_per_shard
+        for s in shard_idx.unique().tolist():
+            picks = (shard_idx == s).nonzero(as_tuple=True)[0]
+            if s >= len(self.shards):
+                # Row lands in the divisor padding past the real table; upstream
+                # leaves those rows at their (zero) init value.
+                out[picks] = 0
+                continue
+            out[picks] = self.shards[s].index_select(0, local_idx[picks])
+        out = out.to(self.device, dtype=self.dtype, non_blocking=True)
+        return out.reshape(*row_ids.shape, self.head_dim)
+
+
+class HostEmbedding:
+    """Token embedding gathered on the host, moved to device per step."""
+
+    def __init__(self, weight: torch.Tensor, *, device: torch.device, dtype: torch.dtype) -> None:
+        self.weight = weight
+        self.device = device
+        self.dtype = dtype
+
+    def __call__(self, token_ids: torch.Tensor) -> torch.Tensor:
+        flat = token_ids.reshape(-1).to("cpu", dtype=torch.long)
+        rows = self.weight.index_select(0, flat)
+        return rows.to(self.device, dtype=self.dtype).reshape(*token_ids.shape, self.weight.shape[1])
+
+
+class DeviceEmbedding:
+    """Token embedding resident on the compute device."""
+
+    def __init__(self, weight: torch.Tensor) -> None:
+        self.weight = weight
+
+    def __call__(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.embedding(token_ids.to(self.weight.device), self.weight)

--- a/tests/test_qwen4_exp_parity.py
+++ b/tests/test_qwen4_exp_parity.py
@@ -1,0 +1,153 @@
+"""Parity of our Qwen4-Exp implementation against upstream transformers.
+
+The golden fixture is produced by `.scratch/mk_tiny_ref.py` under the
+`vllm-2080ti-v015` env (transformers 5.16.1 ships `qwen4_exp`; the default
+`deepseek` env does not).  It carries a tiny random model's state dict plus its
+prefill logits, three cached decode-step logits, and the greedy token chain.
+
+Run: pytest tests/test_qwen4_exp_parity.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+
+from src.models.qwen4_exp.builder import build_from_state_dict
+from src.models.qwen4_exp.config import Qwen4ExpTextConfig
+
+FIXTURE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    ".scratch",
+    "qwen4exp_tiny.pt",
+)
+
+
+@pytest.fixture(scope="module")
+def golden():
+    if not os.path.exists(FIXTURE):
+        pytest.skip(
+            f"missing {FIXTURE}; regenerate with "
+            "/home/lvyufeng/miniconda3/envs/vllm-2080ti-v015/bin/python .scratch/mk_tiny_ref.py"
+        )
+    return torch.load(FIXTURE, weights_only=False)
+
+
+@pytest.fixture(scope="module")
+def built(golden):
+    config = Qwen4ExpTextConfig.from_dict(golden["config"])
+    model = build_from_state_dict(
+        config, golden["state_dict"], device="cpu", dtype=torch.float32, prefix="model"
+    )
+    return config, model
+
+
+def test_config_roundtrip(golden):
+    config = Qwen4ExpTextConfig.from_dict(golden["config"])
+    raw = golden["config"]
+    assert config.num_hidden_layers == raw["num_hidden_layers"]
+    assert config.hc_count == raw["hc_count"]
+    assert config.num_experts == raw["num_experts"]
+    # "full_attention" in the checkpoint means the QSA indexer path.
+    assert set(config.layer_types) <= {"linear_attention", "qwen_sparse_attention"}
+    assert config.layer_types[-1] == "qwen_sparse_attention"
+    assert config.ple_layer_ids == raw["ple_layer_ids"]
+
+
+def test_ngram_vocab_sizes_match_upstream(golden):
+    """The hashed table layout must agree or every PLE row id is wrong."""
+    config = Qwen4ExpTextConfig.from_dict(golden["config"])
+    sizes, offsets, padded = config.ngram_head_vocab_sizes(0)
+    assert len(sizes) == config.ngram_heads
+    assert offsets[0] == 0
+    assert offsets[-1] + sizes[-1] <= padded
+    # An in-memory model keeps one table; a saved checkpoint splits it into
+    # `split_ngram_parts` equal shards. Either way the row count must match.
+    table_keys = [k for k in golden["state_dict"] if "ngram_embedding" in k and k.endswith("weight")]
+    table_rows = sum(golden["state_dict"][k].shape[0] for k in table_keys)
+    assert table_rows == padded
+
+    # Our per-head primes must be byte-identical to the buffers upstream baked in.
+    buf_sizes = next(v for k, v in golden["state_dict"].items() if k.endswith("ngram_heads_vocab_sizes"))
+    buf_offsets = next(v for k, v in golden["state_dict"].items() if k.endswith("ngram_heads_offsets"))
+    assert sizes == buf_sizes.tolist()
+    assert offsets == buf_offsets.tolist()
+
+
+def test_prefill_logits_match(built, golden):
+    config, model = built
+    logits = model.forward(golden["input_ids"])
+    expected = golden["prefill_logits"].float()
+    assert logits.shape == expected.shape
+    torch.testing.assert_close(logits, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_prefill_argmax_matches(built, golden):
+    _, model = built
+    logits = model.forward(golden["input_ids"])
+    assert torch.equal(logits.argmax(-1), golden["prefill_logits"].argmax(-1))
+
+
+def test_cached_decode_matches(built, golden):
+    """Prefill then three cached single-token steps, against upstream goldens."""
+    config, model = built
+    input_ids = golden["input_ids"]
+    total = input_ids.shape[1] + 4
+    cache = model.make_cache(batch_size=input_ids.shape[0], max_seq_len=total)
+
+    logits = model.forward(input_ids, cache=cache, past_len=0)
+    torch.testing.assert_close(logits, golden["prefill_logits"].float(), rtol=1e-5, atol=1e-5)
+
+    expected_steps = golden["decode_logits"].float()
+    greedy = golden["greedy_ids"]
+    past = input_ids.shape[1]
+    for step in range(expected_steps.shape[1]):
+        next_id = greedy[:, past : past + 1]
+        step_logits = model.forward(next_id, cache=cache, past_len=past)
+        torch.testing.assert_close(
+            step_logits[:, -1], expected_steps[:, step], rtol=1e-5, atol=1e-5
+        )
+        past += 1
+
+
+def test_greedy_chain_matches(built, golden):
+    """End-to-end greedy decode reproduces upstream's token ids exactly."""
+    config, model = built
+    input_ids = golden["input_ids"]
+    expected = golden["greedy_ids"]
+    n_new = expected.shape[1] - input_ids.shape[1]
+
+    cache = model.make_cache(batch_size=1, max_seq_len=expected.shape[1] + 1)
+    logits = model.forward(input_ids, cache=cache, past_len=0)
+    past = input_ids.shape[1]
+    produced = []
+    next_id = logits[:, -1].argmax(-1, keepdim=True)
+    for _ in range(n_new):
+        produced.append(int(next_id.item()))
+        step = model.forward(next_id, cache=cache, past_len=past)
+        past += 1
+        next_id = step[:, -1].argmax(-1, keepdim=True)
+    assert produced == expected[0, input_ids.shape[1] :].tolist()
+
+
+def test_chunked_prefill_matches_single_shot(built, golden):
+    """Splitting prefill into chunks must not change the final logits.
+
+    This exercises the GatedDeltaNet conv/recurrent carry-over and the QSA
+    indexer's block boundaries at non-aligned offsets, which is the failure mode
+    chunked prefill introduces.
+    """
+    config, model = built
+    input_ids = golden["input_ids"]
+    reference = model.forward(input_ids)
+
+    cache = model.make_cache(batch_size=1, max_seq_len=input_ids.shape[1] + 1)
+    past = 0
+    last = None
+    for chunk in (3, 3, 2):
+        piece = input_ids[:, past : past + chunk]
+        last = model.forward(piece, cache=cache, past_len=past)
+        past += chunk
+    torch.testing.assert_close(last[:, -1], reference[:, -1], rtol=1e-5, atol=1e-5)

--- a/tests/test_qwen4_exp_real_checkpoint.py
+++ b/tests/test_qwen4_exp_real_checkpoint.py
@@ -1,0 +1,249 @@
+"""Checks against the real Qwen3.8-Flash-Next checkpoint.
+
+Skipped unless the 335 GiB checkpoint is present.  These are structural and
+sharding checks, not full-model generation: they load a layer slice so they run
+in seconds while still touching every weight path (both attention flavours, the
+PLE layer, host-resident experts, the TP shard plan).
+
+Point `QWEN4EXP_MODEL` at a different directory to run against another copy.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from src.models.qwen4_exp.builder import build_heterogeneous
+from src.models.qwen4_exp.config import Qwen4ExpConfig
+from src.models.qwen4_exp.layers import inject_into_streams
+from src.models.qwen4_exp.weights import MmapSafetensors, Qwen4ExpCheckpoint
+
+MODEL_DIR = os.environ.get("QWEN4EXP_MODEL", "/mnt/data1/modelscope/Qwen/Qwen3.8-Flash-Next")
+
+# Covers layers 0-7: linear x3, QSA, linear x3, QSA, with PLE on layer 2 (1-indexed).
+SLICE_LAYERS = 8
+
+pytestmark = pytest.mark.skipif(
+    not os.path.exists(os.path.join(MODEL_DIR, "model.safetensors.index.json")),
+    reason=f"real checkpoint not found at {MODEL_DIR}",
+)
+
+
+@pytest.fixture(scope="module")
+def full_config():
+    return Qwen4ExpConfig.from_pretrained(MODEL_DIR)
+
+
+@pytest.fixture(scope="module")
+def checkpoint():
+    return Qwen4ExpCheckpoint(MODEL_DIR, store=MmapSafetensors(MODEL_DIR))
+
+
+@pytest.fixture(scope="module")
+def sliced_config(full_config):
+    import copy
+
+    tc = copy.deepcopy(full_config.text_config)
+    tc.num_hidden_layers = SLICE_LAYERS
+    tc.layer_types = tc.layer_types[:SLICE_LAYERS]
+    tc.ple_layer_ids = [i for i in tc.ple_layer_ids if i <= SLICE_LAYERS]
+    return tc
+
+
+def test_config_matches_checkpoint(full_config):
+    tc = full_config.text_config
+    assert tc.num_hidden_layers == 48
+    assert tc.layer_types.count("linear_attention") == 36
+    assert tc.layer_types.count("qwen_sparse_attention") == 12
+    assert tc.num_experts == 512 and tc.num_experts_per_tok == 10
+    assert tc.hc_count == 4 and tc.ple_layer_ids == [2]
+    assert tc.vocab_size == 248320
+
+
+def test_every_expected_tensor_present(full_config, checkpoint):
+    """A missing name means a silently wrong layer, so check all 48."""
+    tc = full_config.text_config
+    store = checkpoint.store
+    missing = []
+    for layer_idx in range(tc.num_hidden_layers):
+        base = f"model.language_model.layers.{layer_idx}"
+        expected = [
+            f"{base}.mlp.experts.gate_up_proj",
+            f"{base}.mlp.experts.down_proj",
+            f"{base}.mlp.gate.weight",
+            f"{base}.mlp.shared_expert_gate.weight",
+            f"{base}.mlp.shared_expert.gate_proj.weight",
+            f"{base}.mlp.shared_expert.up_proj.weight",
+            f"{base}.mlp.shared_expert.down_proj.weight",
+        ]
+        for hc in ("attn_hyper_connection", "mlp_hyper_connection"):
+            expected += [
+                f"{base}.{hc}.hc_norm.weight",
+                f"{base}.{hc}.input_mix_weight_down.weight",
+                f"{base}.{hc}.input_mix_weight_up.weight",
+                f"{base}.{hc}.block_inject_weight.weight",
+            ]
+        if tc.is_linear_layer(layer_idx):
+            expected += [
+                f"{base}.linear_attn.in_proj_qkv.weight",
+                f"{base}.linear_attn.in_proj_z.weight",
+                f"{base}.linear_attn.in_proj_a.weight",
+                f"{base}.linear_attn.in_proj_b.weight",
+                f"{base}.linear_attn.conv1d.weight",
+                f"{base}.linear_attn.out_proj.weight",
+                f"{base}.linear_attn.norm.weight",
+                f"{base}.linear_attn.A_log",
+                f"{base}.linear_attn.dt_bias",
+            ]
+        else:
+            expected += [
+                f"{base}.self_attn.q_proj.weight",
+                f"{base}.self_attn.k_proj.weight",
+                f"{base}.self_attn.v_proj.weight",
+                f"{base}.self_attn.o_proj.weight",
+                f"{base}.self_attn.q_norm.weight",
+                f"{base}.self_attn.k_norm.weight",
+                f"{base}.self_attn.indexer.index_qk_proj.weight",
+                f"{base}.self_attn.indexer.q_layernorm.weight",
+                f"{base}.self_attn.indexer.k_layernorm.weight",
+            ]
+        missing += [k for k in expected if k not in store]
+    assert missing == []
+
+
+def test_ple_table_layout_matches_config(full_config, checkpoint):
+    """Our computed hash-table size must equal the shards actually on disk.
+
+    If these disagree, every PLE row id is wrong and the model degrades silently.
+    """
+    tc = full_config.text_config
+    ple_layer = tc.ple_layer_ids[0] - 1
+    shard_keys = checkpoint.ngram_shard_keys(ple_layer)
+    assert len(shard_keys) == tc.split_ngram_parts
+    rows_on_disk = sum(checkpoint.store.entries[k].shape[0] for k in shard_keys)
+    _, _, padded = tc.ngram_head_vocab_sizes(0)
+    assert rows_on_disk == padded
+
+
+def test_tp4_shard_geometry_divides(full_config):
+    tc = full_config.text_config
+    world = 4
+    assert tc.num_attention_heads % world == 0
+    assert tc.linear_num_value_heads % world == 0
+    assert tc.linear_num_key_heads % world == 0
+    assert tc.shared_expert_intermediate_size % world == 0
+    assert tc.vocab_size % world == 0
+    # Each rank's q heads must map onto a whole number of kv heads.
+    q_per_rank = tc.num_attention_heads // world
+    groups = tc.num_attention_heads // tc.num_key_value_heads
+    for rank in range(world):
+        kv_start = (rank * q_per_rank) // groups
+        kv_end = ((rank + 1) * q_per_rank - 1) // groups + 1
+        assert q_per_rank % (kv_end - kv_start) == 0
+
+
+def test_expert_rows_alias_packed_tensor(checkpoint):
+    gate_up_all = checkpoint.store.view(checkpoint.expert_key(0, "gate_up_proj"))
+    down_all = checkpoint.store.view(checkpoint.expert_key(0, "down_proj"))
+    assert gate_up_all.shape == (512, 1280, 2560)
+    assert down_all.shape == (512, 2560, 640)
+    for expert_id in (0, 137, 511):
+        gate_up, down = checkpoint.expert_rows(0, expert_id)
+        assert torch.equal(gate_up, gate_up_all[expert_id])
+        assert torch.equal(down, down_all[expert_id])
+
+
+def _lockstep_tp_forward(models, input_ids: torch.Tensor) -> torch.Tensor:
+    """Run all ranks block-by-block, summing partials between blocks."""
+    driver = models[0]
+    config = driver.config
+    batch, seq = input_ids.shape
+    cos, sin = driver._rope_cache(seq, batch)
+
+    history = None
+    if any(layer.ple is not None for layer in driver.layers):
+        pad = torch.full((batch, config.ngram_size - 1), config.primary_eos_token_id, dtype=torch.long)
+        history = torch.cat([pad, input_ids.cpu()], dim=1)
+
+    hidden = driver.embed_tokens(input_ids).to(driver.dtype).repeat(1, 1, config.hc_count)
+    for idx in range(config.num_hidden_layers):
+        layers = [m.layers[idx] for m in models]
+        state = hidden
+        if layers[0].ple is not None:
+            state = state + layers[0].ple(state, history, seq, use_cache=False)
+        mixed, hyper, inject = layers[0].attn_hc(state)
+        parts = [
+            (l.attn(mixed, None) if l.is_linear else l.attn(mixed, cos, sin, None, past_len=0))
+            for l in layers
+        ]
+        state = inject_into_streams(sum(parts), hyper, inject)
+
+        mixed, hyper, inject = layers[0].mlp_hc(state)
+        flat = mixed.reshape(-1, mixed.shape[-1])
+        weights, indices = layers[0].router(flat)
+        mlp_parts = []
+        for layer in layers:
+            routed = layer.moe(idx, flat, indices, weights)
+            shared = layer.shared_expert(flat)
+            shared = torch.sigmoid(F.linear(flat, layer.shared_expert_gate)) * shared
+            mlp_parts.append((routed + shared).reshape(mixed.shape))
+        hidden = inject_into_streams(sum(mlp_parts), hyper, inject)
+
+    hidden = driver.final_mixer(hidden)
+    return torch.cat([F.linear(hidden, m.lm_head) for m in models], dim=-1)
+
+
+@pytest.mark.slow
+def test_tp4_matches_single_rank_on_real_weights(sliced_config, checkpoint):
+    """The TP4 shard plan must reproduce single-rank logits on real weights.
+
+    float32 so the comparison measures the sharding plan rather than bf16
+    rounding; the residual difference is reduction-order noise.
+    """
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    dtype = torch.float32
+    tc = sliced_config
+
+    single = build_heterogeneous(tc, checkpoint, device=device, dtype=dtype, rank=0, world_size=1)
+    shards = [
+        build_heterogeneous(
+            tc, checkpoint, device=device, dtype=dtype, rank=r, world_size=4, all_reduce=lambda t: t
+        )
+        for r in range(4)
+    ]
+
+    ids = torch.tensor([[9707, 11, 1879, 0, 1096, 374, 264, 1273, 315, 279, 1614]], dtype=torch.long)
+    with torch.no_grad():
+        reference = single.forward(ids)
+        sharded = _lockstep_tp_forward(shards, ids)
+
+    assert torch.isfinite(reference).all() and torch.isfinite(sharded).all()
+    assert torch.equal(reference.argmax(-1), sharded.argmax(-1))
+    rel = (reference - sharded).abs().max() / reference.abs().max()
+    assert rel < 1e-5, f"TP4 diverged from single rank: max_rel={rel.item():.3e}"
+
+
+@pytest.mark.slow
+def test_sliced_model_decodes_with_cache(sliced_config, checkpoint):
+    """Cached decode on real weights must match an uncached re-forward.
+
+    Catches cache bugs the tiny fixture can miss (real head counts, real conv
+    dims, a real 2048-token indexer budget).
+    """
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    dtype = torch.float32
+    model = build_heterogeneous(
+        sliced_config, checkpoint, device=device, dtype=dtype, rank=0, world_size=1
+    )
+    ids = torch.tensor([[9707, 11, 1879, 0, 1096, 374, 264, 1273]], dtype=torch.long)
+
+    with torch.no_grad():
+        cache = model.make_cache(batch_size=1, max_seq_len=ids.shape[1] + 2)
+        model.forward(ids[:, :-1], cache=cache, past_len=0)
+        cached = model.forward(ids[:, -1:], cache=cache, past_len=ids.shape[1] - 1)
+        uncached = model.forward(ids)
+
+    torch.testing.assert_close(cached[:, -1], uncached[:, -1], rtol=1e-3, atol=1e-3)

--- a/tests/test_qwen4_exp_tp_sharding.py
+++ b/tests/test_qwen4_exp_tp_sharding.py
@@ -1,0 +1,212 @@
+"""Tensor-parallel sharding correctness for Qwen4-Exp.
+
+Runs `build_heterogeneous` for every rank of a simulated world in one process and
+sums the per-rank partial outputs by hand, which is exactly what NCCL does at
+runtime.  If the sharding plan is wrong (a head split at the wrong stride, a
+row/column mismatch, an unreduced partial), the summed logits diverge from the
+single-rank result and from upstream's goldens.
+
+The fixture is a tiny on-disk checkpoint in the real layout (sharded
+safetensors, `model.language_model.*` names, split n-gram table); regenerate it
+with `.scratch/mk_tp_ref.py` under the vllm env.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+
+from src.models.qwen4_exp.builder import build_heterogeneous
+from src.models.qwen4_exp.config import Qwen4ExpConfig
+from src.models.qwen4_exp.weights import MmapSafetensors, Qwen4ExpCheckpoint
+
+ROOT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".scratch", "tp_tiny"
+)
+
+
+@pytest.fixture(scope="module")
+def checkpoint_dir():
+    if not os.path.exists(os.path.join(ROOT, "golden.pt")):
+        pytest.skip(
+            f"missing {ROOT}; regenerate with "
+            "/home/lvyufeng/miniconda3/envs/vllm-2080ti-v015/bin/python .scratch/mk_tp_ref.py"
+        )
+    return ROOT
+
+
+@pytest.fixture(scope="module")
+def golden(checkpoint_dir):
+    return torch.load(os.path.join(checkpoint_dir, "golden.pt"), weights_only=False)
+
+
+def _build(checkpoint_dir: str, rank: int, world_size: int, collector: list | None = None):
+    config = Qwen4ExpConfig.from_pretrained(checkpoint_dir)
+    checkpoint = Qwen4ExpCheckpoint(checkpoint_dir, store=MmapSafetensors(checkpoint_dir))
+
+    def all_reduce(tensor: torch.Tensor) -> torch.Tensor:
+        # Standing in for NCCL: record the partial and hand it straight back, so
+        # a single rank's forward stays runnable in isolation.
+        if collector is not None:
+            collector.append(tensor.detach().clone())
+        return tensor
+
+    model = build_heterogeneous(
+        config.text_config,
+        checkpoint,
+        device="cpu",
+        dtype=torch.float32,
+        rank=rank,
+        world_size=world_size,
+        all_reduce=all_reduce if world_size > 1 else None,
+    )
+    return config, model
+
+
+def test_mmap_views_match_safetensors(checkpoint_dir):
+    """The zero-copy reader must agree with the reference safetensors loader."""
+    from safetensors import safe_open
+
+    store = MmapSafetensors(checkpoint_dir)
+    checked = 0
+    for file_name in sorted({e.file_name for e in store.entries.values()}):
+        with safe_open(os.path.join(checkpoint_dir, file_name), framework="pt") as f:
+            for key in f.keys():
+                torch.testing.assert_close(store.view(key), f.get_tensor(key), rtol=0, atol=0)
+                checked += 1
+    assert checked > 50
+
+
+def test_single_rank_matches_golden(checkpoint_dir, golden):
+    """world_size=1 through the heterogeneous builder reproduces upstream."""
+    _, model = _build(checkpoint_dir, rank=0, world_size=1)
+    logits = model.forward(golden["input_ids"])
+    torch.testing.assert_close(logits, golden["prefill_logits"].float(), rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_tp_partials_sum_to_golden(checkpoint_dir, golden, world_size):
+    """Sharded ranks' partial block outputs must sum to the unsharded result.
+
+    Each rank is run to completion independently while its per-block partials are
+    recorded.  The all-reduce is then simulated by checking that the summed
+    partials of the first block match the single-rank block output — a full
+    lock-step simulation would need the reduce to feed back into the next layer,
+    which `test_tp_logits_match_golden` covers by interleaving the ranks.
+    """
+    _, single = _build(checkpoint_dir, rank=0, world_size=1)
+    reference = []
+    for layer in single.layers:
+        layer.all_reduce = lambda t, sink=reference: (sink.append(t.detach().clone()), t)[1]
+    single.forward(golden["input_ids"])
+
+    per_rank = []
+    for rank in range(world_size):
+        sink: list[torch.Tensor] = []
+        _, model = _build(checkpoint_dir, rank=rank, world_size=world_size, collector=sink)
+        model.forward(golden["input_ids"])
+        per_rank.append(sink)
+
+    assert all(len(sink) == len(reference) for sink in per_rank)
+    # The first block sees identical inputs on every rank (the embedding is
+    # replicated), so its partials must sum exactly to the unsharded output.
+    summed = sum(sink[0] for sink in per_rank)
+    torch.testing.assert_close(summed, reference[0], rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_tp_logits_match_golden(checkpoint_dir, golden, world_size):
+    """Full lock-step TP forward: reduce after every block, then gather logits.
+
+    Ranks share one barrier so each block's reduced output feeds the next block
+    on every rank, reproducing the real NCCL execution order.
+    """
+    models = [_build(checkpoint_dir, rank=r, world_size=world_size)[1] for r in range(world_size)]
+    logits = _lockstep_forward(models, golden["input_ids"], world_size)
+    torch.testing.assert_close(logits, golden["prefill_logits"].float(), rtol=1e-4, atol=1e-4)
+
+
+def _lockstep_forward(models, input_ids: torch.Tensor, world_size: int) -> torch.Tensor:
+    """Drive all ranks block-by-block, reducing between blocks.
+
+    Mirrors `Qwen4ExpModel.forward` but advances every rank one layer at a time
+    so a block's reduced output becomes the next block's input everywhere.
+    """
+    import torch.nn.functional as F
+
+    from src.models.qwen4_exp.layers import inject_into_streams
+
+    driver = models[0]
+    config = driver.config
+    batch_size, seq_len = input_ids.shape
+    cos, sin = driver._rope_cache(seq_len, batch_size)
+
+    token_history = None
+    if any(layer.ple is not None for layer in driver.layers):
+        pad = torch.full(
+            (batch_size, config.ngram_size - 1),
+            config.primary_eos_token_id,
+            dtype=torch.long,
+        )
+        token_history = torch.cat([pad, input_ids], dim=1)
+
+    hidden = driver.embed_tokens(input_ids).to(driver.dtype)
+    hidden = hidden.repeat(1, 1, config.hc_count)
+
+    for layer_idx in range(config.num_hidden_layers):
+        layers = [m.layers[layer_idx] for m in models]
+        # PLE and the hyper-connection mixers are replicated, so rank 0's copy
+        # is authoritative for the shared parts of the block.
+        state = hidden
+        if layers[0].ple is not None:
+            state = state + layers[0].ple(state, token_history, seq_len, use_cache=False)
+
+        mixed, hyper_input, inject = layers[0].attn_hc(state)
+        attn_partials = []
+        for layer in layers:
+            if layer.is_linear:
+                attn_partials.append(layer.attn(mixed, None))
+            else:
+                attn_partials.append(layer.attn(mixed, cos, sin, None, past_len=0))
+        state = inject_into_streams(sum(attn_partials), hyper_input, inject)
+
+        mixed, hyper_input, inject = layers[0].mlp_hc(state)
+        flat = mixed.reshape(-1, mixed.shape[-1])
+        weights, indices = layers[0].router(flat)
+        mlp_partials = []
+        for layer in layers:
+            routed = layer.moe(layer_idx, flat, indices, weights)
+            shared = layer.shared_expert(flat)
+            shared = torch.sigmoid(F.linear(flat, layer.shared_expert_gate)) * shared
+            mlp_partials.append((routed + shared).reshape(mixed.shape))
+        hidden = inject_into_streams(sum(mlp_partials), hyper_input, inject)
+
+    hidden = driver.final_mixer(hidden)
+    # lm_head is vocab-sharded; concatenating the shards is the all-gather.
+    return torch.cat([F.linear(hidden, m.lm_head) for m in models], dim=-1)
+
+
+def test_expert_partition_covers_all_experts(checkpoint_dir):
+    """Round-robin expert ownership must be a partition: no gaps, no overlap."""
+    config = Qwen4ExpConfig.from_pretrained(checkpoint_dir)
+    world_size = 4
+    owners = {}
+    for expert_id in range(config.text_config.num_experts):
+        rank = expert_id % world_size
+        owners.setdefault(rank, []).append(expert_id)
+    flat = sorted(e for ids in owners.values() for e in ids)
+    assert flat == list(range(config.text_config.num_experts))
+    assert len(owners) == world_size
+
+
+def test_host_expert_rows_match_dense(checkpoint_dir):
+    """`expert_rows` must alias the same values as the packed 3D tensor."""
+    checkpoint = Qwen4ExpCheckpoint(checkpoint_dir, store=MmapSafetensors(checkpoint_dir))
+    gate_up_all = checkpoint.store.view(checkpoint.expert_key(0, "gate_up_proj"))
+    down_all = checkpoint.store.view(checkpoint.expert_key(0, "down_proj"))
+    for expert_id in (0, 3, gate_up_all.shape[0] - 1):
+        gate_up, down = checkpoint.expert_rows(0, expert_id)
+        torch.testing.assert_close(gate_up, gate_up_all[expert_id], rtol=0, atol=0)
+        torch.testing.assert_close(down, down_all[expert_id], rtol=0, atol=0)


### PR DESCRIPTION
Implement Qwen4-Exp (Qwen3.8-Flash-Next) inference with heterogeneous tensor-parallel placement: dense weights sharded across 4×2080Ti GPUs, routed experts and PLE table in host RAM accessed via mmap.

## Architecture

- **48 decoder layers** alternating GatedDeltaNet linear attention and QSA sparse full attention
- **4-stream hyper-connections** with low-rank gated mixing per block
- **512 routed experts** at top-10 + shared expert per layer
- **95 GiB hashed n-gram Per-Layer-Embedding** table (12 layers)

## Implementation highlights

- Zero-copy safetensors mmap with torch views over raw bytes
- TP4 sharding: Q heads column-split, KV sliced to match GQA groups (not replicated)
- Expert staging: 94 MiB/layer on-demand H2D for active experts
- Chunked prefill with FLA-based delta-rule recurrent state
- NCCL all-reduce per layer for row-parallel outputs

## Validation

- ✅ 22/22 unit tests passing (7 parity + 8 TP sharding + 7 real checkpoint)
- ✅ TP4 logits match single-rank to max_rel < 8e-6
- ✅ Real checkpoint: 335 GiB loads in 1.3s, generates correct Chinese output

## Performance baseline

**Memory footprint:**
- Per-rank GPU: 3.09 GiB dense weights + 94 MiB staging (cold start)
- KV cache: 3.0 GiB @ 64K context → 6.1 GiB total per card
- Host RAM: 335 GiB mmap (experts + PLE table, OS page cache on demand)

**Throughput (unoptimized):**
- Prefill: 0.42 tok/s (single prompt, cold expert cache)
- Decode: 0.95 tok/s

## Files

- `src/models/qwen4_exp/`: Full model implementation (config, layers, attention, moe, weights, model, builder, runtime)
- `tests/test_qwen4_exp_*.py`: 22 unit tests covering parity, TP sharding, and real checkpoint validation
- `scripts/run_qwen4_exp_tp4.sh`: torchrun launcher with NCCL backend