### PR TITLE
Profile Qwen4-Exp heterogeneous TP4 bottlenecks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ This directory contains model-specific support notes, reproducible benchmark def
 - [DSpark speculative decoding](dspark.md)
 - [FlashMemory 1M context](FLASHMEMORY_1M_CONTEXT.md)
 - [MiniMax decode bottleneck analysis](minimax_decode_bottleneck_analysis.md)
+- [Qwen4-Exp performance analysis](qwen4_exp_performance.md)
 - [Qwen quantized KV cache at 65K (TG512)](qwen_kv_cache_65k_tg512.md)
 - [Phase 2 validation results](PHASE2_VALIDATION_RESULTS.md)
 

--- a/docs/qwen4_exp_performance.md
+++ b/docs/qwen4_exp_performance.md
@@ -1,0 +1,111 @@
+# Qwen4-Exp 异构 TP4 性能分析
+
+**日期**：2026-08-28
+**硬件**：4×RTX 2080 Ti（TP4，PCIe Gen3）
+**模型**：Qwen3.8-Flash-Next，真实 checkpoint 位于
+`/mnt/data1/modelscope/Qwen/Qwen3.8-Flash-Next`
+
+## 模型和测量方法
+
+真实配置为 48 层、hidden size 2560、512 个 routed experts、top-10，单个
+BF16 expert 为 9.38 MiB，全 expert 集合约 225 GiB。routed experts 和 PLE
+表通过 mmap 保留在 host，active experts 按需复制到各 GPU。
+
+运行时通过 `--profile` 开启层级 profiler；加入
+`DSV4_QWEN4_MOE_PHASE_PROFILE=1` 后，额外统计 expert staging 和计算时间。
+完整的 staging 微基准可以运行：
+
+```bash
+PYTHONPATH=. python tests/bench_qwen4_exp_staging.py
+```
+
+## 实测基线
+
+以下是 clean run（不启用 profiler）的结果：
+
+| 场景 | chunk | expert cache | prefill | decode |
+|---|---:|---:|---:|---:|
+| 60-token prompt，32-token generation | 512 | 64 | 6.78 tok/s | 1.05 tok/s |
+| 60-token prompt，32-token generation | 512 | 1024 | 6.73 tok/s | **2.75 tok/s** |
+| 570-token prompt，1-token generation | 512 | 64 | 32.6 tok/s | — |
+| 4162-token prompt，1-token generation | 512 | 64 | 38.1 tok/s | — |
+| 4162-token prompt，1-token generation | 4096 | 64 | **151.4 tok/s** | — |
+| 8272-token prompt，1-token generation | 8192 | 64 | **244.1 tok/s** | — |
+
+因此，早先的 0.42/0.95 tok/s 组合不应作为模型能力基线：它对应很短
+生成、chunk=512 和较小 expert cache。长 prefill 的 chunk 大小和 decode
+的 cache 容量必须一起记录。
+
+## 瓶颈结论
+
+### Prefill
+
+60-token profile 的 48 层累计时间中，MoE 占 68.8%，NCCL MLP reduce 占
+10.4%，attention 占 9.6%。MoE 的分相测量为：
+
+```text
+stage 5.091 s   compute 0.601 s   1874 expert calls / 48 MoE calls
+17.16 GiB H2D，cache hit 0%
+```
+
+在 8K prefill 中，单 rank 约搬运 48 GiB；4 个 rank 聚合有效吞吐约
+5.5 GiB/s，与单进程纯 RAM→GPU 微基准 5.4–5.7 GiB/s 一致。因此主要地板
+是共享 PCIe 带宽，而不是 checkpoint 所在机械盘。cold/warm page-cache
+测量只有 1.16–1.37× 差异。
+
+### Decode
+
+32-token decode、cache=1024 的层内累计时间为：MoE 46.6%、attention
+18.6%、MLP NCCL reduce 16.2%、attention NCCL reduce 3.8%。层外约 18%
+花在每一步对 248320 词表做 `all_gather`，以及随后由 `.item()` 引入的
+同步。
+
+cache=64→1024 将 decode 从 1.05 提到 2.75 tok/s；cache=2048 在当前
+BF16 staging 下 OOM。输出在两种 cache 容量下逐字一致。
+
+## 已验证和已否定的方向
+
+1. **增大 prefill chunk 是当前最大的免费收益**：8K prompt 上
+   chunk=512→8192 达到约 4×（38.1→244.1 tok/s），因为 active expert
+   集合很快接近每 rank 的 128 个上限，搬运成本被更多 token 摊薄。
+2. **增大 decode cache 有效**：容量 1024 能保留跨步复用的
+   `(layer, expert)`，但需要 O(1) LRU 实现，不能继续使用
+   `list.pop(0)`。
+3. **合并 active expert H2D 没有收益**：108 expert 的实测为逐 expert
+   loop 155 ms、host gather 后的 batched 方案 215 ms（0.72×）；host
+   `index_select` 本身约 76 ms。不要仅凭减少 DMA call 数就合并 staging。
+4. **TP 分片没有重复搬运**：`ShardedMoE` 的每个 rank 只 fetch 自己的
+   expert，实测 duplication=1.00×。
+5. **prefetch 不是带宽优化**：PCIe 已饱和时，cross-layer prefetch 最多
+   改变时序，不能降低搬运字节数；应在量化后再重新 A/B。
+
+## 朝 500 / 10 的工作分解
+
+当前最佳实测点是长 prefill 244 tok/s、短 decode 2.75 tok/s。
+
+### P0：默认值和低风险运行时修正
+
+- 默认 chunk 调到 4096–8192，并依据可用显存夹取；
+- expert cache 默认 1024；把 LRU 替换为 `OrderedDict` 或 ring；
+- decode 不再 all-gather 全词表，只在各 rank 做 local argmax，然后
+  all-gather `(value, index)`。
+
+### P1：消除 PCIe 地板
+
+- 对 routed expert 使用 FP8/INT4 storage，并在 GPU 侧使用对应的
+  dequant/GEMM kernel；
+- FP8 将 active bytes 约减半，长 prefill 的带宽上限接近 500 tok/s；
+- decode 若要从约 2.75 达到 10 tok/s，预计需要 INT4 或等效的 4× bytes
+  reduction，再叠加 local-vocab reduction 和 batched decode kernel；
+- 所有量化路线必须先做真实权重 logit parity，再做性能 A/B。
+
+### P2：计算和通信收尾
+
+- prefill 中 MoE compute 只占 staging 的约 1/8.5，优先级低于量化；
+  staging 地板松动后再做 grouped/batched expert GEMM；
+- 尝试将两次每层 NCCL reduce 与下一段计算 overlap；
+- 重新评估 cross-layer prefetch，不能把它当作增加 PCIe 带宽的方案。
+
+在当前 PCIe Gen3 机器上，**prefill 500 的必要条件是 expert 量化**；
+仅优化 Python dispatch 或 attention 不可能越过 H2D 下限。**decode 10**
+则需要量化、cache、词表归约和 decode 专用 MoE kernel 的组合。

--- a/src/models/qwen4_exp/builder.py
+++ b/src/models/qwen4_exp/builder.py
@@ -146,6 +146,7 @@ def build_from_state_dict(
     device: torch.device | str = "cpu",
     dtype: torch.dtype = torch.float32,
     prefix: str = LM,
+    profiler=None,
 ) -> Qwen4ExpModel:
     """Single-device model with every expert resident. Small models / tests only."""
     device = torch.device(device)
@@ -195,6 +196,7 @@ def build_from_state_dict(
         final_mixer=_final_mixer(getter, config, prefix=prefix),
         device=device,
         dtype=dtype,
+        profiler=profiler,
     )
 
 
@@ -217,6 +219,7 @@ def build_heterogeneous(
     all_reduce=None,
     expert_cache_capacity: int = 0,
     prefix: str = LM,
+    profiler=None,
 ) -> Qwen4ExpModel:
     """TP-sharded dense weights on GPU, routed experts + PLE table in host RAM.
 
@@ -422,4 +425,5 @@ def build_heterogeneous(
         final_mixer=_final_mixer(dense, config, prefix=prefix),
         device=device,
         dtype=dtype,
+        profiler=profiler,
     )

--- a/src/models/qwen4_exp/model.py
+++ b/src/models/qwen4_exp/model.py
@@ -8,6 +8,7 @@ module code serves the single-GPU reference path and the TP4 heterogeneous path
 from __future__ import annotations
 
 import math
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 
 import torch
@@ -30,6 +31,12 @@ from src.models.qwen4_exp.layers import (
     inject_into_streams,
 )
 from src.models.qwen4_exp.moe import MoEBackend
+
+
+@contextmanager
+def _noop_context():
+    """No-op context manager when profiler is disabled."""
+    yield
 
 
 @dataclass
@@ -219,32 +226,58 @@ class Qwen4ExpDecoderLayer:
         past_len: int,
         token_history: torch.Tensor | None,
         use_cache: bool,
+        profiler=None,
     ) -> torch.Tensor:
-        if self.ple is not None:
-            assert token_history is not None, "PLE layers need the token id history"
-            hidden_states = hidden_states + self.ple(
-                hidden_states, token_history, hidden_states.shape[1], use_cache=use_cache
-            )
+        prof_scope = profiler.scope if profiler else lambda x: _noop_context()
 
-        mixed, hyper_input, inject = self.attn_hc(hidden_states)
-        if self.is_linear:
-            attn_out = self.attn(mixed, cache)
-        else:
-            attn_out = self.attn(mixed, cos, sin, cache, past_len=past_len)
-        if self.all_reduce is not None:
-            attn_out = self.all_reduce(attn_out)
-        hidden_states = inject_into_streams(attn_out, hyper_input, inject)
+        with prof_scope(f"layer_{self.layer_idx}"):
+            if self.ple is not None:
+                assert token_history is not None, "PLE layers need the token id history"
+                with prof_scope("ple"):
+                    ple_out = self.ple(
+                        hidden_states, token_history, hidden_states.shape[1], use_cache=use_cache
+                    )
+                hidden_states = hidden_states + ple_out
 
-        mixed, hyper_input, inject = self.mlp_hc(hidden_states)
-        flat = mixed.reshape(-1, mixed.shape[-1])
-        weights, indices = self.router(flat)
-        routed = self.moe(self.layer_idx, flat, indices, weights)
-        shared = self.shared_expert(flat)
-        shared = torch.sigmoid(F.linear(flat, self.shared_expert_gate)) * shared
-        mlp_out = (routed + shared).reshape(mixed.shape)
-        if self.all_reduce is not None:
-            mlp_out = self.all_reduce(mlp_out)
-        return inject_into_streams(mlp_out, hyper_input, inject)
+            with prof_scope("attn_hc"):
+                mixed, hyper_input, inject = self.attn_hc(hidden_states)
+
+            with prof_scope("attention"):
+                if self.is_linear:
+                    attn_out = self.attn(mixed, cache)
+                else:
+                    attn_out = self.attn(mixed, cos, sin, cache, past_len=past_len)
+
+            if self.all_reduce is not None:
+                with prof_scope("attn_reduce"):
+                    attn_out = self.all_reduce(attn_out)
+
+            with prof_scope("attn_inject"):
+                hidden_states = inject_into_streams(attn_out, hyper_input, inject)
+
+            with prof_scope("mlp_hc"):
+                mixed, hyper_input, inject = self.mlp_hc(hidden_states)
+
+            flat = mixed.reshape(-1, mixed.shape[-1])
+
+            with prof_scope("router"):
+                weights, indices = self.router(flat)
+
+            with prof_scope("moe"):
+                routed = self.moe(self.layer_idx, flat, indices, weights)
+
+            with prof_scope("shared_expert"):
+                shared = self.shared_expert(flat)
+                shared = torch.sigmoid(F.linear(flat, self.shared_expert_gate)) * shared
+
+            mlp_out = (routed + shared).reshape(mixed.shape)
+
+            if self.all_reduce is not None:
+                with prof_scope("mlp_reduce"):
+                    mlp_out = self.all_reduce(mlp_out)
+
+            with prof_scope("mlp_inject"):
+                return inject_into_streams(mlp_out, hyper_input, inject)
 
 
 @dataclass
@@ -281,6 +314,7 @@ class Qwen4ExpModel:
         final_mixer: GatedResidual,
         device: torch.device,
         dtype: torch.dtype,
+        profiler=None,
     ) -> None:
         self.config = config
         self.layers = layers
@@ -289,6 +323,7 @@ class Qwen4ExpModel:
         self.final_mixer = final_mixer
         self.device = device
         self.dtype = dtype
+        self.profiler = profiler
         self.rope = MRoPE(config, device)
         self._cos: torch.Tensor | None = None
         self._sin: torch.Tensor | None = None
@@ -323,27 +358,33 @@ class Qwen4ExpModel:
         cache: Qwen4ExpCache | None = None,
         past_len: int = 0,
     ) -> torch.Tensor:
+        prof_scope = self.profiler.scope if self.profiler else lambda x: _noop_context()
+
         batch_size, seq_len = input_ids.shape
         total_len = past_len + seq_len
-        cos, sin = self._rope_cache(total_len, batch_size)
+
+        with prof_scope("rope_cache"):
+            cos, sin = self._rope_cache(total_len, batch_size)
 
         token_history = None
         if any(layer.ple is not None for layer in self.layers):
-            # Token ids and the n-gram hash live on the CPU (the PLE table is
-            # host-resident), so keep the history there too.
-            ids_cpu = input_ids.to("cpu", dtype=torch.long)
-            if cache is not None and cache.ple_token_history is not None:
-                token_history = torch.cat([cache.ple_token_history, ids_cpu], dim=1)
-            else:
-                pad = torch.full(
-                    (batch_size, self.config.ngram_size - 1),
-                    self.config.primary_eos_token_id,
-                    dtype=torch.long,
-                )
-                token_history = torch.cat([pad, ids_cpu], dim=1)
+            with prof_scope("token_history"):
+                # Token ids and the n-gram hash live on the CPU (the PLE table is
+                # host-resident), so keep the history there too.
+                ids_cpu = input_ids.to("cpu", dtype=torch.long)
+                if cache is not None and cache.ple_token_history is not None:
+                    token_history = torch.cat([cache.ple_token_history, ids_cpu], dim=1)
+                else:
+                    pad = torch.full(
+                        (batch_size, self.config.ngram_size - 1),
+                        self.config.primary_eos_token_id,
+                        dtype=torch.long,
+                    )
+                    token_history = torch.cat([pad, ids_cpu], dim=1)
 
-        hidden = self.embed_tokens(input_ids).to(self.dtype)
-        hidden = hidden.repeat(1, 1, self.config.hc_count)
+        with prof_scope("embed"):
+            hidden = self.embed_tokens(input_ids).to(self.dtype)
+            hidden = hidden.repeat(1, 1, self.config.hc_count)
 
         for idx, layer in enumerate(self.layers):
             hidden = layer(
@@ -354,6 +395,7 @@ class Qwen4ExpModel:
                 past_len=past_len,
                 token_history=token_history,
                 use_cache=cache is not None,
+                profiler=self.profiler,
             )
 
         if cache is not None:
@@ -361,5 +403,8 @@ class Qwen4ExpModel:
             if token_history is not None:
                 cache.ple_token_history = token_history[:, -(self.config.ngram_size - 1) :].clone()
 
-        hidden = self.final_mixer(hidden)
-        return F.linear(hidden, self.lm_head)
+        with prof_scope("final_mixer"):
+            hidden = self.final_mixer(hidden)
+
+        with prof_scope("lm_head"):
+            return F.linear(hidden, self.lm_head)

--- a/src/models/qwen4_exp/moe.py
+++ b/src/models/qwen4_exp/moe.py
@@ -37,12 +37,16 @@ def _dispatch_experts(
     weights: torch.Tensor,
     num_experts: int,
     expert_weights,
+    stats: dict | None = None,
 ) -> torch.Tensor:
     """Group tokens by expert, run each expert once, scatter-add the results.
 
     `expert_weights(expert_id)` returns `(gate_up, down)` on the compute device.
     Experts are visited in ascending id so the accumulation order is fixed and
     the result is run-to-run reproducible.
+
+    When `stats` is given, per-phase wall time is accumulated into it.  The
+    timing path synchronizes and is meant for profiling runs only.
     """
     out = torch.zeros_like(hidden_states)
     flat_experts = indices.reshape(-1)
@@ -50,6 +54,28 @@ def _dispatch_experts(
     sorted_experts = flat_experts[order]
     unique, counts = torch.unique_consecutive(sorted_experts, return_counts=True)
     top_k = indices.shape[1]
+
+    if stats is None:
+        offset = 0
+        unique_list = unique.tolist()
+        counts_list = counts.tolist()
+        for expert_id, count in zip(unique_list, counts_list):
+            slot = order[offset : offset + count]
+            offset += count
+            if expert_id >= num_experts:
+                continue
+            token_idx = slot // top_k
+            k_idx = slot % top_k
+            gate_up, down = expert_weights(int(expert_id))
+            contrib = swiglu_expert(hidden_states[token_idx], gate_up, down)
+            contrib = contrib * weights[token_idx, k_idx].unsqueeze(-1).to(contrib.dtype)
+            out.index_add_(0, token_idx, contrib.to(out.dtype))
+        return out
+
+    import time
+
+    dev = hidden_states.device
+    sync = torch.cuda.synchronize if dev.type == "cuda" else lambda *a: None
 
     offset = 0
     unique_list = unique.tolist()
@@ -61,10 +87,22 @@ def _dispatch_experts(
             continue
         token_idx = slot // top_k
         k_idx = slot % top_k
+
+        sync(dev)
+        t0 = time.perf_counter()
         gate_up, down = expert_weights(int(expert_id))
+        sync(dev)
+        t1 = time.perf_counter()
         contrib = swiglu_expert(hidden_states[token_idx], gate_up, down)
         contrib = contrib * weights[token_idx, k_idx].unsqueeze(-1).to(contrib.dtype)
         out.index_add_(0, token_idx, contrib.to(out.dtype))
+        sync(dev)
+        t2 = time.perf_counter()
+
+        stats["stage_s"] = stats.get("stage_s", 0.0) + (t1 - t0)
+        stats["compute_s"] = stats.get("compute_s", 0.0) + (t2 - t1)
+        stats["experts"] = stats.get("experts", 0) + 1
+    stats["calls"] = stats.get("calls", 0) + 1
     return out
 
 
@@ -121,11 +159,15 @@ class HostExpertMoE:
         self._order: list[tuple[int, int]] = []
         self.stage_bytes = 0
         self.stage_calls = 0
+        self.cache_hits = 0
+        # Set to a dict to collect per-phase timings (profiling only).
+        self.phase_stats: dict | None = None
 
     def _fetch(self, layer_idx: int, expert_id: int) -> tuple[torch.Tensor, torch.Tensor]:
         key = (layer_idx, expert_id)
         hit = self._cache.get(key)
         if hit is not None:
+            self.cache_hits += 1
             return hit
         gate_up_cpu, down_cpu = self.reader.expert_rows(layer_idx, expert_id)
         gate_up = gate_up_cpu.to(self.device, dtype=self.dtype, non_blocking=True)
@@ -153,6 +195,7 @@ class HostExpertMoE:
             weights,
             self.num_experts,
             lambda e: self._fetch(layer_idx, e),
+            stats=self.phase_stats,
         )
 
 

--- a/src/models/qwen4_exp/profiler.py
+++ b/src/models/qwen4_exp/profiler.py
@@ -1,0 +1,126 @@
+"""Hierarchical profiler for Qwen4-Exp runtime.
+
+Usage:
+    from src.models.qwen4_exp.profiler import Profiler
+
+    prof = Profiler(enabled=True)
+    with prof.scope("forward"):
+        with prof.scope("attention"):
+            ...
+
+    prof.report()  # prints tree of accumulated times
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ScopeStats:
+    """Accumulated stats for one named scope."""
+    count: int = 0
+    total_s: float = 0.0
+    children: dict[str, ScopeStats] = field(default_factory=dict)
+
+
+class Profiler:
+    """Lightweight hierarchical timer with CUDA sync."""
+
+    def __init__(self, enabled: bool = True, device=None):
+        self.enabled = enabled
+        self.device = device
+        self.root = ScopeStats()
+        self._stack: list[tuple[str, ScopeStats, float]] = []
+
+    @contextmanager
+    def scope(self, name: str):
+        """Enter a named timing scope."""
+        if not self.enabled:
+            yield
+            return
+
+        # Navigate to current scope
+        parent = self.root
+        for scope_name, _, _ in self._stack:
+            parent = parent.children.setdefault(scope_name, ScopeStats())
+
+        # Create/get child
+        stats = parent.children.setdefault(name, ScopeStats())
+
+        # Sync and start
+        if self.device is not None and self.device.type == "cuda":
+            import torch
+            torch.cuda.synchronize(self.device)
+        t0 = time.perf_counter()
+
+        self._stack.append((name, stats, t0))
+        try:
+            yield
+        finally:
+            self._stack.pop()
+            if self.device is not None and self.device.type == "cuda":
+                import torch
+                torch.cuda.synchronize(self.device)
+            elapsed = time.perf_counter() - t0
+            stats.count += 1
+            stats.total_s += elapsed
+
+    def reset(self):
+        """Clear all accumulated stats."""
+        self.root = ScopeStats()
+        self._stack.clear()
+
+    def report(self, min_percent: float = 0.5) -> str:
+        """Generate a tree report of accumulated times.
+
+        Args:
+            min_percent: Hide children contributing < this % of parent time.
+        """
+        if not self.enabled or not self.root.children:
+            return "(profiler disabled or no data)"
+
+        lines = []
+
+        def walk(node: ScopeStats, name: str, indent: int, parent_s: float):
+            # Compute self time (total - children)
+            child_s = sum(c.total_s for c in node.children.values())
+            self_s = node.total_s - child_s
+
+            pct = 100.0 * node.total_s / parent_s if parent_s > 0 else 0.0
+            avg_ms = 1000.0 * node.total_s / node.count if node.count > 0 else 0.0
+
+            prefix = "  " * indent
+            lines.append(
+                f"{prefix}{name:30s}  {node.count:6d} calls  "
+                f"{node.total_s:7.3f}s ({pct:5.1f}%)  "
+                f"{avg_ms:7.2f} ms/call"
+            )
+
+            # Show self time if significant children exist
+            if child_s > 0.001 and self_s / node.total_s > 0.01:
+                self_pct = 100.0 * self_s / node.total_s
+                lines.append(
+                    f"{prefix}  {'<self>':28s}          "
+                    f"{self_s:7.3f}s ({self_pct:5.1f}%)"
+                )
+
+            # Recurse into children (sorted by time desc)
+            for child_name, child_stats in sorted(
+                node.children.items(), key=lambda kv: kv[1].total_s, reverse=True
+            ):
+                if 100.0 * child_stats.total_s / node.total_s >= min_percent:
+                    walk(child_stats, child_name, indent + 1, node.total_s)
+
+        # Fake root for top-level scopes
+        if self.root.children:
+            total = sum(c.total_s for c in self.root.children.values())
+            lines.append(f"{'=== Profiler Report ===':<50s}  Total: {total:.3f}s")
+            for name, stats in sorted(
+                self.root.children.items(), key=lambda kv: kv[1].total_s, reverse=True
+            ):
+                walk(stats, name, 0, total)
+
+        return "\n".join(lines)

--- a/src/models/qwen4_exp/runtime.py
+++ b/src/models/qwen4_exp/runtime.py
@@ -21,6 +21,7 @@ import argparse
 import json
 import os
 import time
+from contextlib import nullcontext
 from dataclasses import dataclass
 
 import torch
@@ -92,6 +93,7 @@ def load_model(
     *,
     dtype: torch.dtype = torch.bfloat16,
     expert_cache_capacity: int = 0,
+    profiler=None,
 ) -> tuple[Qwen4ExpModel, Qwen4ExpConfig]:
     config = Qwen4ExpConfig.from_pretrained(model_dir)
     checkpoint = Qwen4ExpCheckpoint(model_dir, store=MmapSafetensors(model_dir))
@@ -104,6 +106,7 @@ def load_model(
         world_size=ctx.world_size,
         all_reduce=make_all_reduce(ctx),
         expert_cache_capacity=expert_cache_capacity,
+        profiler=profiler,
     )
     return model, config
 
@@ -128,13 +131,17 @@ def generate(
     prompt_len = input_ids.shape[1]
     cache = model.make_cache(batch_size=input_ids.shape[0], max_seq_len=prompt_len + max_new_tokens + 1)
 
+    profiler = model.profiler
+    prof_scope = profiler.scope if profiler else lambda _name: nullcontext()
+
     t0 = time.perf_counter()
     logits = None
     past = 0
-    while past < prompt_len:
-        piece = input_ids[:, past : past + chunk_size]
-        logits = model.forward(piece, cache=cache, past_len=past)
-        past += piece.shape[1]
+    with prof_scope("prefill"):
+        while past < prompt_len:
+            piece = input_ids[:, past : past + chunk_size]
+            logits = model.forward(piece, cache=cache, past_len=past)
+            past += piece.shape[1]
     if ctx.device.type == "cuda":
         torch.cuda.synchronize()
     prefill_s = time.perf_counter() - t0
@@ -143,16 +150,17 @@ def generate(
     produced: list[int] = []
     t1 = time.perf_counter()
     next_id = logits.argmax(-1, keepdim=True)
-    for _ in range(max_new_tokens):
-        token = int(next_id.item())
-        produced.append(token)
-        if on_token is not None and ctx.rank == 0:
-            on_token(token)
-        if token in eos_token_ids:
-            break
-        step = model.forward(next_id.to(ctx.device), cache=cache, past_len=past)
-        past += 1
-        next_id = gather_logits(step[:, -1], ctx).argmax(-1, keepdim=True)
+    with prof_scope("decode"):
+        for _ in range(max_new_tokens):
+            token = int(next_id.item())
+            produced.append(token)
+            if on_token is not None and ctx.rank == 0:
+                on_token(token)
+            if token in eos_token_ids:
+                break
+            step = model.forward(next_id.to(ctx.device), cache=cache, past_len=past)
+            past += 1
+            next_id = gather_logits(step[:, -1], ctx).argmax(-1, keepdim=True)
     if ctx.device.type == "cuda":
         torch.cuda.synchronize()
     decode_s = time.perf_counter() - t1
@@ -199,19 +207,31 @@ def run_tp4(
     dtype: torch.dtype = torch.bfloat16,
     expert_cache_capacity: int = 0,
     raw_prompt: bool = False,
+    enable_profile: bool = False,
 ) -> dict:
+    from src.models.qwen4_exp.profiler import Profiler
+
     ctx = init_distributed()
+    profiler = Profiler(enabled=enable_profile, device=ctx.device) if enable_profile else None
+
     if ctx.rank == 0:
         print(f"[rank{ctx.rank}] loading {model_dir} world_size={ctx.world_size}", flush=True)
 
     t0 = time.perf_counter()
     model, config = load_model(
-        model_dir, ctx, dtype=dtype, expert_cache_capacity=expert_cache_capacity
+        model_dir, ctx, dtype=dtype, expert_cache_capacity=expert_cache_capacity, profiler=profiler
     )
     load_s = time.perf_counter() - t0
     if ctx.rank == 0:
         mem = torch.cuda.memory_allocated(ctx.device) / 2**30 if ctx.device.type == "cuda" else 0.0
         print(f"[rank{ctx.rank}] loaded in {load_s:.1f}s, {mem:.2f} GiB on device", flush=True)
+
+    # All layers share one MoE backend instance; reach it through layer 0.
+    moe_backend = getattr(model.layers[0], "moe", None)
+    moe_backend = getattr(moe_backend, "inner", moe_backend)  # unwrap ShardedMoE
+    moe_phase_profile = enable_profile and os.environ.get("DSV4_QWEN4_MOE_PHASE_PROFILE") == "1"
+    if moe_phase_profile and hasattr(moe_backend, "phase_stats"):
+        moe_backend.phase_stats = {}
 
     tokenizer = _load_tokenizer(model_dir)
     text = prompt if raw_prompt else _apply_chat_template(model_dir, prompt)
@@ -233,6 +253,24 @@ def run_tp4(
         print(f"[rank0] output: {result['text']!r}", flush=True)
         print(f"[rank0] stats: {json.dumps(stats, indent=2)}", flush=True)
 
+        if moe_phase_profile and getattr(moe_backend, "phase_stats", None):
+            ps = moe_backend.phase_stats
+            staged = moe_backend.stage_calls
+            hits = moe_backend.cache_hits
+            gib = moe_backend.stage_bytes / 2**30
+            print(
+                "\n[rank0] moe phases: "
+                f"stage {ps.get('stage_s', 0.0):.3f}s  "
+                f"compute {ps.get('compute_s', 0.0):.3f}s  "
+                f"expert-calls {ps.get('experts', 0)} over {ps.get('calls', 0)} moe calls\n"
+                f"[rank0] staging: {staged} misses / {hits} hits "
+                f"({100.0 * hits / max(1, staged + hits):.1f}% hit), {gib:.2f} GiB H2D",
+                flush=True,
+            )
+
+        if profiler and profiler.enabled:
+            print("\n" + profiler.report())
+
     if ctx.initialized:
         import torch.distributed as dist
 
@@ -245,6 +283,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Qwen4-Exp TP heterogeneous inference")
     parser.add_argument("--model", required=True, help="checkpoint directory")
     parser.add_argument("--prompt", default="Hello, who are you?")
+    parser.add_argument("--prompt-file", help="read the prompt from a file instead of --prompt")
     parser.add_argument("--max-new-tokens", type=int, default=32)
     parser.add_argument("--chunk-size", type=int, default=512)
     parser.add_argument("--dtype", default="bfloat16", choices=["bfloat16", "float16", "float32"])
@@ -255,16 +294,23 @@ def main() -> None:
         help="number of staged experts to keep on device (0 = restage every step)",
     )
     parser.add_argument("--raw-prompt", action="store_true", help="skip the chat template")
+    parser.add_argument("--profile", action="store_true", help="enable hierarchical profiler")
     args = parser.parse_args()
+
+    prompt = args.prompt
+    if args.prompt_file:
+        with open(args.prompt_file) as f:
+            prompt = f.read()
 
     run_tp4(
         args.model,
-        args.prompt,
+        prompt,
         max_new_tokens=args.max_new_tokens,
         chunk_size=args.chunk_size,
         dtype=getattr(torch, args.dtype),
         expert_cache_capacity=args.expert_cache,
         raw_prompt=args.raw_prompt,
+        enable_profile=args.profile,
     )
 
 

--- a/tests/bench_qwen4_exp_staging.py
+++ b/tests/bench_qwen4_exp_staging.py
@@ -1,0 +1,230 @@
+"""Where does Qwen4-Exp expert staging time actually go?
+
+Four probes against the real Qwen3.8-Flash-Next checkpoint, each answering one
+question that came up while profiling the heterogeneous TP4 path:
+
+  sizes    - how many distinct experts does a chunk of N tokens touch, and how
+             many bytes does that cost per layer / per 48-layer pass?
+  source   - is staging bound by the checkpoint disk or by PCIe?  Compares a
+             cold first touch, a warm page-cache touch, and a pure RAM->GPU copy.
+  batched  - does gathering a layer's active experts into one contiguous host
+             buffer and issuing a single H2D beat the per-expert loop?
+  shard    - does `ShardedMoE` make each rank stage experts it never computes
+             with (i.e. is there duplicated H2D across ranks)?
+
+Single process, no TP: the staging path is per-rank anyway, so these numbers are
+per-rank.  The aggregate PCIe figure only shows up in a real 4-rank run.
+
+Run: python tests/bench_qwen4_exp_staging.py [--probe sizes,source,batched,shard]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.models.qwen4_exp.config import Qwen4ExpConfig
+from src.models.qwen4_exp.layers import swiglu_expert
+from src.models.qwen4_exp.moe import ShardedMoE
+from src.models.qwen4_exp.weights import MmapSafetensors, Qwen4ExpCheckpoint
+
+MODEL = os.environ.get("QWEN4EXP_MODEL", "/mnt/data1/modelscope/Qwen/Qwen3.8-Flash-Next")
+MIB = float(2**20)
+GIB = float(2**30)
+
+
+def _sync(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def _stage_loop(ckpt, layer, experts, device, dtype) -> tuple[float, int]:
+    """Per-expert staging, the shape `HostExpertMoE._fetch` uses."""
+    _sync(device)
+    t0 = time.perf_counter()
+    nbytes = 0
+    for expert_id in experts:
+        gate_up, down = ckpt.expert_rows(layer, expert_id)
+        gate_up.to(device, dtype=dtype, non_blocking=True)
+        down.to(device, dtype=dtype, non_blocking=True)
+        nbytes += (gate_up.numel() + down.numel()) * 2
+    _sync(device)
+    return time.perf_counter() - t0, nbytes
+
+
+def probe_sizes(ckpt, config, device, dtype) -> None:
+    """Active expert count and byte cost per chunk size."""
+    gate_up, down = ckpt.expert_rows(0, 0)
+    per_expert = (gate_up.numel() + down.numel()) * 2
+    layers = config.num_hidden_layers
+
+    print(f"num_experts={config.num_experts} top_k={config.num_experts_per_tok} "
+          f"hidden={config.hidden_size} moe_intermediate={config.moe_intermediate_size}")
+    print(f"per-expert bf16 = {per_expert / MIB:.2f} MiB "
+          f"(gate_up{tuple(gate_up.shape)} down{tuple(down.shape)})")
+    print(f"full expert set = {config.num_experts * layers * per_expert / GIB:.1f} GiB\n")
+
+    print(f"{'tokens':>7}  {'unique':>6}  {'MiB/layer':>10}  {'GiB/pass':>9}")
+    for n_tok in (1, 8, 60, 512, 4096):
+        generator = torch.Generator().manual_seed(0)
+        # Uniform routing is the worst case; real routing is more concentrated.
+        indices = torch.stack([
+            torch.randperm(config.num_experts, generator=generator)[: config.num_experts_per_tok]
+            for _ in range(n_tok)
+        ])
+        unique = int(torch.unique(indices).numel())
+        print(f"{n_tok:>7}  {unique:>6}  {unique * per_expert / MIB:>10.1f}  "
+              f"{layers * unique * per_expert / GIB:>9.2f}")
+    print("\nnote: capped at num_experts, so past a few hundred tokens a larger chunk "
+          "costs the same H2D but amortises it over more tokens.")
+
+
+def probe_source(ckpt, config, device, dtype, *, layer: int = 17, count: int = 96) -> None:
+    """Disk-bound or PCIe-bound?  cold vs warm vs pure RAM->GPU."""
+    experts = list(range(count))
+    cold_s, nbytes = _stage_loop(ckpt, layer, experts, device, dtype)
+    warm_s, _ = _stage_loop(ckpt, layer, experts, device, dtype)
+
+    gib = nbytes / GIB
+    print(f"layer={layer} experts={count} payload={gib:.3f} GiB")
+    print(f"cold (disk + H2D): {cold_s * 1e3:7.1f} ms  {gib / cold_s:5.2f} GiB/s  "
+          f"{cold_s / count * 1e3:5.2f} ms/expert")
+    print(f"warm (cache+ H2D): {warm_s * 1e3:7.1f} ms  {gib / warm_s:5.2f} GiB/s  "
+          f"{warm_s / count * 1e3:5.2f} ms/expert")
+
+    # Pure PCIe: host tensors already materialised outside the mapping.
+    resident = [
+        (ckpt.expert_rows(layer, e)[0].clone(), ckpt.expert_rows(layer, e)[1].clone())
+        for e in experts
+    ]
+    _sync(device)
+    t0 = time.perf_counter()
+    for gate_up, down in resident:
+        gate_up.to(device, dtype=dtype, non_blocking=True)
+        down.to(device, dtype=dtype, non_blocking=True)
+    _sync(device)
+    h2d_s = time.perf_counter() - t0
+    print(f"h2d  (RAM  -> GPU): {h2d_s * 1e3:7.1f} ms  {gib / h2d_s:5.2f} GiB/s  "
+          f"{h2d_s / count * 1e3:5.2f} ms/expert")
+
+    print(f"\ncold/warm = {cold_s / warm_s:.2f}x   warm/h2d = {warm_s / h2d_s:.2f}x")
+    print("=> disk-bound" if cold_s > 2 * warm_s else "=> not disk-bound; PCIe is the floor")
+
+
+def probe_batched(ckpt, config, device, dtype, *, layer: int = 10, count: int = 108) -> None:
+    """One contiguous H2D vs the per-expert loop (count ~ a 512-token chunk)."""
+    experts = list(range(count))
+    ids = torch.tensor(experts, dtype=torch.long)
+    gate_up_all = ckpt.store.view(ckpt.expert_key(layer, "gate_up_proj"))
+    down_all = ckpt.store.view(ckpt.expert_key(layer, "down_proj"))
+
+    def batched() -> tuple[float, float]:
+        _sync(device)
+        t0 = time.perf_counter()
+        gate_up = torch.index_select(gate_up_all, 0, ids)
+        down = torch.index_select(down_all, 0, ids)
+        gathered = time.perf_counter()
+        gate_up.to(device, dtype=dtype, non_blocking=True)
+        down.to(device, dtype=dtype, non_blocking=True)
+        _sync(device)
+        return time.perf_counter() - t0, gathered - t0
+
+    _stage_loop(ckpt, layer, experts, device, dtype)  # warm pages + allocator
+    batched()
+    loop = [_stage_loop(ckpt, layer, experts, device, dtype)[0] for _ in range(3)]
+    batch = [batched() for _ in range(3)]
+
+    gate_up, down = ckpt.expert_rows(layer, 0)
+    gib = count * (gate_up.numel() + down.numel()) * 2 / GIB
+    print(f"layer={layer} experts={count} payload={gib:.3f} GiB")
+    print("loop:    " + "  ".join(f"{x * 1e3:6.1f} ms" for x in loop))
+    print("batched: " + "  ".join(f"{x * 1e3:6.1f} ms" for x, _ in batch))
+    print("  gather: " + "  ".join(f"{g * 1e3:6.1f} ms" for _, g in batch))
+    speedup = min(loop) / min(x for x, _ in batch)
+    print(f"\nbatched speedup = {speedup:.2f}x "
+          f"({'win' if speedup > 1.05 else 'no win: host gather eats the savings'})")
+
+
+class _FetchSpy:
+    """Stands in for HostExpertMoE, recording which experts get fetched."""
+
+    def __init__(self, num_experts: int) -> None:
+        self.num_experts = num_experts
+        self.fetched: set[int] = set()
+
+    def __call__(self, layer_idx, hidden_states, indices, weights):
+        for expert_id in torch.unique(indices.reshape(-1)).tolist():
+            if expert_id < self.num_experts:
+                self.fetched.add(int(expert_id))
+        return torch.zeros_like(hidden_states)
+
+
+def probe_shard(ckpt, config, device, dtype, *, world_size: int = 4) -> None:
+    """Does any rank stage an expert it never computes with?"""
+    gate_up, down = ckpt.expert_rows(0, 0)
+    per_expert = (gate_up.numel() + down.numel()) * 2
+    num_experts, top_k = config.num_experts, config.num_experts_per_tok
+
+    for n_tok in (1, 60, 512):
+        generator = torch.Generator().manual_seed(1234)
+        # Bias the scores so routing is concentrated, as it is in practice.
+        logits = torch.randn(n_tok, num_experts, generator=generator)
+        logits += torch.linspace(3.0, 0.0, num_experts).unsqueeze(0)
+        indices = logits.topk(top_k, dim=-1).indices
+        weights = torch.ones(n_tok, top_k)
+        hidden = torch.zeros(n_tok, 8)
+
+        unique = int(torch.unique(indices).numel())
+        per_rank = []
+        for rank in range(world_size):
+            spy = _FetchSpy(num_experts)
+            ShardedMoE(spy, rank, world_size)(0, hidden, indices, weights)
+            per_rank.append(len(spy.fetched))
+
+        print(f"tokens={n_tok:>4}  unique/layer={unique:>3}  per-rank={per_rank}  "
+              f"sum={sum(per_rank)}  duplication={sum(per_rank) / max(1, unique):.2f}x")
+        print(f"           rank0 {per_rank[0] * per_expert / MIB:7.1f} MiB/layer, "
+              f"{config.num_hidden_layers * per_rank[0] * per_expert / GIB:5.2f} GiB/pass")
+
+
+PROBES = {
+    "sizes": probe_sizes,
+    "source": probe_source,
+    "batched": probe_batched,
+    "shard": probe_shard,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--model", default=MODEL)
+    parser.add_argument("--probe", default="sizes,source,batched,shard",
+                        help="comma-separated: " + ",".join(PROBES))
+    parser.add_argument("--dtype", default="bfloat16", choices=["bfloat16", "float16"])
+    args = parser.parse_args()
+
+    if not os.path.exists(os.path.join(args.model, "model.safetensors.index.json")):
+        print(f"checkpoint not found at {args.model}; set --model or QWEN4EXP_MODEL")
+        return
+
+    config = Qwen4ExpConfig.from_pretrained(args.model).text_config
+    ckpt = Qwen4ExpCheckpoint(args.model, store=MmapSafetensors(args.model))
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    dtype = getattr(torch, args.dtype)
+
+    for name in [p.strip() for p in args.probe.split(",") if p.strip()]:
+        if name not in PROBES:
+            print(f"unknown probe {name!r}; choose from {','.join(PROBES)}")
+            continue
+        print(f"\n=== {name} ===")
+        PROBES[name](ckpt, config, device, dtype)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add hierarchical prefill/decode and per-layer profiler instrumentation for the Qwen4-Exp heterogeneous TP4 runtime.
- Add opt-in MoE staging/compute phase accounting, including H2D bytes, cache hits, and expert calls.
- Consolidate real-checkpoint staging probes into a reproducible benchmark.
- Document measured bottlenecks and the work decomposition toward 500 tok/s prefill and 10 tok/s decode.

## Measurements

- Real Qwen3.8-Flash-Next checkpoint: 48 layers, 512 routed experts, top-10.
- Best clean prefill measured: 244.1 tok/s on an 8,272-token prompt with chunk=8192.
- Best clean decode measured: 2.75 tok/s with expert cache=1024.
- Four-rank staging aggregate: about 5.5 GiB/s, matching the RAM-to-GPU PCIe microbenchmark; prefill is therefore primarily PCIe-staging bound.
- Host gather plus batched H2D was measured at 0.75x the per-expert loop, so it is explicitly not selected as an optimization.
- TP sharding probe measured 1.00x expert-transfer duplication.

## Validation

- `PYTHONPATH=. pytest -q tests/test_qwen4_exp_parity.py tests/test_qwen4_exp_real_checkpoint.py -m "not slow"`
- Result: 12 passed, 2 deselected.
- `tests/bench_qwen4_exp_staging.py` completed against the real checkpoint.
- `.scratch/` remains local-only and is not included in this PR.

## Follow-up roadmap

- Increase chunk size and use an O(1) expert-cache LRU where memory allows.
- Reduce expert storage to FP8/INT4 to remove the PCIe floor.
- Replace full-vocabulary greedy all-gather with local argmax reduction.
- Add decode-specific batched expert execution and investigate NCCL overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)