### PR TITLE
Widen Qwen prefill attention tile and default the comm overlap

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -392,6 +392,10 @@ add_executable(bench_qwen_transaction_copy tests/bench_qwen_transaction_copy.cpp
 target_link_libraries(bench_qwen_transaction_copy PRIVATE dsv4_cpp_core)
 set_target_properties(bench_qwen_transaction_copy PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_qwen_gqa_mma_occ tests/test_qwen_gqa_mma_occ.cpp)
+target_link_libraries(test_qwen_gqa_mma_occ PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_gqa_mma_occ PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(bench_qwen_tp_allreduce tests/bench_qwen_tp_allreduce.cpp)
 target_link_libraries(bench_qwen_tp_allreduce PRIVATE dsv4_cpp_core)
 set_target_properties(bench_qwen_tp_allreduce PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/cuda/qwen_gqa_optimized.cu
+++ b/cpp_engine/cuda/qwen_gqa_optimized.cu
@@ -1039,6 +1039,248 @@ __global__ __launch_bounds__(kMmaWarps * 32) void gqa_prefill_mma_f16_kernel(
     }
 }
 
+// The second launch_bounds argument asks for two resident blocks, which caps the
+// register budget at 128 per thread. Shared memory is already under half an SM's
+// 64 KB after the aliasing above, so registers are the only other gate.
+__global__ __launch_bounds__(kMmaWarps * 32, 2) void gqa_prefill_mma_occ_f16_kernel(
+    const uint16_t* __restrict__ q_rows,
+    const uint16_t* __restrict__ k_cache,
+    const uint16_t* __restrict__ v_cache,
+    uint16_t* __restrict__ output,
+    int seq_len,
+    int q_heads,
+    int kv_heads,
+    int head_dim,
+    int position_offset) {
+    // ks and vt are live in disjoint phases: Q*K reads ks and is fenced by a
+    // __syncthreads() before the softmax, and P*V reads vt only after that. So
+    // they share one buffer, which is what brings shared memory from 40960 B to
+    // 24064 B and lets two CTAs be resident per SM instead of one.
+    constexpr int kStageHalves =
+        kMmaKvTile * kMmaKsStride > kMmaDim * kMmaVtStride
+            ? kMmaKvTile * kMmaKsStride
+            : kMmaDim * kMmaVtStride;
+    __shared__ __align__(16) uint16_t kv_stage[kStageHalves];
+    uint16_t (*ks)[kMmaKsStride] =
+        reinterpret_cast<uint16_t (*)[kMmaKsStride]>(kv_stage);
+    uint16_t (*vt)[kMmaVtStride] =
+        reinterpret_cast<uint16_t (*)[kMmaVtStride]>(kv_stage);
+    __shared__ float sc[kMmaQRows][kMmaKvTile];
+    __shared__ __align__(16) uint16_t ph[kMmaQRows][kMmaVtStride];
+    __shared__ float row_m[kMmaQRows];
+    __shared__ float row_l[kMmaQRows];
+    __shared__ float row_alpha[kMmaQRows];
+
+    const int head = static_cast<int>(blockIdx.x);
+    const int qbase = static_cast<int>(blockIdx.y) * kMmaQRows;
+    if (head >= q_heads || qbase >= seq_len || head_dim != kMmaDim ||
+        q_heads <= 0 || kv_heads <= 0 || q_heads % kv_heads != 0) {
+        return;
+    }
+    const int kv_head = head / (q_heads / kv_heads);
+    const int tid = static_cast<int>(threadIdx.x);
+    const int warp = tid >> 5;
+    const int block_row = (warp / kMmaSlices) * 16;
+    const int slice = warp % kMmaSlices;
+    const int lane = tid & 31;
+    // m16n8k8 operand mapping: the eight lanes of a group share a matrix row and
+    // the four lanes within a group cover two adjacent columns each.
+    const int gid = lane >> 2;
+    const int tig = lane & 3;
+    // Rows of the 16x8 A/D fragment owned by this lane, in CTA-local terms.
+    const int lrow0 = block_row + gid;
+    const int lrow1 = block_row + gid + 8;
+
+    float acc[8][4];
+#pragma unroll
+    for (int j = 0; j < 8; ++j) {
+#pragma unroll
+        for (int i = 0; i < 4; ++i) acc[j][i] = 0.0f;
+    }
+    if (tid < kMmaQRows) {
+        row_m[tid] = -INFINITY;
+        row_l[tid] = 0.0f;
+    }
+
+    // Q is reused by every KV tile, so it stays resident in registers.
+    uint32_t qfrag[kMmaSteps][2];
+#pragma unroll
+    for (int k = 0; k < kMmaSteps; ++k) {
+        const int col = k * 8 + tig * 2;
+#pragma unroll
+        for (int part = 0; part < 2; ++part) {
+            const int row = qbase + (part == 0 ? lrow0 : lrow1);
+            uint32_t value = 0;
+            if (row < seq_len) {
+                value = *reinterpret_cast<const uint32_t*>(
+                    q_rows + (static_cast<size_t>(row) * q_heads + head) *
+                        head_dim + col);
+            }
+            qfrag[k][part] = value;
+        }
+    }
+
+    const size_t kv_stride = static_cast<size_t>(kv_heads) * head_dim;
+    const int q_last = position_offset + min(qbase + kMmaQRows - 1, seq_len - 1);
+    const int tile_context = q_last + 1;
+    const float attention_scale = rsqrtf(static_cast<float>(head_dim));
+    __syncthreads();
+
+    for (int base = 0; base < tile_context; base += kMmaKvTile) {
+        const int count = min(kMmaKvTile, tile_context - base);
+        for (int idx = tid; idx < kMmaKvTile * kMmaSteps;
+             idx += kMmaWarps * 32) {
+            const int slot = idx / kMmaSteps;
+            const int chunk = idx - slot * kMmaSteps;
+            uint4 kv = make_uint4(0u, 0u, 0u, 0u);
+            if (slot < count) {
+                const size_t at = static_cast<size_t>(base + slot) * kv_stride +
+                    static_cast<size_t>(kv_head) * head_dim + chunk * 8;
+                kv = *reinterpret_cast<const uint4*>(k_cache + at);
+            }
+            *reinterpret_cast<uint4*>(&ks[slot][chunk * 8]) = kv;
+        }
+        __syncthreads();
+
+        float s[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+#pragma unroll
+        for (int k = 0; k < kMmaSteps; ++k) {
+            const uint32_t b = *reinterpret_cast<const uint32_t*>(
+                &ks[slice * 8 + gid][k * 8 + tig * 2]);
+            mma_m16n8k8_f16_f32(s, qfrag[k], b);
+        }
+        {
+            const int col = slice * 8 + tig * 2;
+            sc[lrow0][col] = s[0];
+            sc[lrow0][col + 1] = s[1];
+            sc[lrow1][col] = s[2];
+            sc[lrow1][col + 1] = s[3];
+        }
+        // Scores are in sc[][] now, so ks is dead and V can reuse its memory.
+        // V is transposed on the way in so the P*V B operand, which wants eight
+        // consecutive positions for one dim, is a 4-byte shared load.
+        __syncthreads();
+        for (int idx = tid; idx < kMmaKvTile * kMmaSteps;
+             idx += kMmaWarps * 32) {
+            const int slot = idx / kMmaSteps;
+            const int chunk = idx - slot * kMmaSteps;
+            uint4 vv = make_uint4(0u, 0u, 0u, 0u);
+            if (slot < count) {
+                const size_t at = static_cast<size_t>(base + slot) * kv_stride +
+                    static_cast<size_t>(kv_head) * head_dim + chunk * 8;
+                vv = *reinterpret_cast<const uint4*>(v_cache + at);
+            }
+            const uint16_t* src = reinterpret_cast<const uint16_t*>(&vv);
+#pragma unroll
+            for (int i = 0; i < 8; ++i) vt[chunk * 8 + i][slot] = src[i];
+        }
+        __syncthreads();
+
+        // Online softmax over the 16x32 tile. Eight threads share a row, so the
+        // row reductions are three shuffles inside a warp.
+        {
+            const int row = tid >> 3;
+            const int col0 = (tid & 7) * 4;
+            const int token = qbase + row;
+            const int limit = token < seq_len ? position_offset + token : -1;
+            const float m_old = row_m[row];
+            const float l_old = row_l[row];
+            float sv[4];
+            float local_max = -INFINITY;
+#pragma unroll
+            for (int i = 0; i < 4; ++i) {
+                const int col = col0 + i;
+                float value = -INFINITY;
+                if (col < count && base + col <= limit) {
+                    value = sc[row][col] * attention_scale;
+                }
+                sv[i] = value;
+                local_max = fmaxf(local_max, value);
+            }
+#pragma unroll
+            for (int off = 1; off < 8; off <<= 1) {
+                local_max = fmaxf(local_max,
+                                  __shfl_xor_sync(0xffffffffu, local_max, off));
+            }
+            const float m_new = fmaxf(m_old, local_max);
+            float local_sum = 0.0f;
+#pragma unroll
+            for (int i = 0; i < 4; ++i) {
+                // The numerator is rounded to half for the tensor-core operand,
+                // so the denominator sums the rounded values to keep the two
+                // consistent.
+                uint16_t bits = 0;
+                if (m_new != -INFINITY && sv[i] != -INFINITY) {
+                    bits = float_to_half(expf(sv[i] - m_new));
+                    local_sum += half_to_float(bits);
+                }
+                ph[row][col0 + i] = bits;
+            }
+#pragma unroll
+            for (int off = 1; off < 8; off <<= 1) {
+                local_sum += __shfl_xor_sync(0xffffffffu, local_sum, off);
+            }
+            __syncwarp();
+            if ((tid & 7) == 0) {
+                const float alpha =
+                    m_old == -INFINITY ? 0.0f : expf(m_old - m_new);
+                row_alpha[row] = alpha;
+                row_m[row] = m_new;
+                row_l[row] = l_old * alpha + local_sum;
+            }
+        }
+        __syncthreads();
+
+        {
+            const float alpha0 = row_alpha[lrow0];
+            const float alpha1 = row_alpha[lrow1];
+#pragma unroll
+            for (int j = 0; j < 8; ++j) {
+                acc[j][0] *= alpha0;
+                acc[j][1] *= alpha0;
+                acc[j][2] *= alpha1;
+                acc[j][3] *= alpha1;
+            }
+#pragma unroll
+            for (int kt = 0; kt < kMmaKvTile / 8; ++kt) {
+                uint32_t a[2];
+                a[0] = *reinterpret_cast<const uint32_t*>(
+                    &ph[lrow0][kt * 8 + tig * 2]);
+                a[1] = *reinterpret_cast<const uint32_t*>(
+                    &ph[lrow1][kt * 8 + tig * 2]);
+#pragma unroll
+                for (int j = 0; j < 8; ++j) {
+                    const uint32_t b = *reinterpret_cast<const uint32_t*>(
+                        &vt[slice * 64 + j * 8 + gid][kt * 8 + tig * 2]);
+                    mma_m16n8k8_f16_f32(acc[j], a, b);
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    const float inv0 = row_l[lrow0] > 0.0f ? 1.0f / row_l[lrow0] : 0.0f;
+    const float inv1 = row_l[lrow1] > 0.0f ? 1.0f / row_l[lrow1] : 0.0f;
+    const int row0 = qbase + lrow0;
+    const int row1 = qbase + lrow1;
+#pragma unroll
+    for (int j = 0; j < 8; ++j) {
+        const int dim = slice * 64 + j * 8 + tig * 2;
+        if (row0 < seq_len) {
+            uint16_t* out = output +
+                (static_cast<size_t>(row0) * q_heads + head) * head_dim + dim;
+            out[0] = float_to_half(acc[j][0] * inv0);
+            out[1] = float_to_half(acc[j][1] * inv0);
+        }
+        if (row1 < seq_len) {
+            uint16_t* out = output +
+                (static_cast<size_t>(row1) * q_heads + head) * head_dim + dim;
+            out[0] = float_to_half(acc[j][2] * inv1);
+            out[1] = float_to_half(acc[j][3] * inv1);
+        }
+    }
+}
+
 // Two adjacent query rows and three Q heads sharing a KV head are processed by
 // one CTA. Each K/V element is loaded once for six attention outputs.
 __global__ void gqa_prefill_tiled_f16_kernel(
@@ -1835,6 +2077,21 @@ bool qwen_gqa_prefill_attention_f16_tiled_cuda(
             const dim3 mma_grid(
                 static_cast<unsigned>(q_heads),
                 static_cast<unsigned>((seq_len + kMmaQRows - 1) / kMmaQRows), 1);
+            // The occupancy variant aliases the K and V staging buffers, which
+            // are live in disjoint phases, cutting shared memory 40960 -> 24064 B
+            // so two CTAs fit per SM instead of one. The cost is one extra
+            // __syncthreads() and a second pass over the KV tile addresses per
+            // iteration; the benefit is 1.15x on the kernel and +1.4% end-to-end
+            // at bitwise parity. Set DSV4_QWEN_GQA_MMA_OCC=0 to disable.
+            const char* mma_occ = std::getenv("DSV4_QWEN_GQA_MMA_OCC");
+            if (mma_occ == nullptr || std::strcmp(mma_occ, "0") != 0) {
+                gqa_prefill_mma_occ_f16_kernel<<<
+                    mma_grid, kMmaWarps * 32, 0,
+                    static_cast<cudaStream_t>(stream)>>>(
+                    q, k_cache, v_cache, output, seq_len, q_heads, kv_heads,
+                    head_dim, position_offset);
+                return cudaGetLastError() == cudaSuccess;
+            }
             gqa_prefill_mma_f16_kernel<<<
                 mma_grid, kMmaWarps * 32, 0,
                 static_cast<cudaStream_t>(stream)>>>(

--- a/cpp_engine/cuda/qwen_gqa_optimized.cu
+++ b/cpp_engine/cuda/qwen_gqa_optimized.cu
@@ -799,9 +799,10 @@ __device__ __forceinline__ void mma_m16n8k8_f16_f32(
 // warps are indexed as (row block, slice): for Q*K each slice takes eight KV
 // positions, for P*V each slice takes 64 of the 256 head dims. Both products are
 // therefore full-width tensor-core work and the only scalar phase left is the
-// 32x32 softmax. Two row blocks per CTA is what makes the ~43 KiB of K/V staging
-// worth its occupancy cost: the tile is loaded once for twice the output.
-constexpr int kMmaQRows = 32;
+// 32x32 softmax. Four row blocks per CTA cuts long-context KV traffic in half.
+// A 512-thread CTA is intentionally limited to one resident block so the
+// accumulator registers are not forced to spill by a two-block launch bound.
+constexpr int kMmaQRows = 64;
 constexpr int kMmaRowBlocks = kMmaQRows / 16;
 constexpr int kMmaKvTile = 32;
 constexpr int kMmaDim = 256;
@@ -1039,10 +1040,13 @@ __global__ __launch_bounds__(kMmaWarps * 32) void gqa_prefill_mma_f16_kernel(
     }
 }
 
-// The second launch_bounds argument asks for two resident blocks, which caps the
-// register budget at 128 per thread. Shared memory is already under half an SM's
-// 64 KB after the aliasing above, so registers are the only other gate.
-__global__ __launch_bounds__(kMmaWarps * 32, 2) void gqa_prefill_mma_occ_f16_kernel(
+// At 64 query rows the CTA is 512 threads, and asking for two resident blocks
+// would cap registers at 64 per thread and spill the accumulators: measured at
+// the real TP4 shape that costs 3.2x on the deep-history cases (268.4 ms against
+// 83.6 at offset 61440). One resident block per SM is therefore requested
+// explicitly, and the wider row tile pays for the lost occupancy by halving how
+// often the KV history is re-streamed.
+__global__ __launch_bounds__(kMmaWarps * 32, 1) void gqa_prefill_mma_occ_f16_kernel(
     const uint16_t* __restrict__ q_rows,
     const uint16_t* __restrict__ k_cache,
     const uint16_t* __restrict__ v_cache,
@@ -1054,8 +1058,8 @@ __global__ __launch_bounds__(kMmaWarps * 32, 2) void gqa_prefill_mma_occ_f16_ker
     int position_offset) {
     // ks and vt are live in disjoint phases: Q*K reads ks and is fenced by a
     // __syncthreads() before the softmax, and P*V reads vt only after that. So
-    // they share one buffer, which is what brings shared memory from 40960 B to
-    // 24064 B and lets two CTAs be resident per SM instead of one.
+    // they share one buffer, which keeps the K/V staging at 17408 B instead of
+    // 40960 B and leaves room for the wider row tile's sc/ph arrays.
     constexpr int kStageHalves =
         kMmaKvTile * kMmaKsStride > kMmaDim * kMmaVtStride
             ? kMmaKvTile * kMmaKsStride
@@ -2083,6 +2087,13 @@ bool qwen_gqa_prefill_attention_f16_tiled_cuda(
             // __syncthreads() and a second pass over the KV tile addresses per
             // iteration; the benefit is 1.15x on the kernel and +1.4% end-to-end
             // at bitwise parity. Set DSV4_QWEN_GQA_MMA_OCC=0 to disable.
+            // Pairing two Q heads of one KV head into a CTA was tried and
+            // rejected: it halves the KV traffic on paper, but two sets of Q
+            // fragments and P*V accumulators need ~192 registers per thread, so
+            // ptxas spills 400 bytes and the kernel runs 3x slower (249.0 ms
+            // against 83.6 at 4096 rows, offset 61440) despite bit-identical
+            // output. Sharing a tile across heads needs the accumulators moved to
+            // shared memory first.
             const char* mma_occ = std::getenv("DSV4_QWEN_GQA_MMA_OCC");
             if (mma_occ == nullptr || std::strcmp(mma_occ, "0") != 0) {
                 gqa_prefill_mma_occ_f16_kernel<<<

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -1753,15 +1753,20 @@ struct QwenEngine::Impl {
              rows * q_heads, head_dim);
         norm(layer.full.k_norm, k.f16_data(), k_norm.f16_data(),
              rows * kv_heads, head_dim);
-        require_launch(qwen_partial_rope_rows_f16_cuda(
-            q_norm.f16_data(), k_norm.f16_data(), position_offset, rows,
-            static_cast<int>(config.partial_rotary_dim()),
-            static_cast<float>(config.rope_theta), q_heads, kv_heads, head_dim),
-            "FP16 partial RoPE");
+        {
+            PhaseScope sub(this, "full.rope");
+            require_launch(qwen_partial_rope_rows_f16_cuda(
+                q_norm.f16_data(), k_norm.f16_data(), position_offset, rows,
+                static_cast<int>(config.partial_rotary_dim()),
+                static_cast<float>(config.rope_theta), q_heads, kv_heads, head_dim),
+                "FP16 partial RoPE");
+        }
 
         const QwenKvCacheDType cache_dtype = options.kv_cache_dtype;
         const int attention_window = options.attention_window;
         const int sink_tokens = options.attention_sink_tokens;
+        {
+        PhaseScope append_scope(this, "full.kv_append");
         if (cache_dtype == QwenKvCacheDType::Fp8) {
             require_launch(qwen_append_kv_cache_fp8_cuda(
                 k_norm.f16_data(), v.f16_data(), layer.full.k_cache.fp8_data(),
@@ -1786,6 +1791,7 @@ struct QwenEngine::Impl {
                 k_norm.f16_data(), v.f16_data(), layer.full.k_cache.f16_data(),
                 layer.full.v_cache.f16_data(), rows, kv_heads, head_dim,
                 position_offset, max_context), "append FP16 full KV cache");
+        }
         }
 
         if (rows == 1) {
@@ -2031,6 +2037,7 @@ struct QwenEngine::Impl {
         // wider TP4 candidate is selected separately through LONG_TILE.
         } else if (qwen_env_enabled_default("DSV4_QWEN_GQA_OPTIMIZED") ||
                    attention_window > 0) {
+            PhaseScope sub(this, "full.attn_kernel");
             require_launch(qwen_gqa_prefill_attention_f16_tiled_cuda(
                 q_norm.f16_data(), layer.full.k_cache.f16_data(),
                 layer.full.v_cache.f16_data(), attention.f16_data(), rows,
@@ -2038,6 +2045,7 @@ struct QwenEngine::Impl {
                 attention_window, sink_tokens),
                 "prefill optimized FP16-cache GQA");
         } else {
+            PhaseScope sub(this, "full.attn_kernel");
             require_launch(qwen_gqa_prefill_attention_f16_cuda(
                 q_norm.f16_data(), layer.full.k_cache.f16_data(),
                 layer.full.v_cache.f16_data(), attention.f16_data(), rows,
@@ -2130,6 +2138,7 @@ struct QwenEngine::Impl {
         } else {
             projection(layer.gate, post.f16_data(), gate->f16_data(), rows, "mlp.gate");
             projection(layer.up, post.f16_data(), up->f16_data(), rows, "mlp.up");
+            PhaseScope sub(this, "swiglu.act");
             require_launch(qwen_silu_mul_rows_f16_cuda(
                 gate->f16_data(), up->f16_data(), intermediate.f16_data(), rows,
                 static_cast<int>(layer.gate.weight.shape[0])), "FP16 SwiGLU");

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -397,11 +397,13 @@ struct QwenEngine::Impl {
     bool sampling_rng_ready = false;
     std::vector<float> host_uniform_scratch;
     QwenWorkspace workspace;
-    // Optional NCCL stream candidate. Every collective is bracketed by events
-    // on the default compute stream, so enabling this cannot expose a partially
-    // reduced tensor to the next layer. It is opt-in because the dependency
-    // chain may leave no useful work to overlap on the target verify topology.
-    const bool use_nccl_comm_stream = qwen_env_enabled("QWEN_NCCL_COMM_STREAM");
+    // Separate NCCL stream. Every collective is bracketed by events on the
+    // default compute stream, so enabling this cannot expose a partially reduced
+    // tensor to the next layer. It is on by default because the sliced
+    // projection+all-reduce pipeline below needs it to hide any of the
+    // collective; `=0` restores the single-stream behaviour.
+    const bool use_nccl_comm_stream =
+        qwen_env_enabled_default("QWEN_NCCL_COMM_STREAM");
     cudaStream_t nccl_comm_stream = nullptr;
     cudaEvent_t nccl_comm_ready = nullptr;
     cudaEvent_t nccl_comm_done = nullptr;
@@ -1308,23 +1310,22 @@ struct QwenEngine::Impl {
     // Number of row slices used by the overlapped projection+all-reduce path.
     // 0 or 1 disables slicing entirely and keeps the serial behaviour.
     //
-    // Opt-in, and deliberately not defaulted on. Measured serially on the real
-    // 64-layer TP4 checkpoint with QWEN_NCCL_COMM_STREAM=1 and both the mlp.down
-    // and lin.out sites overlapped, against the same binary's serial default:
+    // Four slices is the default. Measured serially on the real 64-layer TP4
+    // checkpoint with QWEN_NCCL_COMM_STREAM=1 and both the mlp.down and lin.out
+    // sites overlapped, against the same binary's serial path:
     //
-    //   context   serial    slices=4   prefill   decode
-    //     8192    1221.9     1218.3    1.00x     25.24 -> 24.92
-    //    32768    1228.3     1272.6    1.04x     20.85 -> 20.79
-    //    65536    1065.3     1098.6    1.03x     19.52 -> 19.34
+    //   context   serial    slices=4   slices=8   prefill
+    //    65536    1275.7     1325.8     1304.1     1.04x
     //
-    // Only 3-4% at long context, nothing at 8K, and decode is consistently a
-    // little worse because the comm stream competes for SMs with kernels that had
-    // the device to themselves. The collective is bytes-bound at ~26 GB/s of ring
-    // bandwidth, so most of it simply cannot hide behind one layer's GEMMs.
-    // Enable with QWEN_COMM_OVERLAP_SLICES=4 for long-context prefill-heavy work.
+    // Eight slices is worse than four: the per-slice GEMM gets short enough that
+    // the collective no longer has a full slice of compute to hide under. The
+    // gain used to be 3% when attention dominated; with the 64-row attention tile
+    // the collective is 28.6% of prefill, so hiding part of it is worth more.
+    // The collective is bytes-bound at ~8.8 GB/s of ring bandwidth per rank, so
+    // it cannot be made faster, only hidden. Set 0 or 1 to disable.
     int comm_overlap_slices() const {
         static const int slices =
-            qwen_env_int("QWEN_COMM_OVERLAP_SLICES", 0);
+            qwen_env_int("QWEN_COMM_OVERLAP_SLICES", 4);
         return slices;
     }
 
@@ -2097,7 +2098,11 @@ struct QwenEngine::Impl {
             full_attention(layer, normalized.f16_data(), attention.f16_data(),
                            rows, position_offset);
         }
-        if (qwen_env_enabled("QWEN_FUSE_ATTN_RESID_NORM")) {
+        // One fused pass replaces the residual copy, the add, and the norm. It is
+        // the default: measured on the real 65K TP4 prefill it saves 1.51 s
+        // (55.80 -> 54.28 s) with identical generated tokens. `=0` restores the
+        // three separate passes for A/B.
+        if (qwen_env_enabled_default("QWEN_FUSE_ATTN_RESID_NORM")) {
             PhaseScope scope(this, "attn_resid_norm");
             require_launch(
                 qwen_residual_add_rmsnorm_fp16_gamma_rows_f16_cuda(

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -170,6 +170,17 @@ DeviceLinear fuse_linear_rows(const DeviceLinear& first,
         first.fp8 != second.fp8) {
         return fused;
     }
+    // The two operands must dispatch to the same kernel family, and both must
+    // carry a logical shape: `projection` reads kind and logical_shape, not the
+    // storage shape, so a fused linear that leaves them defaulted would either
+    // pick the wrong kernel or throw. NVFP4 is never fused because its packed
+    // rows and per-tensor factors do not concatenate.
+    if (first.kind != second.kind ||
+        first.kind == QwenLinearKind::NvFp4Group16 ||
+        first.logical_shape.size() != 2 || second.logical_shape.size() != 2 ||
+        first.logical_shape[1] != second.logical_shape[1]) {
+        return fused;
+    }
     if (first.fp8 &&
         (first.scale.data == nullptr || second.scale.data == nullptr ||
          first.scale.shape.size() != 2 || second.scale.shape.size() != 2 ||
@@ -178,6 +189,9 @@ DeviceLinear fuse_linear_rows(const DeviceLinear& first,
         return fused;
     }
 
+    fused.kind = first.kind;
+    fused.logical_shape = {first.logical_shape[0] + second.logical_shape[0],
+                           first.logical_shape[1]};
     const uint64_t first_rows = first.weight.shape[0];
     const uint64_t second_rows = second.weight.shape[0];
     const uint64_t columns = first.weight.shape[1];

--- a/cpp_engine/src/tp_comm.cpp
+++ b/cpp_engine/src/tp_comm.cpp
@@ -1,6 +1,11 @@
 #include "tp_comm.hpp"
 
 #ifdef DSV4_HAVE_NCCL
+// Both are required: qwen_sampler.hpp for the sampler uniforms and
+// qwen_cuda_ops.hpp for the DFlash2 top-k pack/merge kernels used by the
+// global-top1 collective below. The latter is only visible in NCCL builds,
+// which is why dropping it still compiled with NCCL off.
+#include "qwen_cuda_ops.hpp"
 #include "qwen_sampler.hpp"
 
 #include <cuda_runtime.h>

--- a/cpp_engine/tests/test_qwen_gqa_mma_occ.cpp
+++ b/cpp_engine/tests/test_qwen_gqa_mma_occ.cpp
@@ -1,0 +1,169 @@
+// Bitwise parity between the two MMA prefill kernels.
+//
+// The occupancy variant only changes where K and V are staged and when: it
+// aliases the two shared buffers and loads V after Q*K has parked its scores.
+// The arithmetic, the accumulation order, and the online-softmax rescaling are
+// untouched, so the outputs must match bit for bit, not merely within a
+// tolerance. A tolerance-based check here would hide exactly the kind of
+// synchronization bug the aliasing could introduce.
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include "cuda_ops.hpp"
+#include "qwen_cuda_ops.hpp"
+
+namespace {
+
+// Qwen3.8 TP4 shard: 24 q heads over 4 kv heads at head_dim 256, sharded four
+// ways, so one rank runs 6 q heads over 1 kv head.
+constexpr int kQHeads = 6;
+constexpr int kKvHeads = 1;
+constexpr int kHeadDim = 256;
+
+bool run_case(int rows, int position_offset, int& checked) {
+    const int max_context = position_offset + rows;
+    const size_t q_elements =
+        static_cast<size_t>(rows) * kQHeads * kHeadDim;
+    const size_t kv_elements =
+        static_cast<size_t>(max_context) * kKvHeads * kHeadDim;
+
+    std::mt19937 rng(20260828u + static_cast<unsigned>(rows + position_offset));
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<uint16_t> host_q(q_elements);
+    std::vector<uint16_t> host_k(kv_elements);
+    std::vector<uint16_t> host_v(kv_elements);
+    auto fill = [&](std::vector<uint16_t>& out) {
+        for (uint16_t& value : out) {
+            const __half h = __float2half(dist(rng));
+            std::memcpy(&value, &h, sizeof(value));
+        }
+    };
+    fill(host_q);
+    fill(host_k);
+    fill(host_v);
+
+    uint16_t* d_q = nullptr;
+    uint16_t* d_k = nullptr;
+    uint16_t* d_v = nullptr;
+    uint16_t* d_base = nullptr;
+    uint16_t* d_occ = nullptr;
+    if (cudaMalloc(&d_q, q_elements * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_k, kv_elements * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_v, kv_elements * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_base, q_elements * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_occ, q_elements * sizeof(uint16_t)) != cudaSuccess) {
+        std::printf("[SKIP] allocation failed for rows=%d offset=%d\n",
+                    rows, position_offset);
+        return true;
+    }
+    cudaMemcpy(d_q, host_q.data(), q_elements * sizeof(uint16_t),
+               cudaMemcpyHostToDevice);
+    cudaMemcpy(d_k, host_k.data(), kv_elements * sizeof(uint16_t),
+               cudaMemcpyHostToDevice);
+    cudaMemcpy(d_v, host_v.data(), kv_elements * sizeof(uint16_t),
+               cudaMemcpyHostToDevice);
+
+    setenv("DSV4_QWEN_GQA_OPTIMIZED", "1", 1);
+    setenv("DSV4_QWEN_GQA_MMA_TILE", "1", 1);
+
+    setenv("DSV4_QWEN_GQA_MMA_OCC", "0", 1);
+    const bool base_ok = dsv4::qwen_gqa_prefill_attention_f16_tiled_cuda(
+        d_q, d_k, d_v, d_base, rows, kQHeads, kKvHeads, kHeadDim,
+        position_offset, max_context, 0, 0);
+    setenv("DSV4_QWEN_GQA_MMA_OCC", "1", 1);
+    const bool occ_ok = dsv4::qwen_gqa_prefill_attention_f16_tiled_cuda(
+        d_q, d_k, d_v, d_occ, rows, kQHeads, kKvHeads, kHeadDim,
+        position_offset, max_context, 0, 0);
+    cudaDeviceSynchronize();
+
+    std::vector<uint16_t> out_base(q_elements);
+    std::vector<uint16_t> out_occ(q_elements);
+    cudaMemcpy(out_base.data(), d_base, q_elements * sizeof(uint16_t),
+               cudaMemcpyDeviceToHost);
+    cudaMemcpy(out_occ.data(), d_occ, q_elements * sizeof(uint16_t),
+               cudaMemcpyDeviceToHost);
+    cudaFree(d_q);
+    cudaFree(d_k);
+    cudaFree(d_v);
+    cudaFree(d_base);
+    cudaFree(d_occ);
+
+    if (!base_ok || !occ_ok) {
+        std::printf("[FAIL] launch failed rows=%d offset=%d base=%d occ=%d\n",
+                    rows, position_offset, static_cast<int>(base_ok),
+                    static_cast<int>(occ_ok));
+        return false;
+    }
+
+    size_t mismatches = 0;
+    float worst = 0.0f;
+    for (size_t i = 0; i < q_elements; ++i) {
+        if (out_base[i] != out_occ[i]) {
+            ++mismatches;
+            __half a;
+            __half b;
+            std::memcpy(&a, &out_base[i], sizeof(a));
+            std::memcpy(&b, &out_occ[i], sizeof(b));
+            const float diff =
+                std::fabs(__half2float(a) - __half2float(b));
+            if (diff > worst) worst = diff;
+        }
+    }
+    // Guard against both kernels writing nothing, which would make any
+    // comparison trivially pass.
+    size_t nonzero = 0;
+    for (size_t i = 0; i < q_elements; ++i) {
+        if (out_base[i] != 0) ++nonzero;
+    }
+    if (nonzero == 0) {
+        std::printf("[FAIL] rows=%d offset=%d produced an all-zero reference\n",
+                    rows, position_offset);
+        return false;
+    }
+
+    std::printf("  mma occ rows=%5d offset=%6d mismatches=%zu worst=%.3e "
+                "nonzero=%zu/%zu\n",
+                rows, position_offset, mismatches, worst, nonzero, q_elements);
+    ++checked;
+    return mismatches == 0;
+}
+
+}  // namespace
+
+int main() {
+    if (!dsv4::cuda_runtime_available()) {
+        std::printf("[SKIP] test_qwen_gqa_mma_occ requires a CUDA device\n");
+        return 0;
+    }
+    struct Case {
+        int rows;
+        int offset;
+    };
+    // Fresh chunk, second chunk, and the deep-history offsets that dominate
+    // long-context prefill. 150 rows is not a multiple of the 32-row block, so
+    // it exercises the ragged tail.
+    const Case cases[] = {
+        {  32,     0}, { 150,     0}, { 512,     0}, { 512,  4096},
+        {1024,  2048}, {2048,  4096}, {4096,     0}, {4096,  4096},
+        {4096, 16384}, {4096, 61440},
+    };
+    bool ok = true;
+    int checked = 0;
+    for (const Case& item : cases) {
+        if (!run_case(item.rows, item.offset, checked)) ok = false;
+    }
+    if (checked == 0) {
+        std::printf("[FAIL] no case ran\n");
+        return 1;
+    }
+    std::printf("%s test_qwen_gqa_mma_occ (%d cases)\n",
+                ok ? "[PASS]" : "[FAIL]", checked);
+    return ok ? 0 : 1;
+}

--- a/scripts/bench_qwen_long_context.py
+++ b/scripts/bench_qwen_long_context.py
@@ -615,13 +615,13 @@ def main() -> int:
         "max_new_tokens": args.max_new_tokens,
         "prefill_chunk_tokens": args.prefill_chunk_tokens,
         "kv_cache_dtype": args.kv_cache_dtype,
-<<<<<<< HEAD
         "git_revision": git_revision(),
         "binary_metadata": binary_metadata(binary),
+        # Both the ambient CUDA/NCCL environment and the explicit --env overrides
+        # are recorded. They answer different questions: the first says what the
+        # machine was, the second says what the run asked for.
         "environment": environment_metadata(),
-        "serial_cases": True,
-        "phase_profile_diagnostic_only": "QWEN_PHASE_PROFILE" in os.environ,
-=======
+        "env_overrides": env_overrides,
         "qwen_sampling": {
             "temperature": args.qwen_temperature,
             "top_p": args.qwen_top_p,
@@ -629,8 +629,8 @@ def main() -> int:
             "seed": args.qwen_seed,
         },
         "repetitions": args.repetitions,
-        "environment": env_overrides,
->>>>>>> 456f45c (Add Qwen3.8-27B-NVFP4 TP2 runtime with wide INT8 prefill tile)
+        "serial_cases": True,
+        "phase_profile_diagnostic_only": "QWEN_PHASE_PROFILE" in os.environ,
         "results": results,
     }
     result_path = work_dir / "results.json"


### PR DESCRIPTION
## Summary

Qwen FP16 TP4 65K prefill goes 1196.76 -> 1335.90 tok/s (54.76 -> 49.06 s). Three changes, all measured serially on the real 64-layer checkpoint with a single binary, all generating identical tokens with rank parity PASS. Each keeps a `=0` escape hatch.

**1. `kMmaQRows` 32 -> 64.** Every CTA re-streams the KV history for its head, so the row-tile count multiplies history traffic directly. The launch bound has to become one resident block in the same change — at 512 threads a two-block request caps registers at 64/thread and ptxas spills, costing 3.2x on deep history (268.4 ms vs 83.6 at 4096 rows / offset 61440). With `,1`: 1.29x on the kernel, `full.attn_kernel` 16.99 -> 11.40 s.

**2. `QWEN_FUSE_ATTN_RESID_NORM` default on.** One fused pass replaces residual copy + add + norm: 55.80 -> 54.28 s on a same-SHA A/B.

**3. `QWEN_COMM_OVERLAP_SLICES` default 4, `QWEN_NCCL_COMM_STREAM` default on.** `tp_all_reduce` 14.64 -> 2.88 s. slices=8 is worse than 4 (1304 vs 1326 tok/s). The 3% figure in the old comment was measured when attention dominated; the collective is now 28.6% of prefill.

## Testing

- `test_qwen_gqa_mma_occ` — 10/10 cases bit-exact against the base MMA kernel (`mismatches=0`, `worst=0.000e+00`). This is a zero-tolerance check, which is what catches synchronization bugs from the aliased K/V staging.
- `test_qwen_gqa_attention` — PASS, numerical gates unchanged.
- Serial real-checkpoint benchmark, both lengths, final default config: 8192 = 1345.79 tok/s, 65536 = 1335.90 tok/s, `rank_token_parity=PASS` on both. Decode unchanged (20.26 tok/s at 65K).

## Not landed

Against the vLLM-2080Ti reference of 44.377 s / 1476.8 tok/s this is still ~4.7 s / 10.5% short. Three ideas were tried and rejected rather than shipped:

- **Head-pair kernel** (one CTA covering 2 q heads sharing a kv head, to halve KV traffic): output was bit-identical but two sets of `qfrag` and P*V accumulators need ~192 registers/thread; ptxas spills 400 bytes and it runs 3x slower (249.0 vs 83.6 ms). Would need the accumulators in shared memory first. Rationale recorded as a comment at the dispatch site.
- **Prefill chunk 8192**: tie with 4096 (1324.33 vs 1325.77).
- **Row-tile scheduling swizzle**: prefill already runs in 4096-token chunks, so within one launch the tiles differ in scan length only by the chunk width; the cross-chunk imbalance is serialized by the chunk loop regardless.

Remaining headroom is concentrated in `gated_delta` (8.7%), still the serial `for (int t = 0; t < tokens; ++t)` recurrence in `qwen_gdn_flashqla.cu`. MLP GEMMs are at 53.6 TFLOP/s (tensor-core peak) and the collective is at measured NCCL busbw, so neither has room.