### PR TITLE
Optimize Qwen TP4 long-context prefill

### DIFF
--- a/cpp_engine/cuda/qwen_gdn_flashqla.cu
+++ b/cpp_engine/cuda/qwen_gdn_flashqla.cu
@@ -14,6 +14,7 @@
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 #include <cstdint>
+#include <cstdlib>
 
 namespace dsv4 {
 
@@ -81,24 +82,41 @@ __global__ void gdn_flashqla_kernel(
         }
     }
 
-    // Serial recurrence over tokens.
-    for (int t = 0; t < tokens; ++t) {
-        // Broadcast gate and beta to all threads.
-        float gate_value = 0.0f;
-        float beta_value = 0.0f;
-        // Each y-row is an independent warp processing a different state-column
-        // group, so lane 0 of every warp must load the per-head gate and beta.
-        if (threadIdx.x == 0) {
-            gate_value = expf(__half2float(gate[static_cast<size_t>(t) * v_heads + hv]));
-            beta_value = __half2float(beta[static_cast<size_t>(t) * v_heads + hv]);
-        }
-        gate_value = warp_broadcast_lane0(gate_value, 32);
-        beta_value = warp_broadcast_lane0(beta_value, 32);
+    // Software-pipelined operand loads.
+    //
+    // Nothing a token reads depends on the previous token's state, so every load
+    // can be issued one iteration early and its latency overlapped with the
+    // recurrence arithmetic. That matters here because the recurrence is serial in
+    // tokens and the per-token critical path was dominated by memory latency
+    // rather than math: `gate`/`beta` were fetched at the top of the body, and
+    // `v[col]` was fetched by lane 0 *after* the K-state reduction, putting a full
+    // dependent global load in the middle of the chain. Holding token t+1's
+    // operands in registers while token t computes leaves only the shuffle
+    // reductions on the path. The arithmetic, its order, and the reduction widths
+    // are untouched, so results stay bit-identical.
+    float q_next[rows_per_lane];
+    float k_next[rows_per_lane];
+    float v_next[COLS];
+    float gate_next = 0.0f;
+    float beta_next = 0.0f;
 
-        // Load pre-normalized Q and K for this position. Q and K share the key
-        // head hq under GQA; the key row stride is q_heads * D.
-        float k_reg[rows_per_lane];
-        float q_reg[rows_per_lane];
+    // `gate`/`beta` are per-head scalars broadcast across the warp. Each y-row is
+    // an independent warp working a different state-column group, so lane 0 of
+    // every warp loads them; expf is applied at the load site exactly as before.
+    auto load_scalars = [&](int t, float* gate_out, float* beta_out) {
+        float g_value = 0.0f;
+        float b_value = 0.0f;
+        if (threadIdx.x == 0) {
+            g_value = expf(__half2float(gate[static_cast<size_t>(t) * v_heads + hv]));
+            b_value = __half2float(beta[static_cast<size_t>(t) * v_heads + hv]);
+        }
+        *gate_out = g_value;
+        *beta_out = b_value;
+    };
+
+    // Pre-normalized Q and K. Q and K share the key head hq under GQA, so the
+    // key row stride is q_heads * D.
+    auto load_qk = [&](int t, float* q_out, float* k_out) {
 #pragma unroll
         for (int r = 0; r < rows_per_lane; ++r) {
             const int row = r * WIDTH + lane;
@@ -112,9 +130,59 @@ __global__ void gdn_flashqla_kernel(
                 q_value = q_normalized[qk_index];
                 k_value = k_normalized[qk_index];
             }
-            q_reg[r] = q_value;
-            k_reg[r] = k_value;
+            q_out[r] = q_value;
+            k_out[r] = k_value;
         }
+    };
+
+    // Only lane 0 consumes v, matching the original delta computation.
+    auto load_v = [&](int t, float* v_out) {
+#pragma unroll
+        for (int c = 0; c < COLS; ++c) {
+            float value = 0.0f;
+            if (lane == 0) {
+                const int col = col_base + c;
+                if (col < D) {
+                    const size_t v_index =
+                        static_cast<size_t>(t) * v_heads * D +
+                        static_cast<size_t>(hv) * D +
+                        static_cast<size_t>(col);
+                    value = __half2float(v[v_index]);
+                }
+            }
+            v_out[c] = value;
+        }
+    };
+
+    load_scalars(0, &gate_next, &beta_next);
+    load_qk(0, q_next, k_next);
+    load_v(0, v_next);
+
+    // Serial recurrence over tokens.
+    for (int t = 0; t < tokens; ++t) {
+        float k_reg[rows_per_lane];
+        float q_reg[rows_per_lane];
+        float v_reg[COLS];
+#pragma unroll
+        for (int r = 0; r < rows_per_lane; ++r) {
+            q_reg[r] = q_next[r];
+            k_reg[r] = k_next[r];
+        }
+#pragma unroll
+        for (int c = 0; c < COLS; ++c) v_reg[c] = v_next[c];
+        float gate_value = gate_next;
+        float beta_value = beta_next;
+
+        // Issue the next token's loads before consuming this one's, so their
+        // latency hides behind the reductions below.
+        if (t + 1 < tokens) {
+            load_scalars(t + 1, &gate_next, &beta_next);
+            load_qk(t + 1, q_next, k_next);
+            load_v(t + 1, v_next);
+        }
+
+        gate_value = warp_broadcast_lane0(gate_value, 32);
+        beta_value = warp_broadcast_lane0(beta_value, 32);
 
         // Compute K · state for each column: sum over rows (subgroup reduction).
         float kv_partial[COLS];
@@ -128,8 +196,8 @@ __global__ void gdn_flashqla_kernel(
             kv_partial[c] = warp_reduce_sum(sum, WIDTH);
         }
 
-        // Compute delta = (v - gate * K·state) * beta for each column.
-        // Lane 0 loads v[col], broadcasts delta.
+        // Compute delta = (v - gate * K·state) * beta for each column. v is already
+        // in registers from the prefetch, so lane 0 only does arithmetic here.
         float delta[COLS];
 #pragma unroll
         for (int c = 0; c < COLS; ++c) {
@@ -137,11 +205,7 @@ __global__ void gdn_flashqla_kernel(
             if (lane == 0) {
                 const int col = col_base + c;
                 if (col < D) {
-                    const size_t v_index =
-                        static_cast<size_t>(t) * v_heads * D +
-                        static_cast<size_t>(hv) * D +
-                        static_cast<size_t>(col);
-                    delta_value = (__half2float(v[v_index]) - gate_value * kv_partial[c]) *
+                    delta_value = (v_reg[c] - gate_value * kv_partial[c]) *
                                   beta_value;
                 }
             }
@@ -224,7 +288,20 @@ bool qwen_gated_delta_flashqla_sm75_f16_cuda(
     constexpr int COLS = 4;
     constexpr int WIDTH = 16;
     constexpr int subgroups_per_warp = 32 / WIDTH;  // 2
-    constexpr int column_groups_per_block = 8;
+
+    // Column groups per CTA. Every subgroup is fully independent -- it owns COLS
+    // columns of the [D, D] state and never communicates -- so this only decides
+    // how the fixed 32 groups per head are packed into CTAs, never the arithmetic.
+    // Packing 8 groups per CTA leaves grid=(heads,1,2): on the real TP4 shape that
+    // is 16 CTAs for 68 SMs, so three quarters of the device is idle through a
+    // recurrence that is already serial in tokens. Fewer groups per CTA trades
+    // redundant Q/K re-reads (each group reads all D rows of the same q/k row) for
+    // SM coverage; the default is swept in bench_qwen_delta_f16.
+    static const int column_groups_per_block = [] {
+        const char* raw = std::getenv("QWEN_GDN_FLASHQLA_GROUPS_PER_CTA");
+        const int value = raw == nullptr ? 1 : std::atoi(raw);
+        return value >= 1 && value <= 8 ? value : 1;
+    }();
 
     const int groups = D / COLS;  // 32
     const int z = (groups + column_groups_per_block * subgroups_per_warp - 1) /

--- a/cpp_engine/cuda/qwen_gqa_optimized.cu
+++ b/cpp_engine/cuda/qwen_gqa_optimized.cu
@@ -2081,12 +2081,15 @@ bool qwen_gqa_prefill_attention_f16_tiled_cuda(
             const dim3 mma_grid(
                 static_cast<unsigned>(q_heads),
                 static_cast<unsigned>((seq_len + kMmaQRows - 1) / kMmaQRows), 1);
-            // The occupancy variant aliases the K and V staging buffers, which
-            // are live in disjoint phases, cutting shared memory 40960 -> 24064 B
-            // so two CTAs fit per SM instead of one. The cost is one extra
-            // __syncthreads() and a second pass over the KV tile addresses per
-            // iteration; the benefit is 1.15x on the kernel and +1.4% end-to-end
-            // at bitwise parity. Set DSV4_QWEN_GQA_MMA_OCC=0 to disable.
+            // The non-aliased kernel is the production default. After widening
+            // the query tile to 64 rows, both variants are limited to one CTA/SM:
+            // 512 threads already consume the full 1024-thread SM75 block budget,
+            // so aliasing K/V staging no longer buys occupancy. It still pays an
+            // extra barrier and a second address/load pass per KV tile. Serial
+            // same-binary real TP4 65K A/B measured 1400.67/1396.26 tok/s for the
+            // non-aliased path against 1368.73/1352.86 for aliasing, with rank
+            // parity PASS. Set DSV4_QWEN_GQA_MMA_OCC=1 to restore the alias path
+            // for controlled A/B.
             // Pairing two Q heads of one KV head into a CTA was tried and
             // rejected: it halves the KV traffic on paper, but two sets of Q
             // fragments and P*V accumulators need ~192 registers per thread, so
@@ -2095,7 +2098,7 @@ bool qwen_gqa_prefill_attention_f16_tiled_cuda(
             // output. Sharing a tile across heads needs the accumulators moved to
             // shared memory first.
             const char* mma_occ = std::getenv("DSV4_QWEN_GQA_MMA_OCC");
-            if (mma_occ == nullptr || std::strcmp(mma_occ, "0") != 0) {
+            if (mma_occ != nullptr && std::strcmp(mma_occ, "0") != 0) {
                 gqa_prefill_mma_occ_f16_kernel<<<
                     mma_grid, kMmaWarps * 32, 0,
                     static_cast<cudaStream_t>(stream)>>>(

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -2348,8 +2348,17 @@ struct QwenEngine::Impl {
         require_launch(qwen_sigmoid_mul_f16_cuda(
             attention.f16_data(), gate.f16_data(), merged.f16_data(),
             rows * attention_dim), "FP16 full attention output gate");
-        { PhaseScope sub(this, "full.out_proj"); projection(layer.full.out, merged.f16_data(), output, rows, "full.out"); }
-        all_reduce_half(output, rows * static_cast<int>(config.hidden_size), "full.out");
+        // Row-parallel output projection: each slice's rows are complete once its
+        // GEMM lands, so the collective for slice i can run under slice i+1's GEMM.
+        // This site was left serial when mlp.down and lin.out were pipelined, and
+        // at 65K it was the single largest exposed collective in the profile
+        // (ar.full.out 2.12 s against tp_all_reduce's 3.16 s total).
+        if (!projection_all_reduce_overlapped(
+                layer.full.out, merged.f16_data(), output, rows,
+                static_cast<int>(config.hidden_size), "full.out", "full.out")) {
+            { PhaseScope sub(this, "full.out_proj"); projection(layer.full.out, merged.f16_data(), output, rows, "full.out"); }
+            all_reduce_half(output, rows * static_cast<int>(config.hidden_size), "full.out");
+        }
     }
 
     void layer_forward(DeviceLayer& layer, const uint16_t* hidden,


### PR DESCRIPTION
## Summary

Continue the TP4 Qwen3.8-27B prefill optimization after rebasing onto `master`.

- Software-pipeline FlashQLA gated DeltaNet operand loads.
- Overlap the full-attention output projection with its all-reduce.
- Default to the faster non-aliased q64 MMA prefill kernel on SM75.

## Validation

- `test_qwen_gdn_flashqla` PASS
- `test_qwen_gqa_attention` PASS
- `test_qwen_gqa_mma_occ` PASS (10/10 cases, bit-exact)
- `test_qwen_engine` PASS
- Real TP4, 64-layer Qwen3.8-27B-FP8, serial 65K prefill: `1414.28 tok/s`
- Real TP4 rank token parity: PASS
- Compared with the initial `1196.76 tok/s`, this is approximately `18.2%` faster.

The benchmark used the rebased branch binary and a real tokenizer/checkpoint fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)