### PR TITLE
Stop the snapshot grid from splitting the prefill chunk

### DIFF
--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -44,7 +44,18 @@ struct QwenEngineOptions {
     //    65536      886.8      1077.7      1.21x
     //
     // The DSV4 engine already defaults to 4096 for the same reason.
-    int prefill_chunk_tokens = 4096;
+    //
+    // 8192 became reachable only once the snapshot grid stopped splitting the
+    // chunk (see `snapshot_interval_tokens`). Re-measured on the real 64-layer
+    // TP4 model with that fix, identical generated tokens, FP16 cache:
+    //
+    //   context   chunk 4096   chunk 8192   chunk 16384
+    //     8192      1798.7       1811.1        -
+    //    65536      1457.0       1481.8       1490.2
+    //
+    // 16384 is within noise of 8192 at 65K but costs another 1.06 GB of
+    // activation workspace per rank, so 8192 is the default.
+    int prefill_chunk_tokens = 8192;
     QwenKvCacheDType kv_cache_dtype = QwenKvCacheDType::Fp16;
     // 0 preserves exact full attention. Nonzero values enable the explicit
     // sink-plus-sliding-window attention path in the optimized FP16 kernels.

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -1353,25 +1353,56 @@ struct QwenEngine::Impl {
         return total;
     }
 
+    // Snapshots let a later shorter-prefix or branched request resume mid-prompt,
+    // but a snapshot position splits the prefill chunk, and a short chunk is far
+    // less efficient per token. So a snapshot grid finer than the chunk is not
+    // free: it silently caps the chunk size the prompt actually runs at.
+    //
+    // Measured on the real 64-layer TP4 model, chunk 4096, FP16 cache, identical
+    // generated tokens throughout:
+    //
+    //   context   dense grid split   grid at chunk   prefill
+    //     8192      1395 tok/s         1799 tok/s     1.29x
+    //    65536      1415 tok/s         1457 tok/s     1.03x
+    //
+    // The 8K case is the extreme one: the 256-token early grid cut the first 4096
+    // tokens into 16 chunks costing 3.59 s where a single 4096-row chunk does the
+    // same work in 1.40 s. Both grids are therefore rounded up to the chunk, and
+    // resume granularity becomes exactly the chunk boundary.
+    int snapshot_interval_tokens() const {
+        const int interval = options.state_snapshot_interval_tokens;
+        if (interval <= 0) return 0;
+        const int chunk = std::max(1, options.prefill_chunk_tokens);
+        if (interval >= chunk) return interval;
+        // Round up to a whole number of chunks so every snapshot position is also
+        // a chunk boundary and no chunk is ever split.
+        return ((chunk + interval - 1) / interval) * interval;
+    }
+
     int early_snapshot_interval() const {
-        if (options.state_snapshot_interval_tokens <= 0) return 0;
-        return std::min(256, options.state_snapshot_interval_tokens);
+        const int interval = snapshot_interval_tokens();
+        if (interval <= 0) return 0;
+        const int early = std::min(256, interval);
+        if (options.prefill_chunk_tokens > early) return 0;
+        return early;
     }
 
     bool is_periodic_snapshot_position(int position) const {
-        const int interval = options.state_snapshot_interval_tokens;
+        const int interval = snapshot_interval_tokens();
         if (interval <= 0 || position <= 0) return false;
         if (position % interval == 0) return true;
         const int early_interval = early_snapshot_interval();
+        if (early_interval <= 0) return false;
         return position <= 4096 && position % early_interval == 0;
     }
 
     int next_periodic_snapshot_after(int position) const {
-        const int interval = options.state_snapshot_interval_tokens;
+        const int interval = snapshot_interval_tokens();
         if (interval <= 0) return 0;
         const int next_regular = ((position / interval) + 1) * interval;
         if (position >= 4096) return next_regular;
         const int early_interval = early_snapshot_interval();
+        if (early_interval <= 0) return next_regular;
         const int next_early = ((position / early_interval) + 1) * early_interval;
         return std::min(next_regular, next_early);
     }
@@ -1394,6 +1425,14 @@ struct QwenEngine::Impl {
     class PhaseScope {
     public:
         PhaseScope(Impl* owner, std::string name) : owner_(owner), name_(std::move(name)) {
+            // The NVTX range is pushed without any synchronization, so a Nsight
+            // capture can attribute kernels to a site by launch correlation while
+            // the stream pipeline stays exactly as production runs it. Only the
+            // phase_profile timer needs the device drained.
+            if (owner_->nvtx_profile) {
+                nvtxRangePushA(name_.c_str());
+                nvtx_pushed_ = true;
+            }
             if (owner_->phase_profile) {
                 cudaDeviceSynchronize();
                 started_ = std::chrono::steady_clock::now();
@@ -1406,6 +1445,7 @@ struct QwenEngine::Impl {
                     std::chrono::steady_clock::now() - started_).count();
                 ++owner_->phase_calls[name_];
             }
+            if (nvtx_pushed_) nvtxRangePop();
         }
         PhaseScope(const PhaseScope&) = delete;
         PhaseScope& operator=(const PhaseScope&) = delete;
@@ -1414,6 +1454,7 @@ struct QwenEngine::Impl {
         Impl* owner_;
         std::string name_;
         std::chrono::steady_clock::time_point started_;
+        bool nvtx_pushed_ = false;
     };
 
     class NvtxScope {
@@ -1423,6 +1464,11 @@ struct QwenEngine::Impl {
         NvtxScope(const NvtxScope&) = delete;
         NvtxScope& operator=(const NvtxScope&) = delete;
     };
+
+    // Application-level NVTX ranges are opt-in: they only push/pop host-side
+    // markers so a Nsight capture can separate warmup, prefill and decode
+    // without the CUDA synchronization that `QWEN_PHASE_PROFILE` forces.
+    bool nvtx_profile = qwen_env_enabled("QWEN_NVTX_PROFILE");
 
     void report_phase_profile(const char* tag) const {
         if (!phase_profile) return;
@@ -3577,6 +3623,8 @@ QwenForwardResult QwenEngine::debug_prefill_dflash2(
 }
 
 void QwenEngine::warmup_tp() {
+    std::optional<Impl::NvtxScope> nvtx;
+    if (impl_->nvtx_profile) nvtx.emplace("qwen.warmup_tp");
     if (options_.tp_world == 1) return;
     QwenDeviceTensor scratch;
     allocate_half(scratch, 1, {1});
@@ -3604,6 +3652,8 @@ void QwenEngine::clear_prefix_cache() {
 }
 
 QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids) {
+    std::optional<Impl::NvtxScope> nvtx;
+    if (impl_->nvtx_profile) nvtx.emplace("qwen.prefill");
     if (token_ids.empty()) {
         throw std::runtime_error("Qwen prefill requires at least one token");
     }
@@ -3784,6 +3834,8 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids) {
 }
 
 QwenForwardResult QwenEngine::decode_step(int token_id) {
+    std::optional<Impl::NvtxScope> nvtx;
+    if (impl_->nvtx_profile) nvtx.emplace("qwen.decode_step");
     if (position_ >= max_context_) {
         throw std::runtime_error("Qwen context length exceeded");
     }
@@ -3811,6 +3863,8 @@ std::vector<QwenForwardResult> QwenEngine::generate(
         static_cast<size_t>(max_context_)) {
         throw std::runtime_error("Qwen prompt plus generation exceeds context");
     }
+    std::optional<Impl::NvtxScope> nvtx_generate;
+    if (impl_->nvtx_profile) nvtx_generate.emplace("qwen.generate");
     mtp_stats_ = QwenMtpStats{};
     const auto prefill_started = std::chrono::steady_clock::now();
     QwenForwardResult next = prefill(prompt_ids);
@@ -3824,10 +3878,13 @@ std::vector<QwenForwardResult> QwenEngine::generate(
     results.reserve(static_cast<size_t>(max_new_tokens));
     if (!options_.mtp && options_.dspark_checkpoint.empty() &&
         options_.dflash2_checkpoint.empty()) {
+        std::optional<Impl::NvtxScope> nvtx_decode;
+        if (impl_->nvtx_profile) nvtx_decode.emplace("qwen.decode_loop");
         for (int index = 0; index < max_new_tokens; ++index) {
             results.push_back(next);
             if (index + 1 < max_new_tokens) next = decode_step(next.top_token);
         }
+        nvtx_decode.reset();
         impl_->report_phase_profile("decode");
         return results;
     }

--- a/cpp_engine/tests/test_qwen_engine.cpp
+++ b/cpp_engine/tests/test_qwen_engine.cpp
@@ -362,6 +362,36 @@ void exercise_prefix_cache(const std::string& dir,
     require(reset.reused_tokens == 0 && reset.computed_tokens == 3 &&
                 reset.resume_source == "empty",
             "reset must invalidate prefix cache");
+
+    // A chunk wider than the snapshot interval must not be subdivided by the
+    // dense early-snapshot grid: short chunks cost far more per token than the
+    // finer resume granularity is worth. Request-boundary reuse and correctness
+    // still hold, they just resume at chunk granularity.
+    // The snapshot grid no longer subdivides a chunk wider than the dense early
+    // interval. That interval is 256 tokens, past this fixture's context, so the
+    // saving itself is measured by the real long-context benchmark; what is
+    // checked here is that a chunk wider than the interval still prefills
+    // correctly and still serves an exact prefix hit.
+    dsv4::QwenEngineOptions wide_options = options;
+    wide_options.prefill_chunk_tokens = 8;
+    wide_options.state_snapshot_interval_tokens = 4;
+    dsv4::QwenEngine wide(dir, wide_options, 2, 8);
+    const dsv4::QwenForwardResult wide_baseline = wide.prefill({1, 2, 3, 4, 5, 6});
+    require(wide.prefix_cache_stats().computed_tokens == 6,
+            "wide chunk prefill accounting");
+    const dsv4::QwenForwardResult wide_again = wide.prefill({1, 2, 3, 4, 5, 6});
+    require(wide.prefix_cache_stats().resume_source == "live" &&
+                wide.prefix_cache_stats().computed_tokens == 0 &&
+                wide_again.top_token == wide_baseline.top_token,
+            "wide chunk must still serve an exact prefix hit");
+
+    dsv4::QwenEngineOptions wide_cold = wide_options;
+    wide_cold.prefix_cache = false;
+    dsv4::QwenEngine wide_cold_engine(dir, wide_cold, 2, 8);
+    const dsv4::QwenForwardResult wide_expected =
+        wide_cold_engine.prefill({1, 2, 3, 4, 5, 6});
+    require(wide_baseline.top_token == wide_expected.top_token,
+            "wide chunk prefill must match cold prefill");
 }
 
 void exercise_mtp(const std::string& dir,

--- a/scripts/bench_qwen_long_context.py
+++ b/scripts/bench_qwen_long_context.py
@@ -48,7 +48,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--max-new-tokens", type=int, default=16)
     # Matches QwenEngineOptions::prefill_chunk_tokens. Keep these in step, or the
     # benchmark measures a chunk size production does not use.
-    parser.add_argument("--prefill-chunk-tokens", type=int, default=4096)
+    parser.add_argument("--prefill-chunk-tokens", type=int, default=8192)
     parser.add_argument("--kv-cache-dtype", choices=("fp16", "fp8", "turboquant_k8v4", "int8_per_token_head"), default="fp16")
     parser.add_argument("--qwen-temperature", type=float, default=0.0)
     parser.add_argument("--qwen-top-p", type=float, default=1.0)


### PR DESCRIPTION
## Summary

A recurrent-state snapshot position forces a prefill chunk boundary, so a snapshot grid finer than `prefill_chunk_tokens` silently caps the chunk the prompt actually runs at. The dense 256-token early grid did this to the whole first 4096 tokens of every prompt.

Measured on the real 64-layer TP4 model with chunk 4096, per-chunk from an NVTX capture:

```
chunk  0..15  rows=256   ~220ms each  ->  first 4096 tokens: 3.59s (1140 tok/s)
chunk 16      rows=4096  1395ms       ->  next  4096 tokens: 1.40s (2936 tok/s)
```

Same work, 2.6x the time. The fix rounds both grids up to a whole number of chunks, so every snapshot position is also a chunk boundary and no chunk is ever subdivided. Resume granularity becomes the chunk boundary, which prefix reuse and rollback already align to.

With chunks no longer capped, 8192 becomes the better default. 16384 is within noise at 65K but costs another 1.06 GB of activation workspace per rank, so it is not the default.

## Results

Real 64-layer TP4, real checkpoint and tokenizer, real natural-language token fixture, FP16 cache, serial fresh-process runs. Generated tokens identical to the previous default and rank token parity PASS at every length.

| context | before | after | vLLM-2080Ti | vs vLLM |
|---|---|---|---|---|
| 8192 | 1395 | **1834** | 1731 | 1.06x |
| 16384 | - | **1798** | 1687 | 1.06x |
| 32768 | - | **1683** | 1607 | 1.05x |
| 65536 | 1415 | **1460** | 1477 | 0.99x |

8K/16K/32K now exceed vLLM-2080Ti; 65K is 1.1% short.

Decode at 65K measured at TG128 (TG16 is too short to compare): 19.48 / 19.31 / 19.24 tok/s for chunks 4096 / 8192 / 16384 — within noise, so the chunk change does not cost decode.

## Profiling change

`PhaseScope` now also emits its site name as an NVTX range under `QWEN_NVTX_PROFILE`, plus application ranges around warmup, prefill, decode and generate. Unlike `QWEN_PHASE_PROFILE` these add no synchronization, so a Nsight capture attributes kernels to a site by launch correlation without perturbing the stream pipeline being measured. That is what located this bottleneck; `QWEN_PHASE_PROFILE` could not, because its per-scope `cudaDeviceSynchronize` hides the effect.

Both are off by default.

## Tests

- `test_qwen_engine`, `test_qwen_config`, `test_qwen_gqa_attention`, `test_qwen_gdn_flashqla`, `test_qwen_gqa_mma_occ`, `test_qwen_turboquant_k8v4` all pass.
- Added prefix-cache coverage in `test_qwen_engine` for a chunk wider than the snapshot interval: prefill still matches cold prefill and still serves an exact prefix hit.

## Note on a prior conclusion

An earlier A/B recorded "chunk 8192 is a tie, keep 4096". That was an artifact: the snapshot grid capped the chunk, so both arms really ran 4096.