### PR TITLE
Speed up TP4 decode: finer attention splits + wide FP8 weight loads

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -432,6 +432,14 @@ add_executable(bench_qwen_gqa_prefill tests/bench_qwen_gqa_prefill.cpp)
 target_link_libraries(bench_qwen_gqa_prefill PRIVATE dsv4_cpp_core)
 set_target_properties(bench_qwen_gqa_prefill PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(bench_qwen_gqa_decode tests/bench_qwen_gqa_decode.cpp)
+target_link_libraries(bench_qwen_gqa_decode PRIVATE dsv4_cpp_core)
+set_target_properties(bench_qwen_gqa_decode PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(bench_qwen_fp8_swiglu_decode tests/bench_qwen_fp8_swiglu_decode.cpp)
+target_link_libraries(bench_qwen_fp8_swiglu_decode PRIVATE dsv4_cpp_core)
+set_target_properties(bench_qwen_fp8_swiglu_decode PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(bench_qwen_gqa_verify tests/bench_qwen_gqa_verify.cpp)
 target_link_libraries(bench_qwen_gqa_verify PRIVATE dsv4_cpp_core)
 set_target_properties(bench_qwen_gqa_verify PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/cuda/qwen_gqa_optimized.cu
+++ b/cpp_engine/cuda/qwen_gqa_optimized.cu
@@ -19,15 +19,63 @@ constexpr int kQueryRows = 2;
 constexpr int kMaxHeadDim = 256;
 constexpr int kValuesPerThread = kMaxHeadDim / kThreads;
 constexpr int kPrefillCombos = kHeadsPerGroup * kQueryRows;
-constexpr int kDecodeMaxSplits = 64;
+// Hard ceiling for the tunable decode split count. Sizes the merge kernel's
+// shared weight array at 4 bytes per split, so 1024 costs 4 KiB of the 48 KiB
+// budget, and keeps the target honest to 64 positions per split at 65K context.
+constexpr int kDecodeSplitCeiling = 1024;
+// Decode positions per split. The split kernel walks its slice serially and the
+// launch is only kv_heads*groups*splits blocks, so at the real TP4 shape (6 Q
+// heads, 1 KV head, 4 groups of blocks) positions per split, not bytes, set the
+// runtime: the old 2048-position target measured a flat 1.41 ms from 4K to 65K
+// context, about 47 GB/s of the 616 GB/s the card can sustain. A smaller target
+// buys parallelism.
+// Measured at the real TP4 shape against the reference score/value kernels,
+// fused kernel milliseconds, `bench_qwen_gqa_decode`:
+//
+//   context   reference   2048   256    128    64
+//      4096      0.289    1.570  0.152  0.080  0.049
+//      8192      0.865    1.508  0.188  0.106  0.072
+//     16384      1.748    1.441  0.199  0.127  0.128
+//     32768      3.490    3.045  0.237  0.226  0.258
+//     65536      7.042    1.445  0.413  0.438  0.492
+//
+// 256 is the default rather than the faster-looking 128 because it is the
+// smallest target whose generated tokens stay bit-identical to a single
+// sequential split, at every context measured on the real TP4 model. 128 is
+// deterministic run to run but diverges from the sequential reference at token
+// 86 of 128 on the 8K prompt, and it is also slower end to end at 65K (28.3 vs
+// 29.2 tok/s) because it hits the split ceiling there.
+constexpr int kDecodeTargetPositionsDefault = 256;
 // Verify attention splits far more finely than decode: it has only a handful of
 // query rows to fill the device with, so a 32-position tile at 8192 context wants
 // 256 splits where the decode ceiling would force 128. Sizes the merge kernel's
 // shared weight array, so 256 costs 1 KiB of shared memory per merge block.
 constexpr int kVerifyMaxSplits = 256;
-constexpr int kDecodeTargetPositions = 2048;
+// Below this the reference score/value kernels win; the fused launch refuses
+// short contexts so the engine gate has to agree with it.
 constexpr int kDecodeMinContext = 4096;
 constexpr int kVerifyMaxRows = 8;
+
+// Positions per split and the split ceiling, overridable for A/B sweeps. Read
+// once: these are launch geometry, not per-call state.
+int decode_target_positions() {
+    static const int value = [] {
+        const char* env = std::getenv("DSV4_QWEN_DECODE_SPLIT_POSITIONS");
+        const int parsed = env != nullptr ? std::atoi(env) : 0;
+        return parsed > 0 ? parsed : kDecodeTargetPositionsDefault;
+    }();
+    return value;
+}
+
+int decode_max_splits() {
+    static const int value = [] {
+        const char* env = std::getenv("DSV4_QWEN_DECODE_MAX_SPLITS");
+        const int parsed = env != nullptr ? std::atoi(env) : 0;
+        return parsed > 0 ? std::min(parsed, kDecodeSplitCeiling)
+                          : kDecodeSplitCeiling;
+    }();
+    return value;
+}
 
 // A window of 0 keeps exact full attention. Otherwise every query attends to
 // the leading sink prefix plus the most recent window positions, expressed as
@@ -1911,7 +1959,7 @@ __global__ void gqa_decode_merge_f16_kernel(
     int splits) {
     const int head = static_cast<int>(blockIdx.x);
     if (head >= q_heads) return;
-    __shared__ float weights[kDecodeMaxSplits];
+    __shared__ float weights[kDecodeSplitCeiling];
     if (threadIdx.x == 0) {
         const int stride = head_dim + 2;
         float maximum = -INFINITY;
@@ -1945,6 +1993,14 @@ __global__ void gqa_decode_merge_f16_kernel(
 bool valid_shape(int q_heads, int kv_heads, int head_dim) {
     return q_heads > 0 && kv_heads > 0 && q_heads % kv_heads == 0 &&
         head_dim > 0 && head_dim <= kMaxHeadDim;
+}
+
+int decode_split_count(int attended_positions) {
+    if (attended_positions <= 0) return 1;
+    const int splits = std::min(decode_max_splits(),
+        (attended_positions + decode_target_positions() - 1) /
+            decode_target_positions());
+    return std::max(splits, 1);
 }
 
 struct GqaCublasWorkspace {
@@ -2379,6 +2435,10 @@ bool qwen_gqa_verify_attention_f16_cuda(
     return cudaGetLastError() == cudaSuccess;
 }
 
+int qwen_gqa_decode_split_count(int attended_positions) {
+    return decode_split_count(attended_positions);
+}
+
 bool qwen_gqa_decode_attention_f16_fused_cuda(
     const uint16_t* q, const uint16_t* k_cache,
     const uint16_t* v_cache, uint16_t* output, float* partial_scratch,
@@ -2392,9 +2452,7 @@ bool qwen_gqa_decode_attention_f16_fused_cuda(
     const SparseRanges ranges =
         sparse_ranges(context_len, attention_window, sink_tokens);
     const int attended = ranges.total();
-    int splits = std::min(kDecodeMaxSplits,
-        (attended + kDecodeTargetPositions - 1) / kDecodeTargetPositions);
-    splits = std::max(splits, 1);
+    const int splits = decode_split_count(attended);
     const int positions_per_split = (attended + splits - 1) / splits;
     const int groups_per_kv =
         (q_heads / kv_heads + kHeadsPerGroup - 1) / kHeadsPerGroup;

--- a/cpp_engine/cuda/qwen_half_ops.cu
+++ b/cpp_engine/cuda/qwen_half_ops.cu
@@ -50,6 +50,42 @@ __device__ __forceinline__ float fp8_e4m3_to_float(uint8_t code) {
     return __uint_as_float(bits);
 }
 
+// Four E4M3 codes become two packed FP16 words whose values are 2^-8 of the
+// decoded FP8 values. For normal codes the field layout is exact: FP8's
+// exponent bias is 8 lower than FP16's, so one multiply by 256 after the dot
+// product restores the original values. Keep the existing helper for E4M3's
+// unusual exponent-zero encodings instead of silently changing their semantics.
+struct Fp8x4AsHalf2 {
+    uint32_t lo;
+    uint32_t hi;
+};
+
+__device__ __forceinline__ uint16_t fp8_e4m3_to_half_scaled(uint8_t code) {
+    // Exponent zero is E4M3's subnormal range; its value spacing does not match
+    // FP16's at this shift, so decode those few codes the slow way.
+    if ((code & 0x78u) == 0u) {
+        return float_to_half(fp8_e4m3_to_float(code) * (1.0f / 256.0f));
+    }
+    // Normal codes: E4M3 is [s|eeee|mmm] and FP16 is [s|eeeee|mmmmmmmmmm].
+    // Shifting the exponent+mantissa field left by 7 lands the 3 mantissa bits
+    // at FP16's top 3 mantissa bits and the 4 exponent bits at FP16's low 4
+    // exponent bits, leaving FP16's exponent MSB clear. That encodes
+    // 2^(e-7-8) * 1.m, i.e. exactly 2^-8 of the FP8 value.
+    return static_cast<uint16_t>((static_cast<uint16_t>(code & 0x7fu) << 7) |
+                                 (static_cast<uint16_t>(code & 0x80u) << 8));
+}
+
+__device__ __forceinline__ Fp8x4AsHalf2 fp8x4_as_half2_scaled(uchar4 codes) {
+    Fp8x4AsHalf2 out;
+    out.lo = static_cast<uint32_t>(fp8_e4m3_to_half_scaled(codes.x)) |
+             (static_cast<uint32_t>(fp8_e4m3_to_half_scaled(codes.y)) << 16);
+    out.hi = static_cast<uint32_t>(fp8_e4m3_to_half_scaled(codes.z)) |
+             (static_cast<uint32_t>(fp8_e4m3_to_half_scaled(codes.w)) << 16);
+    return out;
+}
+
+constexpr float kFp8E4m3HalfFixup = 256.0f;
+
 __device__ __forceinline__ uint8_t float_to_fp8_e4m3(float value) {
     const bool negative = signbit(value);
     float magnitude = fminf(fabsf(value), 448.0f);
@@ -118,17 +154,19 @@ __global__ void fp8_matvec_f16_kernel(
 // Same decode arithmetic as fp8_matvec_f16_kernel, but each warp owns
 // kRowsPerWarp output rows and reads every FP16 activation element once for
 // all of them. Column order and per-row accumulation order are unchanged, so
-// only the number of activation loads differs.
-template <int kWarps, int kRowsPerWarp>
+// only the number of activation loads differs. The vectorized body widens FP8
+// codes with bit arithmetic; the shared LUT it replaced cost four
+// data-dependent shared loads per weight word, which serialize across banks.
+//
+// kColsPerLane is the columns a lane takes per step. 8 issues one 64-bit weight
+// load instead of two 32-bit ones and halves the loop trip count; measured on
+// the fused gate/up twin of this kernel it lifted the FP8 weight stream from
+// 318 GB/s to 434 GB/s at the TP4 decode shape.
+template <int kWarps, int kRowsPerWarp, int kColsPerLane = 4>
 __global__ void fp8_matvec_f16_multirow_kernel(
     const uint16_t* __restrict__ x, const uint8_t* __restrict__ weight,
     const uint16_t* __restrict__ scale, uint16_t* __restrict__ y,
     int rows, int cols, int weight_stride, int scale_stride) {
-    __shared__ float lut[256];
-    for (int i = static_cast<int>(threadIdx.x); i < 256; i += blockDim.x) {
-        lut[i] = fp8_e4m3_to_float(static_cast<uint8_t>(i));
-    }
-    __syncthreads();
     const int warp = static_cast<int>(threadIdx.x) >> 5;
     const int lane = static_cast<int>(threadIdx.x) & 31;
     const int row_base = (static_cast<int>(blockIdx.x) * kWarps + warp) * kRowsPerWarp;
@@ -145,29 +183,48 @@ __global__ void fp8_matvec_f16_multirow_kernel(
     }
 
     float sums[kRowsPerWarp] = {};
-    const int vec_cols = cols & ~3;
-    for (int col = lane * 4; col < vec_cols; col += 128) {
-        const uint2 packed = *reinterpret_cast<const uint2*>(x + col);
-        const float x0 = half_to_float(static_cast<uint16_t>(packed.x));
-        const float x1 = half_to_float(static_cast<uint16_t>(packed.x >> 16));
-        const float x2 = half_to_float(static_cast<uint16_t>(packed.y));
-        const float x3 = half_to_float(static_cast<uint16_t>(packed.y >> 16));
+    constexpr int kQuads = kColsPerLane / 4;
+    constexpr int kStride = 32 * kColsPerLane;
+    const int vec_cols = cols & ~(kColsPerLane - 1);
+    for (int col = lane * kColsPerLane; col < vec_cols; col += kStride) {
+        float xv[kColsPerLane];
+#pragma unroll
+        for (int q = 0; q < kQuads; ++q) {
+            const uint2 packed = *reinterpret_cast<const uint2*>(x + col + q * 4);
+            xv[q * 4 + 0] = half_to_float(static_cast<uint16_t>(packed.x));
+            xv[q * 4 + 1] = half_to_float(static_cast<uint16_t>(packed.x >> 16));
+            xv[q * 4 + 2] = half_to_float(static_cast<uint16_t>(packed.y));
+            xv[q * 4 + 3] = half_to_float(static_cast<uint16_t>(packed.y >> 16));
+        }
         const int block_col = col / kFp8WeightBlock;
 #pragma unroll
         for (int r = 0; r < kRowsPerWarp; ++r) {
             if (r >= active) break;
-            const uchar4 codes = *reinterpret_cast<const uchar4*>(weight_rows[r] + col);
             const float s = half_to_float(scale_rows[r][block_col]);
-            sums[r] += (x0 * lut[codes.x] + x1 * lut[codes.y] +
-                        x2 * lut[codes.z] + x3 * lut[codes.w]) * s;
+            float span = 0.0f;
+#pragma unroll
+            for (int q = 0; q < kQuads; ++q) {
+                const Fp8x4AsHalf2 w = fp8x4_as_half2_scaled(
+                    *reinterpret_cast<const uchar4*>(
+                        weight_rows[r] + col + q * 4));
+                span +=
+                    xv[q * 4 + 0] * half_to_float(static_cast<uint16_t>(w.lo)) +
+                    xv[q * 4 + 1] * half_to_float(static_cast<uint16_t>(w.lo >> 16)) +
+                    xv[q * 4 + 2] * half_to_float(static_cast<uint16_t>(w.hi)) +
+                    xv[q * 4 + 3] * half_to_float(static_cast<uint16_t>(w.hi >> 16));
+            }
+            sums[r] += span * s;
         }
     }
+    // Exact: the bias correction is a power of two.
+#pragma unroll
+    for (int r = 0; r < kRowsPerWarp; ++r) sums[r] *= kFp8E4m3HalfFixup;
     for (int col = vec_cols + lane; col < cols; col += 32) {
         const float xv = half_to_float(x[col]);
 #pragma unroll
         for (int r = 0; r < kRowsPerWarp; ++r) {
             if (r >= active) break;
-            sums[r] += xv * lut[weight_rows[r][col]] *
+            sums[r] += xv * fp8_e4m3_to_float(weight_rows[r][col]) *
                        half_to_float(scale_rows[r][col / kFp8WeightBlock]);
         }
     }
@@ -660,6 +717,135 @@ __global__ void fp8_swiglu_small_batch_f16_kernel(
             y[static_cast<size_t>(sample) * y_stride + row] =
                 float_to_half(silu(gate_sum) * up_sum);
         }
+    }
+}
+
+// Same fused gate/up decode arithmetic as fp8_swiglu_matvec_f16_kernel, but
+// each lane consumes four contiguous columns per iteration so the FP8 weight
+// stream is read as uchar4 instead of one byte per lane per step. The decode
+// MLP is weight-bandwidth bound, and the scalar loop only reaches ~250 GB/s
+// where the already-vectorized down projection reaches ~480 GB/s.
+//
+// Codes are widened with bit arithmetic instead of the shared LUT. Every lane
+// decodes four data-dependent indices per weight plane per step, and on Turing
+// those scatter across shared banks; the bit path has no such serialization.
+// The E4M3 exponent bias (7) is corrected against the FP16 bias (15) by
+// scaling the accumulated result once per block, so subnormal codes stay exact
+// and the reduction order is unchanged.
+
+// kColsPerLane is the columns a lane takes per step: 4 issues one 32-bit weight
+// load per plane, 8 issues one 64-bit load. Wider means fewer, larger requests
+// and half the loop overhead, at the cost of registers.
+template <int kWarps, int kRowsPerWarp, int kColsPerLane = 4>
+__global__ void fp8_swiglu_matvec_vec4_f16_kernel(
+    const uint16_t* __restrict__ x,
+    const uint8_t* __restrict__ gate_weight,
+    const uint16_t* __restrict__ gate_scale,
+    const uint8_t* __restrict__ up_weight,
+    const uint16_t* __restrict__ up_scale,
+    uint16_t* __restrict__ y, int rows, int cols, int weight_stride,
+    int scale_stride) {
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int lane = static_cast<int>(threadIdx.x) & 31;
+    const int row_base = (static_cast<int>(blockIdx.x) * kWarps + warp) * kRowsPerWarp;
+    if (row_base >= rows) return;
+    const int active = min(kRowsPerWarp, rows - row_base);
+
+    const uint8_t* gate_rows[kRowsPerWarp];
+    const uint8_t* up_rows[kRowsPerWarp];
+    const uint16_t* gate_scales[kRowsPerWarp];
+    const uint16_t* up_scales[kRowsPerWarp];
+#pragma unroll
+    for (int r = 0; r < kRowsPerWarp; ++r) {
+        const int row = min(row_base + r, rows - 1);
+        gate_rows[r] = gate_weight + static_cast<size_t>(row) * weight_stride;
+        up_rows[r] = up_weight + static_cast<size_t>(row) * weight_stride;
+        const size_t block_row =
+            static_cast<size_t>(row / kFp8WeightBlock) * scale_stride;
+        gate_scales[r] = gate_scale + block_row;
+        up_scales[r] = up_scale + block_row;
+    }
+
+    float gate_sum[kRowsPerWarp] = {};
+    float up_sum[kRowsPerWarp] = {};
+    constexpr int kStride = 32 * kColsPerLane;
+    constexpr int kQuads = kColsPerLane / 4;
+    const int vec_cols = cols & ~(kColsPerLane - 1);
+    for (int col = lane * kColsPerLane; col < vec_cols; col += kStride) {
+        float xv[kColsPerLane];
+#pragma unroll
+        for (int q = 0; q < kQuads; ++q) {
+            const uint2 packed = *reinterpret_cast<const uint2*>(x + col + q * 4);
+            xv[q * 4 + 0] = half_to_float(static_cast<uint16_t>(packed.x));
+            xv[q * 4 + 1] = half_to_float(static_cast<uint16_t>(packed.x >> 16));
+            xv[q * 4 + 2] = half_to_float(static_cast<uint16_t>(packed.y));
+            xv[q * 4 + 3] = half_to_float(static_cast<uint16_t>(packed.y >> 16));
+        }
+        // The whole span shares a scale block: kFp8WeightBlock is a multiple of
+        // kColsPerLane and `col` is kColsPerLane-aligned.
+        const int block_col = col / kFp8WeightBlock;
+#pragma unroll
+        for (int r = 0; r < kRowsPerWarp; ++r) {
+            if (r >= active) break;
+            Fp8x4AsHalf2 g[kQuads];
+            Fp8x4AsHalf2 u[kQuads];
+#pragma unroll
+            for (int q = 0; q < kQuads; ++q) {
+                g[q] = fp8x4_as_half2_scaled(*reinterpret_cast<const uchar4*>(
+                    gate_rows[r] + col + q * 4));
+                u[q] = fp8x4_as_half2_scaled(*reinterpret_cast<const uchar4*>(
+                    up_rows[r] + col + q * 4));
+            }
+            // The scale absorbs the 2^8 the packed decode left out. The span's
+            // products are summed before the scale multiply, which is a
+            // different FP32 association than the scalar kernel's; the
+            // generated tokens are checked against it on the real model.
+            const float gs =
+                half_to_float(gate_scales[r][block_col]) * kFp8E4m3HalfFixup;
+            const float us =
+                half_to_float(up_scales[r][block_col]) * kFp8E4m3HalfFixup;
+            float gate_span = 0.0f;
+            float up_span = 0.0f;
+#pragma unroll
+            for (int q = 0; q < kQuads; ++q) {
+                gate_span +=
+                    xv[q * 4 + 0] * half_to_float(static_cast<uint16_t>(g[q].lo)) +
+                    xv[q * 4 + 1] * half_to_float(static_cast<uint16_t>(g[q].lo >> 16)) +
+                    xv[q * 4 + 2] * half_to_float(static_cast<uint16_t>(g[q].hi)) +
+                    xv[q * 4 + 3] * half_to_float(static_cast<uint16_t>(g[q].hi >> 16));
+                up_span +=
+                    xv[q * 4 + 0] * half_to_float(static_cast<uint16_t>(u[q].lo)) +
+                    xv[q * 4 + 1] * half_to_float(static_cast<uint16_t>(u[q].lo >> 16)) +
+                    xv[q * 4 + 2] * half_to_float(static_cast<uint16_t>(u[q].hi)) +
+                    xv[q * 4 + 3] * half_to_float(static_cast<uint16_t>(u[q].hi >> 16));
+            }
+            gate_sum[r] += gate_span * gs;
+            up_sum[r] += up_span * us;
+        }
+    }
+    // The ragged tail decodes through the scalar helper; `cols` is a multiple
+    // of kColsPerLane for every real projection, so this normally runs zero
+    // times.
+    for (int col = vec_cols + lane; col < cols; col += 32) {
+        const float xv = half_to_float(x[col]);
+        const int block_col = col / kFp8WeightBlock;
+#pragma unroll
+        for (int r = 0; r < kRowsPerWarp; ++r) {
+            if (r >= active) break;
+            gate_sum[r] += xv * fp8_e4m3_to_float(gate_rows[r][col]) *
+                           half_to_float(gate_scales[r][block_col]);
+            up_sum[r] += xv * fp8_e4m3_to_float(up_rows[r][col]) *
+                         half_to_float(up_scales[r][block_col]);
+        }
+    }
+#pragma unroll
+    for (int r = 0; r < kRowsPerWarp; ++r) {
+        if (r >= active) break;
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            gate_sum[r] += __shfl_xor_sync(0xffffffffu, gate_sum[r], offset);
+            up_sum[r] += __shfl_xor_sync(0xffffffffu, up_sum[r], offset);
+        }
+        if (lane == 0) y[row_base + r] = float_to_half(silu(gate_sum[r]) * up_sum[r]);
     }
 }
 
@@ -2416,6 +2602,11 @@ bool qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
         !multirow_disabled &&
         (vectorized == nullptr || std::strcmp(vectorized, "0") != 0);
     const int requested_rows = rows_env != nullptr ? std::atoi(rows_env) : 0;
+    // Eight columns per lane per step is the default; `=4` restores the narrower
+    // load for A/B.
+    const char* lane_span = std::getenv("QWEN_FP8_F16_COLS_PER_LANE");
+    const bool narrow_lane_span =
+        lane_span != nullptr && std::strcmp(lane_span, "4") == 0;
     constexpr int kMinBlocks = 136;
     auto blocks_for = [&](int rows_per_warp) {
         return (rows + kWarps * rows_per_warp - 1) / (kWarps * rows_per_warp);
@@ -2428,9 +2619,16 @@ bool qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
                blocks_for(2) >= kMinBlocks) {
         fp8_matvec_f16_multirow_kernel<kWarps, 2><<<blocks_for(2), kWarps * 32, 0, s>>>(
             x, weight, scale, y, rows, cols, weight_stride, scale_stride);
+    } else if (use_vectorized && weight_stride % 8 == 0 && cols % 8 == 0 &&
+               kFp8WeightBlock % 8 == 0 &&
+               reinterpret_cast<uintptr_t>(x) % 8 == 0 && !narrow_lane_span) {
+        fp8_matvec_f16_multirow_kernel<kWarps, 1, 8>
+            <<<blocks_for(1), kWarps * 32, 0, s>>>(
+                x, weight, scale, y, rows, cols, weight_stride, scale_stride);
     } else if (use_vectorized && weight_stride % 4 == 0) {
-        fp8_matvec_f16_multirow_kernel<kWarps, 1><<<blocks_for(1), kWarps * 32, 0, s>>>(
-            x, weight, scale, y, rows, cols, weight_stride, scale_stride);
+        fp8_matvec_f16_multirow_kernel<kWarps, 1, 4>
+            <<<blocks_for(1), kWarps * 32, 0, s>>>(
+                x, weight, scale, y, rows, cols, weight_stride, scale_stride);
     } else {
         fp8_matvec_f16_kernel<kWarps><<<(rows + kWarps - 1) / kWarps,
             kWarps * 32, 0, s>>>(x, weight, scale, y, rows, cols,
@@ -2451,13 +2649,31 @@ bool qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
     const cudaStream_t s = static_cast<cudaStream_t>(stream);
     const char* multirow = std::getenv("QWEN_FP8_F16_MULTIROW");
     const char* rows_env = std::getenv("QWEN_FP8_F16_MULTIROW_ROWS");
+    const char* vectorized = std::getenv("QWEN_FP8_F16_SWIGLU_VECTORIZE");
     const bool use_multirow =
         multirow != nullptr && std::strcmp(multirow, "0") != 0;
     const int requested_rows = rows_env != nullptr ? std::atoi(rows_env) : 0;
+    // The vectorized variant groups four columns per scale multiply, so it is a
+    // different (still deterministic) reduction order than the scalar loop.
+    // `=0` restores the scalar loop for A/B.
+    const bool use_vectorized =
+        vectorized == nullptr || std::strcmp(vectorized, "0") != 0;
     constexpr int kMinBlocks = 136;
     auto blocks_for = [&](int rows_per_warp) {
         return (rows + kWarps * rows_per_warp - 1) / (kWarps * rows_per_warp);
     };
+    const bool aligned = cols % 4 == 0 && weight_stride % 4 == 0 &&
+                         kFp8WeightBlock % 4 == 0 &&
+                         reinterpret_cast<uintptr_t>(x) % 8 == 0;
+    // Columns per lane per step. 8 halves the loop trip count and the weight
+    // request count; `=4` restores the narrower load for A/B.
+    int cols_per_lane = 8;
+    if (const char* width = std::getenv("QWEN_FP8_F16_SWIGLU_COLS_PER_LANE")) {
+        const int parsed = std::atoi(width);
+        if (parsed == 4 || parsed == 8 || parsed == 16) cols_per_lane = parsed;
+    }
+    const bool aligned8 = aligned && cols % 8 == 0 && weight_stride % 8 == 0 &&
+                          kFp8WeightBlock % 8 == 0;
     if (use_multirow && weight_stride % 4 == 0 && requested_rows == 4 &&
         blocks_for(4) >= kMinBlocks) {
         fp8_swiglu_matvec_f16_kernel<kWarps, 4><<<blocks_for(4), kWarps * 32, 0, s>>>(
@@ -2468,9 +2684,25 @@ bool qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
         fp8_swiglu_matvec_f16_kernel<kWarps, 2><<<blocks_for(2), kWarps * 32, 0, s>>>(
             x, gate_weight, gate_scale, up_weight, up_scale, y, rows, cols,
             weight_stride, scale_stride);
+    } else if (use_vectorized && aligned8 && cols % 16 == 0 &&
+               weight_stride % 16 == 0 && kFp8WeightBlock % 16 == 0 &&
+               cols_per_lane == 16) {
+        fp8_swiglu_matvec_vec4_f16_kernel<kWarps, 1, 16>
+            <<<blocks_for(1), kWarps * 32, 0, s>>>(
+                x, gate_weight, gate_scale, up_weight, up_scale, y, rows, cols,
+                weight_stride, scale_stride);
+    } else if (use_vectorized && aligned8 && cols_per_lane >= 8) {
+        fp8_swiglu_matvec_vec4_f16_kernel<kWarps, 1, 8>
+            <<<blocks_for(1), kWarps * 32, 0, s>>>(
+                x, gate_weight, gate_scale, up_weight, up_scale, y, rows, cols,
+                weight_stride, scale_stride);
+    } else if (use_vectorized && aligned) {
+        fp8_swiglu_matvec_vec4_f16_kernel<kWarps, 1, 4>
+            <<<blocks_for(1), kWarps * 32, 0, s>>>(
+                x, gate_weight, gate_scale, up_weight, up_scale, y, rows, cols,
+                weight_stride, scale_stride);
     } else {
-        // The fused gate/up kernel has no aligned vectorized variant yet; keep
-        // its one-row path independent of the weight stride alignment.
+        // Unaligned strides or activations fall back to the scalar loop.
         fp8_swiglu_matvec_f16_kernel<kWarps, 1><<<blocks_for(1), kWarps * 32, 0, s>>>(
             x, gate_weight, gate_scale, up_weight, up_scale, y, rows, cols,
             weight_stride, scale_stride);

--- a/cpp_engine/include/qwen_cuda_ops.hpp
+++ b/cpp_engine/include/qwen_cuda_ops.hpp
@@ -777,6 +777,10 @@ bool qwen_gqa_decode_attention_f16_fused_cuda(
     float* d_partial_scratch, int q_heads, int kv_heads, int head_dim,
     int context_len, int max_context, int attention_window = 0,
     int sink_tokens = 0, void* stream = nullptr);
+// Splits the fused decode kernel will use for this many attended positions. The
+// caller must size `d_partial_scratch` as q_heads * splits * (head_dim + 2), so
+// this has to be the same number the launch computes.
+int qwen_gqa_decode_split_count(int attended_positions);
 bool qwen_gqa_prefill_attention_f16_tiled_cuda(
     const uint16_t* d_q_rows_fp16, const uint16_t* d_k_cache_fp16,
     const uint16_t* d_v_cache_fp16, uint16_t* d_out_rows_fp16,

--- a/cpp_engine/src/qwen_engine.cpp
+++ b/cpp_engine/src/qwen_engine.cpp
@@ -2140,13 +2140,14 @@ struct QwenEngine::Impl {
             const bool optimized_attention =
                 qwen_env_enabled_default("DSV4_QWEN_GQA_OPTIMIZED") ||
                 attention_window > 0;
-            // The compact split/merge decode path crosses over the reference
-            // score/value kernels only at long contexts on SM75.
-            constexpr int kOptimizedDecodeMinContext = 16384;
+            // The split/merge decode path used to lose below 16384 context
+            // because it walked 2048 positions per split serially, leaving the
+            // device idle. At 128 positions per split it wins everywhere it is
+            // allowed to run: 3.6x the reference kernels at 4096 context and
+            // 16.1x at 65536. Its own guard still declines contexts under 4096.
             const bool optimized_decode = cache_dtype == QwenKvCacheDType::Fp16 &&
                 optimized_attention &&
-                (context_length >= kOptimizedDecodeMinContext ||
-                 attention_window > 0);
+                (context_length >= 4096 || attention_window > 0);
             int attended_positions = context_length;
             if (attention_window > 0) {
                 const int sink_count = std::min(sink_tokens, context_length);
@@ -2154,8 +2155,9 @@ struct QwenEngine::Impl {
                     context_length - attention_window, sink_count);
                 attended_positions = sink_count + (context_length - window_start);
             }
-            const int optimized_splits = std::max(1, std::min(
-                64, (attended_positions + 2048 - 1) / 2048));
+            // Must match the launch exactly; it sizes the partial scratch.
+            const int optimized_splits =
+                qwen_gqa_decode_split_count(attended_positions);
             const size_t score_elements = optimized_decode
                 ? static_cast<size_t>(q_heads) * optimized_splits *
                       static_cast<size_t>(head_dim + 2)

--- a/cpp_engine/tests/bench_qwen_fp8_swiglu_decode.cpp
+++ b/cpp_engine/tests/bench_qwen_fp8_swiglu_decode.cpp
@@ -1,0 +1,368 @@
+// Decode-shape A/B for the fused FP8 gate/up SwiGLU matvec: the scalar column
+// loop against the uchar4 vectorized variant. Reports per-call time, the
+// implied weight-stream bandwidth, and each variant's error against a
+// double-precision reference so a reduction-order change can be judged on
+// accuracy rather than only on speed.
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "qwen_cuda_ops.hpp"
+
+namespace {
+
+constexpr int kBlock = 128;
+
+float fp8_e4m3_to_float_host(uint8_t code) {
+    const uint32_t sign = static_cast<uint32_t>(code >> 7) << 31;
+    const int exponent = (code >> 3) & 0xf;
+    const int mantissa = code & 0x7;
+    if (exponent == 0) {
+        if (mantissa == 0) {
+            float zero;
+            const uint32_t bits = sign;
+            std::memcpy(&zero, &bits, sizeof(zero));
+            return zero;
+        }
+        const float value = std::ldexp(static_cast<float>(mantissa) / 8.0f, -6);
+        return (sign != 0u) ? -value : value;
+    }
+    if (exponent == 0xf && mantissa == 0x7) {
+        return (sign != 0u) ? -std::numeric_limits<float>::quiet_NaN()
+                            : std::numeric_limits<float>::quiet_NaN();
+    }
+    const float value = std::ldexp(1.0f + static_cast<float>(mantissa) / 8.0f,
+                                   exponent - 7);
+    return (sign != 0u) ? -value : value;
+}
+
+uint16_t float_to_half_host(float value) {
+    uint32_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    const uint32_t sign = (bits >> 16) & 0x8000u;
+    int32_t exponent = static_cast<int32_t>((bits >> 23) & 0xffu) - 127 + 15;
+    uint32_t mantissa = bits & 0x7fffffu;
+    if (exponent <= 0) return static_cast<uint16_t>(sign);
+    if (exponent >= 31) return static_cast<uint16_t>(sign | 0x7c00u);
+    return static_cast<uint16_t>(sign | (static_cast<uint32_t>(exponent) << 10) |
+                                (mantissa >> 13));
+}
+
+float half_to_float_host(uint16_t value) {
+    const uint32_t sign = static_cast<uint32_t>(value & 0x8000u) << 16;
+    const uint32_t exponent = (value >> 10) & 0x1fu;
+    const uint32_t mantissa = value & 0x3ffu;
+    uint32_t bits;
+    if (exponent == 0) {
+        if (mantissa == 0) {
+            bits = sign;
+        } else {
+            int shift = 0;
+            uint32_t m = mantissa;
+            while ((m & 0x400u) == 0u) {
+                m <<= 1;
+                ++shift;
+            }
+            m &= 0x3ffu;
+            bits = sign | (static_cast<uint32_t>(127 - 15 - shift) << 23) | (m << 13);
+        }
+    } else if (exponent == 31) {
+        bits = sign | 0x7f800000u | (mantissa << 13);
+    } else {
+        bits = sign | ((exponent + 127 - 15) << 23) | (mantissa << 13);
+    }
+    float out;
+    std::memcpy(&out, &bits, sizeof(out));
+    return out;
+}
+
+double silu_double(double v) { return v / (1.0 + std::exp(-v)); }
+
+struct Case {
+    int rows;
+    int cols;
+    const char* label;
+};
+
+}  // namespace
+
+int main() {
+    // Qwen3.8-27B-FP8 TP4: hidden 5120, intermediate 17408 sharded to 4352.
+    const std::vector<Case> cases = {
+        {4352, 5120, "tp4 mlp gate/up"},
+        {17408, 5120, "tp1 mlp gate/up"},
+    };
+    const char* iters_env = std::getenv("BENCH_ITERS");
+    const int iters = iters_env != nullptr && std::atoi(iters_env) > 0
+                          ? std::atoi(iters_env) : 200;
+
+    std::mt19937 rng(1234);
+    // 0x7f and 0xff are E4M3 NaN. A single NaN weight makes every comparison
+    // below false, and std::max(0.0, NaN) returns 0.0, so the error column
+    // would silently read zero.
+    // Codes are drawn from the middle of the E4M3 exponent range, which avoids
+    // both NaN (0x7f/0xff) and magnitudes that would overflow the FP16 output
+    // once 5120 columns are accumulated.
+    auto sample_code = [&](std::mt19937& gen) {
+        std::uniform_int_distribution<int> sign(0, 1);
+        std::uniform_int_distribution<int> exponent(1, 4);
+        std::uniform_int_distribution<int> mantissa(0, 7);
+        return static_cast<uint8_t>((sign(gen) << 7) | (exponent(gen) << 3) |
+                                    mantissa(gen));
+    };
+
+    std::printf("%-18s %6s %6s %10s %10s %10s %10s %8s %8s %8s %8s %9s\n",
+                "case", "rows", "cols", "scalar_ms", "vec4_ms", "vec8_ms",
+                "vec16_ms", "sc_GB/s", "v4_GB/s", "v8_GB/s", "v16_GB/s",
+                "worst_err");
+
+    for (const Case& c : cases) {
+        const int scale_rows = (c.rows + kBlock - 1) / kBlock;
+        const int scale_cols = (c.cols + kBlock - 1) / kBlock;
+        std::vector<uint16_t> x(c.cols);
+        std::vector<uint8_t> gw(static_cast<size_t>(c.rows) * c.cols);
+        std::vector<uint8_t> uw(gw.size());
+        std::vector<uint16_t> gs(static_cast<size_t>(scale_rows) * scale_cols);
+        std::vector<uint16_t> us(gs.size());
+        for (uint16_t& v : x) v = float_to_half_host(
+            std::uniform_real_distribution<float>(-1.0f, 1.0f)(rng));
+        for (uint8_t& v : gw) v = sample_code(rng);
+        for (uint8_t& v : uw) v = sample_code(rng);
+        for (uint16_t& v : gs) v = float_to_half_host(
+            std::uniform_real_distribution<float>(0.01f, 0.05f)(rng));
+        for (uint16_t& v : us) v = float_to_half_host(
+            std::uniform_real_distribution<float>(0.01f, 0.05f)(rng));
+
+        uint16_t* d_x = nullptr;
+        uint8_t* d_gw = nullptr;
+        uint8_t* d_uw = nullptr;
+        uint16_t* d_gs = nullptr;
+        uint16_t* d_us = nullptr;
+        uint16_t* d_y = nullptr;
+        if (cudaMalloc(&d_x, x.size() * 2) != cudaSuccess ||
+            cudaMalloc(&d_gw, gw.size()) != cudaSuccess ||
+            cudaMalloc(&d_uw, uw.size()) != cudaSuccess ||
+            cudaMalloc(&d_gs, gs.size() * 2) != cudaSuccess ||
+            cudaMalloc(&d_us, us.size() * 2) != cudaSuccess ||
+            cudaMalloc(&d_y, static_cast<size_t>(c.rows) * 2) != cudaSuccess) {
+            std::printf("[FAIL] alloc\n");
+            return 1;
+        }
+        cudaMemcpy(d_x, x.data(), x.size() * 2, cudaMemcpyHostToDevice);
+        cudaMemcpy(d_gw, gw.data(), gw.size(), cudaMemcpyHostToDevice);
+        cudaMemcpy(d_uw, uw.data(), uw.size(), cudaMemcpyHostToDevice);
+        cudaMemcpy(d_gs, gs.data(), gs.size() * 2, cudaMemcpyHostToDevice);
+        cudaMemcpy(d_us, us.data(), us.size() * 2, cudaMemcpyHostToDevice);
+
+        // Double-precision reference in plain column order.
+        std::vector<double> ref(c.rows);
+        for (int row = 0; row < c.rows; ++row) {
+            double g = 0.0;
+            double u = 0.0;
+            for (int col = 0; col < c.cols; ++col) {
+                const double xv = half_to_float_host(x[col]);
+                const size_t wi = static_cast<size_t>(row) * c.cols + col;
+                const size_t si = static_cast<size_t>(row / kBlock) * scale_cols +
+                                  col / kBlock;
+                g += xv * fp8_e4m3_to_float_host(gw[wi]) * half_to_float_host(gs[si]);
+                u += xv * fp8_e4m3_to_float_host(uw[wi]) * half_to_float_host(us[si]);
+            }
+            ref[row] = silu_double(g) * u;
+        }
+
+        auto run = [&](bool vectorized, int cols_per_lane, double* ms,
+                       double* err) {
+            setenv("QWEN_FP8_F16_SWIGLU_VECTORIZE", vectorized ? "1" : "0", 1);
+            char width[8];
+            std::snprintf(width, sizeof(width), "%d", cols_per_lane);
+            setenv("QWEN_FP8_F16_SWIGLU_COLS_PER_LANE", width, 1);
+            // The dispatch caches nothing, so the env var takes effect per call.
+            auto launch = [&] {
+                return dsv4::qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
+                    d_x, d_gw, d_gs, d_uw, d_us, d_y, c.rows, c.cols, c.cols,
+                    scale_cols, nullptr);
+            };
+            if (!launch() || cudaDeviceSynchronize() != cudaSuccess) {
+                std::printf("[FAIL] launch vectorized=%d\n",
+                            vectorized ? 1 : 0);
+                std::exit(1);
+            }
+            std::vector<uint16_t> y(c.rows);
+            cudaMemcpy(y.data(), d_y, y.size() * 2, cudaMemcpyDeviceToHost);
+            double worst = 0.0;
+            for (int row = 0; row < c.rows; ++row) {
+                const double got = half_to_float_host(y[row]);
+                const double denom = std::max(1e-3, std::fabs(ref[row]));
+                worst = std::max(worst, std::fabs(got - ref[row]) / denom);
+            }
+            *err = worst;
+
+            cudaEvent_t start;
+            cudaEvent_t stop;
+            cudaEventCreate(&start);
+            cudaEventCreate(&stop);
+            cudaEventRecord(start);
+            for (int i = 0; i < iters; ++i) launch();
+            cudaEventRecord(stop);
+            cudaEventSynchronize(stop);
+            float elapsed = 0.0f;
+            cudaEventElapsedTime(&elapsed, start, stop);
+            cudaEventDestroy(start);
+            cudaEventDestroy(stop);
+            *ms = static_cast<double>(elapsed) / iters;
+        };
+
+        double scalar_ms = 0.0;
+        double vec4_ms = 0.0;
+        double vec8_ms = 0.0;
+        double vec16_ms = 0.0;
+        double scalar_err = 0.0;
+        double vec4_err = 0.0;
+        double vec8_err = 0.0;
+        double vec16_err = 0.0;
+        run(false, 4, &scalar_ms, &scalar_err);
+        run(true, 4, &vec4_ms, &vec4_err);
+        run(true, 8, &vec8_ms, &vec8_err);
+        run(true, 16, &vec16_ms, &vec16_err);
+
+        // Two FP8 weight planes dominate the stream.
+        const double bytes = 2.0 * static_cast<double>(c.rows) * c.cols;
+        std::printf("%-18s %6d %6d %10.4f %10.4f %10.4f %10.4f "
+                    "%8.1f %8.1f %8.1f %8.1f %9.2e\n",
+                    c.label, c.rows, c.cols, scalar_ms, vec4_ms, vec8_ms,
+                    vec16_ms, bytes / (scalar_ms * 1e-3) / 1e9,
+                    bytes / (vec4_ms * 1e-3) / 1e9,
+                    bytes / (vec8_ms * 1e-3) / 1e9,
+                    bytes / (vec16_ms * 1e-3) / 1e9,
+                    std::max(std::max(scalar_err, vec4_err),
+                             std::max(vec8_err, vec16_err)));
+
+        cudaFree(d_x);
+        cudaFree(d_gw);
+        cudaFree(d_uw);
+        cudaFree(d_gs);
+        cudaFree(d_us);
+        cudaFree(d_y);
+    }
+
+    // The plain matvec is the other large decode kernel: the down projection
+    // (5120 x 4352 per rank) plus every attention projection.
+    struct MatvecCase {
+        int rows;
+        int cols;
+        const char* label;
+    };
+    const std::vector<MatvecCase> matvec_cases = {
+        {5120, 4352, "tp4 mlp down"},
+        {1536, 5120, "tp4 attn qkv-ish"},
+    };
+    std::printf("\n%-18s %6s %6s %10s %10s %8s %8s %9s\n", "matvec case",
+                "rows", "cols", "vec4_ms", "vec8_ms", "v4_GB/s", "v8_GB/s",
+                "worst_err");
+    for (const MatvecCase& c : matvec_cases) {
+        const int scale_rows = (c.rows + kBlock - 1) / kBlock;
+        const int scale_cols = (c.cols + kBlock - 1) / kBlock;
+        std::vector<uint16_t> x(c.cols);
+        std::vector<uint8_t> w(static_cast<size_t>(c.rows) * c.cols);
+        std::vector<uint16_t> s(static_cast<size_t>(scale_rows) * scale_cols);
+        std::uniform_real_distribution<float> x_dist(-0.5f, 0.5f);
+        std::uniform_real_distribution<float> s_dist(0.01f, 0.05f);
+        for (uint16_t& value : x) value = float_to_half_host(x_dist(rng));
+        for (uint8_t& value : w) value = sample_code(rng);
+        for (uint16_t& value : s) value = float_to_half_host(s_dist(rng));
+
+        uint16_t* d_x = nullptr;
+        uint8_t* d_w = nullptr;
+        uint16_t* d_s = nullptr;
+        uint16_t* d_y = nullptr;
+        cudaMalloc(&d_x, x.size() * 2);
+        cudaMalloc(&d_w, w.size());
+        cudaMalloc(&d_s, s.size() * 2);
+        cudaMalloc(&d_y, static_cast<size_t>(c.rows) * 2);
+        cudaMemcpy(d_x, x.data(), x.size() * 2, cudaMemcpyHostToDevice);
+        cudaMemcpy(d_w, w.data(), w.size(), cudaMemcpyHostToDevice);
+        cudaMemcpy(d_s, s.data(), s.size() * 2, cudaMemcpyHostToDevice);
+
+        std::vector<double> ref(c.rows);
+        for (int row = 0; row < c.rows; ++row) {
+            double sum = 0.0;
+            for (int col = 0; col < c.cols; ++col) {
+                const size_t wi = static_cast<size_t>(row) * c.cols + col;
+                const size_t si =
+                    static_cast<size_t>(row / kBlock) * scale_cols + col / kBlock;
+                sum += half_to_float_host(x[col]) *
+                       fp8_e4m3_to_float_host(w[wi]) * half_to_float_host(s[si]);
+            }
+            ref[row] = sum;
+        }
+
+        auto run = [&](int cols_per_lane, double* ms, double* err) {
+            setenv("QWEN_FP8_F16_VECTORIZE", "1", 1);
+            setenv("QWEN_FP8_F16_COLS_PER_LANE",
+                   cols_per_lane == 4 ? "4" : "8", 1);
+            auto launch = [&] {
+                return dsv4::qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+                    d_x, d_w, d_s, d_y, c.rows, c.cols, c.cols, scale_cols,
+                    nullptr);
+            };
+            if (!launch() || cudaDeviceSynchronize() != cudaSuccess) {
+                std::printf("[FAIL] matvec launch cols_per_lane=%d\n",
+                            cols_per_lane);
+                std::exit(1);
+            }
+            std::vector<uint16_t> y(c.rows);
+            cudaMemcpy(y.data(), d_y, y.size() * 2, cudaMemcpyDeviceToHost);
+            double worst = 0.0;
+            for (int row = 0; row < c.rows; ++row) {
+                const double denom = std::max(1e-3, std::fabs(ref[row]));
+                worst = std::max(
+                    worst, std::fabs(half_to_float_host(y[row]) - ref[row]) / denom);
+            }
+            *err = worst;
+
+            cudaEvent_t start;
+            cudaEvent_t stop;
+            cudaEventCreate(&start);
+            cudaEventCreate(&stop);
+            cudaEventRecord(start);
+            for (int i = 0; i < iters; ++i) launch();
+            cudaEventRecord(stop);
+            cudaEventSynchronize(stop);
+            float elapsed = 0.0f;
+            cudaEventElapsedTime(&elapsed, start, stop);
+            cudaEventDestroy(start);
+            cudaEventDestroy(stop);
+            *ms = static_cast<double>(elapsed) / iters;
+        };
+
+        double vec4_ms = 0.0;
+        double vec8_ms = 0.0;
+        double vec4_err = 0.0;
+        double vec8_err = 0.0;
+        run(4, &vec4_ms, &vec4_err);
+        run(8, &vec8_ms, &vec8_err);
+        unsetenv("QWEN_FP8_F16_COLS_PER_LANE");
+        unsetenv("QWEN_FP8_F16_VECTORIZE");
+
+        const double bytes = static_cast<double>(c.rows) * c.cols;
+        std::printf("%-18s %6d %6d %10.4f %10.4f %8.1f %8.1f %9.2e\n", c.label,
+                    c.rows, c.cols, vec4_ms, vec8_ms,
+                    bytes / (vec4_ms * 1e-3) / 1e9,
+                    bytes / (vec8_ms * 1e-3) / 1e9,
+                    std::max(vec4_err, vec8_err));
+
+        cudaFree(d_x);
+        cudaFree(d_w);
+        cudaFree(d_s);
+        cudaFree(d_y);
+    }
+    std::printf("[PASS] bench_qwen_fp8_swiglu_decode\n");
+    return 0;
+}

--- a/cpp_engine/tests/bench_qwen_gqa_decode.cpp
+++ b/cpp_engine/tests/bench_qwen_gqa_decode.cpp
@@ -1,0 +1,197 @@
+// Decode-attention crossover at the real Qwen TP4 shape.
+//
+// The engine picks between the reference score/softmax/value kernels and the
+// fused split/merge kernel by a context threshold. This measures where that
+// crossover actually is, and checks the two agree numerically, at the shape a
+// TP4 rank really runs: 6 Q heads, 1 KV head, head_dim 256.
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <random>
+#include <vector>
+
+#include "qwen_cuda_ops.hpp"
+
+namespace {
+
+uint16_t to_half(float value) {
+    uint32_t bits;
+    __builtin_memcpy(&bits, &value, sizeof(bits));
+    const uint32_t sign = (bits >> 16) & 0x8000u;
+    int exponent = static_cast<int>((bits >> 23) & 0xFFu) - 127 + 15;
+    uint32_t mantissa = bits & 0x7FFFFFu;
+    if (exponent <= 0) return static_cast<uint16_t>(sign);
+    if (exponent >= 31) return static_cast<uint16_t>(sign | 0x7C00u);
+    return static_cast<uint16_t>(sign | (static_cast<uint32_t>(exponent) << 10) |
+                                (mantissa >> 13));
+}
+
+float from_half(uint16_t value) {
+    const uint32_t sign = static_cast<uint32_t>(value & 0x8000u) << 16;
+    const uint32_t exponent = (value >> 10) & 0x1Fu;
+    const uint32_t mantissa = value & 0x3FFu;
+    uint32_t bits;
+    if (exponent == 0) {
+        bits = sign;
+    } else if (exponent == 31) {
+        bits = sign | 0x7F800000u | (mantissa << 13);
+    } else {
+        bits = sign | ((exponent - 15 + 127) << 23) | (mantissa << 13);
+    }
+    float result;
+    __builtin_memcpy(&result, &bits, sizeof(result));
+    return result;
+}
+
+void check(cudaError_t status, const char* what) {
+    if (status != cudaSuccess) {
+        std::fprintf(stderr, "[FAIL] %s: %s\n", what, cudaGetErrorString(status));
+        std::exit(1);
+    }
+}
+
+double time_ms(void (*body)(void*), void* arg, int iterations) {
+    body(arg);
+    check(cudaDeviceSynchronize(), "warmup");
+    cudaEvent_t begin, finish;
+    check(cudaEventCreate(&begin), "event create");
+    check(cudaEventCreate(&finish), "event create");
+    check(cudaEventRecord(begin), "event record");
+    for (int i = 0; i < iterations; ++i) body(arg);
+    check(cudaEventRecord(finish), "event record");
+    check(cudaEventSynchronize(finish), "event sync");
+    float elapsed = 0.0f;
+    check(cudaEventElapsedTime(&elapsed, begin, finish), "event elapsed");
+    check(cudaEventDestroy(begin), "event destroy");
+    check(cudaEventDestroy(finish), "event destroy");
+    return static_cast<double>(elapsed) / iterations;
+}
+
+struct Args {
+    const uint16_t* q;
+    const uint16_t* k;
+    const uint16_t* v;
+    uint16_t* out;
+    float* scratch;
+    int q_heads;
+    int kv_heads;
+    int head_dim;
+    int context_len;
+    int max_context;
+};
+
+void run_reference(void* raw) {
+    const Args& a = *static_cast<Args*>(raw);
+    if (!dsv4::qwen_gqa_decode_attention_f16_cuda(
+            a.q, a.k, a.v, a.out, a.scratch, a.q_heads, a.kv_heads, a.head_dim,
+            a.context_len, a.max_context)) {
+        std::fprintf(stderr, "[FAIL] reference decode launch\n");
+        std::exit(1);
+    }
+}
+
+void run_fused(void* raw) {
+    const Args& a = *static_cast<Args*>(raw);
+    if (!dsv4::qwen_gqa_decode_attention_f16_fused_cuda(
+            a.q, a.k, a.v, a.out, a.scratch, a.q_heads, a.kv_heads, a.head_dim,
+            a.context_len, a.max_context, 0, 0)) {
+        std::fprintf(stderr, "[FAIL] fused decode launch\n");
+        std::exit(1);
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    // Real TP4 rank shape unless overridden.
+    const int q_heads = argc > 1 ? std::atoi(argv[1]) : 6;
+    const int kv_heads = argc > 2 ? std::atoi(argv[2]) : 1;
+    const int head_dim = argc > 3 ? std::atoi(argv[3]) : 256;
+    const int max_context = 65552;
+    const int iterations = 50;
+
+    std::mt19937 rng(1234);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+
+    std::vector<uint16_t> host_q(static_cast<size_t>(q_heads) * head_dim);
+    for (uint16_t& value : host_q) value = to_half(dist(rng));
+    const size_t cache_elements =
+        static_cast<size_t>(max_context) * kv_heads * head_dim;
+    std::vector<uint16_t> host_k(cache_elements);
+    std::vector<uint16_t> host_v(cache_elements);
+    for (size_t i = 0; i < cache_elements; ++i) {
+        host_k[i] = to_half(dist(rng));
+        host_v[i] = to_half(dist(rng));
+    }
+
+    uint16_t *q = nullptr, *k = nullptr, *v = nullptr, *out_a = nullptr,
+             *out_b = nullptr;
+    float* scratch = nullptr;
+    check(cudaMalloc(&q, host_q.size() * sizeof(uint16_t)), "malloc q");
+    check(cudaMalloc(&k, cache_elements * sizeof(uint16_t)), "malloc k");
+    check(cudaMalloc(&v, cache_elements * sizeof(uint16_t)), "malloc v");
+    const size_t out_elements = static_cast<size_t>(q_heads) * head_dim;
+    check(cudaMalloc(&out_a, out_elements * sizeof(uint16_t)), "malloc out");
+    check(cudaMalloc(&out_b, out_elements * sizeof(uint16_t)), "malloc out");
+    // Large enough for either layout: q_heads*context for the reference path,
+    // q_heads*splits*(head_dim+2) for the fused one. The split count is tunable,
+    // so ask the kernel rather than assuming it.
+    const size_t scratch_elements =
+        static_cast<size_t>(q_heads) * max_context +
+        static_cast<size_t>(q_heads) *
+            dsv4::qwen_gqa_decode_split_count(max_context) * (head_dim + 2);
+    check(cudaMalloc(&scratch, scratch_elements * sizeof(float)), "malloc scratch");
+    check(cudaMemcpy(q, host_q.data(), host_q.size() * sizeof(uint16_t),
+                     cudaMemcpyHostToDevice), "copy q");
+    check(cudaMemcpy(k, host_k.data(), cache_elements * sizeof(uint16_t),
+                     cudaMemcpyHostToDevice), "copy k");
+    check(cudaMemcpy(v, host_v.data(), cache_elements * sizeof(uint16_t),
+                     cudaMemcpyHostToDevice), "copy v");
+
+    std::printf("decode attention crossover q_heads=%d kv_heads=%d head_dim=%d\n",
+                q_heads, kv_heads, head_dim);
+    std::printf("%9s %12s %12s %8s %12s\n", "context", "reference", "fused",
+                "speedup", "max_diff");
+
+    // The fused kernel declines contexts below its own minimum, so start there.
+    const int contexts[] = {4096, 8192, 16384, 32768, 65536};
+    for (int context_len : contexts) {
+        Args args{q, k, v, out_a, scratch, q_heads, kv_heads, head_dim,
+                  context_len, max_context};
+        const double reference_ms = time_ms(run_reference, &args, iterations);
+        std::vector<uint16_t> host_a(out_elements);
+        check(cudaMemcpy(host_a.data(), out_a, out_elements * sizeof(uint16_t),
+                         cudaMemcpyDeviceToHost), "copy out");
+
+        args.out = out_b;
+        const double fused_ms = time_ms(run_fused, &args, iterations);
+        std::vector<uint16_t> host_b(out_elements);
+        check(cudaMemcpy(host_b.data(), out_b, out_elements * sizeof(uint16_t),
+                         cudaMemcpyDeviceToHost), "copy out");
+
+        float worst = 0.0f;
+        for (size_t i = 0; i < out_elements; ++i) {
+            worst = std::fmax(worst,
+                              std::fabs(from_half(host_a[i]) - from_half(host_b[i])));
+        }
+        std::printf("%9d %10.4fms %10.4fms %7.2fx %12.3e\n", context_len,
+                    reference_ms, fused_ms, reference_ms / fused_ms, worst);
+        if (worst > 5e-3f) {
+            std::fprintf(stderr, "[FAIL] decode paths disagree at context %d\n",
+                         context_len);
+            return 1;
+        }
+    }
+
+    check(cudaFree(q), "free");
+    check(cudaFree(k), "free");
+    check(cudaFree(v), "free");
+    check(cudaFree(out_a), "free");
+    check(cudaFree(out_b), "free");
+    check(cudaFree(scratch), "free");
+    std::printf("[PASS] bench_qwen_gqa_decode\n");
+    return 0;
+}

--- a/cpp_engine/tests/test_qwen_half_ops.cpp
+++ b/cpp_engine/tests/test_qwen_half_ops.cpp
@@ -1538,6 +1538,143 @@ bool check_strided_row_copy(int rows) {
     return true;
 }
 
+// The decode fused gate/up SwiGLU matvec is the largest kernel in a decode
+// step, so it has a vectorized variant that widens FP8 codes with bit
+// arithmetic rather than a table. That shortcut only holds for E4M3's normal
+// codes, so cover every code including the exponent-zero subnormals and both
+// signs, and check the vectorized result against the scalar kernel it replaces.
+bool check_fp8_swiglu_decode_vectorized() {
+    // 5120 is the real Qwen3.8 MLP input width. 2052 is not a multiple of 128,
+    // so it exercises a partial scale block, and 300 leaves a ragged tail that
+    // the vectorized loop hands to the scalar path.
+    struct Case {
+        int rows;
+        int cols;
+    };
+    const Case cases[] = {{4352, 5120}, {136, 2052}, {72, 300}};
+    std::mt19937 rng(5150);
+    std::uniform_real_distribution<float> x_dist(-0.5f, 0.5f);
+    std::uniform_real_distribution<float> scale_dist(0.01f, 0.05f);
+
+    for (const Case& item : cases) {
+        const int weight_stride = item.cols;
+        const int scale_stride = (item.cols + 127) / 128;
+        const size_t weight_elements =
+            static_cast<size_t>(item.rows) * weight_stride;
+        std::vector<uint16_t> host_x(item.cols);
+        std::vector<uint8_t> host_gate(weight_elements);
+        std::vector<uint8_t> host_up(weight_elements);
+        std::vector<uint16_t> host_gate_scale(
+            static_cast<size_t>((item.rows + 127) / 128) * scale_stride);
+        std::vector<uint16_t> host_up_scale(host_gate_scale.size());
+        for (uint16_t& value : host_x) value = to_half(x_dist(rng));
+        // Walk all 256 codes so the subnormal and NaN encodings are covered at
+        // every lane position rather than sampled.
+        for (size_t i = 0; i < weight_elements; ++i) {
+            host_gate[i] = static_cast<uint8_t>(i & 0xffu);
+            host_up[i] = static_cast<uint8_t>((i * 7u + 3u) & 0xffu);
+        }
+        for (uint16_t& value : host_gate_scale) value = to_half(scale_dist(rng));
+        for (uint16_t& value : host_up_scale) value = to_half(scale_dist(rng));
+
+        DeviceBuffer dx, dg, du, dgs, dus, d_vec, d_scalar;
+        uint16_t* px = dx.allocate<uint16_t>(host_x.size());
+        uint8_t* pg = dg.allocate<uint8_t>(host_gate.size());
+        uint8_t* pu = du.allocate<uint8_t>(host_up.size());
+        uint16_t* pgs = dgs.allocate<uint16_t>(host_gate_scale.size());
+        uint16_t* pus = dus.allocate<uint16_t>(host_up_scale.size());
+        uint16_t* py_vec = d_vec.allocate<uint16_t>(item.rows);
+        uint16_t* py_scalar = d_scalar.allocate<uint16_t>(item.rows);
+        if (!px || !pg || !pu || !pgs || !pus || !py_vec || !py_scalar ||
+            cudaMemcpy(px, host_x.data(), host_x.size() * sizeof(uint16_t),
+                       cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(pg, host_gate.data(), host_gate.size(),
+                       cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(pu, host_up.data(), host_up.size(),
+                       cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(pgs, host_gate_scale.data(),
+                       host_gate_scale.size() * sizeof(uint16_t),
+                       cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(pus, host_up_scale.data(),
+                       host_up_scale.size() * sizeof(uint16_t),
+                       cudaMemcpyHostToDevice) != cudaSuccess) {
+            fail("FP8 SwiGLU decode vectorized allocation/copy");
+            return true;
+        }
+
+        // Multi-row dispatch has its own kernel; pin the single-row path so the
+        // comparison is vectorized against scalar and nothing else.
+        setenv("QWEN_FP8_F16_MULTIROW", "0", 1);
+        setenv("QWEN_FP8_F16_SWIGLU_VECTORIZE", "1", 1);
+        const bool vec_ok = dsv4::qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
+                                px, pg, pgs, pu, pus, py_vec, item.rows,
+                                item.cols, weight_stride, scale_stride) &&
+                            cudaDeviceSynchronize() == cudaSuccess;
+        setenv("QWEN_FP8_F16_SWIGLU_VECTORIZE", "0", 1);
+        const bool scalar_ok = dsv4::qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
+                                   px, pg, pgs, pu, pus, py_scalar, item.rows,
+                                   item.cols, weight_stride, scale_stride) &&
+                               cudaDeviceSynchronize() == cudaSuccess;
+        unsetenv("QWEN_FP8_F16_SWIGLU_VECTORIZE");
+        unsetenv("QWEN_FP8_F16_MULTIROW");
+        if (!vec_ok || !scalar_ok) {
+            fail("FP8 SwiGLU decode vectorized launch");
+            return true;
+        }
+
+        std::vector<uint16_t> got(item.rows), want(item.rows);
+        cudaMemcpy(got.data(), py_vec, got.size() * sizeof(uint16_t),
+                   cudaMemcpyDeviceToHost);
+        cudaMemcpy(want.data(), py_scalar, want.size() * sizeof(uint16_t),
+                   cudaMemcpyDeviceToHost);
+
+        double worst_vs_scalar = 0.0;
+        double worst_vs_host = 0.0;
+        double worst_relative = 0.0;
+        for (int row = 0; row < item.rows; ++row) {
+            double gate = 0.0;
+            double up = 0.0;
+            const size_t base = static_cast<size_t>(row) * weight_stride;
+            const size_t scale_base =
+                static_cast<size_t>(row / 128) * scale_stride;
+            for (int col = 0; col < item.cols; ++col) {
+                const double xv = from_half(host_x[col]);
+                gate += xv * from_fp8_e4m3(host_gate[base + col]) *
+                        from_half(host_gate_scale[scale_base + col / 128]);
+                up += xv * from_fp8_e4m3(host_up[base + col]) *
+                      from_half(host_up_scale[scale_base + col / 128]);
+            }
+            const double reference =
+                (gate / (1.0 + std::exp(-gate))) * up;
+            const double vectorized = from_half(got[row]);
+            const double scalar = from_half(want[row]);
+            if (!std::isfinite(vectorized) || !std::isfinite(scalar)) {
+                fail("FP8 SwiGLU decode vectorized produced a non-finite row");
+                return true;
+            }
+            worst_vs_scalar = std::max(worst_vs_scalar,
+                                       std::fabs(vectorized - scalar));
+            worst_vs_host = std::max(worst_vs_host,
+                                     std::fabs(vectorized - reference));
+            const double magnitude = std::max(std::fabs(reference), 1.0e-3);
+            worst_relative = std::max(worst_relative,
+                                      std::fabs(vectorized - reference) / magnitude);
+        }
+        // The vectorized kernel sums four products before applying the block
+        // scale, so it is not bit exact against the scalar kernel; hold it to
+        // the same relative accuracy instead.
+        if (worst_relative > 5.0e-3) {
+            fail("FP8 SwiGLU decode vectorized numerical check");
+            return true;
+        }
+        std::printf("  FP8 SwiGLU decode vectorized rows=%d cols=%d "
+                    "vs_scalar=%.3e vs_host=%.3e rel=%.3e\n",
+                    item.rows, item.cols, worst_vs_scalar, worst_vs_host,
+                    worst_relative);
+    }
+    return true;
+}
+
 // The FP8 fused gate/up SwiGLU kernel runs on every speculative verify batch.
 // Its shared-activation variant must stay bit exact against the register-only
 // kernel or greedy near ties would diverge from plain decode.
@@ -1984,6 +2121,7 @@ int main() {
     check_decode_window_reference();
     check_decode_grid_256k();
     check_fp8_f16_projection();
+    check_fp8_swiglu_decode_vectorized();
     check_resident_fp16_projection();
     check_fp8_channel_projection();
     check_batched_argmax();


### PR DESCRIPTION
## Summary

Two decode-path changes, both on the real TP4 shape (4x2080Ti, Qwen3.8-27B-FP8, full 64 layers, real checkpoint/tokenizer).

**Decode attention splits.** A rank holds 6 Q heads over 1 KV head, so the old geometry (2048 positions/split, 64 split ceiling) launched about 4 blocks on 68 SMs and walked the whole history serially. Now 256 positions/split with a 1024 ceiling. 256 is the smallest target whose generated tokens stay identical to a single sequential split at every context measured — 128 is faster per kernel but diverges at token 86 of the 8K prompt and is slower end to end at 65K. The engine's scratch sizing and the launch now share one accessor instead of both hardcoding the count, and the gate drops from 16384 to the 4096 the kernel enforces.

**FP8 decode MLP.** Both decode kernels took one weight byte per lane per step and widened codes through a shared 256-entry table (four data-dependent shared loads per weight word). They now take eight columns per lane — one 64-bit weight request — and widen codes with bit arithmetic: E4M3's exponent bias is 8 below FP16's, so the field shift lands 2^-8 low and one power-of-two multiply folded into the block scale restores it. Exponent-zero codes keep the old decode path since their spacing doesn't match at that shift.

## Measured

TG128, serial fresh processes, `rank_token_parity=PASS` throughout:

| context | prefill tok/s | decode tok/s | was |
|---|---|---|---|
| 8192 | 1811.74 | 36.87 | 29.04 |
| 16384 | 1780.58 | 36.67 | |
| 32768 | 1661.99 | 35.16 | |
| 65536 | 1439.50 | 30.10 | 26.25 |

Prefill is unchanged. Generated tokens are bit-identical to the scalar kernels at both 8K and 65K, and identical between the 4-wide and 8-wide arms at 65K.

Standalone kernel bandwidth at the TP4 decode shape: fused gate/up 292 -> 438 GB/s, down projection 314 -> 474 GB/s.

Rejected by measurement: 16 columns per lane (384 GB/s vs 438), multirow rows=2/4 (23.8 tok/s), and the wide-group GQA variant (wins 7% at 65K, loses 20-65% at 4K-32K).

## Testing

- `test_qwen_half_ops`, `test_qwen_fp8_online`, `test_qwen_gqa_attention`, `test_qwen_gqa_mma_occ`, `test_qwen_engine`, `test_qwen_config`, `test_qwen_turboquant_k8v4`, `test_qwen_gdn_flashqla` all pass.
- New `check_fp8_swiglu_decode_vectorized` walks all 256 E4M3 codes including subnormals and NaN encodings at every lane position, over three shapes, against both the scalar kernel and a host reference.
- New `bench_qwen_gqa_decode` and `bench_qwen_fp8_swiglu_decode` microbenchmarks.
- FP8 KV cache path re-checked at 8K (unaffected, parity PASS).

Env overrides keep the old geometry available: `QWEN_FP8_F16_COLS_PER_LANE`, `QWEN_FP8_F16_SWIGLU_COLS_PER_LANE`, `DSV4_QWEN_DECODE_SPLIT_POSITIONS`, `DSV4_QWEN_DECODE_MAX_SPLITS`.