### PR TITLE
Cut Qwen TP4 decode latency: split geometry, GDN, KV traffic

### DIFF
--- a/cpp_engine/backends/cuda/kernels/qwen_gqa_optimized.cu
+++ b/cpp_engine/backends/cuda/kernels/qwen_gqa_optimized.cu
@@ -21,31 +21,36 @@ constexpr int kValuesPerThread = kMaxHeadDim / kThreads;
 constexpr int kPrefillCombos = kHeadsPerGroup * kQueryRows;
 // Hard ceiling for the tunable decode split count. Sizes the merge kernel's
 // shared weight array at 4 bytes per split, so 1024 costs 4 KiB of the 48 KiB
-// budget, and keeps the target honest to 64 positions per split at 65K context.
+// budget. The default target sits well under it; the headroom only matters for
+// A/B sweeps that ask for a finer split than the default.
 constexpr int kDecodeSplitCeiling = 1024;
-// Decode positions per split. The split kernel walks its slice serially and the
+// Target decode split count. The split kernel walks its slice serially and the
 // launch is only kv_heads*groups*splits blocks, so at the real TP4 shape (6 Q
-// heads, 1 KV head, 4 groups of blocks) positions per split, not bytes, set the
+// heads, 1 KV head, 2 groups) it is the split count, not bytes, that sets the
 // runtime: the old 2048-position target measured a flat 1.41 ms from 4K to 65K
-// context, about 47 GB/s of the 616 GB/s the card can sustain. A smaller target
-// buys parallelism.
-// Measured at the real TP4 shape against the reference score/value kernels,
-// fused kernel milliseconds, `bench_qwen_gqa_decode`:
+// context, about 47 GB/s of the 616 GB/s the card can sustain.
 //
-//   context   reference   2048   256    128    64
-//      4096      0.289    1.570  0.152  0.080  0.049
-//      8192      0.865    1.508  0.188  0.106  0.072
-//     16384      1.748    1.441  0.199  0.127  0.128
-//     32768      3.490    3.045  0.237  0.226  0.258
-//     65536      7.042    1.445  0.413  0.438  0.492
+// What matters is the number of blocks, not the slice length. The previous
+// default fixed 256 positions per split, which leaves 8K context with 32 splits
+// and 64 blocks -- under one block per SM on the 68-SM card, so most of the
+// device sits idle. Targeting a fixed split count instead scales the slice with
+// the context and keeps the grid at 512 blocks everywhere. Fused kernel
+// milliseconds from `bench_qwen_gqa_decode` at the real TP4 shape, and decode
+// tok/s from the serial full-network TP4 benchmark at TG128:
 //
-// 256 is the default rather than the faster-looking 128 because it is the
-// smallest target whose generated tokens stay bit-identical to a single
-// sequential split, at every context measured on the real TP4 model. 128 is
-// deterministic run to run but diverges from the sequential reference at token
-// 86 of 128 on the 8K prompt, and it is also slower end to end at 65K (28.3 vs
-// 29.2 tok/s) because it hits the split ceiling there.
-constexpr int kDecodeTargetPositionsDefault = 256;
+//   context   fixed 256 pos      target 256 splits
+//              kernel  tok/s      kernel  tok/s
+//      8192    0.2382  37.25      0.0920  39.49   (medians of 3 repetitions)
+//     16384    0.1923  36.69      0.1578  38.68
+//     32768    0.2247  35.37      0.2080  36.11
+//     65536    0.3873  32.05      0.3881  31.59   (same launch either way)
+//
+// 65536 already reached 256 splits under the old default, so its geometry is
+// unchanged and the difference there is run-to-run noise. Pushing past 256 splits
+// regresses: a 32-position slice at 65K asks for 2048 splits, gets clamped to the
+// ceiling, and drops decode to 30.75 tok/s. Generated tokens stay bit-identical to
+// the pre-change sequential baseline for all 128 steps at every context above.
+constexpr int kDecodeTargetSplitsDefault = 256;
 // Verify attention splits far more finely than decode: it has only a handful of
 // query rows to fill the device with, so a 32-position tile at 8192 context wants
 // 256 splits where the decode ceiling would force 128. Sizes the merge kernel's
@@ -56,13 +61,25 @@ constexpr int kVerifyMaxSplits = 256;
 constexpr int kDecodeMinContext = 4096;
 constexpr int kVerifyMaxRows = 8;
 
-// Positions per split and the split ceiling, overridable for A/B sweeps. Read
-// once: these are launch geometry, not per-call state.
-int decode_target_positions() {
+// Target split count, the split ceiling, and a positions-per-split override,
+// all available for A/B sweeps. Read once: these are launch geometry, not
+// per-call state.
+int decode_target_splits() {
+    static const int value = [] {
+        const char* env = std::getenv("DSV4_QWEN_DECODE_TARGET_SPLITS");
+        const int parsed = env != nullptr ? std::atoi(env) : 0;
+        return parsed > 0 ? parsed : kDecodeTargetSplitsDefault;
+    }();
+    return value;
+}
+
+// Setting this pins the slice length and ignores the split target, which is how
+// the fixed-positions geometry that shipped before can still be measured.
+int decode_forced_positions() {
     static const int value = [] {
         const char* env = std::getenv("DSV4_QWEN_DECODE_SPLIT_POSITIONS");
         const int parsed = env != nullptr ? std::atoi(env) : 0;
-        return parsed > 0 ? parsed : kDecodeTargetPositionsDefault;
+        return parsed > 0 ? parsed : 0;
     }();
     return value;
 }
@@ -124,6 +141,14 @@ __device__ __forceinline__ float warp_sum_all(float value) {
 #pragma unroll
     for (int offset = 16; offset > 0; offset >>= 1) {
         value += __shfl_xor_sync(0xffffffffu, value, offset);
+    }
+    return value;
+}
+
+__device__ __forceinline__ float warp_sum_max(float value) {
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        value = fmaxf(value, __shfl_xor_sync(0xffffffffu, value, offset));
     }
     return value;
 }
@@ -1506,7 +1531,15 @@ __global__ void gqa_decode_split_f16_kernel(
     const SparseRanges ranges = sparse_ranges(context_len, window, sink);
     const int start = split * positions_per_split;
     const int end = min(ranges.total(), start + positions_per_split);
-    if (kv_head >= kv_heads || start >= end) return;
+    // An empty split still has to publish its partial. Rounding the slice length
+    // up leaves the last splits with nothing to scan whenever the split count
+    // does not divide the context -- 8193 positions over 256 splits is 33 each,
+    // so seven splits run dry. Returning early would leave their scratch slots
+    // uninitialized and the merge would read them, which showed up as -inf
+    // logits from the second decode step onward. Falling through with a zero-trip
+    // loop writes the neutral (-inf max, zero sum, zero accumulator) partial that
+    // the merge already handles: exp(-inf - max) contributes nothing.
+    if (kv_head >= kv_heads) return;
 
     __shared__ float warp_sums[kHeadsPerGroup][kWarps];
     __shared__ float scores[kHeadsPerGroup];
@@ -1585,7 +1618,11 @@ __global__ void gqa_decode_split_f16_kernel(
                     probability[h] * value[i];
             }
         }
-        __syncthreads();
+        // No trailing barrier is needed. Every thread reads only its own
+        // accumulator registers here, while rescale/probability cannot be
+        // overwritten by the next position until reduce_dot_products() reaches
+        // its first block-wide barrier. That barrier protects the shared
+        // softmax scalars before their next write.
     }
 
     const int partial_stride = head_dim + 2;
@@ -1960,27 +1997,62 @@ __global__ void gqa_decode_merge_f16_kernel(
     const int head = static_cast<int>(blockIdx.x);
     if (head >= q_heads) return;
     __shared__ float weights[kDecodeSplitCeiling];
-    if (threadIdx.x == 0) {
-        const int stride = head_dim + 2;
-        float maximum = -INFINITY;
-        for (int split = 0; split < splits; ++split) {
-            maximum = fmaxf(maximum,
-                partial_output[(static_cast<size_t>(head) * splits + split) * stride]);
+    __shared__ float shared_maximum;
+    const int stride = head_dim + 2;
+    // The running maxima are strided head_dim + 2 apart, so one thread walking
+    // them serializes up to 1024 dependent loads before any output work can
+    // start. fmaxf is associative and commutative, so spreading the scan over
+    // the block and reducing in shared memory finds the same maximum.
+    {
+        float local = -INFINITY;
+        for (int split = static_cast<int>(threadIdx.x); split < splits;
+             split += kThreads) {
+            local = fmaxf(local, partial_output[
+                (static_cast<size_t>(head) * splits + split) * stride]);
         }
+        local = warp_sum_max(local);
+        __shared__ float warp_maxima[kWarps];
+        const int lane = static_cast<int>(threadIdx.x) & 31;
+        const int warp = static_cast<int>(threadIdx.x) >> 5;
+        if (lane == 0) warp_maxima[warp] = local;
+        __syncthreads();
+        if (threadIdx.x == 0) {
+            float maximum = warp_maxima[0];
+#pragma unroll
+            for (int w = 1; w < kWarps; ++w) {
+                maximum = fmaxf(maximum, warp_maxima[w]);
+            }
+            shared_maximum = maximum;
+        }
+        __syncthreads();
+    }
+    // The weights themselves are independent per split, so only the denominator
+    // needs the original left-to-right order; thread 0 sums the already-computed
+    // weights instead of also paying for the expf chain and the strided loads.
+    for (int split = static_cast<int>(threadIdx.x); split < splits;
+         split += kThreads) {
+        const float* source = partial_output +
+            (static_cast<size_t>(head) * splits + split) * stride;
+        weights[split] = expf(source[0] - shared_maximum);
+    }
+    __syncthreads();
+    if (threadIdx.x == 0) {
         float denominator = 0.0f;
         for (int split = 0; split < splits; ++split) {
-            const float* source = partial_output +
-                (static_cast<size_t>(head) * splits + split) * stride;
-            weights[split] = expf(source[0] - maximum);
-            denominator += weights[split] * source[1];
+            denominator += weights[split] * partial_output[
+                (static_cast<size_t>(head) * splits + split) * stride + 1];
         }
-        const float inverse = denominator > 0.0f ? 1.0f / denominator : 0.0f;
-        for (int split = 0; split < splits; ++split) weights[split] *= inverse;
+        shared_maximum = denominator > 0.0f ? 1.0f / denominator : 0.0f;
+    }
+    __syncthreads();
+    const float inverse = shared_maximum;
+    for (int split = static_cast<int>(threadIdx.x); split < splits;
+         split += kThreads) {
+        weights[split] *= inverse;
     }
     __syncthreads();
     for (int d = static_cast<int>(threadIdx.x); d < head_dim; d += kThreads) {
         float value = 0.0f;
-        const int stride = head_dim + 2;
         for (int split = 0; split < splits; ++split) {
             const float* source = partial_output +
                 (static_cast<size_t>(head) * splits + split) * stride;
@@ -1995,12 +2067,22 @@ bool valid_shape(int q_heads, int kv_heads, int head_dim) {
         head_dim > 0 && head_dim <= kMaxHeadDim;
 }
 
+// Never splits finer than one position per split, so short contexts fall back to
+// however many splits they can actually fill.
 int decode_split_count(int attended_positions) {
     if (attended_positions <= 0) return 1;
-    const int splits = std::min(decode_max_splits(),
-        (attended_positions + decode_target_positions() - 1) /
-            decode_target_positions());
-    return std::max(splits, 1);
+    const int forced = decode_forced_positions();
+    const int requested = forced > 0
+        ? (attended_positions + forced - 1) / forced
+        : std::min(decode_target_splits(), attended_positions);
+    const int splits = std::max(std::min(decode_max_splits(), requested), 1);
+    // Rounding the slice up can leave trailing splits with nothing to scan (8193
+    // positions over 256 splits is 33 each, which only fills 249). Re-deriving
+    // the count from the slice length drops those, so the grid and the merge do
+    // not walk dead entries. The engine sizes the partial scratch from this same
+    // function, so the two cannot disagree.
+    const int positions = (attended_positions + splits - 1) / splits;
+    return std::max((attended_positions + positions - 1) / positions, 1);
 }
 
 struct GqaCublasWorkspace {

--- a/cpp_engine/backends/cuda/kernels/qwen_gqa_optimized.cu
+++ b/cpp_engine/backends/cuda/kernels/qwen_gqa_optimized.cu
@@ -46,11 +46,31 @@ constexpr int kDecodeSplitCeiling = 1024;
 //     65536    0.3873  32.05      0.3881  31.59   (same launch either way)
 //
 // 65536 already reached 256 splits under the old default, so its geometry is
-// unchanged and the difference there is run-to-run noise. Pushing past 256 splits
-// regresses: a 32-position slice at 65K asks for 2048 splits, gets clamped to the
-// ceiling, and drops decode to 30.75 tok/s. Generated tokens stay bit-identical to
-// the pre-change sequential baseline for all 128 steps at every context above.
-constexpr int kDecodeTargetSplitsDefault = 256;
+// unchanged and the difference there is run-to-run noise. Generated tokens stay
+// bit-identical to the pre-change sequential baseline for all 128 steps at every
+// context above.
+//
+// The target is now expressed as CTAs per SM rather than a round number, because
+// the optimum tracks occupancy exactly. Once the group covers the whole KV head
+// (see the split kernel) the CTA needs 80 registers, which allows 6 resident per
+// SM, so 68 * 6 = 408 splits is the largest grid that still fits one wave. Fused
+// kernel milliseconds, medians of 3 after discarding the warm-up repetition:
+//
+//   context   256    272 (4/SM)  340 (5/SM)  408 (6/SM)
+//      4096  0.0435    0.0436      0.0460      0.0491
+//      8192  0.0661    0.0665      0.0654      0.0691
+//     16384  0.1095    0.1075      0.1038      0.1035
+//     32768  0.1954    0.1888      0.1766      0.1767
+//     65536  0.3683    0.3487      0.3239      0.3193
+//
+// Long contexts want the full wave; short ones do not, because every CTA writes a
+// fixed (head_dim + 2) * kHPG partial and that scratch traffic stops being
+// amortised once the slice gets short. Splitting the default at 16384 takes the
+// better column on both sides. Going past one wave is strictly worse at every
+// context (476 splits: 0.1321 / 0.2271 / 0.4051), so the ceiling is a real edge.
+constexpr int kDecodeSplitsPerSm = 6;
+constexpr int kDecodeShortSplitsPerSm = 4;
+constexpr int kDecodeShortContext = 16384;
 // Verify attention splits far more finely than decode: it has only a handful of
 // query rows to fill the device with, so a 32-position tile at 8192 context wants
 // 256 splits where the decode ceiling would force 128. Sizes the merge kernel's
@@ -64,13 +84,29 @@ constexpr int kVerifyMaxRows = 8;
 // Target split count, the split ceiling, and a positions-per-split override,
 // all available for A/B sweeps. Read once: these are launch geometry, not
 // per-call state.
-int decode_target_splits() {
+int decode_sm_count() {
     static const int value = [] {
-        const char* env = std::getenv("DSV4_QWEN_DECODE_TARGET_SPLITS");
-        const int parsed = env != nullptr ? std::atoi(env) : 0;
-        return parsed > 0 ? parsed : kDecodeTargetSplitsDefault;
+        int device = 0;
+        if (cudaGetDevice(&device) != cudaSuccess) return 68;
+        cudaDeviceProp properties{};
+        if (cudaGetDeviceProperties(&properties, device) != cudaSuccess) {
+            return 68;  // SM75 2080 Ti, the shape every measurement above used.
+        }
+        return properties.multiProcessorCount;
     }();
     return value;
+}
+
+int decode_target_splits(int attended_positions) {
+    static const int override_value = [] {
+        const char* env = std::getenv("DSV4_QWEN_DECODE_TARGET_SPLITS");
+        const int parsed = env != nullptr ? std::atoi(env) : 0;
+        return parsed > 0 ? parsed : 0;
+    }();
+    if (override_value > 0) return override_value;
+    const int per_sm = attended_positions < kDecodeShortContext
+        ? kDecodeShortSplitsPerSm : kDecodeSplitsPerSm;
+    return decode_sm_count() * per_sm;
 }
 
 // Setting this pins the slice length and ignores the split target, which is how
@@ -1505,8 +1541,16 @@ __global__ void gqa_prefill_tiled_f16_kernel(
     }
 }
 
-// Each CTA computes exact online-softmax partials for three Q heads over one
-// context split while loading their shared K/V row only once.
+// Each CTA computes exact online-softmax partials for kHPG Q heads over one
+// context split while loading their shared K/V row only once. The width matters
+// at long context: with kHPG below q_per_kv the KV head is split across several
+// CTAs that each stream the whole slice, so a 65K step read the 64 MiB cache
+// twice per layer (2 groups x 6 Q heads / 3). Widening the group to cover every
+// Q head sharing the KV head removes that duplicate traffic outright. Per-head
+// arithmetic is untouched: the dot product still reduces over the same lanes in
+// the same warp_sum tree, and the softmax recurrence still walks positions in
+// order, so a given split count gives bit-identical output at any width.
+template <int kHPG>
 __global__ void gqa_decode_split_f16_kernel(
     const uint16_t* __restrict__ q,
     const uint16_t* __restrict__ k_cache,
@@ -1521,13 +1565,12 @@ __global__ void gqa_decode_split_f16_kernel(
     int window,
     int sink) {
     const int q_per_kv = q_heads / kv_heads;
-    const int groups_per_kv =
-        (q_per_kv + kHeadsPerGroup - 1) / kHeadsPerGroup;
+    const int groups_per_kv = (q_per_kv + kHPG - 1) / kHPG;
     const int grouped = static_cast<int>(blockIdx.x) / splits;
     const int split = static_cast<int>(blockIdx.x) % splits;
     const int kv_head = grouped / groups_per_kv;
     const int group = grouped % groups_per_kv;
-    const int first_head = kv_head * q_per_kv + group * kHeadsPerGroup;
+    const int first_head = kv_head * q_per_kv + group * kHPG;
     const SparseRanges ranges = sparse_ranges(context_len, window, sink);
     const int start = split * positions_per_split;
     const int end = min(ranges.total(), start + positions_per_split);
@@ -1541,19 +1584,19 @@ __global__ void gqa_decode_split_f16_kernel(
     // the merge already handles: exp(-inf - max) contributes nothing.
     if (kv_head >= kv_heads) return;
 
-    __shared__ float warp_sums[kHeadsPerGroup][kWarps];
-    __shared__ float scores[kHeadsPerGroup];
-    __shared__ float running_max[kHeadsPerGroup];
-    __shared__ float running_sum[kHeadsPerGroup];
-    __shared__ float rescale[kHeadsPerGroup];
-    __shared__ float probability[kHeadsPerGroup];
+    __shared__ float warp_sums[kHPG][kWarps];
+    __shared__ float scores[kHPG];
+    __shared__ float running_max[kHPG];
+    __shared__ float running_sum[kHPG];
+    __shared__ float rescale[kHPG];
+    __shared__ float probability[kHPG];
 
     const int tid = static_cast<int>(threadIdx.x);
-    float query[kHeadsPerGroup][kValuesPerThread];
-    float accumulator[kHeadsPerGroup][kValuesPerThread] = {};
-    bool active[kHeadsPerGroup];
+    float query[kHPG][kValuesPerThread];
+    float accumulator[kHPG][kValuesPerThread] = {};
+    bool active[kHPG];
 #pragma unroll
-    for (int h = 0; h < kHeadsPerGroup; ++h) {
+    for (int h = 0; h < kHPG; ++h) {
         const int head = first_head + h;
         active[h] = head < (kv_head + 1) * q_per_kv && head < q_heads;
 #pragma unroll
@@ -1584,16 +1627,16 @@ __global__ void gqa_decode_split_f16_kernel(
             key[i] = d < head_dim ? half_to_float(k_cache[kv_base + d]) : 0.0f;
             value[i] = d < head_dim ? half_to_float(v_cache[kv_base + d]) : 0.0f;
         }
-        float dot[kHeadsPerGroup] = {};
+        float dot[kHPG] = {};
 #pragma unroll
-        for (int h = 0; h < kHeadsPerGroup; ++h) {
+        for (int h = 0; h < kHPG; ++h) {
 #pragma unroll
             for (int i = 0; i < kValuesPerThread; ++i) {
                 dot[h] += query[h][i] * key[i];
             }
         }
         reduce_dot_products(dot, warp_sums, scores, attention_scale);
-        if (tid < kHeadsPerGroup) {
+        if (tid < kHPG) {
             if (active[tid]) {
                 const float old_max = running_max[tid];
                 const float new_max = fmaxf(old_max, scores[tid]);
@@ -1611,7 +1654,7 @@ __global__ void gqa_decode_split_f16_kernel(
         }
         __syncthreads();
 #pragma unroll
-        for (int h = 0; h < kHeadsPerGroup; ++h) {
+        for (int h = 0; h < kHPG; ++h) {
 #pragma unroll
             for (int i = 0; i < kValuesPerThread; ++i) {
                 accumulator[h][i] = accumulator[h][i] * rescale[h] +
@@ -1627,7 +1670,7 @@ __global__ void gqa_decode_split_f16_kernel(
 
     const int partial_stride = head_dim + 2;
 #pragma unroll
-    for (int h = 0; h < kHeadsPerGroup; ++h) {
+    for (int h = 0; h < kHPG; ++h) {
         if (!active[h]) continue;
         const int head = first_head + h;
         float* destination = partial_output +
@@ -2074,7 +2117,7 @@ int decode_split_count(int attended_positions) {
     const int forced = decode_forced_positions();
     const int requested = forced > 0
         ? (attended_positions + forced - 1) / forced
-        : std::min(decode_target_splits(), attended_positions);
+        : std::min(decode_target_splits(attended_positions), attended_positions);
     const int splits = std::max(std::min(decode_max_splits(), requested), 1);
     // Rounding the slice up can leave trailing splits with nothing to scan (8193
     // positions over 256 splits is 33 each, which only fills 249). Re-deriving
@@ -2521,6 +2564,28 @@ int qwen_gqa_decode_split_count(int attended_positions) {
     return decode_split_count(attended_positions);
 }
 
+// Widest Q group the decode split kernel is instantiated for. Six covers the
+// TP4 full-attention shape (q_heads 6, kv_heads 1) in a single CTA, which is
+// what removes the duplicate KV stream.
+constexpr int kDecodeMaxHeadsPerGroup = 6;
+
+// Zero keeps the automatic choice: cover the whole KV group so its cache line is
+// read once. An override only exists for A/B sweeps.
+int decode_group_width_override() {
+    static const int value = [] {
+        const char* env = std::getenv("DSV4_QWEN_DECODE_GROUP_HEADS");
+        const int parsed = env != nullptr ? std::atoi(env) : 0;
+        return parsed > 0 ? parsed : 0;
+    }();
+    return value;
+}
+
+int decode_group_width(int q_per_kv) {
+    const int override_width = decode_group_width_override();
+    const int requested = override_width > 0 ? override_width : q_per_kv;
+    return std::max(std::min(requested, kDecodeMaxHeadsPerGroup), 1);
+}
+
 bool qwen_gqa_decode_attention_f16_fused_cuda(
     const uint16_t* q, const uint16_t* k_cache,
     const uint16_t* v_cache, uint16_t* output, float* partial_scratch,
@@ -2536,14 +2601,26 @@ bool qwen_gqa_decode_attention_f16_fused_cuda(
     const int attended = ranges.total();
     const int splits = decode_split_count(attended);
     const int positions_per_split = (attended + splits - 1) / splits;
+    const int group_heads = decode_group_width(q_heads / kv_heads);
     const int groups_per_kv =
-        (q_heads / kv_heads + kHeadsPerGroup - 1) / kHeadsPerGroup;
+        (q_heads / kv_heads + group_heads - 1) / group_heads;
     const int blocks = kv_heads * groups_per_kv * splits;
     const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
-    gqa_decode_split_f16_kernel<<<blocks, kThreads, 0, cuda_stream>>>(
-        q, k_cache, v_cache, partial_scratch, q_heads, kv_heads, head_dim,
-        context_len, splits, positions_per_split, attention_window,
-        sink_tokens);
+#define DSV4_LAUNCH_DECODE_SPLIT(HPG) \
+    gqa_decode_split_f16_kernel<HPG><<<blocks, kThreads, 0, cuda_stream>>>( \
+        q, k_cache, v_cache, partial_scratch, q_heads, kv_heads, head_dim, \
+        context_len, splits, positions_per_split, attention_window, \
+        sink_tokens)
+    switch (group_heads) {
+        case 1: DSV4_LAUNCH_DECODE_SPLIT(1); break;
+        case 2: DSV4_LAUNCH_DECODE_SPLIT(2); break;
+        case 3: DSV4_LAUNCH_DECODE_SPLIT(3); break;
+        case 4: DSV4_LAUNCH_DECODE_SPLIT(4); break;
+        case 5: DSV4_LAUNCH_DECODE_SPLIT(5); break;
+        case 6: DSV4_LAUNCH_DECODE_SPLIT(6); break;
+        default: return false;
+    }
+#undef DSV4_LAUNCH_DECODE_SPLIT
     if (cudaGetLastError() != cudaSuccess) return false;
     gqa_decode_merge_f16_kernel<<<q_heads, kThreads, 0, cuda_stream>>>(
         partial_scratch, output, q_heads, head_dim, splits);

--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -1995,7 +1995,13 @@ struct QwenEngine::Impl {
                         static_cast<int>(config.linear_attention.key_head_dim),
                         static_cast<int>(config.linear_attention.value_head_dim),
                         q_scale));
-        } else if (rows > 1) {
+        } else {
+            // Also covers rows == 1. Decode used to fall through to the step
+            // loop below, which round-trips the [128, 128] state through global
+            // memory twice per token; the sequence kernel holds it in registers
+            // and is bit-exact against the step kernel, so there is no reason to
+            // reserve it for multi-token chunks. See the step-vs-sequence parity
+            // check in test_qwen_half_ops.
             sequenced = qwen_gated_delta_sequence_f16_cuda(
                 layer.linear.state.f32_data(), q.f16_data(), k.f16_data(),
                 v.f16_data(), gates.f16_data(), beta.f16_data(),

--- a/cpp_engine/tests/test_qwen_half_ops.cpp
+++ b/cpp_engine/tests/test_qwen_half_ops.cpp
@@ -1991,6 +1991,133 @@ bool check_gated_delta_prenormalized(int rows = 8, int heads = 12,
     return true;
 }
 
+// The per-token step kernel and the sequence kernel must agree exactly. Decode
+// runs one token at a time, so whichever one the engine picks at rows == 1 has
+// to produce the same state and output as the other, otherwise switching the
+// gate would silently change generated tokens. The two differ only in where the
+// recurrent state lives: the step kernel round-trips it through global memory
+// while the sequence kernel holds it in registers.
+bool check_gated_delta_step_matches_sequence(int rows = 1, int heads = 12,
+                                            int key_heads = 4, int passes = 3,
+                                            float scale = 0.2f) {
+    constexpr int dim = 128;
+    const size_t state_elements = static_cast<size_t>(heads) * dim * dim;
+    const size_t key_elements = static_cast<size_t>(rows) * key_heads * dim;
+    const size_t value_elements = static_cast<size_t>(rows) * heads * dim;
+    const size_t gate_elements = static_cast<size_t>(rows) * heads;
+    std::mt19937 rng(24101 + rows * 13 + heads * 5 + key_heads);
+    std::uniform_real_distribution<float> dist(-scale, scale);
+    std::vector<float> state(state_elements);
+    for (float& value : state) value = dist(rng);
+    std::vector<uint16_t> q(key_elements), k(key_elements), v(value_elements);
+    std::vector<uint16_t> g(gate_elements), beta(gate_elements);
+    for (uint16_t& value : q) value = to_half(dist(rng));
+    for (uint16_t& value : k) value = to_half(dist(rng));
+    for (uint16_t& value : v) value = to_half(dist(rng));
+    for (uint16_t& value : g) value = to_half(dist(rng) - 0.3f);
+    for (uint16_t& value : beta) value = to_half(dist(rng) + 0.5f);
+
+    float* d_state_step = nullptr;
+    float* d_state_sequence = nullptr;
+    uint16_t* d_q = nullptr;
+    uint16_t* d_k = nullptr;
+    uint16_t* d_v = nullptr;
+    uint16_t* d_g = nullptr;
+    uint16_t* d_beta = nullptr;
+    uint16_t* d_step = nullptr;
+    uint16_t* d_sequence = nullptr;
+    auto malloc_copy = [](void** device, const void* host, size_t bytes) {
+        return cudaMalloc(device, bytes) == cudaSuccess &&
+               cudaMemcpy(*device, host, bytes, cudaMemcpyHostToDevice) == cudaSuccess;
+    };
+    if (!malloc_copy(reinterpret_cast<void**>(&d_state_step), state.data(),
+                     state.size() * sizeof(float)) ||
+        !malloc_copy(reinterpret_cast<void**>(&d_state_sequence), state.data(),
+                     state.size() * sizeof(float)) ||
+        !malloc_copy(reinterpret_cast<void**>(&d_q), q.data(),
+                     q.size() * sizeof(uint16_t)) ||
+        !malloc_copy(reinterpret_cast<void**>(&d_k), k.data(),
+                     k.size() * sizeof(uint16_t)) ||
+        !malloc_copy(reinterpret_cast<void**>(&d_v), v.data(),
+                     v.size() * sizeof(uint16_t)) ||
+        !malloc_copy(reinterpret_cast<void**>(&d_g), g.data(),
+                     g.size() * sizeof(uint16_t)) ||
+        !malloc_copy(reinterpret_cast<void**>(&d_beta), beta.data(),
+                     beta.size() * sizeof(uint16_t)) ||
+        cudaMalloc(&d_step, value_elements * sizeof(uint16_t)) != cudaSuccess ||
+        cudaMalloc(&d_sequence, value_elements * sizeof(uint16_t)) != cudaSuccess) {
+        fail("gated delta step-vs-sequence allocation");
+        return false;
+    }
+    const float q_scale = 1.0f / std::sqrt(static_cast<float>(dim));
+    for (int pass = 0; pass < passes; ++pass) {
+        bool launched = true;
+        for (int row = 0; row < rows && launched; ++row) {
+            launched = dsv4::qwen_gated_delta_step_f16_cuda(
+                d_state_step,
+                d_q + static_cast<size_t>(row) * key_heads * dim,
+                d_k + static_cast<size_t>(row) * key_heads * dim,
+                d_v + static_cast<size_t>(row) * heads * dim,
+                d_g + static_cast<size_t>(row) * heads,
+                d_beta + static_cast<size_t>(row) * heads,
+                d_step + static_cast<size_t>(row) * heads * dim,
+                heads, key_heads, dim, dim, q_scale);
+        }
+        if (!launched ||
+            !dsv4::qwen_gated_delta_sequence_f16_cuda(
+                d_state_sequence, d_q, d_k, d_v, d_g, d_beta, d_sequence,
+                rows, heads, key_heads, dim, dim, q_scale) ||
+            cudaDeviceSynchronize() != cudaSuccess) {
+            fail("gated delta step-vs-sequence launch");
+            return false;
+        }
+    }
+    std::vector<uint16_t> step(value_elements), sequence(value_elements);
+    std::vector<float> step_state(state_elements), sequence_state(state_elements);
+    cudaMemcpy(step.data(), d_step, step.size() * sizeof(uint16_t),
+               cudaMemcpyDeviceToHost);
+    cudaMemcpy(sequence.data(), d_sequence, sequence.size() * sizeof(uint16_t),
+               cudaMemcpyDeviceToHost);
+    cudaMemcpy(step_state.data(), d_state_step,
+               step_state.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(sequence_state.data(), d_state_sequence,
+               sequence_state.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    double output_worst = 0.0;
+    double state_worst = 0.0;
+    bool finite = true;
+    for (size_t i = 0; i < step.size(); ++i) {
+        const double candidate = from_half(sequence[i]);
+        if (!std::isfinite(candidate)) finite = false;
+        output_worst = std::max(output_worst,
+                                std::fabs(from_half(step[i]) - candidate));
+    }
+    for (size_t i = 0; i < step_state.size(); ++i) {
+        if (!std::isfinite(sequence_state[i])) finite = false;
+        state_worst = std::max(
+            state_worst, std::fabs(static_cast<double>(step_state[i]) -
+                                   sequence_state[i]));
+    }
+    if (!finite) {
+        fail("gated delta step-vs-sequence finite");
+    } else if (output_worst != 0.0 || state_worst != 0.0) {
+        fail("gated delta step-vs-sequence bit exact");
+    } else {
+        std::printf("  gated delta step-vs-sequence rows=%d heads=%d "
+                    "key_heads=%d passes=%d output=%.3e state=%.3e\n",
+                    rows, heads, key_heads, passes, output_worst, state_worst);
+    }
+    cudaFree(d_state_step);
+    cudaFree(d_state_sequence);
+    cudaFree(d_q);
+    cudaFree(d_k);
+    cudaFree(d_v);
+    cudaFree(d_g);
+    cudaFree(d_beta);
+    cudaFree(d_step);
+    cudaFree(d_sequence);
+    return true;
+}
+
 bool check_fp8_cache() {
     constexpr int q_heads = 6;
     constexpr int kv_heads = 1;
@@ -2139,6 +2266,13 @@ int main() {
     check_gated_delta_prenormalized(8, 12, 12);
     check_gated_delta_prenormalized(8, 4, 1);
     check_gated_delta_prenormalized(8, 12, 4, 3);
+    // rows == 1 is the decode shape the engine gate now routes to the sequence
+    // kernel; the wider rows guard the verify shapes that still use the step loop.
+    check_gated_delta_step_matches_sequence(1);
+    check_gated_delta_step_matches_sequence(2);
+    check_gated_delta_step_matches_sequence(4);
+    check_gated_delta_step_matches_sequence(1, 12, 12);
+    check_gated_delta_step_matches_sequence(1, 4, 1);
     check_gated_delta_prenormalized(8, 12, 4, 3, 2.0f);
     check_fp8_cache();
     if (failures != 0) {


### PR DESCRIPTION
Three decode fixes for Qwen3.8-27B-FP8 on 4x 2080 Ti (TP4), all of the same
class: a launch geometry that under-filled the device or read memory twice.

## Changes

**Target a decode split count instead of a slice length.** The split kernel
pinned 256 positions per split, so an 8K context launched 32 splits = 64 blocks
against 68 SMs. Targeting a split count keeps the grid full at every context.
Also fixes a latent bug: trailing splits with zero positions returned early
without publishing their partial, so the merge read uninitialised scratch and
produced silent `-inf` logits. The count is now re-derived from the slice length
so empty splits are never launched, and the kernel writes a neutral partial if
one ever is.

**Route single-token gated delta through the sequence kernel.** Every GDN gate
required more rows than decode has, so `rows == 1` fell through to the per-token
step kernel, which round-trips the [128, 128] FP32 state through global memory
twice. The sequence kernel holds it in registers and is bit-exact against the
step kernel; a new `test_qwen_half_ops` case checks that equivalence across five
shapes (all report `output=0.000e+00 state=0.000e+00`).

**Read the decode KV cache once per layer.** The split kernel fixed its Q group
at three heads while the TP4 shape has six Q heads per KV head, so two CTAs each
streamed the same slice and a 65K step read the 64 MiB cache twice per layer.
The group width is now templated and defaults to covering the whole KV head. The
wider CTA needs 80 registers (no spill), allowing six resident per SM, so the
split target is expressed as CTAs per SM against the real device count rather
than a round number: 6/SM above 16K attended positions, 4/SM below, because the
fixed per-CTA partial write stops being amortised on short slices.

## Results

Serial full-network TP4 TG128 decode tok/s, real checkpoint and tokenizer,
medians of 3, vLLM on the identical fixture for reference:

| context | before | after | vLLM | ratio |
|---|---|---|---|---|
| 4096 | – | 43.96 | – | – |
| 8192 | 37.25 | 43.35 | 43.34 | 1.000x |
| 16384 | 36.69 | 41.60 | 42.49 | 0.979x |
| 32768 | 35.37 | 38.70 | 41.40 | 0.935x |
| 65536 | 31.59 | 33.80 | 39.85 | 0.848x |

Prefill is unchanged (8192 stays at ~1832 tok/s).

## Testing

- `test_qwen_half_ops`, `test_qwen_gqa_attention`, `test_qwen_config`,
  `test_qwen_sampler`, `test_continuation_attention`, `test_qwen_engine`: PASS
- All 128 generated tokens bit-identical to the pre-change geometry at 4K, 8K,
  16K, 32K and 65K, and identical across repetitions
- Zero `-inf` logits in every run
- `fp8`, `turboquant_k8v4` and `int8_per_token_head` cache paths still run at 8K
  with `rank_token_parity=PASS`; they use separate kernels and are untouched
- Kernel-level A/B via `bench_qwen_gqa_decode` at the real shape, medians of 4
  with the warm-up repetition discarded

Env overrides `DSV4_QWEN_DECODE_GROUP_HEADS` and `DSV4_QWEN_DECODE_TARGET_SPLITS`
exist for A/B sweeps only; defaults need no configuration.
