### PR TITLE
Optimize Qwen4-Exp heterogeneous TP4 prefill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,6 +255,7 @@ outputs/
 
 # Local runtime artifacts
 .tmp/
+.scratch/
 checkpoints/
 *.gguf
 gguf_hfd/

--- a/docs/qwen4_exp_performance.md
+++ b/docs/qwen4_exp_performance.md
@@ -8,8 +8,11 @@
 ## 模型和测量方法
 
 真实配置为 48 层、hidden size 2560、512 个 routed experts、top-10，单个
-BF16 expert 为 9.38 MiB，全 expert 集合约 225 GiB。routed experts 和 PLE
-表通过 mmap 保留在 host，active experts 按需复制到各 GPU。
+BF16 expert 为 9.38 MiB，全 expert 集合约 225 GiB。routed experts 在启动时
+按 rank 装入 host 内存（每 rank 56.25 GiB，4 份互不相交），PLE 表继续通过
+mmap 留在 host，active experts 按需复制到各 GPU。运行时默认启用该预加载；
+`--mmap-experts` 仅用于诊断旧的按需 fault 路径。市面上说的“host resident”
+在本文特指这份显式拷贝，不把 page cache 命中当作实现保证。
 
 运行时通过 `--profile` 开启层级 profiler；加入
 `DSV4_QWEN4_MOE_PHASE_PROFILE=1` 后，额外统计 expert staging 和计算时间。
@@ -36,6 +39,28 @@ PYTHONPATH=. python tests/bench_qwen4_exp_staging.py
 生成、chunk=512 和较小 expert cache。长 prefill 的 chunk 大小和 decode
 的 cache 容量必须一起记录。
 
+### host 常驻 vs 按需 mmap 的 A/B（2026-08-29，同机连续两跑）
+
+60-token prompt、8-token generation、chunk 512、expert cache 1024，TP4：
+
+| 模式 | 加载 | prefill | decode | 每 rank H2D 速率 | 生成期磁盘读 |
+|---|---:|---:|---:|---:|---:|
+| `resident`（默认） | 732 s 一次性 | **18.96 tok/s** | 1.97 tok/s | 2.741 GiB/s | 0.01 GiB |
+| `--mmap-experts` | 1.3 s | 9.16 tok/s | 2.38 tok/s | 2.006 GiB/s | 0.00 GiB |
+
+读法（不要过度解读）：
+
+- prefill 2.07×、H2D 速率 1.37×，来自 pinned host 内存的 DMA 而不是 pageable
+  mmap 页；两跑 staging 字节数完全相同（19.89 GiB，2173 miss / 567 hit），
+  所以差异纯粹是搬运路径；
+- decode 一列两跑都只有 8 个 token，差值 0.4 tok/s 在这个长度上不可引用
+  （见 memory `perf_claims_need_tg_length`）；要结论必须跑 ≥32 token；
+- **mmap 臂的磁盘读也是 0.00 GiB**：它紧跟在 resident 跑之后，expert 页还在
+  page cache 里。这个 A/B 因此只测出了"pinned 拷贝 vs 暖 page cache"，
+  没测出"vs 冷盘"。冷盘对比需要 drop_caches（需要 root），当前未做；
+- 732 s 的加载在第一次冷读时是 0.10–0.12 GiB/s 的盘瓶颈；暖 page cache 下
+  同样的预加载只要约 4 s（实测 1.19–1.24 GiB/s，4 层 4.69 GiB）。
+
 ## 瓶颈结论
 
 ### Prefill
@@ -48,10 +73,29 @@ stage 5.091 s   compute 0.601 s   1874 expert calls / 48 MoE calls
 17.16 GiB H2D，cache hit 0%
 ```
 
-在 8K prefill 中，单 rank 约搬运 48 GiB；4 个 rank 聚合有效吞吐约
-5.5 GiB/s，与单进程纯 RAM→GPU 微基准 5.4–5.7 GiB/s 一致。因此主要地板
-是共享 PCIe 带宽，而不是 checkpoint 所在机械盘。cold/warm page-cache
-测量只有 1.16–1.37× 差异。
+在 8K prefill 中，单 rank 约搬运 48 GiB，实测有效吞吐约 1.39 GiB/s/rank。
+
+**修正（2026-08-29）**：此前的"主要地板是共享 PCIe 带宽"结论已被证伪。
+原推理把 4 rank 的**聚合**吞吐（5.55 GiB/s）与单进程**单链路**微基准
+（5.4–5.7 GiB/s）相比，属于量级错配。重测的 4 进程聚合吞吐为：
+
+```text
+mmap  20.86 GiB/s    ram  21.37 GiB/s    pinned  42.54 GiB/s
+```
+
+即真实 run 的 1.39 GiB/s/rank 比同一代码路径孤立跑低 3.6×，PCIe 远未饱和。
+
+真正的地板是 checkpoint 所在的机械盘 `sdc`（ST4000VX015）：
+
+```text
+裸 O_DIRECT 顺序读        0.109 GiB/s（1/2/4/8 线程均为 0.112–0.125，并行无效）
+未触碰层（30/31）冷读     0.06  GiB/s
+同层暖 page cache         1.09–1.14 GiB/s   → 冷/暖差 18.8×
+暖 mmap → GPU             5.2–6.5 GiB/s
+```
+
+此前"cold/warm 只差 1.16–1.37×"的测量无效：它的冷臂重读了已经 fault
+过的第 17 层，两臂实际都命中 page cache。
 
 ### Decode
 
@@ -76,8 +120,14 @@ BF16 staging 下 OOM。输出在两种 cache 容量下逐字一致。
    `index_select` 本身约 76 ms。不要仅凭减少 DMA call 数就合并 staging。
 4. **TP 分片没有重复搬运**：`ShardedMoE` 的每个 rank 只 fetch 自己的
    expert，实测 duplication=1.00×。
-5. **prefetch 不是带宽优化**：PCIe 已饱和时，cross-layer prefetch 最多
-   改变时序，不能降低搬运字节数；应在量化后再重新 A/B。
+5. **grouped expert GEMM 有效**：`_dispatch_experts` 的 per-expert Python
+   循环换成 grouped `bmm`，decode 形状 2.41×/2.90×，prefill 形状
+   4.45×/5.03×，max_abs_diff 0–3.9e-03。
+6. **NUMA pinning 影响很大**：pinned-bounce 路径在 node0 与 node1 之间
+   差 3.3×（9.66 vs 2.90 GiB/s）。GPU0/1 挂 node0，GPU2/3 挂 node1
+   （两者 NV2 互连，但对 host 都是 SYS）。
+7. **vocab reduce 可省**：full-vocab all_gather 换成 local argmax +
+   `(value, index)` all_gather，3.112 → 2.497 ms/step，argmax 逐位一致。
 
 ## 朝 500 / 10 的工作分解
 
@@ -90,22 +140,51 @@ BF16 staging 下 OOM。输出在两种 cache 容量下逐字一致。
 - decode 不再 all-gather 全词表，只在各 rank 做 local argmax，然后
   all-gather `(value, index)`。
 
-### P1：消除 PCIe 地板
+### P1：routed expert 常驻 host 内存（已实现）
 
-- 对 routed expert 使用 FP8/INT4 storage，并在 GPU 侧使用对应的
-  dequant/GEMM kernel；
-- FP8 将 active bytes 约减半，长 prefill 的带宽上限接近 500 tok/s；
-- decode 若要从约 2.75 达到 10 tok/s，预计需要 INT4 或等效的 4× bytes
-  reduction，再叠加 local-vocab reduction 和 batched decode kernel；
-- 所有量化路线必须先做真实权重 logit parity，再做性能 A/B。
+目标是消掉机械盘，而不是换一块更快的盘。本机 MemFree 约 962 GiB，BF16
+expert 全集 225 GiB，完全装得下；暖 mmap→GPU 5.2–6.5 GiB/s 也高于本机
+NVMe 的 2.2 GiB/s，所以迁 NVMe 严格劣于常驻 host 内存。
 
-### P2：计算和通信收尾
+实现形态（`weights.HostExpertShard` + `Qwen4ExpCheckpoint.preload_experts`）：
+启动时每个 rank 把**自己那份** routed expert 从 mmap 拷进 host 内存，之后
+`expert_rows()` 只读这份常驻拷贝，稳态 staging 不再有机会 fault 到盘上。
 
-- prefill 中 MoE compute 只占 staging 的约 1/8.5，优先级低于量化；
-  staging 地板松动后再做 grouped/batched expert GEMM；
+- 无需 POSIX-shm 第二份拷贝：ownership 是 `expert_id % world_size == rank`
+  （`ShardedMoE` 的既有规则），4 个 shard 互不相交、加起来正好是 225 GiB
+  的一份全量，每 rank 56.25 GiB。`SharedCPUMoEWeightArena` 只作布局参考，
+  它的 `build_specs()` 是写死 int8 的，存不了 BF16；
+- pin 是可行的：`ulimit -l` ≈ 126 GiB 是**每进程**上限，56.25 GiB 在限内。
+  实测每层 1.172 GiB/rank pin 成功。pin 失败时退回 pageable 并把已装载的
+  层一起转成 pageable，不留下半 pin 状态（`--pageable-experts` 可强制）；
+- 每层两个连续 host tensor（`[128, 1280, 2560]` / `[128, 2560, 640]`），
+  48 层共 96 次分配，而不是 12,288 次 per-expert 分配；
+- 装载按 layer 推进并在 rank 间设 barrier：4 个进程读同一批文件区域，让
+  盘头留在一个区域内，而不是各自在 225 GiB 上乱跳；
+- 已知陷阱（都已避开）：不要对整个 mmap 做 `cudaHostRegister`（会造出巨量
+  Dirty 页并拖慢无关 I/O）；routed expert 的**计算**仍在 GPU，没有走 GLM
+  上已证伪的 CPU 侧 MoE；
+- 首次装载仍要过一次机械盘，这是一次性成本：实测 0.102 GiB/s，
+  56.25 GiB/rank ≈ 9.2 min，属于加载期而不是稳态延迟，报性能时必须分开算。
+
+### P2：dispatch、NUMA、词表
+
+- 用 grouped `bmm` 替换 `_dispatch_experts` 的 per-expert 循环（已测
+  2.41–5.03×），并把 `HostExpertMoE` 的 `list.pop(0)` LRU 换成 O(1)；
+- 按 rank 做 CPU/NUMA 亲和，复用
+  `_cpu_affinity_for_rank`（`src/models/deepseek_v4/generation.py:67`），
+  让 GPU0/1 的 staging 落在 node0、GPU2/3 落在 node1；
+- decode 不再 all-gather 全词表，只做 local argmax + `(value, index)`
+  all_gather（3.112 → 2.497 ms/step）。
+
+### P3：量化和通信收尾
+
+- host 常驻之后再评估 FP8/INT4 storage：此时它的作用是压 PCIe bytes 和
+  放宽 pin 上限，而不是绕开盘；
 - 尝试将两次每层 NCCL reduce 与下一段计算 overlap；
-- 重新评估 cross-layer prefetch，不能把它当作增加 PCIe 带宽的方案。
+- 重新评估 cross-layer prefetch，只有在 staging 不再是盘 I/O 之后才有
+  意义。
 
-在当前 PCIe Gen3 机器上，**prefill 500 的必要条件是 expert 量化**；
-仅优化 Python dispatch 或 attention 不可能越过 H2D 下限。**decode 10**
-则需要量化、cache、词表归约和 decode 专用 MoE kernel 的组合。
+结论：**prefill 和 decode 的第一必要条件都是 routed expert 常驻 host
+内存并在 4 rank 间共享单份拷贝**。在仍然向机械盘要页的前提下，优化
+Python dispatch、attention 或量化都会被 0.06–0.11 GiB/s 的冷读吃掉。

--- a/docs/qwen4_exp_performance.md
+++ b/docs/qwen4_exp_performance.md
@@ -1,190 +1,297 @@
-# Qwen4-Exp 异构 TP4 性能分析
+# Qwen4-Exp Heterogeneous TP4 Performance
 
-**日期**：2026-08-28
-**硬件**：4×RTX 2080 Ti（TP4，PCIe Gen3）
-**模型**：Qwen3.8-Flash-Next，真实 checkpoint 位于
+**Date:** 2026-08-31
+
+**Hardware:** 4 x RTX 2080 Ti, TP4 over PCIe Gen3
+**Model:** Qwen3.8-Flash-Next, real checkpoint at
 `/mnt/data1/modelscope/Qwen/Qwen3.8-Flash-Next`
 
-## 模型和测量方法
+## Runtime architecture
 
-真实配置为 48 层、hidden size 2560、512 个 routed experts、top-10，单个
-BF16 expert 为 9.38 MiB，全 expert 集合约 225 GiB。routed experts 在启动时
-按 rank 装入 host 内存（每 rank 56.25 GiB，4 份互不相交），PLE 表继续通过
-mmap 留在 host，active experts 按需复制到各 GPU。运行时默认启用该预加载；
-`--mmap-experts` 仅用于诊断旧的按需 fault 路径。市面上说的“host resident”
-在本文特指这份显式拷贝，不把 page cache 命中当作实现保证。
+The real model has 48 layers, hidden size 2560, 512 routed experts, and top-10
+routing. One BF16 routed expert is 9.375 MiB, and the full routed-expert set is
+about 225 GiB.
 
-运行时通过 `--profile` 开启层级 profiler；加入
-`DSV4_QWEN4_MOE_PHASE_PROFILE=1` 后，额外统计 expert staging 和计算时间。
-完整的 staging 微基准可以运行：
+The routed experts are copied explicitly into host RAM during model startup:
+
+- expert ownership is round-robin: `expert_id % world_size == rank`;
+- every rank owns 128 experts per layer, or 56.25 GiB across 48 layers;
+- the four disjoint rank shards together hold exactly one copy of the expert
+  set;
+- the shard is pinned by default, with an all-or-nothing pageable fallback;
+- only active experts are copied to the rank's GPU and all MoE arithmetic runs
+  on the GPU;
+- the 95 GiB PLE table remains host-side.
+
+This document uses *host-resident* only for the explicit 56.25 GiB/rank copy.
+A warm mmap or page-cache hit is not treated as host residency. The latest warm
+preload took about 53 seconds per rank; it is a one-time load cost and is not
+included in steady-state throughput.
+
+## Authoritative 8K TP4 prefill result
+
+Measurement conditions:
+
+- 8192 real tokenizer tokens;
+- one 8192-token chunk;
+- TP4;
+- expert cache capacity 1024;
+- pinned 56.25 GiB host expert shard per rank;
+- first pass discarded as warmup;
+- no synchronization-heavy profiler in the timed region;
+- all rows below produced token 97792;
+- preload excluded.
+
+### Accuracy-first path
+
+The accuracy-first candidate uses transient FP16 tensor-core dense projections
+and the CUDA hyper-connection RMSNorm/injection path. Decode rows stay BF16
+because all prefill precision gates require at least 128 rows.
+
+| Path | Warm samples | Mean wall | Mean throughput | Peak/rank |
+|---|---:|---:|---:|---:|
+| BF16 baseline | 788.07 / 784.47 tok/s | 10.419 s | **786.27 tok/s** | 14.108 GiB |
+| FP16 dense + CUDA HC | 951.04 / 947.77 tok/s | 8.629 s | **949.41 tok/s** | 13.839 GiB |
+| BF16 baseline recheck | 770.43 / 767.59 tok/s | 10.653 s | **769.01 tok/s** | 14.108 GiB |
+
+The candidate is a 20.7% gain over the first baseline mean and reaches a stable
+about 950 tok/s, just below the 1000 tok/s target.
+
+A 512-token prompt plus 32 forced-token decisions was checked on Chinese,
+English, and code inputs. Chinese and code matched all greedy decisions. The
+English arm changed decisions 4 and 23; the baseline margins were 0.7500 and
+0.1875 respectively. Therefore this path is still opt-in rather than a strict
+parity default.
+
+The prefill precision switches do not affect single-token decode. With cache
+1024 and a 512-token prefix, a separate 32-step forced-token A/B measured:
+
+| Prompt | BF16 decode | Candidate decode |
+|---|---:|---:|
+| Chinese | 4.365 tok/s | 4.363 tok/s |
+| English | 4.378 tok/s | 4.388 tok/s |
+| Code | 4.367 tok/s | 4.370 tok/s |
+
+This is within run noise and confirms the rows=1 BF16 fallback protects decode.
+
+### Throughput-first path: target exceeded, not promoted
+
+A more accurate FP16 GEMM form uses FP16 tensor-core inputs, FP32 accumulation,
+and one BF16 output cast. Applying it to dense projections and the HC mix-down
+and mix-up projections gives:
+
+| Path | Warm samples | Mean wall | Mean throughput | Peak/rank |
+|---|---:|---:|---:|---:|
+| BF16 baseline | 784.68 / 780.69 / 777.29 tok/s | 10.491 s | **780.89 tok/s** | 14.108 GiB |
+| FP32-output dense + HC down/up | 1063.42 / 1061.49 / 1059.48 tok/s | 7.718 s | **1061.46 tok/s** | 13.961 GiB |
+| BF16 baseline recheck | 765.46 / 762.26 / 760.08 tok/s | 10.742 s | **762.60 tok/s** | 14.108 GiB |
+
+This exceeds the 1000 tok/s goal by 6.1% and is 35.9% faster than the first
+baseline mean. It is not promoted as a correctness-safe default:
+
+- 512-token Chinese and code prompts matched all 33 decisions;
+- the English prompt changed decisions 19 and 23;
+- decision 19 was an exact baseline tie, but decision 23 had a baseline margin
+  of 0.1875 and the candidate selected the other token with a 0.9375 margin;
+- a 2048-token plus 8-decision matrix matched all decisions on all three
+  prompts, so the mismatch is prompt- and margin-sensitive rather than a
+  general runtime failure.
+
+The correct status is therefore: **the performance target is reached by an
+experimental precision mode, while the accuracy-first mode remains about
+950 tok/s**.
+
+The 8192-token chunk is also the correct operating point. A clean strict-BF16
+sweep measured 154.70, 257.88, 409.14, 580.68, and 753.25 tok/s for chunks 512,
+1024, 2048, 4096, and 8192 respectively. Smaller chunks do not improve
+correctness and sharply increase repeated per-layer dispatch, communication,
+and active-expert staging overhead.
+
+## Remaining prefill attribution
+
+A synchronization-heavy real TP4 profile is for attribution only. Under the
+accuracy-first configuration, the main 8K phases were:
+
+| Phase | Calls | Total | Per call |
+|---|---:|---:|---:|
+| Routed MoE | 48 | 7.777 s | 162.03 ms |
+| Attention | 48 | 1.484 s | 30.92 ms |
+| MLP hyper-connection | 48 | 0.863 s | 17.97 ms |
+| Attention hyper-connection | 48 | 0.844 s | 17.58 ms |
+| MLP all-reduce | 48 | 0.666 s | 13.88 ms |
+| Attention all-reduce | 48 | 0.356 s | 7.41 ms |
+| Router | 48 | 0.207 s | 4.31 ms |
+| PLE | 1 | 0.149 s | 148.98 ms |
+
+MoE attribution on rank 0 reported 4.189 seconds staging, 3.090 seconds
+compute, 4652 active expert calls, and 42.59 GiB H2D. Turning off the existing
+copy-stream prefetch reduced the no-profile path from about 950 tok/s to about
+727 tok/s, so the overlap must remain enabled.
+
+Attention sub-phases were:
+
+| Sub-phase | Calls | Total | Per call |
+|---|---:|---:|---:|
+| Core | 48 | 0.808 s | 16.84 ms |
+| Projection | 48 | 0.294 s | 6.12 ms |
+| QSA indexer | 12 | 0.165 s | 13.73 ms |
+| Output | 48 | 0.139 s | 2.89 ms |
+| GatedDeltaNet convolution | 36 | 0.076 s | 2.12 ms |
+
+The isolated 8K GatedDeltaNet layer measured about 20.2 ms with transient FP16
+projections. Its recurrent core was 8.66 ms. Sweeping 1/2/4/8 work groups per
+CTA did not improve the full layer, so CTA grouping is not the next lever.
+
+A synchronization-free 512-token PyTorch trace also showed that all 96 NCCL
+collectives ran on the default compute stream: NCCL occupied 327.46 ms, BF16
+GEMMs 1.353 s, and pinned H2D copies 2.651 s, with zero timeline overlap between
+NCCL and either GEMM or H2D. Moving NCCL to a separate stream reduced an
+isolated 8192 x 2560 all-reduce from 7.54 to 7.28 ms, but an independent 0.58 ms
+GEMM still did not overlap because both kernels saturate SM resources. The real
+8K path gained only about 0.8%, so simple stream reassignment is not a path to
+strict-parity 1000 tok/s. Projection slicing or a reduce-scatter formulation is
+needed to create useful pipeline granularity.
+
+## Numerical gates and rejected candidates
+
+The parity harness generates one BF16 greedy chain per prompt, feeds that same
+chain to every candidate, and reports the BF16 top-1/top-2 margin for every
+mismatch. Exact ties are separated from real flips.
+
+### Rejected or diagnostic precision paths
+
+| Candidate | Kernel or 8K result | Parity verdict |
+|---|---:|---|
+| FP16 dense projections alone | fast | English decision 1 flips at BF16 margin 3.4375 |
+| FP32-output dense projections alone | 885.48 tok/s | Only an exact-tie English decision changes; no non-tie flip in the 512+32 matrix |
+| FP32-output dense + CUDA HC | 956.80 tok/s | English decision 23 flips at margin 0.1875; grouped RMSNorm is not bit-exact |
+| FP32-output dense + HC mix-down only | 1013.28 tok/s | English decisions 0 and 1 flip at margins 4.3750 and 3.4375 |
+| FP32-output dense + HC mix-up only | 1005.89 tok/s | English decision 0 flips at margin 4.3750 |
+| FP32-output dense + HC injection only | 940.27 tok/s | English decision 23 flips at margin 0.1875 |
+| FP16 dense + FP16 HC down/up | earlier 1043.35 tok/s was not reproducible | Chinese decision 5 flips at margin 0.9375 |
+| FP32-output dense + HC down/up | 1061.46 tok/s | English decision 23 flips at margin 0.1875 |
+| Full FP16 routed MoE | 2.65x kernel speedup | English decision 0 flips at margin 4.375 |
+| FP16 gate / BF16 down MoE | 1.75x kernel speedup | real Chinese and English flips |
+| BF16 gate / FP16 down MoE | 1.23x kernel speedup | English decision 23 flips at margin 0.1875 |
+
+The routed-MoE FP16 experiments are kept opt-in and disabled by default. Their
+small average activation error is not sufficient to preserve real generation.
+
+### Exact-BF16 hyper-connection limits
+
+Two scale-then-activation pairs now use dedicated CUDA kernels when
+`DSV4_QWEN4_HC_CUDA=1`: HC mix-down divide plus SiLU, and block-injection divide
+plus `2 * sigmoid`. Direct tests at 1, 7, and 8192 rows are bit-identical to the
+PyTorch BF16 expressions. At 8192 rows the isolated pairs improved from about
+0.069 to 0.054 ms and from 0.083 to 0.049 ms respectively. Their aggregate
+end-to-end ceiling is only about 5 ms per 8192-token prefill because each pair is
+small relative to the model wall.
+
+The larger CUDA grouped RMSNorm used by the same HC switch is not strictly
+bit-exact to PyTorch: on real layer-0 weights at 8192 rows, 99.999541% of values
+were equal and the maximum absolute difference was 0.0625. Therefore references
+to the CUDA HC configuration mean an accuracy-tested near-parity path, not a
+bit-exact implementation. The activation kernels themselves remain exact.
+
+A steady-state TP4 run with two global 8K warmups is the usable end-to-end
+measurement for the two activation fusions. With prompt=8192, chunk=8192,
+TP4, and expert cache=1024, strict BF16 measured 769.12 / 765.31 tok/s
+(767.21 mean), CUDA HC measured 801.09 / 799.17 tok/s (800.13 mean), and the
+BF16 recheck measured 752.99 / 750.73 tok/s (751.86 mean). All arms produced
+token 97792. This comparison includes the pre-existing non-exact CUDA grouped
+RMSNorm and injection kernels; it does not isolate the roughly 5 ms activation
+fusion gain. A later confirmatory run suffered an external machine-wide
+slowdown from about 786 to 428 tok/s and is discarded rather than averaged into
+these numbers. A 512-token Chinese prompt plus eight forced decode decisions
+also kept every greedy decision unchanged; the full-logit delta reflects the
+pre-existing grouped-RMSNorm approximation rather than rows=1 activation use.
+
+An isolated strict-BF16 HC call at 8192 rows measured 25.363 ms. The two BF16
+mix GEMMs consumed 7.071 and 7.610 ms; a kernel trace attributed 14.134 of
+16.950 ms of CUDA time to `aten::mm`. On SM75 these GEMMs use
+`magma_sgemmEx_kernel` at about 50% occupancy.
+
+A separate optimistic compute-floor probe replaced every staged expert pair by
+one GPU-resident pair, removing all 42.76 GiB of expert H2D while preserving the
+same dispatch and GEMM shapes. At prompt=8192/chunk=8192/TP4, the real path
+measured 779.93 tok/s (10.504 s) and the no-H2D floor measured 909.07 tok/s
+(9.011 s). Perfect staging overlap therefore still cannot reach 1000 tok/s,
+which requires 8.192 s; at least 0.819 s of compute and/or launch overhead must
+also be removed. Elementwise or reduction fusion cannot supply that margin. The
+remaining strict-path work must target the HC/attention/MoE compute structure,
+not H2D overlap alone.
+
+The weighted mean is already a 100%-occupancy BF16 multiply followed by a
+100%-occupancy `MeanOps` reduction. Replacing `.mean(-2)` with
+`.sum(-2) / hc_count` is bit-identical but slower. Hand-written left-to-right,
+pairwise, and `einsum` reductions do not reproduce PyTorch's reduction order;
+`einsum` is also much slower. These variants were rejected.
+
+### Split-K and cached FP16 weight experiments
+
+Splitting the K dimension into FP16 tensor-core partial GEMMs does not reproduce
+the SM75 BF16 linear result. Equal-element fractions remained roughly
+0.9984-0.9997 for every tested chunk size, while BF16 itself was not bit-equal
+to an FP32 reference. Chunk sizes below 256 were also slower than BF16.
+
+Caching FP16 mirrors of dense weights did not materially improve isolated GEMMs:
+for example, the 8K GatedDeltaNet QKV projection was 2.360 ms with a transient
+weight conversion and 2.365 ms with a cached FP16 weight. Permanent mirrors
+would consume substantial VRAM without a measurable benefit, so weights remain
+BF16 and conversion is transient.
+
+## Confirmed architecture decisions
+
+1. **Keep routed experts explicitly resident in host RAM.** Mechanical-disk mmap
+   faults must never be part of steady-state inference.
+2. **Keep per-rank round-robin ownership.** TP4 stages one disjoint 56.25 GiB
+   shard per rank and never duplicates routed-expert work.
+3. **Keep active-only H2D.** The full-local-layer grouped BF16 path increases
+   H2D bytes by about 31.6% and regressed real 8K TP4 prefill to 577.13 tok/s.
+   `DSV4_QWEN4_MOE_GROUPED` stays disabled by default.
+4. **Keep MoE copy-stream prefetch enabled.** It is worth about 950 versus
+   727 tok/s in the current accuracy-first path.
+5. **Keep prefill and decode precision paths separate.** Large prefill rows may
+   use the experimental FP16 tensor-core modes; rows=1 remain BF16.
+6. **Do not promote a candidate from token 0 alone.** Real forced-token matrices
+   and baseline margins are required.
+
+## Reproduction commands
+
+Accuracy-first 8K A/B:
 
 ```bash
-PYTHONPATH=. python tests/bench_qwen4_exp_staging.py
+PYTHONPATH=. \
+DSV4_QWEN4_DENSE_FP16=1 \
+DSV4_QWEN4_HC_CUDA=1 \
+/home/lvyufeng/miniconda3/envs/deepseek/bin/torchrun \
+  --standalone --nproc_per_node=4 \
+  .scratch/bench_qwen4_exp_tp_fp16_matrix.py \
+  --prompt-tokens 8192 --chunk-size 8192 \
+  --expert-cache 1024 --repeat 3 --global-warmup 2 \
+  --arms baseline,dense_hc_cuda,baseline_recheck
 ```
 
-## 实测基线
+Throughput-first 8K A/B:
 
-以下是 clean run（不启用 profiler）的结果：
-
-| 场景 | chunk | expert cache | prefill | decode |
-|---|---:|---:|---:|---:|
-| 60-token prompt，32-token generation | 512 | 64 | 6.78 tok/s | 1.05 tok/s |
-| 60-token prompt，32-token generation | 512 | 1024 | 6.73 tok/s | **2.75 tok/s** |
-| 570-token prompt，1-token generation | 512 | 64 | 32.6 tok/s | — |
-| 4162-token prompt，1-token generation | 512 | 64 | 38.1 tok/s | — |
-| 4162-token prompt，1-token generation | 4096 | 64 | **151.4 tok/s** | — |
-| 8272-token prompt，1-token generation | 8192 | 64 | **244.1 tok/s** | — |
-
-因此，早先的 0.42/0.95 tok/s 组合不应作为模型能力基线：它对应很短
-生成、chunk=512 和较小 expert cache。长 prefill 的 chunk 大小和 decode
-的 cache 容量必须一起记录。
-
-### host 常驻 vs 按需 mmap 的 A/B（2026-08-29，同机连续两跑）
-
-60-token prompt、8-token generation、chunk 512、expert cache 1024，TP4：
-
-| 模式 | 加载 | prefill | decode | 每 rank H2D 速率 | 生成期磁盘读 |
-|---|---:|---:|---:|---:|---:|
-| `resident`（默认） | 732 s 一次性 | **18.96 tok/s** | 1.97 tok/s | 2.741 GiB/s | 0.01 GiB |
-| `--mmap-experts` | 1.3 s | 9.16 tok/s | 2.38 tok/s | 2.006 GiB/s | 0.00 GiB |
-
-读法（不要过度解读）：
-
-- prefill 2.07×、H2D 速率 1.37×，来自 pinned host 内存的 DMA 而不是 pageable
-  mmap 页；两跑 staging 字节数完全相同（19.89 GiB，2173 miss / 567 hit），
-  所以差异纯粹是搬运路径；
-- decode 一列两跑都只有 8 个 token，差值 0.4 tok/s 在这个长度上不可引用
-  （见 memory `perf_claims_need_tg_length`）；要结论必须跑 ≥32 token；
-- **mmap 臂的磁盘读也是 0.00 GiB**：它紧跟在 resident 跑之后，expert 页还在
-  page cache 里。这个 A/B 因此只测出了"pinned 拷贝 vs 暖 page cache"，
-  没测出"vs 冷盘"。冷盘对比需要 drop_caches（需要 root），当前未做；
-- 732 s 的加载在第一次冷读时是 0.10–0.12 GiB/s 的盘瓶颈；暖 page cache 下
-  同样的预加载只要约 4 s（实测 1.19–1.24 GiB/s，4 层 4.69 GiB）。
-
-## 瓶颈结论
-
-### Prefill
-
-60-token profile 的 48 层累计时间中，MoE 占 68.8%，NCCL MLP reduce 占
-10.4%，attention 占 9.6%。MoE 的分相测量为：
-
-```text
-stage 5.091 s   compute 0.601 s   1874 expert calls / 48 MoE calls
-17.16 GiB H2D，cache hit 0%
+```bash
+PYTHONPATH=. \
+/home/lvyufeng/miniconda3/envs/deepseek/bin/torchrun \
+  --standalone --nproc_per_node=4 \
+  .scratch/bench_qwen4_exp_tp_fp16_matrix.py \
+  --prompt-tokens 8192 --chunk-size 8192 \
+  --expert-cache 1024 --repeat 4 --global-warmup 2 \
+  --arms baseline,dense_fp32_hc_down_up_fp32,baseline_recheck
 ```
 
-在 8K prefill 中，单 rank 约搬运 48 GiB，实测有效吞吐约 1.39 GiB/s/rank。
+Forced-token margin matrix:
 
-**修正（2026-08-29）**：此前的"主要地板是共享 PCIe 带宽"结论已被证伪。
-原推理把 4 rank 的**聚合**吞吐（5.55 GiB/s）与单进程**单链路**微基准
-（5.4–5.7 GiB/s）相比，属于量级错配。重测的 4 进程聚合吞吐为：
-
-```text
-mmap  20.86 GiB/s    ram  21.37 GiB/s    pinned  42.54 GiB/s
+```bash
+PYTHONPATH=. \
+/home/lvyufeng/miniconda3/envs/deepseek/bin/torchrun \
+  --standalone --nproc_per_node=4 \
+  .scratch/check_qwen4_exp_tp_long_matrix.py \
+  --prompt-tokens 512 --decode-tokens 32 --expert-cache 0 \
+  --prompts chinese,english,code \
+  --arms dense_fp32_hc_down_up_fp32
 ```
-
-即真实 run 的 1.39 GiB/s/rank 比同一代码路径孤立跑低 3.6×，PCIe 远未饱和。
-
-真正的地板是 checkpoint 所在的机械盘 `sdc`（ST4000VX015）：
-
-```text
-裸 O_DIRECT 顺序读        0.109 GiB/s（1/2/4/8 线程均为 0.112–0.125，并行无效）
-未触碰层（30/31）冷读     0.06  GiB/s
-同层暖 page cache         1.09–1.14 GiB/s   → 冷/暖差 18.8×
-暖 mmap → GPU             5.2–6.5 GiB/s
-```
-
-此前"cold/warm 只差 1.16–1.37×"的测量无效：它的冷臂重读了已经 fault
-过的第 17 层，两臂实际都命中 page cache。
-
-### Decode
-
-32-token decode、cache=1024 的层内累计时间为：MoE 46.6%、attention
-18.6%、MLP NCCL reduce 16.2%、attention NCCL reduce 3.8%。层外约 18%
-花在每一步对 248320 词表做 `all_gather`，以及随后由 `.item()` 引入的
-同步。
-
-cache=64→1024 将 decode 从 1.05 提到 2.75 tok/s；cache=2048 在当前
-BF16 staging 下 OOM。输出在两种 cache 容量下逐字一致。
-
-## 已验证和已否定的方向
-
-1. **增大 prefill chunk 是当前最大的免费收益**：8K prompt 上
-   chunk=512→8192 达到约 4×（38.1→244.1 tok/s），因为 active expert
-   集合很快接近每 rank 的 128 个上限，搬运成本被更多 token 摊薄。
-2. **增大 decode cache 有效**：容量 1024 能保留跨步复用的
-   `(layer, expert)`，但需要 O(1) LRU 实现，不能继续使用
-   `list.pop(0)`。
-3. **合并 active expert H2D 没有收益**：108 expert 的实测为逐 expert
-   loop 155 ms、host gather 后的 batched 方案 215 ms（0.72×）；host
-   `index_select` 本身约 76 ms。不要仅凭减少 DMA call 数就合并 staging。
-4. **TP 分片没有重复搬运**：`ShardedMoE` 的每个 rank 只 fetch 自己的
-   expert，实测 duplication=1.00×。
-5. **grouped expert GEMM 有效**：`_dispatch_experts` 的 per-expert Python
-   循环换成 grouped `bmm`，decode 形状 2.41×/2.90×，prefill 形状
-   4.45×/5.03×，max_abs_diff 0–3.9e-03。
-6. **NUMA pinning 影响很大**：pinned-bounce 路径在 node0 与 node1 之间
-   差 3.3×（9.66 vs 2.90 GiB/s）。GPU0/1 挂 node0，GPU2/3 挂 node1
-   （两者 NV2 互连，但对 host 都是 SYS）。
-7. **vocab reduce 可省**：full-vocab all_gather 换成 local argmax +
-   `(value, index)` all_gather，3.112 → 2.497 ms/step，argmax 逐位一致。
-
-## 朝 500 / 10 的工作分解
-
-当前最佳实测点是长 prefill 244 tok/s、短 decode 2.75 tok/s。
-
-### P0：默认值和低风险运行时修正
-
-- 默认 chunk 调到 4096–8192，并依据可用显存夹取；
-- expert cache 默认 1024；把 LRU 替换为 `OrderedDict` 或 ring；
-- decode 不再 all-gather 全词表，只在各 rank 做 local argmax，然后
-  all-gather `(value, index)`。
-
-### P1：routed expert 常驻 host 内存（已实现）
-
-目标是消掉机械盘，而不是换一块更快的盘。本机 MemFree 约 962 GiB，BF16
-expert 全集 225 GiB，完全装得下；暖 mmap→GPU 5.2–6.5 GiB/s 也高于本机
-NVMe 的 2.2 GiB/s，所以迁 NVMe 严格劣于常驻 host 内存。
-
-实现形态（`weights.HostExpertShard` + `Qwen4ExpCheckpoint.preload_experts`）：
-启动时每个 rank 把**自己那份** routed expert 从 mmap 拷进 host 内存，之后
-`expert_rows()` 只读这份常驻拷贝，稳态 staging 不再有机会 fault 到盘上。
-
-- 无需 POSIX-shm 第二份拷贝：ownership 是 `expert_id % world_size == rank`
-  （`ShardedMoE` 的既有规则），4 个 shard 互不相交、加起来正好是 225 GiB
-  的一份全量，每 rank 56.25 GiB。`SharedCPUMoEWeightArena` 只作布局参考，
-  它的 `build_specs()` 是写死 int8 的，存不了 BF16；
-- pin 是可行的：`ulimit -l` ≈ 126 GiB 是**每进程**上限，56.25 GiB 在限内。
-  实测每层 1.172 GiB/rank pin 成功。pin 失败时退回 pageable 并把已装载的
-  层一起转成 pageable，不留下半 pin 状态（`--pageable-experts` 可强制）；
-- 每层两个连续 host tensor（`[128, 1280, 2560]` / `[128, 2560, 640]`），
-  48 层共 96 次分配，而不是 12,288 次 per-expert 分配；
-- 装载按 layer 推进并在 rank 间设 barrier：4 个进程读同一批文件区域，让
-  盘头留在一个区域内，而不是各自在 225 GiB 上乱跳；
-- 已知陷阱（都已避开）：不要对整个 mmap 做 `cudaHostRegister`（会造出巨量
-  Dirty 页并拖慢无关 I/O）；routed expert 的**计算**仍在 GPU，没有走 GLM
-  上已证伪的 CPU 侧 MoE；
-- 首次装载仍要过一次机械盘，这是一次性成本：实测 0.102 GiB/s，
-  56.25 GiB/rank ≈ 9.2 min，属于加载期而不是稳态延迟，报性能时必须分开算。
-
-### P2：dispatch、NUMA、词表
-
-- 用 grouped `bmm` 替换 `_dispatch_experts` 的 per-expert 循环（已测
-  2.41–5.03×），并把 `HostExpertMoE` 的 `list.pop(0)` LRU 换成 O(1)；
-- 按 rank 做 CPU/NUMA 亲和，复用
-  `_cpu_affinity_for_rank`（`src/models/deepseek_v4/generation.py:67`），
-  让 GPU0/1 的 staging 落在 node0、GPU2/3 落在 node1；
-- decode 不再 all-gather 全词表，只做 local argmax + `(value, index)`
-  all_gather（3.112 → 2.497 ms/step）。
-
-### P3：量化和通信收尾
-
-- host 常驻之后再评估 FP8/INT4 storage：此时它的作用是压 PCIe bytes 和
-  放宽 pin 上限，而不是绕开盘；
-- 尝试将两次每层 NCCL reduce 与下一段计算 overlap；
-- 重新评估 cross-layer prefetch，只有在 staging 不再是盘 I/O 之后才有
-  意义。
-
-结论：**prefill 和 decode 的第一必要条件都是 routed expert 常驻 host
-内存并在 4 rank 间共享单份拷贝**。在仍然向机械盘要页的前提下，优化
-Python dispatch、attention 或量化都会被 0.06–0.11 GiB/s 的冷读吃掉。

--- a/scripts/run_qwen4_exp_tp4.sh
+++ b/scripts/run_qwen4_exp_tp4.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # TP4 heterogeneous inference for Qwen3.8-Flash-Next.
 #
-# Dense weights are sharded across the four 2080 Ti cards; the 225 GiB routed
-# experts and 95 GiB PLE table stay in host RAM and are read through the shared
-# page cache, so the four ranks pay for one copy between them.
+# Dense weights are sharded across the four 2080 Ti cards.  Each rank loads its
+# disjoint 56.25 GiB share of the 225 GiB routed experts into host RAM at
+# startup (round-robin by expert id, so the four shards are one full copy); the
+# 95 GiB PLE table stays host-resident through the mapping.
 #
 # Usage: scripts/run_qwen4_exp_tp4.sh [prompt] [max_new_tokens]
 set -euo pipefail

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,10 @@ setup(
                 str(CSRC / "cuda_kernel_impl.cu"),
                 str(CSRC / "minimax_rope_kernel.cu"),
                 str(CSRC / "llama_mmq" / "gguf_mma_wrapper.cu"),
+                str(CSRC / "qwen4_exp_moe.cu"),
+                str(CSRC / "qwen4_exp_gated_delta.cu"),
+                str(CSRC / "qwen4_exp_qsa.cu"),
+                str(CSRC / "qwen4_exp_hyper_connection.cu"),
             ],
             libraries=["cublas"],
             extra_compile_args={

--- a/src/csrc/cuda_kernel.cpp
+++ b/src/csrc/cuda_kernel.cpp
@@ -178,6 +178,215 @@ torch::Tensor moe_prefill_int8_grouped_forward_cuda(
     const torch::Tensor& w3s,
     double swiglu_limit);
 
+torch::Tensor qwen4_exp_moe_prefill_bf16_forward_cuda(
+    const torch::Tensor& x,
+    const torch::Tensor& route_tokens,
+    const torch::Tensor& route_weights,
+    const torch::Tensor& seg_starts,
+    const torch::Tensor& gate_up,
+    const torch::Tensor& down,
+    double swiglu_limit);
+
+std::vector<torch::Tensor> qwen4_exp_gated_delta_bf16_forward_cuda(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& gate,
+    const torch::Tensor& beta,
+    const torch::Tensor& initial_state,
+    double norm_eps,
+    int64_t groups_per_block);
+
+torch::Tensor qwen4_exp_qsa_bf16_forward_cuda(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& selected,
+    double softmax_scale);
+
+torch::Tensor qwen4_exp_grouped_rms_norm_cuda(
+    const torch::Tensor& input,
+    const torch::Tensor& weight,
+    int64_t group_size,
+    double eps);
+
+torch::Tensor qwen4_exp_inject_cuda(
+    const torch::Tensor& block_output,
+    const torch::Tensor& hyper_input,
+    const torch::Tensor& injection_weights,
+    int64_t groups);
+
+torch::Tensor qwen4_exp_hc_silu_bf16_cuda(
+    const torch::Tensor& input,
+    int64_t groups);
+
+torch::Tensor qwen4_exp_hc_inject_gate_bf16_cuda(
+    const torch::Tensor& input,
+    int64_t groups);
+
+torch::Tensor qwen4_exp_grouped_rms_norm(
+    const torch::Tensor& input,
+    const torch::Tensor& weight,
+    int64_t group_size,
+    double eps) {
+    TORCH_CHECK(input.dim() >= 2, "input must have at least two dimensions");
+    TORCH_CHECK(weight.dim() == 1, "weight must be one-dimensional");
+    TORCH_CHECK(group_size > 0 && input.size(-1) % group_size == 0, "group_size must divide the last dimension");
+    TORCH_CHECK(weight.size(0) == input.size(-1), "weight size must match the last input dimension");
+    TORCH_CHECK(input.is_cuda() && weight.is_cuda(), "input and weight must be CUDA tensors");
+    TORCH_CHECK(input.device() == weight.device(), "input and weight must share one CUDA device");
+    TORCH_CHECK(input.is_contiguous() && weight.is_contiguous(), "input and weight must be contiguous");
+    TORCH_CHECK(input.scalar_type() == weight.scalar_type(), "input and weight dtype must match");
+    TORCH_CHECK(
+        input.scalar_type() == torch::kFloat16 ||
+        input.scalar_type() == torch::kBFloat16 ||
+        input.scalar_type() == torch::kFloat32,
+        "input must be float16, bfloat16, or float32");
+    TORCH_CHECK(eps > 0.0, "eps must be positive");
+    return qwen4_exp_grouped_rms_norm_cuda(input, weight, group_size, eps);
+}
+
+torch::Tensor qwen4_exp_inject(
+    const torch::Tensor& block_output,
+    const torch::Tensor& hyper_input,
+    const torch::Tensor& injection_weights,
+    int64_t groups) {
+    TORCH_CHECK(block_output.dim() >= 2, "block_output must have at least two dimensions");
+    TORCH_CHECK(hyper_input.dim() == block_output.dim(), "hyper_input rank must match block_output");
+    TORCH_CHECK(injection_weights.dim() == block_output.dim(), "injection_weights rank mismatch");
+    TORCH_CHECK(groups > 0, "groups must be positive");
+    TORCH_CHECK(hyper_input.size(-1) == groups * block_output.size(-1), "hyper_input last dimension mismatch");
+    for (int64_t dim = 0; dim + 1 < block_output.dim(); ++dim) {
+        TORCH_CHECK(block_output.size(dim) == hyper_input.size(dim), "block_output/hyper_input shape mismatch");
+        TORCH_CHECK(block_output.size(dim) == injection_weights.size(dim), "block_output/injection_weights shape mismatch");
+    }
+    TORCH_CHECK(injection_weights.size(-1) == groups, "injection_weights group dimension mismatch");
+    TORCH_CHECK(block_output.is_cuda() && hyper_input.is_cuda() && injection_weights.is_cuda(), "all inputs must be CUDA tensors");
+    TORCH_CHECK(block_output.device() == hyper_input.device() && block_output.device() == injection_weights.device(), "all inputs must share one CUDA device");
+    TORCH_CHECK(block_output.is_contiguous() && hyper_input.is_contiguous() && injection_weights.is_contiguous(), "all inputs must be contiguous");
+    TORCH_CHECK(block_output.scalar_type() == hyper_input.scalar_type() && block_output.scalar_type() == injection_weights.scalar_type(), "all inputs must have the same dtype");
+    TORCH_CHECK(
+        block_output.scalar_type() == torch::kFloat16 ||
+        block_output.scalar_type() == torch::kBFloat16 ||
+        block_output.scalar_type() == torch::kFloat32,
+        "inputs must be float16, bfloat16, or float32");
+    return qwen4_exp_inject_cuda(block_output, hyper_input, injection_weights, groups);
+}
+
+namespace {
+
+void check_qwen4_exp_hc_activation(const torch::Tensor& input, int64_t groups) {
+    TORCH_CHECK(groups > 0, "groups must be positive");
+    TORCH_CHECK(input.is_cuda(), "input must be a CUDA tensor");
+    TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
+    TORCH_CHECK(input.scalar_type() == torch::kBFloat16, "input must be bfloat16");
+}
+
+}  // namespace
+
+torch::Tensor qwen4_exp_hc_silu(const torch::Tensor& input, int64_t groups) {
+    check_qwen4_exp_hc_activation(input, groups);
+    return qwen4_exp_hc_silu_bf16_cuda(input, groups);
+}
+
+torch::Tensor qwen4_exp_hc_inject_gate(const torch::Tensor& input, int64_t groups) {
+    check_qwen4_exp_hc_activation(input, groups);
+    return qwen4_exp_hc_inject_gate_bf16_cuda(input, groups);
+}
+
+torch::Tensor qwen4_exp_qsa_bf16_forward(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& selected,
+    double softmax_scale) {
+    TORCH_CHECK(query.dim() == 4, "query must have shape [B, Q, Hq, 256]");
+    TORCH_CHECK(key.dim() == 4, "key must have shape [B, Hkv, K, 256]");
+    TORCH_CHECK(value.sizes() == key.sizes(), "value shape must match key");
+    TORCH_CHECK(selected.dim() == 3, "selected must have shape [B, Q, S]");
+    TORCH_CHECK(query.size(0) == key.size(0), "query/key batch mismatch");
+    TORCH_CHECK(selected.size(0) == query.size(0) && selected.size(1) == query.size(1), "selected/query shape mismatch");
+    TORCH_CHECK(query.size(3) == 256 && key.size(3) == 256, "Qwen4-Exp QSA requires 256-dimensional heads");
+    TORCH_CHECK(key.size(1) > 0 && query.size(2) % key.size(1) == 0, "query heads must be divisible by KV heads");
+    TORCH_CHECK(query.size(2) / key.size(1) <= 12, "Qwen4-Exp QSA supports at most 12 query heads per KV head");
+    TORCH_CHECK(selected.size(2) > 0, "selected must contain at least one slot");
+    TORCH_CHECK(query.is_cuda() && key.is_cuda() && value.is_cuda() && selected.is_cuda(), "QSA inputs must be CUDA tensors");
+    TORCH_CHECK(query.device() == key.device() && query.device() == value.device() && query.device() == selected.device(), "QSA inputs must share one CUDA device");
+    TORCH_CHECK(query.is_contiguous() && key.is_contiguous() && value.is_contiguous() && selected.is_contiguous(), "QSA inputs must be contiguous");
+    TORCH_CHECK(query.scalar_type() == torch::kBFloat16 && key.scalar_type() == torch::kBFloat16 && value.scalar_type() == torch::kBFloat16, "query/key/value must be bfloat16");
+    TORCH_CHECK(selected.scalar_type() == torch::kInt32, "selected must be int32");
+    TORCH_CHECK(softmax_scale > 0.0, "softmax_scale must be positive");
+    return qwen4_exp_qsa_bf16_forward_cuda(
+        query, key, value, selected, softmax_scale);
+}
+
+std::vector<torch::Tensor> qwen4_exp_gated_delta_bf16_forward(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& gate,
+    const torch::Tensor& beta,
+    const torch::Tensor& initial_state,
+    double norm_eps,
+    int64_t groups_per_block) {
+    TORCH_CHECK(query.dim() == 4, "query must have shape [B, T, Hk, 128]");
+    TORCH_CHECK(key.sizes() == query.sizes(), "key shape must match query");
+    TORCH_CHECK(value.dim() == 4, "value must have shape [B, T, Hv, 128]");
+    TORCH_CHECK(gate.dim() == 3, "gate must have shape [B, T, Hv]");
+    TORCH_CHECK(beta.sizes() == gate.sizes(), "beta shape must match gate");
+    TORCH_CHECK(initial_state.dim() == 4, "initial_state must have shape [B, Hv, 128, 128]");
+    TORCH_CHECK(query.size(0) == 1, "Qwen4-Exp gated delta currently supports batch size 1");
+    TORCH_CHECK(query.size(1) == value.size(1), "query/value token count mismatch");
+    TORCH_CHECK(query.size(3) == 128 && value.size(3) == 128, "Qwen4-Exp gated delta requires 128-dimensional heads");
+    TORCH_CHECK(value.size(0) == 1 && gate.size(0) == 1 && initial_state.size(0) == 1, "batch dimensions must match");
+    TORCH_CHECK(gate.size(1) == value.size(1) && gate.size(2) == value.size(2), "gate/value shape mismatch");
+    TORCH_CHECK(initial_state.size(1) == value.size(2) && initial_state.size(2) == 128 && initial_state.size(3) == 128, "state/value shape mismatch");
+    TORCH_CHECK(value.size(2) % query.size(2) == 0, "value heads must be divisible by key heads");
+    TORCH_CHECK(query.is_cuda() && key.is_cuda() && value.is_cuda() && gate.is_cuda() && beta.is_cuda() && initial_state.is_cuda(), "gated delta inputs must be CUDA tensors");
+    TORCH_CHECK(query.device() == key.device() && query.device() == value.device() && query.device() == gate.device() && query.device() == beta.device() && query.device() == initial_state.device(), "gated delta inputs must share one CUDA device");
+    TORCH_CHECK(query.is_contiguous() && key.is_contiguous() && value.is_contiguous() && gate.is_contiguous() && beta.is_contiguous() && initial_state.is_contiguous(), "gated delta inputs must be contiguous");
+    TORCH_CHECK(query.scalar_type() == torch::kBFloat16 && key.scalar_type() == torch::kBFloat16 && value.scalar_type() == torch::kBFloat16 && beta.scalar_type() == torch::kBFloat16, "query/key/value/beta must be bfloat16");
+    TORCH_CHECK(gate.scalar_type() == torch::kFloat32 && initial_state.scalar_type() == torch::kFloat32, "gate/state must be float32");
+    TORCH_CHECK(norm_eps > 0.0, "norm_eps must be positive");
+    TORCH_CHECK(groups_per_block == 1 || groups_per_block == 2 || groups_per_block == 4 || groups_per_block == 8, "groups_per_block must be 1, 2, 4, or 8");
+    return qwen4_exp_gated_delta_bf16_forward_cuda(
+        query, key, value, gate, beta, initial_state, norm_eps, groups_per_block);
+}
+
+torch::Tensor qwen4_exp_moe_prefill_bf16_forward(
+    const torch::Tensor& x,
+    const torch::Tensor& route_tokens,
+    const torch::Tensor& route_weights,
+    const torch::Tensor& seg_starts,
+    const torch::Tensor& gate_up,
+    const torch::Tensor& down,
+    double swiglu_limit) {
+    TORCH_CHECK(x.dim() == 2, "x must have shape [T, H]");
+    TORCH_CHECK(route_tokens.dim() == 1, "route_tokens must have shape [R]");
+    TORCH_CHECK(route_weights.dim() == 1, "route_weights must have shape [R]");
+    TORCH_CHECK(seg_starts.dim() == 1, "seg_starts must have shape [E + 1]");
+    TORCH_CHECK(gate_up.dim() == 3, "gate_up must have shape [E, 2I, H]");
+    TORCH_CHECK(down.dim() == 3, "down must have shape [E, H, I]");
+    TORCH_CHECK(route_tokens.size(0) == route_weights.size(0), "route count mismatch");
+    TORCH_CHECK(seg_starts.size(0) == gate_up.size(0) + 1, "segment/expert count mismatch");
+    TORCH_CHECK(gate_up.size(0) == down.size(0), "expert count mismatch");
+    TORCH_CHECK(gate_up.size(1) % 2 == 0, "gate_up intermediate dimension must be even");
+    TORCH_CHECK(gate_up.size(2) == x.size(1), "gate_up input dimension mismatch");
+    TORCH_CHECK(down.size(1) == x.size(1), "down output dimension mismatch");
+    TORCH_CHECK(down.size(2) == gate_up.size(1) / 2, "down input dimension mismatch");
+    TORCH_CHECK(x.is_cuda() && route_tokens.is_cuda() && route_weights.is_cuda() && seg_starts.is_cuda(), "inputs must be CUDA tensors");
+    TORCH_CHECK(gate_up.is_cuda() && down.is_cuda(), "weights must be CUDA tensors");
+    TORCH_CHECK(x.is_contiguous() && route_tokens.is_contiguous() && route_weights.is_contiguous() && seg_starts.is_contiguous(), "inputs must be contiguous");
+    TORCH_CHECK(gate_up.is_contiguous() && down.is_contiguous(), "weights must be contiguous");
+    TORCH_CHECK(x.scalar_type() == torch::kBFloat16, "x must be bfloat16");
+    TORCH_CHECK(gate_up.scalar_type() == torch::kBFloat16 && down.scalar_type() == torch::kBFloat16, "weights must be bfloat16");
+    TORCH_CHECK(route_tokens.scalar_type() == torch::kInt64, "route_tokens must be int64");
+    TORCH_CHECK(route_weights.scalar_type() == torch::kFloat32, "route_weights must be float32");
+    TORCH_CHECK(seg_starts.scalar_type() == torch::kInt32 || seg_starts.scalar_type() == torch::kInt64, "seg_starts must be int32 or int64");
+    return qwen4_exp_moe_prefill_bf16_forward_cuda(
+        x, route_tokens, route_weights, seg_starts, gate_up, down, swiglu_limit);
+}
+
 torch::Tensor moe_prefill_int8_grouped_gemm_forward_cuda(
     const torch::Tensor& x,
     const torch::Tensor& route_tokens,
@@ -2021,6 +2230,13 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("moe_single_token_fp4_forward", &moe_single_token_fp4_forward, "single-token top-k MoE FP4 (e2m1fn_x2 + e8m0 block) forward (CUDA)");
     m.def("moe_multi_token_fp4_forward", &moe_multi_token_fp4_forward, "small-batch top-k MoE FP4 forward, active experts only (CUDA)");
     m.def("moe_prefill_int8_grouped_forward", &moe_prefill_int8_grouped_forward, "prefill MoE grouped int8 forward (CUDA)");
+    m.def("qwen4_exp_moe_prefill_bf16_forward", &qwen4_exp_moe_prefill_bf16_forward, "Qwen4-Exp raw BF16 grouped prefill MoE forward (CUDA)");
+    m.def("qwen4_exp_gated_delta_bf16_forward", &qwen4_exp_gated_delta_bf16_forward, "Qwen4-Exp BF16 gated-delta recurrent scan (CUDA)");
+    m.def("qwen4_exp_qsa_bf16_forward", &qwen4_exp_qsa_bf16_forward, "Qwen4-Exp indexed BF16 GQA attention (CUDA)");
+    m.def("qwen4_exp_grouped_rms_norm", &qwen4_exp_grouped_rms_norm, "Qwen4-Exp grouped RMSNorm with centered gain (CUDA)");
+    m.def("qwen4_exp_inject", &qwen4_exp_inject, "Qwen4-Exp hyper-connection stream injection (CUDA)");
+    m.def("qwen4_exp_hc_silu", &qwen4_exp_hc_silu, "Qwen4-Exp hyper-connection scaled SiLU (CUDA)");
+    m.def("qwen4_exp_hc_inject_gate", &qwen4_exp_hc_inject_gate, "Qwen4-Exp hyper-connection injection gate (CUDA)");
     m.def("moe_prefill_int8_grouped_gemm_forward", &moe_prefill_int8_grouped_gemm_forward, "prefill MoE grouped-GEMM int8 forward (CUDA)");
     m.def("moe_prefill_fp4_grouped_gemm_forward", &moe_prefill_fp4_grouped_gemm_forward, "prefill MoE grouped-GEMM FP4 forward (CUDA)");
     m.def("fp4_weight_to_int8_forward", &fp4_weight_to_int8_forward, "convert FP4 block-scaled weights to int8 row-scaled weights (CUDA)");

--- a/src/csrc/qwen4_exp_gated_delta.cu
+++ b/src/csrc/qwen4_exp_gated_delta.cu
@@ -1,0 +1,383 @@
+#include <torch/extension.h>
+
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/util/BFloat16.h>
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+
+namespace {
+
+constexpr int kDim = 128;
+constexpr int kCols = 4;
+constexpr int kWidth = 16;
+constexpr int kRowsPerLane = kDim / kWidth;
+constexpr int kSubgroupsPerWarp = 32 / kWidth;
+
+__device__ __forceinline__ float subgroup_sum(float value) {
+#pragma unroll
+    for (int offset = kWidth / 2; offset > 0; offset >>= 1) {
+        value += __shfl_down_sync(0xffffffffU, value, offset, kWidth);
+    }
+    return value;
+}
+
+__device__ __forceinline__ float subgroup_broadcast(float value) {
+    return __shfl_sync(0xffffffffU, value, 0, kWidth);
+}
+
+__global__ void normalize_qk_bf16_kernel(
+    const c10::BFloat16* __restrict__ query,
+    const c10::BFloat16* __restrict__ key,
+    float* __restrict__ query_normalized,
+    float* __restrict__ key_normalized,
+    int rows,
+    int key_heads,
+    float eps) {
+    const int vector = static_cast<int>(blockIdx.x);
+    const int lane = static_cast<int>(threadIdx.x);
+    if (vector >= rows * key_heads) {
+        return;
+    }
+
+    const int64_t base = static_cast<int64_t>(vector) * kDim;
+    float q_sum = 0.0f;
+    float k_sum = 0.0f;
+#pragma unroll
+    for (int col = lane; col < kDim; col += 32) {
+        const float q = static_cast<float>(query[base + col]);
+        const float k = static_cast<float>(key[base + col]);
+        q_sum = fmaf(q, q, q_sum);
+        k_sum = fmaf(k, k, k_sum);
+    }
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        q_sum += __shfl_down_sync(0xffffffffU, q_sum, offset);
+        k_sum += __shfl_down_sync(0xffffffffU, k_sum, offset);
+    }
+    const float q_inv = rsqrtf(__shfl_sync(0xffffffffU, q_sum, 0) + eps);
+    const float k_inv = rsqrtf(__shfl_sync(0xffffffffU, k_sum, 0) + eps);
+#pragma unroll
+    for (int col = lane; col < kDim; col += 32) {
+        query_normalized[base + col] = static_cast<float>(query[base + col]) * q_inv;
+        key_normalized[base + col] = static_cast<float>(key[base + col]) * k_inv;
+    }
+}
+
+template <int GroupsPerBlock>
+__global__ void gated_delta_bf16_kernel(
+    const float* __restrict__ query,
+    const float* __restrict__ key,
+    const c10::BFloat16* __restrict__ value,
+    const float* __restrict__ gate,
+    const c10::BFloat16* __restrict__ beta,
+    float* __restrict__ state,
+    c10::BFloat16* __restrict__ output,
+    int rows,
+    int key_heads,
+    int value_heads,
+    float query_scale) {
+    const int value_head = static_cast<int>(blockIdx.x);
+    const int subgroup = static_cast<int>(threadIdx.x) / kWidth;
+    const int lane = static_cast<int>(threadIdx.x) % kWidth;
+    const int group =
+        (static_cast<int>(blockIdx.z) * GroupsPerBlock +
+         static_cast<int>(threadIdx.y)) *
+            kSubgroupsPerWarp +
+        subgroup;
+    const int col_base = group * kCols;
+    const int key_head = value_head / (value_heads / key_heads);
+
+    float state_shard[kCols][kRowsPerLane];
+#pragma unroll
+    for (int col_slot = 0; col_slot < kCols; ++col_slot) {
+        const int col = col_base + col_slot;
+#pragma unroll
+        for (int row_slot = 0; row_slot < kRowsPerLane; ++row_slot) {
+            const int row = row_slot * kWidth + lane;
+            float state_value = 0.0f;
+            if (col < kDim) {
+                const int64_t index =
+                    (static_cast<int64_t>(value_head) * kDim + row) * kDim + col;
+                state_value = state[index];
+            }
+            state_shard[col_slot][row_slot] = state_value;
+        }
+    }
+
+    float query_next[kRowsPerLane];
+    float key_next[kRowsPerLane];
+    float value_next[kCols];
+    float decay_next = 0.0f;
+    float beta_next = 0.0f;
+
+    auto load_qk = [&](int token, float* query_out, float* key_out) {
+#pragma unroll
+        for (int row_slot = 0; row_slot < kRowsPerLane; ++row_slot) {
+            const int row = row_slot * kWidth + lane;
+            const int64_t index =
+                (static_cast<int64_t>(token) * key_heads + key_head) * kDim + row;
+            query_out[row_slot] = query[index];
+            key_out[row_slot] = key[index];
+        }
+    };
+    auto load_value = [&](int token, float* value_out) {
+#pragma unroll
+        for (int col_slot = 0; col_slot < kCols; ++col_slot) {
+            float value_scalar = 0.0f;
+            if (lane == 0) {
+                const int col = col_base + col_slot;
+                if (col < kDim) {
+                    const int64_t index =
+                        (static_cast<int64_t>(token) * value_heads + value_head) *
+                            kDim +
+                        col;
+                    value_scalar = static_cast<float>(value[index]);
+                }
+            }
+            value_out[col_slot] = value_scalar;
+        }
+    };
+    auto load_scalars = [&](int token, float* decay_out, float* beta_out) {
+        float decay = 0.0f;
+        float beta_scalar = 0.0f;
+        if (threadIdx.x == 0) {
+            const int64_t index =
+                static_cast<int64_t>(token) * value_heads + value_head;
+            decay = expf(gate[index]);
+            beta_scalar = static_cast<float>(beta[index]);
+        }
+        *decay_out = decay;
+        *beta_out = beta_scalar;
+    };
+
+    load_qk(0, query_next, key_next);
+    load_value(0, value_next);
+    load_scalars(0, &decay_next, &beta_next);
+
+    for (int token = 0; token < rows; ++token) {
+        float query_row[kRowsPerLane];
+        float key_row[kRowsPerLane];
+        float value_row[kCols];
+#pragma unroll
+        for (int row_slot = 0; row_slot < kRowsPerLane; ++row_slot) {
+            query_row[row_slot] = query_next[row_slot];
+            key_row[row_slot] = key_next[row_slot];
+        }
+#pragma unroll
+        for (int col_slot = 0; col_slot < kCols; ++col_slot) {
+            value_row[col_slot] = value_next[col_slot];
+        }
+        float decay = decay_next;
+        float beta_scalar = beta_next;
+
+        if (token + 1 < rows) {
+            load_qk(token + 1, query_next, key_next);
+            load_value(token + 1, value_next);
+            load_scalars(token + 1, &decay_next, &beta_next);
+        }
+
+        decay = __shfl_sync(0xffffffffU, decay, 0);
+        beta_scalar = __shfl_sync(0xffffffffU, beta_scalar, 0);
+
+        float memory[kCols];
+#pragma unroll
+        for (int col_slot = 0; col_slot < kCols; ++col_slot) {
+            float sum = 0.0f;
+#pragma unroll
+            for (int row_slot = 0; row_slot < kRowsPerLane; ++row_slot) {
+                sum = fmaf(
+                    state_shard[col_slot][row_slot], key_row[row_slot], sum);
+            }
+            memory[col_slot] = subgroup_sum(sum);
+        }
+
+        float delta[kCols];
+#pragma unroll
+        for (int col_slot = 0; col_slot < kCols; ++col_slot) {
+            float delta_scalar = 0.0f;
+            if (lane == 0 && col_base + col_slot < kDim) {
+                delta_scalar =
+                    (value_row[col_slot] - decay * memory[col_slot]) * beta_scalar;
+            }
+            delta[col_slot] = subgroup_broadcast(delta_scalar);
+        }
+
+        float attention[kCols];
+#pragma unroll
+        for (int col_slot = 0; col_slot < kCols; ++col_slot) {
+            float sum = 0.0f;
+#pragma unroll
+            for (int row_slot = 0; row_slot < kRowsPerLane; ++row_slot) {
+                const float new_state = fmaf(
+                    key_row[row_slot], delta[col_slot],
+                    decay * state_shard[col_slot][row_slot]);
+                state_shard[col_slot][row_slot] = new_state;
+                sum = fmaf(new_state, query_row[row_slot], sum);
+            }
+            attention[col_slot] = subgroup_sum(sum);
+        }
+
+        if (lane == 0) {
+            const int64_t base =
+                (static_cast<int64_t>(token) * value_heads + value_head) * kDim;
+#pragma unroll
+            for (int col_slot = 0; col_slot < kCols; ++col_slot) {
+                const int col = col_base + col_slot;
+                if (col < kDim) {
+                    output[base + col] =
+                        c10::BFloat16(attention[col_slot] * query_scale);
+                }
+            }
+        }
+    }
+
+#pragma unroll
+    for (int col_slot = 0; col_slot < kCols; ++col_slot) {
+        const int col = col_base + col_slot;
+#pragma unroll
+        for (int row_slot = 0; row_slot < kRowsPerLane; ++row_slot) {
+            const int row = row_slot * kWidth + lane;
+            if (col < kDim) {
+                const int64_t index =
+                    (static_cast<int64_t>(value_head) * kDim + row) * kDim + col;
+                state[index] = state_shard[col_slot][row_slot];
+            }
+        }
+    }
+}
+
+template <int GroupsPerBlock>
+void launch_gated_delta(
+    const float* query,
+    const float* key,
+    const c10::BFloat16* value,
+    const float* gate,
+    const c10::BFloat16* beta,
+    float* state,
+    c10::BFloat16* output,
+    int rows,
+    int key_heads,
+    int value_heads,
+    float query_scale,
+    cudaStream_t stream) {
+    constexpr int groups = kDim / kCols;
+    constexpr int groups_per_cta = GroupsPerBlock * kSubgroupsPerWarp;
+    const dim3 block(32, GroupsPerBlock);
+    const dim3 grid(
+        value_heads,
+        1,
+        (groups + groups_per_cta - 1) / groups_per_cta);
+    gated_delta_bf16_kernel<GroupsPerBlock><<<grid, block, 0, stream>>>(
+        query,
+        key,
+        value,
+        gate,
+        beta,
+        state,
+        output,
+        rows,
+        key_heads,
+        value_heads,
+        query_scale);
+}
+
+}  // namespace
+
+std::vector<torch::Tensor> qwen4_exp_gated_delta_bf16_forward_cuda(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& gate,
+    const torch::Tensor& beta,
+    const torch::Tensor& initial_state,
+    double norm_eps,
+    int64_t groups_per_block) {
+    c10::cuda::CUDAGuard device_guard(query.device());
+
+    const int rows = static_cast<int>(query.size(1));
+    const int key_heads = static_cast<int>(query.size(2));
+    const int value_heads = static_cast<int>(value.size(2));
+    auto query_normalized = torch::empty(query.sizes(), query.options().dtype(torch::kFloat32));
+    auto key_normalized = torch::empty(key.sizes(), key.options().dtype(torch::kFloat32));
+    auto output = torch::empty(value.sizes(), value.options());
+    auto state = initial_state.clone();
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+    normalize_qk_bf16_kernel<<<rows * key_heads, 32, 0, stream>>>(
+        query.data_ptr<c10::BFloat16>(),
+        key.data_ptr<c10::BFloat16>(),
+        query_normalized.data_ptr<float>(),
+        key_normalized.data_ptr<float>(),
+        rows,
+        key_heads,
+        static_cast<float>(norm_eps));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    const float query_scale = 1.0f / std::sqrt(static_cast<float>(kDim));
+    switch (groups_per_block) {
+        case 2:
+            launch_gated_delta<2>(
+                query_normalized.data_ptr<float>(),
+                key_normalized.data_ptr<float>(),
+                value.data_ptr<c10::BFloat16>(),
+                gate.data_ptr<float>(),
+                beta.data_ptr<c10::BFloat16>(),
+                state.data_ptr<float>(),
+                output.data_ptr<c10::BFloat16>(),
+                rows,
+                key_heads,
+                value_heads,
+                query_scale,
+                stream);
+            break;
+        case 4:
+            launch_gated_delta<4>(
+                query_normalized.data_ptr<float>(),
+                key_normalized.data_ptr<float>(),
+                value.data_ptr<c10::BFloat16>(),
+                gate.data_ptr<float>(),
+                beta.data_ptr<c10::BFloat16>(),
+                state.data_ptr<float>(),
+                output.data_ptr<c10::BFloat16>(),
+                rows,
+                key_heads,
+                value_heads,
+                query_scale,
+                stream);
+            break;
+        case 8:
+            launch_gated_delta<8>(
+                query_normalized.data_ptr<float>(),
+                key_normalized.data_ptr<float>(),
+                value.data_ptr<c10::BFloat16>(),
+                gate.data_ptr<float>(),
+                beta.data_ptr<c10::BFloat16>(),
+                state.data_ptr<float>(),
+                output.data_ptr<c10::BFloat16>(),
+                rows,
+                key_heads,
+                value_heads,
+                query_scale,
+                stream);
+            break;
+        default:
+            launch_gated_delta<1>(
+                query_normalized.data_ptr<float>(),
+                key_normalized.data_ptr<float>(),
+                value.data_ptr<c10::BFloat16>(),
+                gate.data_ptr<float>(),
+                beta.data_ptr<c10::BFloat16>(),
+                state.data_ptr<float>(),
+                output.data_ptr<c10::BFloat16>(),
+                rows,
+                key_heads,
+                value_heads,
+                query_scale,
+                stream);
+            break;
+    }
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return {output, state};
+}

--- a/src/csrc/qwen4_exp_hyper_connection.cu
+++ b/src/csrc/qwen4_exp_hyper_connection.cu
@@ -1,0 +1,231 @@
+#include <torch/extension.h>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/util/BFloat16.h>
+#include <cuda_runtime.h>
+
+#include <cstdint>
+
+namespace {
+
+constexpr int kWarpSize = 32;
+constexpr int kThreads = 256;
+constexpr int kMaxWarps = kThreads / kWarpSize;
+
+__device__ __forceinline__ float warp_sum(float value) {
+    #pragma unroll
+    for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+        value += __shfl_down_sync(0xffffffff, value, offset);
+    }
+    return value;
+}
+
+template <typename scalar_t>
+__global__ void qwen4_exp_grouped_rms_norm_kernel(
+    const scalar_t* __restrict__ input,
+    const scalar_t* __restrict__ weight,
+    scalar_t* __restrict__ output,
+    int64_t rows,
+    int groups,
+    int group_size,
+    float eps) {
+    const int64_t row_group = blockIdx.x;
+    if (row_group >= rows * groups) {
+        return;
+    }
+    const int group = static_cast<int>(row_group % groups);
+    const int64_t row = row_group / groups;
+    const int64_t base = (row * groups + group) * group_size;
+
+    float square_sum = 0.0f;
+    for (int col = threadIdx.x; col < group_size; col += blockDim.x) {
+        const float value = static_cast<float>(input[base + col]);
+        square_sum += value * value;
+    }
+    square_sum = warp_sum(square_sum);
+
+    __shared__ float warp_sums[kMaxWarps];
+    const int warp = threadIdx.x / kWarpSize;
+    const int lane = threadIdx.x % kWarpSize;
+    if (lane == 0) {
+        warp_sums[warp] = square_sum;
+    }
+    __syncthreads();
+
+    float total = threadIdx.x < kMaxWarps ? warp_sums[lane] : 0.0f;
+    if (warp == 0) {
+        total = warp_sum(total);
+        if (lane == 0) {
+            warp_sums[0] = total;
+        }
+    }
+    __syncthreads();
+    const float inv_rms = rsqrtf(warp_sums[0] / static_cast<float>(group_size) + eps);
+
+    for (int col = threadIdx.x; col < group_size; col += blockDim.x) {
+        const int64_t index = base + col;
+        const float gain = 1.0f + static_cast<float>(weight[group * group_size + col]);
+        output[index] = scalar_t(static_cast<float>(input[index]) * inv_rms * gain);
+    }
+}
+
+__global__ void qwen4_exp_hc_silu_bf16_kernel(
+    const c10::BFloat16* __restrict__ input,
+    c10::BFloat16* __restrict__ output,
+    int64_t elements,
+    float scale) {
+    const int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index >= elements) {
+        return;
+    }
+    const float value = static_cast<float>(input[index]) * scale;
+    output[index] = c10::BFloat16(value / (1.0f + expf(-value)));
+}
+
+__global__ void qwen4_exp_hc_inject_gate_bf16_kernel(
+    const c10::BFloat16* __restrict__ input,
+    c10::BFloat16* __restrict__ output,
+    int64_t elements,
+    float scale) {
+    const int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index >= elements) {
+        return;
+    }
+    const float value = static_cast<float>(input[index]) * scale;
+    output[index] = c10::BFloat16(2.0f / (1.0f + expf(-value)));
+}
+
+template <typename scalar_t>
+__global__ void qwen4_exp_inject_kernel(
+    const scalar_t* __restrict__ block_output,
+    const scalar_t* __restrict__ hyper_input,
+    const scalar_t* __restrict__ injection_weights,
+    scalar_t* __restrict__ output,
+    int64_t elements,
+    int hidden,
+    int groups) {
+    const int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index >= elements) {
+        return;
+    }
+    const int col = static_cast<int>(index % hidden);
+    const int group = static_cast<int>((index / hidden) % groups);
+    const int64_t row = index / (static_cast<int64_t>(groups) * hidden);
+    const float block = static_cast<float>(block_output[row * hidden + col]);
+    const float residual = static_cast<float>(hyper_input[index]);
+    const float scale = static_cast<float>(injection_weights[row * groups + group]);
+    const scalar_t injection = scalar_t(block * scale);
+    output[index] = scalar_t(residual + static_cast<float>(injection));
+}
+
+}  // namespace
+
+torch::Tensor qwen4_exp_grouped_rms_norm_cuda(
+    const torch::Tensor& input,
+    const torch::Tensor& weight,
+    int64_t group_size,
+    double eps) {
+    c10::cuda::CUDAGuard device_guard(input.device());
+    const int64_t rows = input.numel() / input.size(-1);
+    const int groups = static_cast<int>(input.size(-1) / group_size);
+    auto output = torch::empty_like(input);
+
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        at::kHalf,
+        at::kBFloat16,
+        input.scalar_type(),
+        "qwen4_exp_grouped_rms_norm",
+        [&] {
+            qwen4_exp_grouped_rms_norm_kernel<scalar_t><<<
+                rows * groups,
+                kThreads,
+                0,
+                at::cuda::getCurrentCUDAStream()>>>(
+                input.data_ptr<scalar_t>(),
+                weight.data_ptr<scalar_t>(),
+                output.data_ptr<scalar_t>(),
+                rows,
+                groups,
+                static_cast<int>(group_size),
+                static_cast<float>(eps));
+        });
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor qwen4_exp_hc_silu_bf16_cuda(
+    const torch::Tensor& input,
+    int64_t groups) {
+    c10::cuda::CUDAGuard device_guard(input.device());
+    auto output = torch::empty_like(input);
+    const int64_t elements = input.numel();
+    const int blocks = static_cast<int>((elements + kThreads - 1) / kThreads);
+
+    qwen4_exp_hc_silu_bf16_kernel<<<
+        blocks,
+        kThreads,
+        0,
+        at::cuda::getCurrentCUDAStream()>>>(
+        input.data_ptr<c10::BFloat16>(),
+        output.data_ptr<c10::BFloat16>(),
+        elements,
+        1.0f / static_cast<float>(groups));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor qwen4_exp_hc_inject_gate_bf16_cuda(
+    const torch::Tensor& input,
+    int64_t groups) {
+    c10::cuda::CUDAGuard device_guard(input.device());
+    auto output = torch::empty_like(input);
+    const int64_t elements = input.numel();
+    const int blocks = static_cast<int>((elements + kThreads - 1) / kThreads);
+
+    qwen4_exp_hc_inject_gate_bf16_kernel<<<
+        blocks,
+        kThreads,
+        0,
+        at::cuda::getCurrentCUDAStream()>>>(
+        input.data_ptr<c10::BFloat16>(),
+        output.data_ptr<c10::BFloat16>(),
+        elements,
+        1.0f / static_cast<float>(groups));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+torch::Tensor qwen4_exp_inject_cuda(
+    const torch::Tensor& block_output,
+    const torch::Tensor& hyper_input,
+    const torch::Tensor& injection_weights,
+    int64_t groups) {
+    c10::cuda::CUDAGuard device_guard(hyper_input.device());
+    auto output = torch::empty_like(hyper_input);
+    const int hidden = static_cast<int>(block_output.size(-1));
+    const int64_t elements = hyper_input.numel();
+    const int blocks = static_cast<int>((elements + kThreads - 1) / kThreads);
+
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        at::kHalf,
+        at::kBFloat16,
+        hyper_input.scalar_type(),
+        "qwen4_exp_inject",
+        [&] {
+            qwen4_exp_inject_kernel<scalar_t><<<
+                blocks,
+                kThreads,
+                0,
+                at::cuda::getCurrentCUDAStream()>>>(
+                block_output.data_ptr<scalar_t>(),
+                hyper_input.data_ptr<scalar_t>(),
+                injection_weights.data_ptr<scalar_t>(),
+                output.data_ptr<scalar_t>(),
+                elements,
+                hidden,
+                static_cast<int>(groups));
+        });
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}

--- a/src/csrc/qwen4_exp_moe.cu
+++ b/src/csrc/qwen4_exp_moe.cu
@@ -1,0 +1,289 @@
+#include <torch/extension.h>
+
+#include <ATen/cuda/CUDABlas.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/util/BFloat16.h>
+#include <cuda_runtime.h>
+#include <cublas_v2.h>
+
+#include <algorithm>
+#include <cstdint>
+
+namespace {
+
+constexpr int kThreads = 256;
+
+inline int ceil_div(int value, int divisor) {
+    return (value + divisor - 1) / divisor;
+}
+
+__global__ void gather_routes_padded_kernel(
+    const c10::BFloat16* __restrict__ x,
+    const int64_t* __restrict__ route_tokens,
+    const int32_t* __restrict__ seg_starts,
+    const float* __restrict__ route_weights,
+    c10::BFloat16* __restrict__ x_pad,
+    float* __restrict__ weight_pad,
+    int experts,
+    int max_count,
+    int hidden) {
+    const int index = blockIdx.x * blockDim.x + threadIdx.x;
+    const int total = experts * max_count * hidden;
+    if (index >= total) {
+        return;
+    }
+
+    const int col = index % hidden;
+    const int row = (index / hidden) % max_count;
+    const int expert = index / (max_count * hidden);
+    const int begin = seg_starts[expert];
+    const int end = seg_starts[expert + 1];
+    const int route = begin + row;
+    const bool valid = route < end;
+    const int64_t dst = static_cast<int64_t>(index);
+    if (!valid) {
+        x_pad[dst] = c10::BFloat16(0.0f);
+        if (col == 0) {
+            weight_pad[static_cast<int64_t>(expert) * max_count + row] = 0.0f;
+        }
+        return;
+    }
+
+    const int64_t token = route_tokens[route];
+    x_pad[dst] = x[token * hidden + col];
+    if (col == 0) {
+        weight_pad[static_cast<int64_t>(expert) * max_count + row] = route_weights[route];
+    }
+}
+
+__global__ void swiglu_routes_kernel(
+    const c10::BFloat16* __restrict__ gate_up,
+    const float* __restrict__ route_weights,
+    c10::BFloat16* __restrict__ hidden,
+    int experts,
+    int max_count,
+    int inter,
+    float swiglu_limit) {
+    const int index = blockIdx.x * blockDim.x + threadIdx.x;
+    const int total = experts * max_count * inter;
+    if (index >= total) {
+        return;
+    }
+
+    const int col = index % inter;
+    const int row = (index / inter) % max_count;
+    const int expert = index / (max_count * inter);
+    const int64_t base =
+        (static_cast<int64_t>(expert) * max_count + row) * (2 * inter);
+    float gate = static_cast<float>(gate_up[base + col]);
+    float up = static_cast<float>(gate_up[base + inter + col]);
+    if (swiglu_limit > 0.0f) {
+        up = fminf(fmaxf(up, -swiglu_limit), swiglu_limit);
+        gate = fminf(gate, swiglu_limit);
+    }
+    const float value = (gate / (1.0f + expf(-gate))) * up *
+        route_weights[static_cast<int64_t>(expert) * max_count + row];
+    hidden[(static_cast<int64_t>(expert) * max_count + row) * inter + col] =
+        c10::BFloat16(value);
+}
+
+__global__ void scatter_routes_kernel(
+    const c10::BFloat16* __restrict__ out_routes,
+    const int64_t* __restrict__ route_tokens,
+    const int32_t* __restrict__ seg_starts,
+    float* __restrict__ output,
+    int experts,
+    int max_count,
+    int hidden) {
+    const int index = blockIdx.x * blockDim.x + threadIdx.x;
+    const int total = experts * max_count * hidden;
+    if (index >= total) {
+        return;
+    }
+
+    const int col = index % hidden;
+    const int row = (index / hidden) % max_count;
+    const int expert = index / (max_count * hidden);
+    const int begin = seg_starts[expert];
+    const int end = seg_starts[expert + 1];
+    const int route = begin + row;
+    if (route >= end) {
+        return;
+    }
+    const int64_t token = route_tokens[route];
+    const float value = static_cast<float>(
+        out_routes[(static_cast<int64_t>(expert) * max_count + row) * hidden + col]);
+    atomicAdd(output + token * hidden + col, value);
+}
+
+cublasStatus_t strided_batched_bf16_gemm(
+    cublasHandle_t handle,
+    int m,
+    int n,
+    int k,
+    const c10::BFloat16* a,
+    long long stride_a,
+    const c10::BFloat16* b,
+    long long stride_b,
+    c10::BFloat16* c,
+    long long stride_c,
+    int batch_count) {
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+    return cublasGemmStridedBatchedEx(
+        handle,
+        CUBLAS_OP_T,
+        CUBLAS_OP_N,
+        m,
+        n,
+        k,
+        &alpha,
+        a,
+        CUDA_R_16BF,
+        k,
+        stride_a,
+        b,
+        CUDA_R_16BF,
+        k,
+        stride_b,
+        &beta,
+        c,
+        CUDA_R_16BF,
+        m,
+        stride_c,
+        batch_count,
+        CUBLAS_COMPUTE_32F,
+        CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+}
+
+}  // namespace
+
+torch::Tensor qwen4_exp_moe_prefill_bf16_forward_cuda(
+    const torch::Tensor& x,
+    const torch::Tensor& route_tokens,
+    const torch::Tensor& route_weights,
+    const torch::Tensor& seg_starts,
+    const torch::Tensor& gate_up,
+    const torch::Tensor& down,
+    double swiglu_limit) {
+    c10::cuda::CUDAGuard device_guard(x.device());
+
+    const int tokens = static_cast<int>(x.size(0));
+    const int hidden = static_cast<int>(x.size(1));
+    const int experts = static_cast<int>(gate_up.size(0));
+    const int inter = static_cast<int>(gate_up.size(1) / 2);
+    const int routes = static_cast<int>(route_tokens.size(0));
+
+    auto seg_i32 = seg_starts.scalar_type() == torch::kInt32
+        ? seg_starts.contiguous()
+        : seg_starts.to(torch::kInt32);
+    auto x_contig = x.contiguous();
+    auto route_tokens_contig = route_tokens.contiguous();
+    auto route_weights_contig = route_weights.contiguous();
+    auto gate_up_contig = gate_up.contiguous();
+    auto down_contig = down.contiguous();
+    auto output = torch::zeros({tokens, hidden}, x.options().dtype(torch::kFloat32));
+
+    if (routes == 0 || experts == 0) {
+        return output.to(x.scalar_type());
+    }
+
+    auto counts = seg_i32.slice(0, 1, experts + 1) -
+        seg_i32.slice(0, 0, experts);
+    const int max_count = counts.max().item<int>();
+    if (max_count <= 0) {
+        return output.to(x.scalar_type());
+    }
+
+    auto x_pad = torch::empty(
+        {experts, max_count, hidden}, x.options().dtype(torch::kBFloat16));
+    auto weight_pad = torch::empty(
+        {experts, max_count}, x.options().dtype(torch::kFloat32));
+    auto gate_pad = torch::empty(
+        {experts, max_count, 2 * inter}, x.options().dtype(torch::kBFloat16));
+    auto hidden_pad = torch::empty(
+        {experts, max_count, inter}, x.options().dtype(torch::kBFloat16));
+    auto out_pad = torch::empty(
+        {experts, max_count, hidden}, x.options().dtype(torch::kBFloat16));
+
+    const int gather_total = experts * max_count * hidden;
+    gather_routes_padded_kernel<<<
+        ceil_div(gather_total, kThreads), kThreads, 0,
+        at::cuda::getCurrentCUDAStream()>>>(
+        x_contig.data_ptr<c10::BFloat16>(),
+        route_tokens_contig.data_ptr<int64_t>(),
+        seg_i32.data_ptr<int32_t>(),
+        route_weights_contig.data_ptr<float>(),
+        x_pad.data_ptr<c10::BFloat16>(),
+        weight_pad.data_ptr<float>(),
+        experts,
+        max_count,
+        hidden);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+    TORCH_CHECK(
+        cublasSetStream(handle, at::cuda::getCurrentCUDAStream()) == CUBLAS_STATUS_SUCCESS,
+        "failed to set cuBLAS stream for Qwen4-Exp BF16 MoE");
+
+    cublasStatus_t status = strided_batched_bf16_gemm(
+        handle,
+        2 * inter,
+        max_count,
+        hidden,
+        gate_up_contig.data_ptr<c10::BFloat16>(),
+        static_cast<long long>(2 * inter) * hidden,
+        x_pad.data_ptr<c10::BFloat16>(),
+        static_cast<long long>(max_count) * hidden,
+        gate_pad.data_ptr<c10::BFloat16>(),
+        static_cast<long long>(max_count) * (2 * inter),
+        experts);
+    TORCH_CHECK(
+        status == CUBLAS_STATUS_SUCCESS,
+        "Qwen4-Exp BF16 w13 grouped GEMM failed with cuBLAS status ",
+        static_cast<int>(status));
+
+    const int hidden_total = experts * max_count * inter;
+    swiglu_routes_kernel<<<
+        ceil_div(hidden_total, kThreads), kThreads, 0,
+        at::cuda::getCurrentCUDAStream()>>>(
+        gate_pad.data_ptr<c10::BFloat16>(),
+        weight_pad.data_ptr<float>(),
+        hidden_pad.data_ptr<c10::BFloat16>(),
+        experts,
+        max_count,
+        inter,
+        static_cast<float>(swiglu_limit));
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    status = strided_batched_bf16_gemm(
+        handle,
+        hidden,
+        max_count,
+        inter,
+        down_contig.data_ptr<c10::BFloat16>(),
+        static_cast<long long>(hidden) * inter,
+        hidden_pad.data_ptr<c10::BFloat16>(),
+        static_cast<long long>(max_count) * inter,
+        out_pad.data_ptr<c10::BFloat16>(),
+        static_cast<long long>(max_count) * hidden,
+        experts);
+    TORCH_CHECK(
+        status == CUBLAS_STATUS_SUCCESS,
+        "Qwen4-Exp BF16 w2 grouped GEMM failed with cuBLAS status ",
+        static_cast<int>(status));
+
+    const int output_total = experts * max_count * hidden;
+    scatter_routes_kernel<<<
+        ceil_div(output_total, kThreads), kThreads, 0,
+        at::cuda::getCurrentCUDAStream()>>>(
+        out_pad.data_ptr<c10::BFloat16>(),
+        route_tokens_contig.data_ptr<int64_t>(),
+        seg_i32.data_ptr<int32_t>(),
+        output.data_ptr<float>(),
+        experts,
+        max_count,
+        hidden);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output.to(x.scalar_type());
+}

--- a/src/csrc/qwen4_exp_qsa.cu
+++ b/src/csrc/qwen4_exp_qsa.cu
@@ -1,0 +1,503 @@
+#include <torch/extension.h>
+
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/util/BFloat16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+constexpr int kDim = 256;
+constexpr int kWarpSize = 32;
+constexpr int kMaxHeadsPerKv = 12;
+constexpr int kMmaRows = 16;
+constexpr int kMmaKvTile = 32;
+constexpr int kMmaSlices = 4;
+constexpr int kMmaSteps = kDim / 8;
+constexpr int kMmaWarps = kMmaSlices;
+constexpr int kMmaThreads = kMmaWarps * kWarpSize;
+constexpr int kMmaKsStride = kDim + 8;
+constexpr int kMmaVtStride = kMmaKvTile + 2;
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 750
+#define QWEN4_EXP_QSA_MMA_AVAILABLE 1
+#endif
+
+union HalfBits {
+    __half value;
+    uint16_t bits;
+};
+
+__device__ __forceinline__ uint16_t float_to_half_bits(float value) {
+    HalfBits converted;
+    converted.value = __float2half_rn(value);
+    return converted.bits;
+}
+
+__device__ __forceinline__ float half_bits_to_float(uint16_t bits) {
+    HalfBits converted;
+    converted.bits = bits;
+    return __half2float(converted.value);
+}
+
+__device__ __forceinline__ uint32_t pack_half2(float first, float second) {
+    return static_cast<uint32_t>(float_to_half_bits(first)) |
+        (static_cast<uint32_t>(float_to_half_bits(second)) << 16);
+}
+
+__device__ __forceinline__ void mma_m16n8k8_f16_f32(
+    float (&d)[4], const uint32_t (&a)[2], uint32_t b) {
+#ifdef QWEN4_EXP_QSA_MMA_AVAILABLE
+    asm volatile(
+        "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+        "{%0, %1, %2, %3}, {%4, %5}, {%6}, {%0, %1, %2, %3};"
+        : "+f"(d[0]), "+f"(d[1]), "+f"(d[2]), "+f"(d[3])
+        : "r"(a[0]), "r"(a[1]), "r"(b));
+#else
+    (void)d;
+    (void)a;
+    (void)b;
+#endif
+}
+
+template <int HeadsPerKv>
+__global__ __launch_bounds__(kMmaThreads) void qsa_mma_bf16_kernel(
+    const c10::BFloat16* __restrict__ query,
+    const c10::BFloat16* __restrict__ key,
+    const c10::BFloat16* __restrict__ value,
+    const int32_t* __restrict__ selected,
+    c10::BFloat16* __restrict__ output,
+    int batch,
+    int query_len,
+    int query_heads,
+    int kv_heads,
+    int kv_len,
+    int selected_len,
+    float softmax_scale) {
+    __shared__ __align__(16) uint16_t ks[kMmaKvTile][kMmaKsStride];
+    __shared__ __align__(16) uint16_t vt[kDim][kMmaVtStride];
+    __shared__ float scores[kMmaRows][kMmaKvTile];
+    __shared__ __align__(16) uint16_t probabilities[kMmaRows][kMmaVtStride];
+    __shared__ float row_max[kMmaRows];
+    __shared__ float row_sum[kMmaRows];
+    __shared__ float row_alpha[kMmaRows];
+    __shared__ int32_t token_ids[kMmaKvTile];
+
+    const int query_row = static_cast<int>(blockIdx.x);
+    const int kv_head = static_cast<int>(blockIdx.y);
+    const int batch_index = query_row / query_len;
+    const int query_index = query_row - batch_index * query_len;
+    if (batch_index >= batch || kv_head >= kv_heads) return;
+
+    const int tid = static_cast<int>(threadIdx.x);
+    const int warp = tid >> 5;
+    const int slice = warp;
+    const int lane = tid & (kWarpSize - 1);
+    const int gid = lane >> 2;
+    const int tig = lane & 3;
+    const int row0 = gid;
+    const int row1 = gid + 8;
+    const int first_head = kv_head * HeadsPerKv;
+    const int active_heads = min(HeadsPerKv, query_heads - first_head);
+    const int64_t query_row_base =
+        (static_cast<int64_t>(batch_index) * query_len + query_index) *
+        query_heads * kDim;
+    const int64_t kv_batch_stride =
+        static_cast<int64_t>(kv_heads) * kv_len * kDim;
+    const int64_t kv_head_base =
+        static_cast<int64_t>(batch_index) * kv_batch_stride +
+        static_cast<int64_t>(kv_head) * kv_len * kDim;
+    const int32_t* selected_row =
+        selected + (static_cast<int64_t>(batch_index) * query_len + query_index) *
+                       selected_len;
+
+    uint32_t query_fragment[kMmaSteps][2];
+#pragma unroll
+    for (int step = 0; step < kMmaSteps; ++step) {
+        const int dim = step * 8 + tig * 2;
+        float first0 = 0.0f;
+        float second0 = 0.0f;
+        float first1 = 0.0f;
+        float second1 = 0.0f;
+        if (row0 < active_heads) {
+            const int64_t at = query_row_base +
+                static_cast<int64_t>(first_head + row0) * kDim + dim;
+            first0 = static_cast<float>(query[at]);
+            second0 = static_cast<float>(query[at + 1]);
+        }
+        if (row1 < active_heads) {
+            const int64_t at = query_row_base +
+                static_cast<int64_t>(first_head + row1) * kDim + dim;
+            first1 = static_cast<float>(query[at]);
+            second1 = static_cast<float>(query[at + 1]);
+        }
+        query_fragment[step][0] = pack_half2(first0, second0);
+        query_fragment[step][1] = pack_half2(first1, second1);
+    }
+
+    float accumulator[8][4] = {};
+    if (tid < kMmaRows) {
+        row_max[tid] = -INFINITY;
+        row_sum[tid] = 0.0f;
+    }
+    __syncthreads();
+
+    for (int selected_base = 0; selected_base < selected_len;
+         selected_base += kMmaKvTile) {
+        const int count = min(kMmaKvTile, selected_len - selected_base);
+        if (tid < kMmaKvTile) {
+            token_ids[tid] = tid < count
+                ? selected_row[selected_base + tid]
+                : -1;
+        }
+        __syncthreads();
+
+        for (int idx = tid; idx < kMmaKvTile * kMmaSteps;
+             idx += kMmaThreads) {
+            const int slot = idx / kMmaSteps;
+            const int chunk = idx - slot * kMmaSteps;
+            const int token = token_ids[slot];
+            uint16_t key_half[8] = {};
+            uint16_t value_half[8] = {};
+            if (token >= 0 && token < kv_len) {
+                const int64_t at = kv_head_base +
+                    static_cast<int64_t>(token) * kDim + chunk * 8;
+#pragma unroll
+                for (int item = 0; item < 8; ++item) {
+                    key_half[item] =
+                        float_to_half_bits(static_cast<float>(key[at + item]));
+                    value_half[item] =
+                        float_to_half_bits(static_cast<float>(value[at + item]));
+                }
+            }
+            *reinterpret_cast<uint4*>(&ks[slot][chunk * 8]) =
+                *reinterpret_cast<const uint4*>(key_half);
+#pragma unroll
+            for (int item = 0; item < 8; ++item) {
+                vt[chunk * 8 + item][slot] = value_half[item];
+            }
+        }
+        __syncthreads();
+
+        float score_fragment[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+#pragma unroll
+        for (int step = 0; step < kMmaSteps; ++step) {
+            const uint32_t b = *reinterpret_cast<const uint32_t*>(
+                &ks[slice * 8 + gid][step * 8 + tig * 2]);
+            mma_m16n8k8_f16_f32(score_fragment, query_fragment[step], b);
+        }
+        const int score_col = slice * 8 + tig * 2;
+        scores[row0][score_col] = score_fragment[0];
+        scores[row0][score_col + 1] = score_fragment[1];
+        scores[row1][score_col] = score_fragment[2];
+        scores[row1][score_col + 1] = score_fragment[3];
+        __syncthreads();
+
+        if (tid < kMmaRows) {
+            const int head_slot = tid;
+            const float old_max = row_max[head_slot];
+            const float old_sum = row_sum[head_slot];
+            float tile_max = -INFINITY;
+            float scaled_scores[kMmaKvTile];
+#pragma unroll
+            for (int col = 0; col < kMmaKvTile; ++col) {
+                const float score = head_slot < active_heads &&
+                        token_ids[col] >= 0 && token_ids[col] < kv_len
+                    ? scores[head_slot][col] * softmax_scale
+                    : -INFINITY;
+                scaled_scores[col] = score;
+                tile_max = fmaxf(tile_max, score);
+            }
+            const float next_max = fmaxf(old_max, tile_max);
+            const float alpha = old_max == -INFINITY
+                ? 0.0f
+                : expf(old_max - next_max);
+            float tile_sum = 0.0f;
+#pragma unroll
+            for (int col = 0; col < kMmaKvTile; ++col) {
+                uint16_t bits = 0;
+                if (scaled_scores[col] != -INFINITY) {
+                    bits = float_to_half_bits(
+                        expf(scaled_scores[col] - next_max));
+                    tile_sum += half_bits_to_float(bits);
+                }
+                probabilities[head_slot][col] = bits;
+            }
+            row_alpha[head_slot] = alpha;
+            row_max[head_slot] = next_max;
+            row_sum[head_slot] = old_sum * alpha + tile_sum;
+        }
+        __syncthreads();
+
+        const float alpha0 = row_alpha[row0];
+        const float alpha1 = row_alpha[row1];
+#pragma unroll
+        for (int item = 0; item < 8; ++item) {
+            accumulator[item][0] *= alpha0;
+            accumulator[item][1] *= alpha0;
+            accumulator[item][2] *= alpha1;
+            accumulator[item][3] *= alpha1;
+        }
+#pragma unroll
+        for (int kt = 0; kt < kMmaKvTile / 8; ++kt) {
+            uint32_t a[2];
+            a[0] = *reinterpret_cast<const uint32_t*>(
+                &probabilities[row0][kt * 8 + tig * 2]);
+            a[1] = *reinterpret_cast<const uint32_t*>(
+                &probabilities[row1][kt * 8 + tig * 2]);
+#pragma unroll
+            for (int item = 0; item < 8; ++item) {
+                const uint32_t b = *reinterpret_cast<const uint32_t*>(
+                    &vt[slice * 64 + item * 8 + gid][kt * 8 + tig * 2]);
+                mma_m16n8k8_f16_f32(accumulator[item], a, b);
+            }
+        }
+        __syncthreads();
+    }
+
+    const float inverse0 = row0 < active_heads && row_sum[row0] > 0.0f
+        ? 1.0f / row_sum[row0]
+        : 0.0f;
+    const float inverse1 = row1 < active_heads && row_sum[row1] > 0.0f
+        ? 1.0f / row_sum[row1]
+        : 0.0f;
+#pragma unroll
+    for (int item = 0; item < 8; ++item) {
+        const int dim = slice * 64 + item * 8 + tig * 2;
+        if (row0 < active_heads) {
+            const int64_t at = query_row_base +
+                static_cast<int64_t>(first_head + row0) * kDim + dim;
+            output[at] = c10::BFloat16(accumulator[item][0] * inverse0);
+            output[at + 1] = c10::BFloat16(accumulator[item][1] * inverse0);
+        }
+        if (row1 < active_heads) {
+            const int64_t at = query_row_base +
+                static_cast<int64_t>(first_head + row1) * kDim + dim;
+            output[at] = c10::BFloat16(accumulator[item][2] * inverse1);
+            output[at + 1] = c10::BFloat16(accumulator[item][3] * inverse1);
+        }
+    }
+}
+
+template <int HeadsPerKv>
+__global__ void qsa_scalar_bf16_kernel(
+    const c10::BFloat16* __restrict__ query,
+    const c10::BFloat16* __restrict__ key,
+    const c10::BFloat16* __restrict__ value,
+    const int32_t* __restrict__ selected,
+    c10::BFloat16* __restrict__ output,
+    int batch,
+    int query_len,
+    int query_heads,
+    int kv_heads,
+    int kv_len,
+    int selected_len,
+    float softmax_scale) {
+    const int query_row = static_cast<int>(blockIdx.x);
+    const int kv_head = static_cast<int>(blockIdx.y);
+    const int batch_index = query_row / query_len;
+    const int query_index = query_row - batch_index * query_len;
+    if (batch_index >= batch || kv_head >= kv_heads) return;
+
+    const int lane = static_cast<int>(threadIdx.x) & (kWarpSize - 1);
+    const int head_slot = static_cast<int>(threadIdx.x) / kWarpSize;
+    const int query_head = kv_head * HeadsPerKv + head_slot;
+    if (head_slot >= HeadsPerKv || query_head >= query_heads) return;
+
+    constexpr unsigned kFullMask = 0xffffffffU;
+    const int64_t query_base =
+        ((static_cast<int64_t>(batch_index) * query_len + query_index) *
+             query_heads +
+         query_head) *
+        kDim;
+
+    float query_fragment[8];
+    float output_fragment[8];
+#pragma unroll
+    for (int item = 0; item < 8; ++item) {
+        const int dim = lane + item * kWarpSize;
+        query_fragment[item] = static_cast<float>(query[query_base + dim]);
+        output_fragment[item] = 0.0f;
+    }
+
+    const int32_t* selected_row =
+        selected + (static_cast<int64_t>(batch_index) * query_len + query_index) *
+                       selected_len;
+    const int64_t kv_batch_stride =
+        static_cast<int64_t>(kv_heads) * kv_len * kDim;
+    const int64_t kv_head_base =
+        static_cast<int64_t>(batch_index) * kv_batch_stride +
+        static_cast<int64_t>(kv_head) * kv_len * kDim;
+
+    float running_max = -INFINITY;
+    float running_sum = 0.0f;
+    for (int selected_index = 0; selected_index < selected_len;
+         ++selected_index) {
+        int token = lane == 0 ? selected_row[selected_index] : 0;
+        token = __shfl_sync(kFullMask, token, 0);
+        if (token < 0 || token >= kv_len) continue;
+
+        const int64_t token_base =
+            kv_head_base + static_cast<int64_t>(token) * kDim;
+        float sum = 0.0f;
+#pragma unroll
+        for (int item = 0; item < 8; ++item) {
+            const int dim = lane + item * kWarpSize;
+            sum = fmaf(
+                query_fragment[item],
+                static_cast<float>(key[token_base + dim]),
+                sum);
+        }
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            sum += __shfl_down_sync(kFullMask, sum, offset);
+        }
+
+        float alpha = 0.0f;
+        float weight = 0.0f;
+        if (lane == 0) {
+            const float score = sum * softmax_scale;
+            const float next_max = fmaxf(running_max, score);
+            alpha = running_max == -INFINITY
+                ? 0.0f
+                : expf(running_max - next_max);
+            weight = expf(score - next_max);
+            running_max = next_max;
+            running_sum = running_sum * alpha + weight;
+        }
+        alpha = __shfl_sync(kFullMask, alpha, 0);
+        weight = __shfl_sync(kFullMask, weight, 0);
+
+#pragma unroll
+        for (int item = 0; item < 8; ++item) {
+            const int dim = lane + item * kWarpSize;
+            const float value_item = static_cast<float>(value[token_base + dim]);
+            output_fragment[item] =
+                output_fragment[item] * alpha + value_item * weight;
+        }
+    }
+
+    float inverse = lane == 0 && running_sum > 0.0f
+        ? 1.0f / running_sum
+        : 0.0f;
+    inverse = __shfl_sync(kFullMask, inverse, 0);
+#pragma unroll
+    for (int item = 0; item < 8; ++item) {
+        const int dim = lane + item * kWarpSize;
+        output[query_base + dim] =
+            c10::BFloat16(output_fragment[item] * inverse);
+    }
+}
+
+template <int HeadsPerKv>
+void launch_qsa(
+    const c10::BFloat16* query,
+    const c10::BFloat16* key,
+    const c10::BFloat16* value,
+    const int32_t* selected,
+    c10::BFloat16* output,
+    int batch,
+    int query_len,
+    int query_heads,
+    int kv_heads,
+    int kv_len,
+    int selected_len,
+    float softmax_scale,
+    bool use_mma,
+    cudaStream_t stream) {
+    static_assert(HeadsPerKv >= 1 && HeadsPerKv <= kMaxHeadsPerKv);
+    const dim3 grid(batch * query_len, kv_heads);
+    if (use_mma) {
+        qsa_mma_bf16_kernel<HeadsPerKv>
+            <<<grid, kMmaThreads, 0, stream>>>(
+                query,
+                key,
+                value,
+                selected,
+                output,
+                batch,
+                query_len,
+                query_heads,
+                kv_heads,
+                kv_len,
+                selected_len,
+                softmax_scale);
+        return;
+    }
+    qsa_scalar_bf16_kernel<HeadsPerKv>
+        <<<grid, HeadsPerKv * kWarpSize, 0, stream>>>(
+            query,
+            key,
+            value,
+            selected,
+            output,
+            batch,
+            query_len,
+            query_heads,
+            kv_heads,
+            kv_len,
+            selected_len,
+            softmax_scale);
+}
+
+}  // namespace
+
+torch::Tensor qwen4_exp_qsa_bf16_forward_cuda(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& value,
+    const torch::Tensor& selected,
+    double softmax_scale) {
+    c10::cuda::CUDAGuard device_guard(query.device());
+    const int batch = static_cast<int>(query.size(0));
+    const int query_len = static_cast<int>(query.size(1));
+    const int query_heads = static_cast<int>(query.size(2));
+    const int kv_heads = static_cast<int>(key.size(1));
+    const int kv_len = static_cast<int>(key.size(2));
+    const int selected_len = static_cast<int>(selected.size(2));
+    const int heads_per_kv = query_heads / kv_heads;
+    const char* mma_env = std::getenv("DSV4_QWEN4_QSA_MMA");
+    const bool use_mma = selected_len >= kMmaKvTile && mma_env != nullptr &&
+        std::strcmp(mma_env, "0") != 0;
+    auto output = torch::empty(query.sizes(), query.options());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+#define QWEN4_EXP_LAUNCH_QSA(HEADS)                                       \
+    launch_qsa<HEADS>(                                                     \
+        query.data_ptr<c10::BFloat16>(),                                   \
+        key.data_ptr<c10::BFloat16>(),                                     \
+        value.data_ptr<c10::BFloat16>(),                                   \
+        selected.data_ptr<int32_t>(),                                      \
+        output.data_ptr<c10::BFloat16>(),                                  \
+        batch,                                                             \
+        query_len,                                                         \
+        query_heads,                                                       \
+        kv_heads,                                                          \
+        kv_len,                                                            \
+        selected_len,                                                      \
+        static_cast<float>(softmax_scale),                                 \
+        use_mma,                                                           \
+        stream)
+    switch (heads_per_kv) {
+        case 1: QWEN4_EXP_LAUNCH_QSA(1); break;
+        case 2: QWEN4_EXP_LAUNCH_QSA(2); break;
+        case 3: QWEN4_EXP_LAUNCH_QSA(3); break;
+        case 4: QWEN4_EXP_LAUNCH_QSA(4); break;
+        case 5: QWEN4_EXP_LAUNCH_QSA(5); break;
+        case 6: QWEN4_EXP_LAUNCH_QSA(6); break;
+        case 7: QWEN4_EXP_LAUNCH_QSA(7); break;
+        case 8: QWEN4_EXP_LAUNCH_QSA(8); break;
+        case 9: QWEN4_EXP_LAUNCH_QSA(9); break;
+        case 10: QWEN4_EXP_LAUNCH_QSA(10); break;
+        case 11: QWEN4_EXP_LAUNCH_QSA(11); break;
+        case 12: QWEN4_EXP_LAUNCH_QSA(12); break;
+    }
+#undef QWEN4_EXP_LAUNCH_QSA
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return output;
+}

--- a/src/models/qwen4_exp/attention.py
+++ b/src/models/qwen4_exp/attention.py
@@ -8,12 +8,19 @@ a regular KV cache plus the indexer's raw pre-pool key cache.
 from __future__ import annotations
 
 import math
+import os
 
 import torch
 import torch.nn.functional as F
 
+from src.kernels.cuda_loader import load_cuda_kernel
 from src.models.qwen4_exp.config import Qwen4ExpTextConfig
-from src.models.qwen4_exp.layers import RMSNorm, RMSNormGated, apply_rotary_pos_emb
+from src.models.qwen4_exp.layers import (
+    RMSNorm,
+    RMSNormGated,
+    apply_rotary_pos_emb,
+    prefill_linear,
+)
 
 
 def l2norm(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
@@ -71,6 +78,107 @@ def recurrent_gated_delta_rule(
         out[:, :, i] = (state * q_t.unsqueeze(-1)).sum(dim=-2)
 
     return out.transpose(1, 2).contiguous().to(initial_dtype), state
+
+
+def cuda_gated_delta_rule(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """SM75 recurrent scan for the real BF16, D=128, batch-one path.
+
+    The kernel retains the float32 recurrent state and pre-normalizes Q/K in
+    float32, but shards each 128x128 state across sub-warps so a long prefill is
+    one CUDA launch rather than Python-controlled chunk algebra. Unsupported
+    shapes return ``None`` and leave the established PyTorch path untouched.
+    """
+    if (
+        query.device.type != "cuda"
+        or query.dtype is not torch.bfloat16
+        or query.shape[0] != 1
+        or query.shape[-1] != 128
+        or key.shape != query.shape
+        or value.shape[0] != 1
+        or value.shape[1] != query.shape[1]
+        or value.shape[-1] != 128
+        or value.shape[2] % query.shape[2] != 0
+        or beta.dtype is not torch.bfloat16
+        or g.dtype is not torch.float32
+    ):
+        return None
+
+    ext = load_cuda_kernel()
+    if ext is None or not hasattr(ext, "qwen4_exp_gated_delta_bf16_forward"):
+        return None
+
+    if initial_state is None:
+        initial_state = torch.zeros(
+            query.shape[0],
+            value.shape[2],
+            query.shape[-1],
+            value.shape[-1],
+            device=query.device,
+            dtype=torch.float32,
+        )
+    groups_per_block = int(os.environ.get("DSV4_QWEN4_GDN_GROUPS_PER_CTA", "1"))
+    if groups_per_block not in (1, 2, 4, 8):
+        groups_per_block = 1
+    output, state = ext.qwen4_exp_gated_delta_bf16_forward(
+        query.contiguous(),
+        key.contiguous(),
+        value.contiguous(),
+        g.contiguous(),
+        beta.contiguous(),
+        initial_state.contiguous(),
+        1e-6,
+        groups_per_block,
+    )
+    return output, state
+
+
+def cuda_qsa_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    selected_indices: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor | None:
+    """Indexed BF16 GQA attention for the real TP4 sparse-attention shape."""
+    enabled = os.environ.get("DSV4_QWEN4_QSA_CUDA", "1").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    if (
+        not enabled
+        or query.device.type != "cuda"
+        or query.dtype is not torch.bfloat16
+        or key.dtype is not torch.bfloat16
+        or value.dtype is not torch.bfloat16
+        or query.shape[0] != 1
+        or query.shape[-1] != 256
+        or key.shape != value.shape
+        or key.shape[0] != query.shape[0]
+        or key.shape[-1] != query.shape[-1]
+        or query.shape[1] % key.shape[1] != 0
+        or query.shape[1] // key.shape[1] > 12
+        or selected_indices.shape[:2] != (query.shape[0], query.shape[2])
+    ):
+        return None
+
+    ext = load_cuda_kernel()
+    if ext is None or not hasattr(ext, "qwen4_exp_qsa_bf16_forward"):
+        return None
+    return ext.qwen4_exp_qsa_bf16_forward(
+        query.transpose(1, 2).contiguous(),
+        key.contiguous(),
+        value.contiguous(),
+        selected_indices.contiguous().to(torch.int32),
+        float(softmax_scale),
+    )
 
 
 def chunk_gated_delta_rule(
@@ -231,14 +339,31 @@ class GatedDeltaNet:
         self.norm = RMSNormGated(
             weights["norm"], config.rms_norm_eps, activation=config.output_gate_type or config.hidden_act
         )
+        self.cuda_rule_enabled = os.environ.get(
+            "DSV4_QWEN4_GDN_CUDA", "1"
+        ).lower() in {"1", "true", "yes"}
+        self.last_profile: dict[str, float] = {}
 
     def __call__(self, hidden_states: torch.Tensor, cache: GatedDeltaNetCache | None) -> torch.Tensor:
         batch_size, seq_len, _ = hidden_states.shape
+        profile = os.environ.get("DSV4_QWEN4_ATTN_PHASE_PROFILE", "0").lower() in {
+            "1",
+            "true",
+            "yes",
+        }
+        if profile:
+            import time
 
-        mixed_qkv = F.linear(hidden_states, self.in_proj_qkv).transpose(1, 2)  # (b, conv_dim, seq)
-        z = F.linear(hidden_states, self.in_proj_z).reshape(batch_size, seq_len, -1, self.head_v_dim)
-        b = F.linear(hidden_states, self.in_proj_b)
-        a = F.linear(hidden_states, self.in_proj_a)
+            torch.cuda.synchronize(hidden_states.device)
+            started = time.perf_counter()
+
+        mixed_qkv = prefill_linear(hidden_states, self.in_proj_qkv).transpose(1, 2)  # (b, conv_dim, seq)
+        z = prefill_linear(hidden_states, self.in_proj_z).reshape(batch_size, seq_len, -1, self.head_v_dim)
+        b = prefill_linear(hidden_states, self.in_proj_b)
+        a = prefill_linear(hidden_states, self.in_proj_a)
+        if profile:
+            torch.cuda.synchronize(hidden_states.device)
+            after_projection = time.perf_counter()
 
         conv_weight = self.conv1d_weight.squeeze(1)
         channels = conv_weight.shape[0]
@@ -252,6 +377,9 @@ class GatedDeltaNet:
             conv_in = F.pad(mixed_qkv, (self.conv_kernel_size - 1, 0))
         conv_out = F.conv1d(conv_in, conv_weight.unsqueeze(1), None, padding=0, groups=channels)
         mixed_qkv = F.silu(conv_out[:, :, -seq_len:])
+        if profile:
+            torch.cuda.synchronize(hidden_states.device)
+            after_conv = time.perf_counter()
 
         mixed_qkv = mixed_qkv.transpose(1, 2)
         query, key, value = torch.split(
@@ -265,14 +393,24 @@ class GatedDeltaNet:
         # float32 on A_log: in bf16 exp() of a large magnitude saturates to inf.
         g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias.float())
 
-        repeat = self.num_v_heads // self.num_k_heads
-        if repeat > 1:
-            query = query.repeat_interleave(repeat, dim=2)
-            key = key.repeat_interleave(repeat, dim=2)
-
         initial_state = cache.recurrent_state if (cache is not None and cache.initialized) else None
-        rule = recurrent_gated_delta_rule if seq_len == 1 else chunk_gated_delta_rule
-        core_attn_out, last_state = rule(query, key, value, g, beta, initial_state)
+        cuda_result = (
+            cuda_gated_delta_rule(query, key, value, g, beta, initial_state)
+            if self.cuda_rule_enabled and seq_len > 1
+            else None
+        )
+        if cuda_result is None:
+            repeat = self.num_v_heads // self.num_k_heads
+            if repeat > 1:
+                query = query.repeat_interleave(repeat, dim=2)
+                key = key.repeat_interleave(repeat, dim=2)
+            rule = recurrent_gated_delta_rule if seq_len == 1 else chunk_gated_delta_rule
+            core_attn_out, last_state = rule(query, key, value, g, beta, initial_state)
+        else:
+            core_attn_out, last_state = cuda_result
+        if profile:
+            torch.cuda.synchronize(hidden_states.device)
+            after_core = time.perf_counter()
         if cache is not None:
             cache.recurrent_state = last_state
             cache.initialized = True
@@ -280,7 +418,17 @@ class GatedDeltaNet:
         core_attn_out = self.norm(
             core_attn_out.reshape(-1, self.head_v_dim), z.reshape(-1, self.head_v_dim)
         ).reshape(batch_size, seq_len, -1)
-        return F.linear(core_attn_out, self.out_proj)
+        output = prefill_linear(core_attn_out, self.out_proj)
+        if profile:
+            torch.cuda.synchronize(hidden_states.device)
+            finished = time.perf_counter()
+            self.last_profile = {
+                "projection": after_projection - started,
+                "conv": after_conv - after_projection,
+                "core": after_core - after_conv,
+                "output": finished - after_core,
+            }
+        return output
 
 
 # ---------------------------------------------------------------------------
@@ -340,9 +488,9 @@ class QSAIndexer:
         past_len: int,
         raw_keys_override: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        """Returns a bool mask (batch, 1, seq, kv_len): True where a token is selected."""
+        """Return padded selected token indices with ``-1`` marking invalid slots."""
         batch_size, seq_len, _ = hidden_states.shape
-        qk = F.linear(hidden_states, self.qk_proj)
+        qk = prefill_linear(hidden_states, self.qk_proj)
         q, token_k = torch.split(
             qk, [self.n_heads * self.head_dim, self.kv_heads * self.head_dim], dim=-1
         )
@@ -362,8 +510,29 @@ class QSAIndexer:
         # Every query at absolute position p sees keys [0, p]; block boundaries
         # are therefore query-dependent only through how many keys are visible.
         num_blocks_total = kv_len // self.compress_ratio
+        if kv_len <= self.budget:
+            selected_width = kv_len
+            key_ids = torch.arange(kv_len, device=hidden_states.device)
+            visible_keys = past_len + torch.arange(seq_len, device=hidden_states.device) + 1
+            indices = key_ids.view(1, 1, -1).expand(batch_size, seq_len, -1)
+            return indices.masked_fill(
+                key_ids.view(1, 1, -1) >= visible_keys.view(1, -1, 1), -1
+            ).to(torch.int32)
+
+        selected_width = min(
+            kv_len,
+            self.budget + self.compress_ratio - 1,
+        )
         if num_blocks_total == 0:
-            return torch.ones(batch_size, 1, seq_len, kv_len, dtype=torch.bool, device=hidden_states.device)
+            key_ids = torch.arange(kv_len, device=hidden_states.device)
+            visible_keys = past_len + torch.arange(seq_len, device=hidden_states.device) + 1
+            indices = key_ids.view(1, 1, -1).expand(batch_size, seq_len, -1)
+            indices = indices.masked_fill(
+                key_ids.view(1, 1, -1) >= visible_keys.view(1, -1, 1), -1
+            )
+            if kv_len < selected_width:
+                indices = F.pad(indices, (0, selected_width - kv_len), value=-1)
+            return indices[:, :, :selected_width].to(torch.int32)
 
         # Pool + RoPE all complete blocks once (shared across queries).
         block_tokens = torch.arange(
@@ -397,19 +566,32 @@ class QSAIndexer:
         # -inf rows mean "fewer visible blocks than topk"; drop those picks.
         selected_valid = torch.gather(block_ok.unsqueeze(0).expand(batch_size, -1, -1), 2, selected_blocks)
 
-        mask = torch.zeros(batch_size, seq_len, kv_len, dtype=torch.bool, device=hidden_states.device)
         block_expand = block_tokens[selected_blocks]  # (batch, seq, topk, compress_ratio)
         valid_expand = selected_valid.unsqueeze(-1).expand_as(block_expand)
-        flat_idx = block_expand.reshape(batch_size, seq_len, -1)
-        flat_valid = valid_expand.reshape(batch_size, seq_len, -1)
-        mask.scatter_(2, flat_idx, flat_valid)
+        selected_tokens = block_expand.reshape(batch_size, seq_len, -1)
+        selected_tokens = selected_tokens.masked_fill(
+            ~valid_expand.reshape(batch_size, seq_len, -1), -1
+        )
 
-        # The tail past the last complete visible block is always attendable.
-        key_ids = torch.arange(kv_len, device=hidden_states.device)
-        tail_start = (blocks_visible * self.compress_ratio).view(-1, 1)
-        tail = (key_ids.view(1, -1) >= tail_start) & (key_ids.view(1, -1) < visible_keys.view(-1, 1))
-        mask |= tail.unsqueeze(0)
-        return mask.unsqueeze(1)
+        # Append every possible partial-block tail slot. Invalid positions stay -1,
+        # which keeps the output rectangular without constructing a dense mask.
+        tail_offsets = torch.arange(
+            self.compress_ratio - 1, device=hidden_states.device
+        ).view(1, 1, -1)
+        tail_start = (blocks_visible * self.compress_ratio).view(1, seq_len, 1)
+        tail_tokens = tail_start + tail_offsets
+        tail_valid = tail_tokens < visible_keys.view(1, seq_len, 1)
+        tail_tokens = tail_tokens.expand(batch_size, -1, -1).masked_fill(
+            ~tail_valid.expand(batch_size, -1, -1), -1
+        )
+        selected_tokens = torch.cat([selected_tokens, tail_tokens], dim=-1)
+        if selected_tokens.shape[-1] < selected_width:
+            selected_tokens = F.pad(
+                selected_tokens,
+                (0, selected_width - selected_tokens.shape[-1]),
+                value=-1,
+            )
+        return selected_tokens[:, :, :selected_width].to(torch.int32)
 
 
 class QSAAttention:
@@ -435,6 +617,7 @@ class QSAAttention:
         self.q_norm = RMSNorm(weights["q_norm"], config.rms_norm_eps)
         self.k_norm = RMSNorm(weights["k_norm"], config.rms_norm_eps)
         self.indexer = QSAIndexer(config, weights, n_heads=indexer_heads)
+        self.last_profile: dict[str, float] = {}
 
     def __call__(
         self,
@@ -446,16 +629,29 @@ class QSAAttention:
         past_len: int,
     ) -> torch.Tensor:
         batch_size, seq_len, _ = hidden_states.shape
-        selected = self.indexer(hidden_states, cos, sin, cache, past_len=past_len)
+        profile = os.environ.get("DSV4_QWEN4_ATTN_PHASE_PROFILE", "0").lower() in {
+            "1",
+            "true",
+            "yes",
+        }
+        if profile:
+            import time
 
-        qg = F.linear(hidden_states, self.q_proj).view(batch_size, seq_len, -1, self.head_dim * 2)
+            torch.cuda.synchronize(hidden_states.device)
+            started = time.perf_counter()
+        selected = self.indexer(hidden_states, cos, sin, cache, past_len=past_len)
+        if profile:
+            torch.cuda.synchronize(hidden_states.device)
+            after_indexer = time.perf_counter()
+
+        qg = prefill_linear(hidden_states, self.q_proj).view(batch_size, seq_len, -1, self.head_dim * 2)
         query, gate = torch.chunk(qg, 2, dim=-1)
         gate = gate.reshape(batch_size, seq_len, -1)
         query = self.q_norm(query).transpose(1, 2)
         key = self.k_norm(
-            F.linear(hidden_states, self.k_proj).view(batch_size, seq_len, -1, self.head_dim)
+            prefill_linear(hidden_states, self.k_proj).view(batch_size, seq_len, -1, self.head_dim)
         ).transpose(1, 2)
-        value = F.linear(hidden_states, self.v_proj).view(batch_size, seq_len, -1, self.head_dim).transpose(1, 2)
+        value = prefill_linear(hidden_states, self.v_proj).view(batch_size, seq_len, -1, self.head_dim).transpose(1, 2)
 
         cur_cos, cur_sin = cos[:, -seq_len:], sin[:, -seq_len:]
         query, key = apply_rotary_pos_emb(query, cur_cos, cur_sin, k=key, unsqueeze_dim=1)
@@ -466,18 +662,76 @@ class QSAAttention:
             cache.length = past_len + seq_len
             key = cache.k[:, :, : cache.length]
             value = cache.v[:, :, : cache.length]
+        if profile:
+            torch.cuda.synchronize(hidden_states.device)
+            after_projection = time.perf_counter()
 
-        kv_len = key.shape[2]
-        query_abs = past_len + torch.arange(seq_len, device=hidden_states.device)
-        causal = torch.arange(kv_len, device=hidden_states.device).view(1, -1) <= query_abs.view(-1, 1)
-        allow = causal.view(1, 1, seq_len, kv_len) & selected
-
-        key = key.repeat_interleave(self.num_kv_groups, dim=1)
-        value = value.repeat_interleave(self.num_kv_groups, dim=1)
-        attn_weights = torch.matmul(query, key.transpose(2, 3)) * self.scaling
-        attn_weights = attn_weights.masked_fill(~allow, torch.finfo(attn_weights.dtype).min)
-        attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
-        attn_out = torch.matmul(attn_weights, value).transpose(1, 2).reshape(batch_size, seq_len, -1)
+        indexed_out = cuda_qsa_attention(
+            query, key, value, selected, self.scaling
+        )
+        if indexed_out is None:
+            # Bound fallback workspace by query rows and keep the KV-head axis
+            # explicit. Repeating gathered K/V across every query head allocates
+            # several GiB even at 2K and can OOM before the optional extension is
+            # available.
+            query_rows = max(
+                1,
+                int(os.environ.get("DSV4_QWEN4_QSA_FALLBACK_ROWS", "16")),
+            )
+            key_tokens = key.transpose(1, 2)
+            value_tokens = value.transpose(1, 2)
+            chunks = []
+            for begin in range(0, seq_len, query_rows):
+                end = min(seq_len, begin + query_rows)
+                selected_chunk = selected[:, begin:end]
+                safe_selected = selected_chunk.clamp_min(0).to(torch.long)
+                batch_index = torch.arange(
+                    batch_size, device=hidden_states.device
+                ).view(batch_size, 1, 1).expand_as(safe_selected)
+                gathered_key = key_tokens[batch_index, safe_selected]
+                gathered_value = value_tokens[batch_index, safe_selected]
+                query_chunk = query.transpose(1, 2)[:, begin:end]
+                query_chunk = query_chunk.unflatten(
+                    2,
+                    (self.num_kv_heads, self.num_kv_groups),
+                )
+                scores = torch.einsum(
+                    "bqkgd,bqskd->bqkgs",
+                    query_chunk,
+                    gathered_key,
+                ) * self.scaling
+                scores = scores.masked_fill(
+                    (selected_chunk < 0).unsqueeze(2).unsqueeze(2),
+                    torch.finfo(scores.dtype).min,
+                )
+                probabilities = F.softmax(
+                    scores,
+                    dim=-1,
+                    dtype=torch.float32,
+                ).to(query.dtype)
+                chunk = torch.einsum(
+                    "bqkgs,bqskd->bqkgd",
+                    probabilities,
+                    gathered_value,
+                )
+                chunks.append(
+                    chunk.flatten(2, 3)
+                )
+            indexed_out = torch.cat(chunks, dim=1)
+        attn_out = indexed_out.reshape(batch_size, seq_len, -1)
+        if profile:
+            torch.cuda.synchronize(hidden_states.device)
+            after_core = time.perf_counter()
 
         attn_out = attn_out * torch.sigmoid(gate)
-        return F.linear(attn_out, self.o_proj)
+        output = prefill_linear(attn_out, self.o_proj)
+        if profile:
+            torch.cuda.synchronize(hidden_states.device)
+            finished = time.perf_counter()
+            self.last_profile = {
+                "indexer": after_indexer - started,
+                "projection": after_projection - after_indexer,
+                "core": after_core - after_projection,
+                "output": finished - after_core,
+            }
+        return output

--- a/src/models/qwen4_exp/layers.py
+++ b/src/models/qwen4_exp/layers.py
@@ -9,16 +9,165 @@ goldens captured from it.  Nothing here is TP-aware; sharding happens in
 from __future__ import annotations
 
 import math
+import os
 
 import torch
 import torch.nn.functional as F
 
+from src.kernels.cuda_loader import load_cuda_kernel
 from src.models.qwen4_exp.config import Qwen4ExpTextConfig
 
 
 # ---------------------------------------------------------------------------
 # Norms
 # ---------------------------------------------------------------------------
+
+
+def _env_enabled(name: str, default: str = "0") -> bool:
+    return os.environ.get(name, default).lower() in {"1", "true", "yes"}
+
+
+def _dense_fp16_enabled(rows: int) -> bool:
+    min_rows = max(
+        1,
+        int(os.environ.get("DSV4_QWEN4_DENSE_FP16_MIN_ROWS", "128")),
+    )
+    return _env_enabled("DSV4_QWEN4_DENSE_FP16", "0") and rows >= min_rows
+
+
+def _dense_fp16_fp32_output_enabled(rows: int) -> bool:
+    min_rows = max(
+        1,
+        int(os.environ.get("DSV4_QWEN4_DENSE_FP16_MIN_ROWS", "128")),
+    )
+    return (
+        _env_enabled("DSV4_QWEN4_DENSE_FP16_FP32_OUTPUT", "0")
+        and rows >= min_rows
+    )
+
+
+def _fp16_fp32_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    flat = x.reshape(-1, x.shape[-1]).to(torch.float16)
+    output = torch.mm(
+        flat,
+        weight.to(torch.float16).t(),
+        out_dtype=torch.float32,
+    )
+    return output.to(torch.bfloat16).reshape(
+        *x.shape[:-1],
+        weight.shape[0],
+    )
+
+
+def prefill_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    """Use optional SM75 tensor-core GEMM for large BF16 projections."""
+    rows = x.numel() // x.shape[-1]
+    supported = (
+        x.device.type == "cuda"
+        and x.dtype is torch.bfloat16
+        and weight.device == x.device
+        and weight.dtype is torch.bfloat16
+    )
+    if supported and _dense_fp16_fp32_output_enabled(rows):
+        return _fp16_fp32_linear(x, weight)
+    if supported and _dense_fp16_enabled(rows):
+        return F.linear(
+            x.to(torch.float16),
+            weight.to(torch.float16),
+        ).to(torch.bfloat16)
+    return F.linear(x, weight)
+
+
+def _hc_fp16_components(rows: int) -> tuple[bool, bool, bool]:
+    min_rows = max(
+        1,
+        int(os.environ.get("DSV4_QWEN4_HC_FP16_MIN_ROWS", "128")),
+    )
+    if rows < min_rows:
+        return False, False, False
+    all_enabled = _env_enabled("DSV4_QWEN4_HC_FP16", "0")
+    return (
+        all_enabled or _env_enabled("DSV4_QWEN4_HC_FP16_MIX_DOWN", "0"),
+        all_enabled or _env_enabled("DSV4_QWEN4_HC_FP16_MIX_UP", "0"),
+        all_enabled or _env_enabled("DSV4_QWEN4_HC_FP16_INJECT", "0"),
+    )
+
+
+def _hc_fp16_enabled(rows: int) -> bool:
+    return any(_hc_fp16_components(rows))
+
+
+def _hc_fp16_fp32_output_enabled(rows: int) -> bool:
+    return (
+        _hc_fp16_enabled(rows)
+        and _env_enabled("DSV4_QWEN4_HC_FP16_FP32_OUTPUT", "0")
+    )
+
+
+def _hc_cuda_enabled(rows: int) -> bool:
+    min_rows = max(
+        1,
+        int(os.environ.get("DSV4_QWEN4_HC_CUDA_MIN_ROWS", "128")),
+    )
+    return (
+        _env_enabled("DSV4_QWEN4_HC_CUDA", "0")
+        and rows >= min_rows
+    ) or _hc_fp16_enabled(rows)
+
+
+def _cuda_hc_activation(
+    name: str,
+    x: torch.Tensor,
+    groups: int,
+) -> torch.Tensor | None:
+    """Fuse an HC scale-then-activation pair without changing its rounding.
+
+    The reference path divides a BF16 GEMM result by `hc_count` and then applies
+    the activation in BF16.  Both kernels keep the divide and the activation in
+    float32 and round once on store, which is bit-identical to the reference on
+    every value measured so far, so this stays on the exact path.
+    """
+    if (
+        not _hc_cuda_enabled(x.numel() // x.shape[-1])
+        or x.device.type != "cuda"
+        or x.dtype is not torch.bfloat16
+        or not x.is_contiguous()
+    ):
+        return None
+    ext = load_cuda_kernel()
+    if ext is None or not hasattr(ext, name):
+        return None
+    return getattr(ext, name)(x, groups)
+
+
+def _cuda_grouped_rms_norm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    group_size: int,
+    eps: float,
+) -> torch.Tensor | None:
+    if (
+        not _hc_cuda_enabled(x.numel() // x.shape[-1])
+        or x.device.type != "cuda"
+        or not x.is_contiguous()
+        or not weight.is_contiguous()
+        or x.dtype not in (torch.float16, torch.bfloat16, torch.float32)
+        or weight.dtype is not x.dtype
+        or weight.device != x.device
+        or x.shape[-1] != weight.numel()
+        or x.shape[-1] % group_size != 0
+    ):
+        return None
+    ext = load_cuda_kernel()
+    if ext is None or not hasattr(ext, "qwen4_exp_grouped_rms_norm"):
+        return None
+    return ext.qwen4_exp_grouped_rms_norm(x, weight, group_size, eps)
 
 
 class RMSNorm:
@@ -35,6 +184,15 @@ class RMSNorm:
         self.group_size = group_size
 
     def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        if self.group_size is not None:
+            output = _cuda_grouped_rms_norm(
+                x,
+                self.weight,
+                self.group_size,
+                self.eps,
+            )
+            if output is not None:
+                return output
         in_dtype = x.dtype
         h = x.to(torch.float32)
         if self.group_size is not None:
@@ -167,13 +325,108 @@ class GatedResidual:
 
     def __call__(self, hyper_input: torch.Tensor):
         normed = self.hc_norm(hyper_input)
-        w = F.silu(F.linear(normed, self.mix_down) / self.hc_count)
-        w = torch.sigmoid(F.linear(w, self.mix_up))
+        rows = hyper_input.numel() // hyper_input.shape[-1]
+        fp16_down, fp16_up, fp16_inject = _hc_fp16_components(rows)
+        fp16_supported = (
+            normed.device.type == "cuda"
+            and normed.dtype is torch.bfloat16
+            and self.mix_down.dtype is torch.bfloat16
+            and self.mix_up.dtype is torch.bfloat16
+            and (
+                self.block_inject is None
+                or self.block_inject.dtype is torch.bfloat16
+            )
+        )
+        if not fp16_supported:
+            fp16_down = fp16_up = fp16_inject = False
+
+        fp32_output = (
+            fp16_supported and _hc_fp16_fp32_output_enabled(rows)
+        )
+        compute_input_fp16 = (
+            normed.to(torch.float16)
+            if (fp16_down or fp16_inject) and not fp32_output
+            else None
+        )
+        if fp16_down:
+            if fp32_output:
+                down = F.silu(
+                    _fp16_fp32_linear(normed, self.mix_down)
+                    / self.hc_count
+                )
+            else:
+                assert compute_input_fp16 is not None
+                down = F.silu(
+                    F.linear(
+                        compute_input_fp16,
+                        self.mix_down.to(torch.float16),
+                    )
+                    / self.hc_count
+                )
+        else:
+            raw_down = F.linear(normed, self.mix_down)
+            down = _cuda_hc_activation(
+                "qwen4_exp_hc_silu",
+                raw_down,
+                self.hc_count,
+            )
+            if down is None:
+                down = F.silu(raw_down / self.hc_count)
+
+        if fp16_up:
+            if fp32_output:
+                w = torch.sigmoid(
+                    _fp16_fp32_linear(
+                        down.to(normed.dtype),
+                        self.mix_up,
+                    )
+                )
+            else:
+                up_input = (
+                    down
+                    if down.dtype is torch.float16
+                    else down.to(torch.float16)
+                )
+                w = torch.sigmoid(
+                    F.linear(up_input, self.mix_up.to(torch.float16))
+                ).to(normed.dtype)
+        else:
+            up_input = (
+                down
+                if down.dtype is normed.dtype
+                else down.to(normed.dtype)
+            )
+            w = torch.sigmoid(F.linear(up_input, self.mix_up))
+
         w = w.unflatten(-1, (self.hc_count, self.hidden_size))
         mixed = (w * normed.unflatten(-1, (self.hc_count, self.hidden_size))).mean(dim=-2)
         if self.block_inject is None:
             return mixed
-        inject = 2 * torch.sigmoid(F.linear(normed, self.block_inject) / self.hc_count)
+        if fp16_inject:
+            if fp32_output:
+                inject = 2 * torch.sigmoid(
+                    _fp16_fp32_linear(normed, self.block_inject)
+                    / self.hc_count
+                )
+            else:
+                assert compute_input_fp16 is not None
+                inject = 2 * torch.sigmoid(
+                    F.linear(
+                        compute_input_fp16,
+                        self.block_inject.to(torch.float16),
+                    )
+                    / self.hc_count
+                )
+                inject = inject.to(normed.dtype)
+        else:
+            raw_inject = F.linear(normed, self.block_inject)
+            inject = _cuda_hc_activation(
+                "qwen4_exp_hc_inject_gate",
+                raw_inject,
+                self.hc_count,
+            )
+            if inject is None:
+                inject = 2 * torch.sigmoid(raw_inject / self.hc_count)
         return mixed, hyper_input, inject
 
 
@@ -181,6 +434,31 @@ def inject_into_streams(
     block_output: torch.Tensor, hyper_input: torch.Tensor, injection_weights: torch.Tensor
 ) -> torch.Tensor:
     """Scatter a block's output back into all hyper-connection streams."""
+    groups = injection_weights.shape[-1]
+    if (
+        _hc_cuda_enabled(
+            block_output.numel() // block_output.shape[-1]
+        )
+        and block_output.device.type == "cuda"
+        and block_output.is_contiguous()
+        and hyper_input.is_contiguous()
+        and injection_weights.is_contiguous()
+        and block_output.dtype in (torch.float16, torch.bfloat16, torch.float32)
+        and hyper_input.dtype is block_output.dtype
+        and injection_weights.dtype is block_output.dtype
+        and block_output.device == hyper_input.device == injection_weights.device
+        and hyper_input.shape[:-1] == block_output.shape[:-1]
+        and injection_weights.shape[:-1] == block_output.shape[:-1]
+        and hyper_input.shape[-1] == groups * block_output.shape[-1]
+    ):
+        ext = load_cuda_kernel()
+        if ext is not None and hasattr(ext, "qwen4_exp_inject"):
+            return ext.qwen4_exp_inject(
+                block_output,
+                hyper_input,
+                injection_weights,
+                groups,
+            )
     injection = block_output.unsqueeze(-2) * injection_weights.unsqueeze(-1)
     return hyper_input + injection.flatten(-2)
 
@@ -308,7 +586,10 @@ class DenseMLP:
         self.down_proj = down_proj
 
     def __call__(self, x: torch.Tensor) -> torch.Tensor:
-        return F.linear(F.silu(F.linear(x, self.gate_proj)) * F.linear(x, self.up_proj), self.down_proj)
+        hidden = F.silu(
+            prefill_linear(x, self.gate_proj)
+        ) * prefill_linear(x, self.up_proj)
+        return prefill_linear(hidden, self.down_proj)
 
 
 def swiglu_expert(

--- a/src/models/qwen4_exp/model.py
+++ b/src/models/qwen4_exp/model.py
@@ -29,6 +29,7 @@ from src.models.qwen4_exp.layers import (
     RMSNorm,
     TopKRouter,
     inject_into_streams,
+    prefill_linear,
 )
 from src.models.qwen4_exp.moe import MoEBackend
 
@@ -119,10 +120,10 @@ class PLELayer:
     ) -> torch.Tensor:
         row_ids = self.hasher.row_ids(token_history, out_len)
         embeddings = self.ngram_table(row_ids).flatten(-2).to(hidden_states.dtype)
-        key_normed = self.norm_key(F.linear(embeddings, self.key_proj)).unflatten(
+        key_normed = self.norm_key(prefill_linear(embeddings, self.key_proj)).unflatten(
             -1, (self.hc_count, self.hidden_size)
         )
-        value = F.linear(embeddings, self.value_proj)
+        value = prefill_linear(embeddings, self.value_proj)
         query_normed = self.norm_query(hidden_states).unflatten(-1, (self.hc_count, self.hidden_size))
         gate = (key_normed * query_normed).sum(dim=-1, keepdim=True) / math.sqrt(self.hidden_size)
         # Signed sqrt keeps the gate's sign while compressing its magnitude.
@@ -248,6 +249,11 @@ class Qwen4ExpDecoderLayer:
                 else:
                     attn_out = self.attn(mixed, cos, sin, cache, past_len=past_len)
 
+            if profiler is not None and hasattr(self.attn, "last_profile"):
+                for name, elapsed in self.attn.last_profile.items():
+                    profiler.add_external(f"attention_{name}", elapsed)
+                self.attn.last_profile.clear()
+
             if self.all_reduce is not None:
                 with prof_scope("attn_reduce"):
                     attn_out = self.all_reduce(attn_out)
@@ -268,7 +274,9 @@ class Qwen4ExpDecoderLayer:
 
             with prof_scope("shared_expert"):
                 shared = self.shared_expert(flat)
-                shared = torch.sigmoid(F.linear(flat, self.shared_expert_gate)) * shared
+                shared = torch.sigmoid(
+                    prefill_linear(flat, self.shared_expert_gate)
+                ) * shared
 
             mlp_out = (routed + shared).reshape(mixed.shape)
 
@@ -357,6 +365,7 @@ class Qwen4ExpModel:
         *,
         cache: Qwen4ExpCache | None = None,
         past_len: int = 0,
+        last_token_only: bool = False,
     ) -> torch.Tensor:
         prof_scope = self.profiler.scope if self.profiler else lambda x: _noop_context()
 
@@ -403,6 +412,8 @@ class Qwen4ExpModel:
             if token_history is not None:
                 cache.ple_token_history = token_history[:, -(self.config.ngram_size - 1) :].clone()
 
+        if last_token_only:
+            hidden = hidden[:, -1:]
         with prof_scope("final_mixer"):
             hidden = self.final_mixer(hidden)
 

--- a/src/models/qwen4_exp/moe.py
+++ b/src/models/qwen4_exp/moe.py
@@ -4,10 +4,12 @@ Two implementations share one interface:
 
 * `InMemoryMoE` keeps `gate_up_proj`/`down_proj` as dense tensors on whatever
   device they were handed.  Used by tests and small models.
-* `HostExpertMoE` reads expert rows straight out of the mmap'd safetensors on
-  demand and runs the SwiGLU on the GPU, staging only the active experts.  This
-  is what makes the 225 GiB expert set usable on 4x22 GiB cards: a decode step
-  touches at most `top_k` experts per layer (6.6 MiB each in BF16).
+* `HostExpertMoE` reads expert rows from the host through
+  `reader.expert_rows()` and runs the SwiGLU on the GPU, staging only the active
+  experts.  This is what makes the 225 GiB expert set usable on 4x22 GiB cards: a
+  decode step touches at most `top_k` experts per layer (6.6 MiB each in BF16).
+  The reader normally serves those rows from this rank's resident host shard (see
+  `weights.HostExpertShard`); the mmap is only the fallback.
 """
 
 from __future__ import annotations
@@ -133,12 +135,12 @@ class InMemoryMoE:
 
 
 class HostExpertMoE:
-    """Experts stay in host RAM (mmap'd checkpoint); active ones are staged to GPU.
+    """Experts stay in host RAM; active ones are staged to GPU per step.
 
-    The reader must expose `expert_rows(layer_idx, expert_id)` returning CPU
-    tensors that alias the mapping.  A small LRU keeps recently used experts on
-    device, which pays off during prefill where consecutive chunks reuse the same
-    hot experts.
+    The reader must expose `expert_rows(layer_idx, expert_id)` returning host
+    tensors — resident shard rows when preloaded, mmap views otherwise.  A small
+    LRU keeps recently used experts on device, which pays off during prefill where
+    consecutive chunks reuse the same hot experts.
     """
 
     def __init__(

--- a/src/models/qwen4_exp/moe.py
+++ b/src/models/qwen4_exp/moe.py
@@ -14,11 +14,22 @@ Two implementations share one interface:
 
 from __future__ import annotations
 
+import os
+from collections import OrderedDict
+from dataclasses import dataclass
 from typing import Protocol
 
 import torch
 
+from src.kernels.cuda_loader import load_cuda_kernel
 from src.models.qwen4_exp.layers import swiglu_expert
+
+
+@dataclass
+class _PendingExpert:
+    gate_up: torch.Tensor
+    down: torch.Tensor
+    ready: torch.cuda.Event | None
 
 
 class MoEBackend(Protocol):
@@ -40,6 +51,8 @@ def _dispatch_experts(
     num_experts: int,
     expert_weights,
     stats: dict | None = None,
+    stager=None,
+    compute_dtype: torch.dtype | None = None,
 ) -> torch.Tensor:
     """Group tokens by expert, run each expert once, scatter-add the results.
 
@@ -61,6 +74,8 @@ def _dispatch_experts(
         offset = 0
         unique_list = unique.tolist()
         counts_list = counts.tolist()
+        expert_ids = [int(expert_id) for expert_id in unique_list if expert_id < num_experts]
+        prefetched = stager(expert_ids) if stager is not None else None
         for expert_id, count in zip(unique_list, counts_list):
             slot = order[offset : offset + count]
             offset += count
@@ -68,8 +83,13 @@ def _dispatch_experts(
                 continue
             token_idx = slot // top_k
             k_idx = slot % top_k
-            gate_up, down = expert_weights(int(expert_id))
-            contrib = swiglu_expert(hidden_states[token_idx], gate_up, down)
+            gate_up, down = next(prefetched) if prefetched is not None else expert_weights(int(expert_id))
+            expert_input = hidden_states[token_idx]
+            if compute_dtype is not None:
+                expert_input = expert_input.to(compute_dtype)
+                gate_up = gate_up.to(compute_dtype)
+                down = down.to(compute_dtype)
+            contrib = swiglu_expert(expert_input, gate_up, down)
             contrib = contrib * weights[token_idx, k_idx].unsqueeze(-1).to(contrib.dtype)
             out.index_add_(0, token_idx, contrib.to(out.dtype))
         return out
@@ -95,7 +115,12 @@ def _dispatch_experts(
         gate_up, down = expert_weights(int(expert_id))
         sync(dev)
         t1 = time.perf_counter()
-        contrib = swiglu_expert(hidden_states[token_idx], gate_up, down)
+        expert_input = hidden_states[token_idx]
+        if compute_dtype is not None:
+            expert_input = expert_input.to(compute_dtype)
+            gate_up = gate_up.to(compute_dtype)
+            down = down.to(compute_dtype)
+        contrib = swiglu_expert(expert_input, gate_up, down)
         contrib = contrib * weights[token_idx, k_idx].unsqueeze(-1).to(contrib.dtype)
         out.index_add_(0, token_idx, contrib.to(out.dtype))
         sync(dev)
@@ -157,32 +182,191 @@ class HostExpertMoE:
         self.device = device
         self.dtype = dtype
         self.cache_capacity = cache_capacity
-        self._cache: dict[tuple[int, int], tuple[torch.Tensor, torch.Tensor]] = {}
-        self._order: list[tuple[int, int]] = []
+        self._cache: OrderedDict[tuple[int, int], tuple[torch.Tensor, torch.Tensor]] = OrderedDict()
         self.stage_bytes = 0
         self.stage_calls = 0
         self.cache_hits = 0
         # Set to a dict to collect per-phase timings (profiling only).
         self.phase_stats: dict | None = None
+        self.prefetch_enabled = os.environ.get("DSV4_QWEN4_MOE_PREFETCH", "1").lower() in {
+            "1", "true", "yes"
+        }
+        self._copy_stream: torch.cuda.Stream | None = None
+        self._cuda_ext = None
+        self.grouped_enabled = os.environ.get("DSV4_QWEN4_MOE_GROUPED", "0").lower() in {
+            "1", "true", "yes"
+        }
+        self.grouped_min_tokens = int(os.environ.get("DSV4_QWEN4_MOE_GROUPED_MIN_TOKENS", "128"))
+        self.grouped_max_padding = float(os.environ.get("DSV4_QWEN4_MOE_GROUPED_MAX_PADDING", "2.5"))
+        self.grouped_min_free_gib = float(
+            os.environ.get("DSV4_QWEN4_MOE_GROUPED_MIN_FREE_GIB", "2.0")
+        )
+        self.fp16_compute_min_tokens = max(
+            1,
+            int(os.environ.get("DSV4_QWEN4_MOE_FP16_MIN_TOKENS", "128")),
+        )
+
+    def _cache_put(self, key: tuple[int, int], pair: tuple[torch.Tensor, torch.Tensor]) -> None:
+        if self.cache_capacity <= 0:
+            return
+        self._cache[key] = pair
+        self._cache.move_to_end(key)
+        while len(self._cache) > self.cache_capacity:
+            self._cache.popitem(last=False)
+
+    def _cache_get(self, key: tuple[int, int]):
+        hit = self._cache.get(key)
+        if hit is not None:
+            self._cache.move_to_end(key)
+            self.cache_hits += 1
+        return hit
 
     def _fetch(self, layer_idx: int, expert_id: int) -> tuple[torch.Tensor, torch.Tensor]:
         key = (layer_idx, expert_id)
-        hit = self._cache.get(key)
+        hit = self._cache_get(key)
         if hit is not None:
-            self.cache_hits += 1
             return hit
         gate_up_cpu, down_cpu = self.reader.expert_rows(layer_idx, expert_id)
         gate_up = gate_up_cpu.to(self.device, dtype=self.dtype, non_blocking=True)
         down = down_cpu.to(self.device, dtype=self.dtype, non_blocking=True)
         self.stage_bytes += gate_up.numel() * gate_up.element_size() + down.numel() * down.element_size()
         self.stage_calls += 1
-        if self.cache_capacity > 0:
-            self._cache[key] = (gate_up, down)
-            self._order.append(key)
-            while len(self._order) > self.cache_capacity:
-                evicted = self._order.pop(0)
-                self._cache.pop(evicted, None)
+        self._cache_put(key, (gate_up, down))
         return gate_up, down
+
+    def _grouped_bf16(self, layer_idx: int, hidden_states, indices, weights):
+        """Run a dense-local-expert BF16 grouped prefill, or return None."""
+        if hidden_states.shape[0] < self.grouped_min_tokens:
+            return None
+        shard = getattr(self.reader, "expert_shard", None)
+        if shard is None or not shard.has_layer(layer_idx):
+            return None
+        if self.dtype is not torch.bfloat16:
+            return None
+        if shard.world_size <= 1:
+            # A single-rank shard contains all experts; copying a full layer is
+            # unnecessarily large, so keep the per-expert path there.
+            return None
+        if self._cuda_ext is None:
+            self._cuda_ext = load_cuda_kernel()
+        if self._cuda_ext is None or not hasattr(
+            self._cuda_ext, "qwen4_exp_moe_prefill_bf16_forward"
+        ):
+            return None
+
+        gate_up_cpu, down_cpu = shard.layer_tensors(layer_idx)
+        layer_bytes = (
+            gate_up_cpu.numel() * gate_up_cpu.element_size()
+            + down_cpu.numel() * down_cpu.element_size()
+        )
+        try:
+            free_bytes, _ = torch.cuda.mem_get_info(self.device)
+        except RuntimeError:
+            return None
+        reserve_bytes = max(0, int(self.grouped_min_free_gib * (1 << 30)))
+        if free_bytes < layer_bytes + reserve_bytes:
+            return None
+
+        flat = indices.reshape(-1)
+        top_k = indices.shape[1]
+        order = torch.argsort(flat, stable=True)
+        sorted_ids = flat[order]
+        unique, counts = torch.unique_consecutive(sorted_ids, return_counts=True)
+
+        unique_list = [int(e) for e in unique.tolist()]
+        counts_list = [int(c) for c in counts.tolist()]
+        local_experts = shard.num_local_experts
+        offset = 0
+        route_tokens = []
+        route_weights = []
+        counts_by_local = [0] * local_experts
+        for expert_id, count in zip(unique_list, counts_list):
+            begin, offset = offset, offset + count
+            if expert_id >= self.num_experts or not shard.owns(expert_id):
+                continue
+            local_id = shard.local_index(expert_id)
+            if local_id < 0 or local_id >= local_experts:
+                return None
+            slots = order[begin:offset]
+            route_tokens.append((slots // top_k).to(torch.int64))
+            route_weights.append(weights.reshape(-1)[slots].to(torch.float32))
+            counts_by_local[local_id] = count
+        if not route_tokens:
+            # This is the expected result for a ShardedMoE rank with no local
+            # routes.  The caller's all-reduce will combine the zero partial.
+            return torch.zeros_like(hidden_states)
+
+        route_count = sum(counts_by_local)
+        max_count = max(counts_by_local)
+        padding_ratio = shard.num_local_experts * max_count / max(1, route_count)
+        if padding_ratio > self.grouped_max_padding:
+            return None
+
+        route_tokens = torch.cat(route_tokens).contiguous()
+        route_weights = torch.cat(route_weights).contiguous()
+        seg = [0]
+        for count in counts_by_local:
+            seg.append(seg[-1] + count)
+        seg_starts = torch.tensor(seg, device=hidden_states.device, dtype=torch.int32)
+
+        # Keep the local shard's expert-id layout intact.  This replaces many
+        # small H2D copies with two contiguous layer copies; zero-route experts
+        # are represented by empty segments and never contribute to the output.
+        if self._copy_stream is None:
+            self._copy_stream = torch.cuda.Stream(device=self.device)
+        current = torch.cuda.current_stream(self.device)
+        with torch.cuda.stream(self._copy_stream):
+            gate_up = gate_up_cpu.to(self.device, dtype=self.dtype, non_blocking=True)
+            down = down_cpu.to(self.device, dtype=self.dtype, non_blocking=True)
+            ready = torch.cuda.Event()
+            ready.record(self._copy_stream)
+        current.wait_event(ready)
+        gate_up.record_stream(current)
+        down.record_stream(current)
+        self.stage_bytes += gate_up.numel() * gate_up.element_size() + down.numel() * down.element_size()
+        self.stage_calls += 1
+        return self._cuda_ext.qwen4_exp_moe_prefill_bf16_forward(
+            hidden_states.contiguous(),
+            route_tokens,
+            route_weights,
+            seg_starts,
+            gate_up,
+            down,
+            0.0,
+        )
+
+    def _prefetch(self, layer_idx: int, expert_ids: list[int]):
+        """Stage one layer's active experts on a copy stream in expert-id order."""
+        if self._copy_stream is None:
+            self._copy_stream = torch.cuda.Stream(device=self.device)
+        current = torch.cuda.current_stream(self.device)
+        pending: list[_PendingExpert] = []
+        with torch.cuda.stream(self._copy_stream):
+            for expert_id in expert_ids:
+                key = (layer_idx, expert_id)
+                hit = self._cache_get(key)
+                if hit is not None:
+                    pending.append(_PendingExpert(hit[0], hit[1], None))
+                    continue
+                gate_up_cpu, down_cpu = self.reader.expert_rows(layer_idx, expert_id)
+                gate_up = gate_up_cpu.to(self.device, dtype=self.dtype, non_blocking=True)
+                down = down_cpu.to(self.device, dtype=self.dtype, non_blocking=True)
+                event = torch.cuda.Event()
+                event.record(self._copy_stream)
+                pending.append(_PendingExpert(gate_up, down, event))
+                self.stage_bytes += gate_up.numel() * gate_up.element_size() + down.numel() * down.element_size()
+                self.stage_calls += 1
+                self._cache_put(key, (gate_up, down))
+
+        def consume():
+            for item in pending:
+                if item.ready is not None:
+                    current.wait_event(item.ready)
+                item.gate_up.record_stream(current)
+                item.down.record_stream(current)
+                yield item.gate_up, item.down
+
+        return consume()
 
     def __call__(
         self,
@@ -191,13 +375,40 @@ class HostExpertMoE:
         indices: torch.Tensor,
         weights: torch.Tensor,
     ) -> torch.Tensor:
+        if (
+            self.grouped_enabled
+            and self.phase_stats is None
+            and hidden_states.device.type == "cuda"
+        ):
+            grouped = self._grouped_bf16(layer_idx, hidden_states, indices, weights)
+            if grouped is not None:
+                return grouped
+
+        use_prefetch = (
+            self.prefetch_enabled
+            and self.phase_stats is None
+            and hidden_states.device.type == "cuda"
+        )
+        fp16_compute_enabled = os.environ.get(
+            "DSV4_QWEN4_MOE_FP16_COMPUTE", "0"
+        ).lower() in {"1", "true", "yes"}
+        compute_dtype = (
+            torch.float16
+            if fp16_compute_enabled
+            and hidden_states.device.type == "cuda"
+            and hidden_states.dtype is torch.bfloat16
+            and hidden_states.shape[0] >= self.fp16_compute_min_tokens
+            else None
+        )
         return _dispatch_experts(
             hidden_states,
             indices,
             weights,
             self.num_experts,
             lambda e: self._fetch(layer_idx, e),
-            stats=self.phase_stats,
+            stats=None if use_prefetch else self.phase_stats,
+            stager=(lambda expert_ids: self._prefetch(layer_idx, expert_ids)) if use_prefetch else None,
+            compute_dtype=compute_dtype,
         )
 
 

--- a/src/models/qwen4_exp/profiler.py
+++ b/src/models/qwen4_exp/profiler.py
@@ -68,10 +68,66 @@ class Profiler:
             stats.count += 1
             stats.total_s += elapsed
 
+    def add_external(self, name: str, elapsed_s: float) -> None:
+        """Add a timer measured by a lower-level implementation."""
+        if not self.enabled or elapsed_s <= 0.0:
+            return
+        parent = self.root
+        for scope_name, _, _ in self._stack:
+            parent = parent.children.setdefault(scope_name, ScopeStats())
+        stats = parent.children.setdefault(name, ScopeStats())
+        stats.count += 1
+        stats.total_s += elapsed_s
+
     def reset(self):
         """Clear all accumulated stats."""
         self.root = ScopeStats()
         self._stack.clear()
+
+    def aggregate(self, scope_prefix: str = "layer_") -> dict[str, ScopeStats]:
+        """Sum matching children across repeated layer scopes."""
+        aggregated: dict[str, ScopeStats] = {}
+
+        def merge(dst: ScopeStats, src: ScopeStats) -> None:
+            dst.count += src.count
+            dst.total_s += src.total_s
+            for name, child in src.children.items():
+                merge(dst.children.setdefault(name, ScopeStats()), child)
+
+        def visit(node: ScopeStats) -> None:
+            for name, child in node.children.items():
+                if name.startswith(scope_prefix):
+                    for child_name, child_stats in child.children.items():
+                        merge(
+                            aggregated.setdefault(child_name, ScopeStats()),
+                            child_stats,
+                        )
+                else:
+                    visit(child)
+
+        visit(self.root)
+        return aggregated
+
+    def aggregate_report(self, scope_prefix: str = "layer_") -> str:
+        """Report child scopes summed across all matching layer scopes."""
+        aggregated = self.aggregate(scope_prefix)
+        if not aggregated:
+            return "(no matching layer scopes)"
+        total_s = sum(stats.total_s for stats in aggregated.values())
+        lines = [
+            f"{'=== Aggregate Layer Report ===':<50s}  Total: {total_s:.3f}s"
+        ]
+        for name, stats in sorted(
+            aggregated.items(), key=lambda item: item[1].total_s, reverse=True
+        ):
+            percent = 100.0 * stats.total_s / total_s if total_s else 0.0
+            average_ms = 1000.0 * stats.total_s / stats.count if stats.count else 0.0
+            lines.append(
+                f"{name:30s}  {stats.count:6d} calls  "
+                f"{stats.total_s:7.3f}s ({percent:5.1f}%)  "
+                f"{average_ms:7.2f} ms/call"
+            )
+        return "\n".join(lines)
 
     def report(self, min_percent: float = 0.5) -> str:
         """Generate a tree report of accumulated times.

--- a/src/models/qwen4_exp/runtime.py
+++ b/src/models/qwen4_exp/runtime.py
@@ -44,6 +44,113 @@ class TPContext:
     initialized: bool
 
 
+def _env_enabled(name: str, default: str = "0") -> bool:
+    return os.environ.get(name, default).lower() in {"1", "true", "yes"}
+
+
+def _parse_cpu_list(spec: str) -> list[int]:
+    cpus: list[int] = []
+    for part in spec.strip().split(","):
+        if not part:
+            continue
+        if "-" in part:
+            begin, end = (int(value) for value in part.split("-", 1))
+            cpus.extend(range(begin, end + 1))
+        else:
+            cpus.append(int(part))
+    return cpus
+
+
+def _cuda_numa_node(device: torch.device) -> int | None:
+    if device.type != "cuda":
+        return None
+    properties = torch.cuda.get_device_properties(device)
+    pci_id = (
+        f"{properties.pci_domain_id:04x}:{properties.pci_bus_id:02x}:"
+        f"{properties.pci_device_id:02x}.0"
+    )
+    try:
+        with open(f"/sys/bus/pci/devices/{pci_id}/numa_node") as f:
+            node = int(f.read())
+    except (OSError, ValueError):
+        return None
+    return node if node >= 0 else None
+
+
+def _physical_core_groups(cpus: set[int]) -> list[list[int]]:
+    core_map: dict[tuple[int, int], list[int]] = {}
+    for cpu in sorted(cpus):
+        topology = f"/sys/devices/system/cpu/cpu{cpu}/topology"
+        try:
+            with open(os.path.join(topology, "physical_package_id")) as f:
+                package_id = int(f.read())
+            with open(os.path.join(topology, "core_id")) as f:
+                core_id = int(f.read())
+        except (OSError, ValueError):
+            continue
+        core_map.setdefault((package_id, core_id), []).append(cpu)
+    return [sorted(siblings) for _, siblings in sorted(core_map.items())]
+
+
+def _cpu_affinity_for_device(
+    device: torch.device,
+    local_rank: int,
+    local_world_size: int,
+) -> list[int] | None:
+    if not hasattr(os, "sched_getaffinity") or not hasattr(os, "sched_setaffinity"):
+        return None
+    node = _cuda_numa_node(device)
+    if node is None:
+        return None
+    try:
+        with open(f"/sys/devices/system/node/node{node}/cpulist") as f:
+            node_cpus = set(_parse_cpu_list(f.read()))
+    except (OSError, ValueError):
+        return None
+
+    allowed_cpus = set(os.sched_getaffinity(0))
+    core_groups = _physical_core_groups(node_cpus & allowed_cpus)
+    if not core_groups:
+        return None
+
+    visible_ranks = min(local_world_size, torch.cuda.device_count())
+    peer_ranks = [
+        rank
+        for rank in range(visible_ranks)
+        if _cuda_numa_node(torch.device(f"cuda:{rank}")) == node
+    ]
+    if local_rank not in peer_ranks:
+        return None
+
+    peer_index = peer_ranks.index(local_rank)
+    base = len(core_groups) // len(peer_ranks)
+    extra = len(core_groups) % len(peer_ranks)
+    begin = peer_index * base + min(peer_index, extra)
+    count = base + (1 if peer_index < extra else 0)
+    selected = core_groups[begin : begin + count]
+    return sorted(cpu for siblings in selected for cpu in siblings)
+
+
+def _configure_cpu_affinity(ctx: TPContext) -> list[int] | None:
+    if not _env_enabled("DSV4_QWEN4_CPU_AFFINITY", "1") or ctx.device.type != "cuda":
+        return None
+    local_rank = ctx.device.index or 0
+    local_world_size = int(os.environ.get("LOCAL_WORLD_SIZE", str(ctx.world_size)))
+    cpus = _cpu_affinity_for_device(ctx.device, local_rank, local_world_size)
+    if not cpus:
+        if ctx.rank == 0:
+            print("[qwen4exp] NUMA-local CPU affinity unavailable", flush=True)
+        return None
+    os.sched_setaffinity(0, cpus)
+    cpu_spec = ",".join(str(cpu) for cpu in cpus)
+    print(
+        f"[qwen4exp] rank {ctx.rank}: GPU {local_rank} bound to CPUs "
+        f"{cpu_spec} ({len(cpus)} logical CPUs)",
+        flush=True,
+    )
+    return cpus
+
+
 def init_distributed() -> TPContext:
     """Join the torchrun-provided process group, or fall back to single-rank."""
     import torch.distributed as dist
@@ -101,6 +208,7 @@ def load_model(
     pin_experts: bool = True,
     profiler=None,
 ) -> tuple[Qwen4ExpModel, Qwen4ExpConfig]:
+    _configure_cpu_affinity(ctx)
     config = Qwen4ExpConfig.from_pretrained(model_dir)
     checkpoint = Qwen4ExpCheckpoint(model_dir, store=MmapSafetensors(model_dir))
     if host_expert_memory:
@@ -168,10 +276,15 @@ def generate(
     t0 = time.perf_counter()
     logits = None
     past = 0
-    with prof_scope("prefill"):
+    with torch.inference_mode(), prof_scope("prefill"):
         while past < prompt_len:
             piece = input_ids[:, past : past + chunk_size]
-            logits = model.forward(piece, cache=cache, past_len=past)
+            logits = model.forward(
+                piece,
+                cache=cache,
+                past_len=past,
+                last_token_only=True,
+            )
             past += piece.shape[1]
     if ctx.device.type == "cuda":
         torch.cuda.synchronize()
@@ -181,7 +294,7 @@ def generate(
     produced: list[int] = []
     t1 = time.perf_counter()
     next_id = logits.argmax(-1, keepdim=True)
-    with prof_scope("decode"):
+    with torch.inference_mode(), prof_scope("decode"):
         for _ in range(max_new_tokens):
             token = int(next_id.item())
             produced.append(token)
@@ -308,7 +421,9 @@ def run_tp4(
             )
 
         if profiler and profiler.enabled:
-            print("\n" + profiler.report())
+            print("\n" + profiler.aggregate_report())
+            if _env_enabled("DSV4_QWEN4_PROFILE_TREE"):
+                print("\n" + profiler.report())
 
     if ctx.initialized:
         import torch.distributed as dist

--- a/src/models/qwen4_exp/runtime.py
+++ b/src/models/qwen4_exp/runtime.py
@@ -1,15 +1,19 @@
 """TP4 heterogeneous runtime for Qwen4-Exp.
 
 Launch layout: one process per GPU, NCCL for the per-layer all-reduce.  Dense
-weights are sharded (see `builder.build_heterogeneous`); routed experts and the
-95 GiB PLE table stay in host RAM and are read through the shared page cache, so
-the four ranks pay for one copy between them.
+weights are sharded (see `builder.build_heterogeneous`); routed experts are
+loaded into each rank's disjoint host-RAM shard at startup, and the 95 GiB PLE
+table stays host-resident through the existing mapping.  Only active experts are
+staged to GPU during a step.
 
-Memory per rank (BF16, 4 ranks):
+Device memory per rank (BF16, 4 ranks):
   dense sharded weights   ~2.6 GiB   (attn/linear-attn projections, HC mixers)
   lm_head shard            0.30 GiB
   KV + conv/recurrent      grows with context
   staged experts        top_k * 6.6 MiB per layer, freed each step
+
+Host memory per rank:
+  resident expert shard    56.25 GiB (128 of 512 experts x 48 layers)
 
 Entry point: `python -m src.models.qwen4_exp.runtime --model DIR --prompt ...`
 under torchrun, or `run_tp4()` from another module.
@@ -93,10 +97,37 @@ def load_model(
     *,
     dtype: torch.dtype = torch.bfloat16,
     expert_cache_capacity: int = 0,
+    host_expert_memory: bool = True,
+    pin_experts: bool = True,
     profiler=None,
 ) -> tuple[Qwen4ExpModel, Qwen4ExpConfig]:
     config = Qwen4ExpConfig.from_pretrained(model_dir)
     checkpoint = Qwen4ExpCheckpoint(model_dir, store=MmapSafetensors(model_dir))
+    if host_expert_memory:
+        # Pull this rank's routed experts off the disk-backed mapping and into
+        # host RAM before any step runs, so steady-state staging never seeks.
+        import torch.distributed as dist
+
+        distributed = ctx.world_size > 1 and dist.is_initialized()
+        started = time.perf_counter()
+        shard = checkpoint.preload_experts(
+            config.text_config.num_hidden_layers,
+            rank=ctx.rank,
+            world_size=ctx.world_size,
+            pin=pin_experts,
+            progress=ctx.rank == 0 and os.environ.get("QWEN4EXP_PRELOAD_PROGRESS") == "1",
+            barrier=dist.barrier if distributed else None,
+        )
+        elapsed = time.perf_counter() - started
+        print(
+            f"[qwen4exp] rank {ctx.rank}: {shard.num_local_experts} experts/layer "
+            f"x {shard.stats()['layers']} layers resident, "
+            f"{shard.resident_bytes / (1 << 30):.2f} GiB "
+            f"({'pinned' if shard.pinned else 'pageable'}) in {elapsed:.1f}s",
+            flush=True,
+        )
+        if distributed:
+            dist.barrier()
     model = build_heterogeneous(
         config.text_config,
         checkpoint,
@@ -206,6 +237,8 @@ def run_tp4(
     chunk_size: int = 512,
     dtype: torch.dtype = torch.bfloat16,
     expert_cache_capacity: int = 0,
+    host_expert_memory: bool = True,
+    pin_experts: bool = True,
     raw_prompt: bool = False,
     enable_profile: bool = False,
 ) -> dict:
@@ -219,7 +252,13 @@ def run_tp4(
 
     t0 = time.perf_counter()
     model, config = load_model(
-        model_dir, ctx, dtype=dtype, expert_cache_capacity=expert_cache_capacity, profiler=profiler
+        model_dir,
+        ctx,
+        dtype=dtype,
+        expert_cache_capacity=expert_cache_capacity,
+        host_expert_memory=host_expert_memory,
+        pin_experts=pin_experts,
+        profiler=profiler,
     )
     load_s = time.perf_counter() - t0
     if ctx.rank == 0:
@@ -293,6 +332,16 @@ def main() -> None:
         default=0,
         help="number of staged experts to keep on device (0 = restage every step)",
     )
+    parser.add_argument(
+        "--mmap-experts",
+        action="store_true",
+        help="diagnostic fallback: read routed experts from the mmap on demand",
+    )
+    parser.add_argument(
+        "--pageable-experts",
+        action="store_true",
+        help="keep the resident host shard pageable instead of requesting pinned memory",
+    )
     parser.add_argument("--raw-prompt", action="store_true", help="skip the chat template")
     parser.add_argument("--profile", action="store_true", help="enable hierarchical profiler")
     args = parser.parse_args()
@@ -309,6 +358,8 @@ def main() -> None:
         chunk_size=args.chunk_size,
         dtype=getattr(torch, args.dtype),
         expert_cache_capacity=args.expert_cache,
+        host_expert_memory=not args.mmap_experts,
+        pin_experts=not args.pageable_experts,
         raw_prompt=args.raw_prompt,
         enable_profile=args.profile,
     )

--- a/src/models/qwen4_exp/weights.py
+++ b/src/models/qwen4_exp/weights.py
@@ -307,6 +307,10 @@ class HostExpertShard:
         local = self.local_index(expert_id)
         return self._gate_up[layer_idx][local], self._down[layer_idx][local]
 
+    def layer_tensors(self, layer_idx: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return this rank's contiguous local expert tensors for grouped prefill."""
+        return self._gate_up[layer_idx], self._down[layer_idx]
+
     def stats(self) -> dict[str, object]:
         return {
             "rank": self.rank,

--- a/src/models/qwen4_exp/weights.py
+++ b/src/models/qwen4_exp/weights.py
@@ -1,14 +1,20 @@
-"""Zero-copy safetensors access for Qwen4-Exp.
+"""Safetensors access for Qwen4-Exp: mmap reads plus host-resident experts.
 
 The checkpoint is 335 GiB, of which 225 GiB is routed experts and 95 GiB is the
-PLE n-gram table.  Neither fits in 4x22 GiB of VRAM, and copying them into
-process memory would double the footprint, so both are read through `mmap`: the
-host page cache (1 TB of RAM here) becomes the expert/embedding store and the
-GPU only ever sees the rows a step actually touches.
+PLE n-gram table.  Neither fits in 4x22 GiB of VRAM, so both live on the host and
+the GPU only ever sees the rows a step actually touches.
 
 `MmapSafetensors` maps each shard once and hands out torch views over the raw
 bytes.  BF16 has no numpy dtype, so the mapping is `uint16` and reinterpreted
 with `Tensor.view(torch.bfloat16)`.
+
+Reading experts through the mapping alone is not enough: the mapping is backed by
+a mechanical disk here, so a page that is not resident costs a seek.
+`HostExpertShard` therefore copies this rank's routed experts into host RAM once
+at startup (pinned when the memlock limit allows), and `Qwen4ExpCheckpoint`
+serves `expert_rows` from that copy afterwards.  Under TP the shards are disjoint
+(`expert_id % world_size == rank`), so the four ranks together hold exactly one
+copy of the expert set.
 """
 
 from __future__ import annotations
@@ -121,6 +127,35 @@ class MmapSafetensors:
         self._views[key] = tensor
         return tensor
 
+    def advise_dontneed(self, key: str) -> int:
+        """Drop this process's page-table entries for one tensor's byte range.
+
+        Used after a tensor has been copied into resident host memory: without it
+        the process keeps ~56 GiB of mapped expert pages referenced on top of the
+        56 GiB copy.  This only drops *this* process's references — the pages stay
+        in the shared page cache, so a sibling rank reading interleaved rows in
+        the same region is not forced back to the disk.  Returns the bytes advised.
+        """
+        import mmap as _mmap
+
+        entry = self.entries[key]
+        raw = self._map(entry.file_name)
+        handle = getattr(raw, "_mmap", None)
+        if handle is None or not hasattr(handle, "madvise"):
+            return 0
+        base = self._data_offsets[entry.file_name]
+        page = _mmap.PAGESIZE
+        # Align inwards so only pages wholly inside this tensor are dropped.
+        start = -(-(base + entry.begin) // page) * page
+        end = ((base + entry.end) // page) * page
+        if end <= start:
+            return 0
+        try:
+            handle.madvise(_mmap.MADV_DONTNEED, start, end - start)
+        except (OSError, ValueError):
+            return 0
+        return end - start
+
     def load(self, key: str, *, device=None, dtype=None) -> torch.Tensor:
         """Copy a tensor out of the mapping, optionally to a device/dtype."""
         tensor = self.view(key)
@@ -133,6 +168,156 @@ class MmapSafetensors:
         return tensor
 
 
+class HostExpertShard:
+    """This rank's routed experts, copied out of the mapping into host RAM.
+
+    One pair of contiguous host tensors per layer, indexed by *local* expert id
+    (`expert_id // world_size`), so a 48-layer TP4 shard is 96 allocations rather
+    than 12,288 expert-row ones.  Pinned memory is requested because the H2D
+    staging in `HostExpertMoE` is the consumer, but a 56 GiB pin can exceed
+    `ulimit -l`; on failure the shard falls back to pageable memory once and says
+    so, rather than dying at load time.
+    """
+
+    def __init__(
+        self,
+        *,
+        num_layers: int,
+        rank: int = 0,
+        world_size: int = 1,
+        pin_memory: bool = True,
+    ) -> None:
+        if world_size < 1 or not (0 <= rank < world_size):
+            raise ValueError(f"bad shard placement: rank={rank} world_size={world_size}")
+        self.num_layers = int(num_layers)
+        self.rank = int(rank)
+        self.world_size = int(world_size)
+        self.pin_requested = bool(pin_memory)
+        self.pinned = False
+        self.resident_bytes = 0
+        self.num_local_experts = 0
+        self._gate_up: dict[int, torch.Tensor] = {}
+        self._down: dict[int, torch.Tensor] = {}
+        self._loaded: set[int] = set()
+        self._pin_fallback_reported = False
+
+    # -- placement --------------------------------------------------------
+
+    def owns(self, expert_id: int) -> bool:
+        return (int(expert_id) % self.world_size) == self.rank
+
+    def local_index(self, expert_id: int) -> int:
+        return int(expert_id) // self.world_size
+
+    def local_expert_ids(self, num_experts: int) -> list[int]:
+        return [e for e in range(int(num_experts)) if self.owns(e)]
+
+    # -- allocation -------------------------------------------------------
+
+    def _fall_back_to_pageable(self, exc: RuntimeError) -> None:
+        """Convert already loaded layers before retrying the failed allocation."""
+        self.pin_requested = False
+        if not self._pin_fallback_reported:
+            print(
+                f"[qwen4exp] pinning the expert shard failed ({exc}); "
+                "falling back to pageable host memory",
+                flush=True,
+            )
+            self._pin_fallback_reported = True
+        if self.pinned:
+            # Do not leave a mixed shard behind: pageable clones replace all
+            # earlier pinned layers before the current layer is allocated.
+            self._gate_up = {layer: tensor.clone() for layer, tensor in self._gate_up.items()}
+            self._down = {layer: tensor.clone() for layer, tensor in self._down.items()}
+            self.pinned = False
+            import gc
+
+            gc.collect()
+
+    def _alloc_pair(
+        self,
+        gate_up_shape: tuple[int, ...],
+        gate_up_dtype: torch.dtype,
+        down_shape: tuple[int, ...],
+        down_dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Both of a layer's buffers, pinned together or pageable together.
+
+        Allocating them separately could leave a layer half-pinned if the memlock
+        limit is hit between the two, so a failure on either discards the pair.
+        """
+        if self.pin_requested:
+            try:
+                gate_up = torch.empty(gate_up_shape, dtype=gate_up_dtype, pin_memory=True)
+                down = torch.empty(down_shape, dtype=down_dtype, pin_memory=True)
+                self.pinned = True
+                return gate_up, down
+            except RuntimeError as exc:  # memlock limit, most likely
+                # Release a half-allocated pair first: if gate_up pinned and down
+                # did not, holding it would keep locked pages during the clones.
+                gate_up = down = None
+                self._fall_back_to_pageable(exc)
+        return (
+            torch.empty(gate_up_shape, dtype=gate_up_dtype),
+            torch.empty(down_shape, dtype=down_dtype),
+        )
+
+    def load_layer(
+        self,
+        layer_idx: int,
+        gate_up_all: torch.Tensor,
+        down_all: torch.Tensor,
+    ) -> int:
+        """Copy this rank's rows of one layer in; returns the bytes copied."""
+        if layer_idx in self._loaded:
+            return 0
+        num_experts = gate_up_all.shape[0]
+        if down_all.shape[0] != num_experts:
+            raise ValueError(
+                f"expert count mismatch in layer {layer_idx}: "
+                f"gate_up {gate_up_all.shape[0]} vs down {down_all.shape[0]}"
+            )
+        ids = self.local_expert_ids(num_experts)
+        gate_up, down = self._alloc_pair(
+            (len(ids), *gate_up_all.shape[1:]),
+            gate_up_all.dtype,
+            (len(ids), *down_all.shape[1:]),
+            down_all.dtype,
+        )
+        # Sequential in expert id, which is also sequential in file offset: the
+        # backing store is a mechanical disk, so ordering matters more than
+        # parallelism here.
+        for local, expert_id in enumerate(ids):
+            gate_up[local].copy_(gate_up_all[expert_id])
+            down[local].copy_(down_all[expert_id])
+        self._gate_up[layer_idx] = gate_up
+        self._down[layer_idx] = down
+        self._loaded.add(layer_idx)
+        self.num_local_experts = len(ids)
+        copied = gate_up.numel() * gate_up.element_size() + down.numel() * down.element_size()
+        self.resident_bytes += copied
+        return copied
+
+    # -- access -----------------------------------------------------------
+
+    def has_layer(self, layer_idx: int) -> bool:
+        return layer_idx in self._loaded
+
+    def rows(self, layer_idx: int, expert_id: int) -> tuple[torch.Tensor, torch.Tensor]:
+        local = self.local_index(expert_id)
+        return self._gate_up[layer_idx][local], self._down[layer_idx][local]
+
+    def stats(self) -> dict[str, object]:
+        return {
+            "rank": self.rank,
+            "world_size": self.world_size,
+            "layers": len(self._loaded),
+            "local_experts": self.num_local_experts,
+            "resident_bytes": self.resident_bytes,
+            "pinned": self.pinned,
+        }
+
+
 class Qwen4ExpCheckpoint:
     """Names and lazily reads Qwen4-Exp tensors from a checkpoint directory."""
 
@@ -141,6 +326,7 @@ class Qwen4ExpCheckpoint:
     def __init__(self, root: str, *, store: MmapSafetensors | None = None) -> None:
         self.root = root
         self.store = store if store is not None else MmapSafetensors(root)
+        self.expert_shard: HostExpertShard | None = None
 
     # -- naming -----------------------------------------------------------
 
@@ -152,8 +338,71 @@ class Qwen4ExpCheckpoint:
 
     # -- routed experts ---------------------------------------------------
 
+    def preload_experts(
+        self,
+        num_layers: int,
+        *,
+        rank: int = 0,
+        world_size: int = 1,
+        pin: bool = True,
+        progress: bool = False,
+        barrier=None,
+        release_mapping: bool = True,
+    ) -> HostExpertShard:
+        """Copy this rank's routed experts into host RAM and serve them from there.
+
+        Called once at load time.  Afterwards `expert_rows` no longer touches the
+        mapping for owned experts, so steady-state staging reads RAM instead of
+        risking a disk seek.  Foreign experts are never loaded; under TP they are
+        another rank's responsibility and `ShardedMoE` masks them out.
+
+        `barrier` (when given) is called after each layer.  The ranks interleave
+        rows within one layer, so keeping them on the same layer keeps the
+        mechanical disk's head in one region instead of letting four processes
+        seek across the whole 225 GiB expert set independently.
+
+        `release_mapping` drops each layer's mapped pages from this process once
+        it has been copied.  Without it a rank ends up holding its 56 GiB copy
+        *and* 56 GiB of mapped expert pages (measured RSS 113 GiB), which at four
+        ranks is most of the machine's RAM for no benefit.
+        """
+        shard = HostExpertShard(
+            num_layers=num_layers,
+            rank=rank,
+            world_size=world_size,
+            pin_memory=pin,
+        )
+        for layer_idx in range(num_layers):
+            gate_up_key = self.expert_key(layer_idx, "gate_up_proj")
+            down_key = self.expert_key(layer_idx, "down_proj")
+            shard.load_layer(layer_idx, self.store.view(gate_up_key), self.store.view(down_key))
+            if barrier is not None:
+                # Siblings finish the same layer before anyone drops its pages, so
+                # MADV_DONTNEED never pulls a region a sibling is still reading.
+                barrier()
+            if release_mapping:
+                self.store.advise_dontneed(gate_up_key)
+                self.store.advise_dontneed(down_key)
+            if progress:
+                gib = shard.resident_bytes / (1 << 30)
+                print(
+                    f"[qwen4exp] rank {rank}: experts resident through layer "
+                    f"{layer_idx} ({gib:.2f} GiB)",
+                    flush=True,
+                )
+        self.expert_shard = shard
+        return shard
+
     def expert_rows(self, layer_idx: int, expert_id: int) -> tuple[torch.Tensor, torch.Tensor]:
-        """One expert's `(gate_up, down)` as host views (no copy)."""
+        """One expert's `(gate_up, down)` as host tensors (no copy, no device transfer).
+
+        Served from the resident shard when this rank owns the expert and the
+        shard is loaded; otherwise from the mapping, which is both the
+        `--mmap-experts` diagnostic path and what the tiny test fixtures use.
+        """
+        shard = self.expert_shard
+        if shard is not None and shard.has_layer(layer_idx) and shard.owns(expert_id):
+            return shard.rows(layer_idx, expert_id)
         gate_up = self.store.view(self.expert_key(layer_idx, "gate_up_proj"))[expert_id]
         down = self.store.view(self.expert_key(layer_idx, "down_proj"))[expert_id]
         return gate_up, down

--- a/tests/test_qwen4_exp_gated_delta_cuda.py
+++ b/tests/test_qwen4_exp_gated_delta_cuda.py
@@ -1,0 +1,112 @@
+"""Correctness tests for the Qwen4-Exp BF16 gated-delta CUDA scan."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.kernels.cuda_loader import load_cuda_kernel
+from src.models.qwen4_exp.attention import recurrent_gated_delta_rule
+
+
+def _extension():
+    ext = load_cuda_kernel()
+    if ext is None or not hasattr(ext, "qwen4_exp_gated_delta_bf16_forward"):
+        pytest.skip("cuda_kernel extension with Qwen4-Exp gated delta is unavailable")
+    return ext
+
+
+def _run_cuda(query, key, value, g, beta, state, groups_per_block=1):
+    return _extension().qwen4_exp_gated_delta_bf16_forward(
+        query.contiguous(),
+        key.contiguous(),
+        value.contiguous(),
+        g.contiguous(),
+        beta.contiguous(),
+        state.contiguous(),
+        1e-6,
+        groups_per_block,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("tokens", [1, 7, 65])
+def test_qwen4_exp_gated_delta_matches_sequential_reference(tokens):
+    device = torch.device("cuda")
+    torch.manual_seed(41 + tokens)
+    key_heads, value_heads = 2, 6
+    query = torch.randn(1, tokens, key_heads, 128, device=device, dtype=torch.bfloat16) * 0.1
+    key = torch.randn_like(query) * 0.1
+    value = torch.randn(1, tokens, value_heads, 128, device=device, dtype=torch.bfloat16) * 0.1
+    g = -(torch.rand(1, tokens, value_heads, device=device, dtype=torch.float32) * 0.04 + 0.001)
+    beta = torch.sigmoid(
+        torch.randn(1, tokens, value_heads, device=device, dtype=torch.bfloat16)
+    )
+    state = torch.randn(1, value_heads, 128, 128, device=device, dtype=torch.float32) * 0.001
+
+    repeat = value_heads // key_heads
+    want_output, want_state = recurrent_gated_delta_rule(
+        query.repeat_interleave(repeat, dim=2),
+        key.repeat_interleave(repeat, dim=2),
+        value,
+        g,
+        beta,
+        state.clone(),
+    )
+    got_output, got_state = _run_cuda(query, key, value, g, beta, state)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(got_output, want_output, rtol=2e-2, atol=2e-3)
+    torch.testing.assert_close(got_state, want_state, rtol=3e-3, atol=3e-4)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_qwen4_exp_gated_delta_chunk_carry_matches_single_scan():
+    device = torch.device("cuda")
+    torch.manual_seed(71)
+    tokens, split = 17, 6
+    key_heads, value_heads = 2, 6
+    query = torch.randn(1, tokens, key_heads, 128, device=device, dtype=torch.bfloat16) * 0.1
+    key = torch.randn_like(query) * 0.1
+    value = torch.randn(1, tokens, value_heads, 128, device=device, dtype=torch.bfloat16) * 0.1
+    g = -(torch.rand(1, tokens, value_heads, device=device, dtype=torch.float32) * 0.04 + 0.001)
+    beta = torch.sigmoid(
+        torch.randn(1, tokens, value_heads, device=device, dtype=torch.bfloat16)
+    )
+    state = torch.zeros(1, value_heads, 128, 128, device=device, dtype=torch.float32)
+
+    whole_output, whole_state = _run_cuda(query, key, value, g, beta, state)
+    first_output, first_state = _run_cuda(
+        query[:, :split], key[:, :split], value[:, :split], g[:, :split], beta[:, :split], state
+    )
+    second_output, second_state = _run_cuda(
+        query[:, split:],
+        key[:, split:],
+        value[:, split:],
+        g[:, split:],
+        beta[:, split:],
+        first_state,
+    )
+    chunked_output = torch.cat([first_output, second_output], dim=1)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(chunked_output, whole_output, rtol=0, atol=0)
+    torch.testing.assert_close(second_state, whole_state, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_qwen4_exp_gated_delta_launch_packing_is_exact():
+    device = torch.device("cuda")
+    torch.manual_seed(97)
+    query = torch.randn(1, 9, 2, 128, device=device, dtype=torch.bfloat16) * 0.1
+    key = torch.randn_like(query) * 0.1
+    value = torch.randn(1, 9, 6, 128, device=device, dtype=torch.bfloat16) * 0.1
+    g = -(torch.rand(1, 9, 6, device=device, dtype=torch.float32) * 0.04 + 0.001)
+    beta = torch.sigmoid(torch.randn(1, 9, 6, device=device, dtype=torch.bfloat16))
+    state = torch.zeros(1, 6, 128, 128, device=device, dtype=torch.float32)
+
+    reference_output, reference_state = _run_cuda(query, key, value, g, beta, state, 1)
+    for groups in (2, 4, 8):
+        output, final_state = _run_cuda(query, key, value, g, beta, state, groups)
+        torch.testing.assert_close(output, reference_output, rtol=0, atol=0)
+        torch.testing.assert_close(final_state, reference_state, rtol=0, atol=0)

--- a/tests/test_qwen4_exp_hc_activation_cuda.py
+++ b/tests/test_qwen4_exp_hc_activation_cuda.py
@@ -1,0 +1,50 @@
+"""Bit-exactness tests for the fused Qwen4-Exp hyper-connection activations."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from src.kernels.cuda_loader import load_cuda_kernel
+
+
+def _extension():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    ext = load_cuda_kernel()
+    required = ("qwen4_exp_hc_silu", "qwen4_exp_hc_inject_gate")
+    if ext is None or any(not hasattr(ext, name) for name in required):
+        pytest.skip("Qwen4-Exp hyper-connection activations are unavailable")
+    return ext
+
+
+@pytest.mark.parametrize("tokens", [1, 7, 8192])
+def test_hc_silu_is_bit_exact(tokens: int) -> None:
+    ext = _extension()
+    torch.manual_seed(20260901 + tokens)
+    groups, rank = 4, 320
+    raw = torch.randn(1, tokens, rank, device="cuda", dtype=torch.bfloat16) * 8
+    want = F.silu(raw / groups)
+    got = ext.qwen4_exp_hc_silu(raw.contiguous(), groups)
+    torch.testing.assert_close(got, want, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("tokens", [1, 7, 8192])
+def test_hc_inject_gate_is_bit_exact(tokens: int) -> None:
+    ext = _extension()
+    torch.manual_seed(20261001 + tokens)
+    groups = 4
+    raw = torch.randn(1, tokens, groups, device="cuda", dtype=torch.bfloat16) * 8
+    want = 2 * torch.sigmoid(raw / groups)
+    got = ext.qwen4_exp_hc_inject_gate(raw.contiguous(), groups)
+    torch.testing.assert_close(got, want, rtol=0, atol=0)
+
+
+def test_hc_activations_reject_non_bf16() -> None:
+    ext = _extension()
+    raw = torch.randn(4, 320, device="cuda", dtype=torch.float32)
+    with pytest.raises(RuntimeError):
+        ext.qwen4_exp_hc_silu(raw, 4)
+    with pytest.raises(RuntimeError):
+        ext.qwen4_exp_hc_inject_gate(raw, 4)

--- a/tests/test_qwen4_exp_hyper_connection_cuda.py
+++ b/tests/test_qwen4_exp_hyper_connection_cuda.py
@@ -1,0 +1,96 @@
+"""Correctness tests for Qwen4-Exp hyper-connection CUDA primitives."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.kernels.cuda_loader import load_cuda_kernel
+
+
+def _extension():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    ext = load_cuda_kernel()
+    required = (
+        "qwen4_exp_grouped_rms_norm",
+        "qwen4_exp_inject",
+    )
+    if ext is None or any(not hasattr(ext, name) for name in required):
+        pytest.skip("Qwen4-Exp hyper-connection CUDA extension is unavailable")
+    return ext
+
+
+@pytest.mark.parametrize("tokens", [1, 7, 8192])
+def test_grouped_rms_norm_bf16_matches_reference(tokens: int) -> None:
+    ext = _extension()
+    torch.manual_seed(20260830 + tokens)
+    groups, group_size = 4, 2560
+    hidden = torch.randn(
+        1,
+        tokens,
+        groups * group_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    weight = torch.randn(
+        groups * group_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    ) * 0.05
+
+    h = hidden.float().reshape(1, tokens, groups, group_size)
+    h = h * torch.rsqrt(h.pow(2).mean(-1, keepdim=True) + 1e-6)
+    want = (
+        h.flatten(-2) * (1.0 + weight.float())
+    ).to(hidden.dtype)
+    got = ext.qwen4_exp_grouped_rms_norm(
+        hidden.contiguous(),
+        weight.contiguous(),
+        group_size,
+        1e-6,
+    )
+    torch.testing.assert_close(got, want, rtol=8e-3, atol=2e-3)
+
+
+@pytest.mark.parametrize("tokens", [1, 7, 8192])
+def test_inject_bf16_matches_reference(tokens: int) -> None:
+    ext = _extension()
+    torch.manual_seed(20260930 + tokens)
+    groups, hidden_size = 4, 2560
+    block_output = torch.randn(
+        1,
+        tokens,
+        hidden_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    hyper_input = torch.randn(
+        1,
+        tokens,
+        groups * hidden_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    injection_weights = torch.sigmoid(
+        torch.randn(
+            1,
+            tokens,
+            groups,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+    ) * 2
+
+    injection = (
+        block_output.unsqueeze(-2)
+        * injection_weights.unsqueeze(-1)
+    )
+    want = hyper_input + injection.flatten(-2)
+    got = ext.qwen4_exp_inject(
+        block_output.contiguous(),
+        hyper_input.contiguous(),
+        injection_weights.contiguous(),
+        groups,
+    )
+    torch.testing.assert_close(got, want, rtol=0, atol=0)

--- a/tests/test_qwen4_exp_moe_cuda.py
+++ b/tests/test_qwen4_exp_moe_cuda.py
@@ -1,0 +1,72 @@
+"""Correctness tests for the raw-BF16 Qwen4-Exp grouped MoE kernel."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from src.kernels.cuda_loader import load_cuda_kernel
+
+
+def _reference(x, route_tokens, route_weights, seg_starts, gate_up, down):
+    out = torch.zeros(x.shape, device=x.device, dtype=torch.float32)
+    for expert in range(gate_up.shape[0]):
+        begin = int(seg_starts[expert].item())
+        end = int(seg_starts[expert + 1].item())
+        for route in range(begin, end):
+            token = int(route_tokens[route].item())
+            gate, up = F.linear(x[token : token + 1], gate_up[expert]).chunk(2, dim=-1)
+            hidden = F.silu(gate) * up
+            value = F.linear(hidden, down[expert]) * route_weights[route]
+            out[token] += value[0].float()
+    return out.to(x.dtype)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_qwen4_exp_bf16_grouped_matches_reference():
+    ext = load_cuda_kernel()
+    if ext is None or not hasattr(ext, "qwen4_exp_moe_prefill_bf16_forward"):
+        pytest.skip("cuda_kernel extension with Qwen kernel is unavailable")
+
+    device = torch.device("cuda")
+    torch.manual_seed(17)
+    tokens, hidden, inter, experts = 7, 32, 16, 5
+    x = torch.randn(tokens, hidden, device=device, dtype=torch.bfloat16)
+    gate_up = torch.randn(experts, 2 * inter, hidden, device=device, dtype=torch.bfloat16) * 0.05
+    down = torch.randn(experts, hidden, inter, device=device, dtype=torch.bfloat16) * 0.05
+
+    # Expert 2 has no routes; repeated token routes check scatter accumulation.
+    route_tokens = torch.tensor([6, 0, 3, 0, 5, 1, 3, 2], device=device, dtype=torch.int64)
+    route_weights = torch.tensor(
+        [0.2, 0.7, 0.3, 0.1, 0.4, 0.8, 0.6, 0.5], device=device, dtype=torch.float32
+    )
+    seg_starts = torch.tensor([0, 2, 4, 4, 6, 8], device=device, dtype=torch.int32)
+
+    got = ext.qwen4_exp_moe_prefill_bf16_forward(
+        x, route_tokens, route_weights, seg_starts, gate_up, down, 0.0
+    )
+    want = _reference(x, route_tokens, route_weights, seg_starts, gate_up, down)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(got, want, rtol=3e-2, atol=3e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_qwen4_exp_bf16_grouped_empty_routes():
+    ext = load_cuda_kernel()
+    if ext is None or not hasattr(ext, "qwen4_exp_moe_prefill_bf16_forward"):
+        pytest.skip("cuda_kernel extension with Qwen kernel is unavailable")
+
+    device = torch.device("cuda")
+    x = torch.randn(3, 16, device=device, dtype=torch.bfloat16)
+    gate_up = torch.randn(2, 8, 16, device=device, dtype=torch.bfloat16)
+    down = torch.randn(2, 16, 4, device=device, dtype=torch.bfloat16)
+    empty = torch.empty(0, device=device, dtype=torch.int64)
+    empty_w = torch.empty(0, device=device, dtype=torch.float32)
+    seg_starts = torch.zeros(3, device=device, dtype=torch.int32)
+    got = ext.qwen4_exp_moe_prefill_bf16_forward(
+        x, empty, empty_w, seg_starts, gate_up, down, 0.0
+    )
+    assert got.shape == x.shape
+    assert got.dtype == x.dtype
+    assert torch.count_nonzero(got) == 0

--- a/tests/test_qwen4_exp_parity.py
+++ b/tests/test_qwen4_exp_parity.py
@@ -132,6 +132,18 @@ def test_greedy_chain_matches(built, golden):
     assert produced == expected[0, input_ids.shape[1] :].tolist()
 
 
+def test_last_token_only_matches_full_logits(built, golden):
+    _config, model = built
+    input_ids = golden["input_ids"]
+
+    full = model.forward(input_ids)
+    last = model.forward(input_ids, last_token_only=True)
+
+    assert last.shape == full[:, -1:].shape
+    torch.testing.assert_close(last, full[:, -1:], rtol=1e-5, atol=1e-7)
+    assert torch.equal(last.argmax(-1), full[:, -1:].argmax(-1))
+
+
 def test_chunked_prefill_matches_single_shot(built, golden):
     """Splitting prefill into chunks must not change the final logits.
 

--- a/tests/test_qwen4_exp_prefill_linear.py
+++ b/tests/test_qwen4_exp_prefill_linear.py
@@ -1,0 +1,83 @@
+"""Tests for the optional SM75 FP16 prefill projection path."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+from src.models.qwen4_exp.layers import prefill_linear
+
+
+def test_prefill_linear_cpu_is_exact(monkeypatch) -> None:
+    monkeypatch.setenv("DSV4_QWEN4_DENSE_FP16", "1")
+    x = torch.randn(9, 32, dtype=torch.bfloat16)
+    weight = torch.randn(17, 32, dtype=torch.bfloat16)
+
+    got = prefill_linear(x, weight)
+    want = F.linear(x, weight)
+
+    torch.testing.assert_close(got, want, rtol=0, atol=0)
+
+
+def test_prefill_linear_small_cuda_rows_keep_bf16(monkeypatch) -> None:
+    if not torch.cuda.is_available():
+        return
+    monkeypatch.setenv("DSV4_QWEN4_DENSE_FP16", "1")
+    monkeypatch.setenv("DSV4_QWEN4_DENSE_FP16_MIN_ROWS", "128")
+    x = torch.randn(1, 32, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(17, 32, device="cuda", dtype=torch.bfloat16)
+
+    got = prefill_linear(x, weight)
+    want = F.linear(x, weight)
+
+    torch.testing.assert_close(got, want, rtol=0, atol=0)
+
+
+def test_prefill_linear_large_cuda_rows_use_close_fp16(monkeypatch) -> None:
+    if not torch.cuda.is_available():
+        return
+    monkeypatch.setenv("DSV4_QWEN4_DENSE_FP16", "1")
+    monkeypatch.setenv("DSV4_QWEN4_DENSE_FP16_MIN_ROWS", "8")
+    torch.manual_seed(20260830)
+    x = torch.randn(8, 64, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(48, 64, device="cuda", dtype=torch.bfloat16) * 0.05
+
+    got = prefill_linear(x, weight)
+    want = F.linear(x, weight)
+
+    torch.testing.assert_close(got, want, rtol=2e-2, atol=2e-3)
+
+
+def test_prefill_linear_fp16_fp32_output_matches_explicit_mm(monkeypatch) -> None:
+    if not torch.cuda.is_available():
+        return
+    monkeypatch.setenv("DSV4_QWEN4_DENSE_FP16", "0")
+    monkeypatch.setenv("DSV4_QWEN4_DENSE_FP16_FP32_OUTPUT", "1")
+    monkeypatch.setenv("DSV4_QWEN4_DENSE_FP16_MIN_ROWS", "8")
+    torch.manual_seed(20260831)
+    x = torch.randn(2, 4, 64, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(48, 64, device="cuda", dtype=torch.bfloat16) * 0.05
+
+    got = prefill_linear(x, weight)
+    explicit = torch.mm(
+        x.reshape(-1, 64).to(torch.float16),
+        weight.to(torch.float16).t(),
+        out_dtype=torch.float32,
+    ).to(torch.bfloat16).reshape(2, 4, 48)
+
+    torch.testing.assert_close(got, explicit, rtol=0, atol=0)
+
+
+def test_prefill_linear_fp16_fp32_output_keeps_small_rows_bf16(monkeypatch) -> None:
+    if not torch.cuda.is_available():
+        return
+    monkeypatch.setenv("DSV4_QWEN4_DENSE_FP16", "0")
+    monkeypatch.setenv("DSV4_QWEN4_DENSE_FP16_FP32_OUTPUT", "1")
+    monkeypatch.setenv("DSV4_QWEN4_DENSE_FP16_MIN_ROWS", "128")
+    x = torch.randn(1, 64, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(48, 64, device="cuda", dtype=torch.bfloat16)
+
+    got = prefill_linear(x, weight)
+    want = F.linear(x, weight)
+
+    torch.testing.assert_close(got, want, rtol=0, atol=0)

--- a/tests/test_qwen4_exp_profiler.py
+++ b/tests/test_qwen4_exp_profiler.py
@@ -1,0 +1,33 @@
+"""Profiler aggregation tests for Qwen4-Exp."""
+
+from __future__ import annotations
+
+from src.models.qwen4_exp.profiler import Profiler
+
+
+def test_aggregate_sums_layer_children() -> None:
+    profiler = Profiler()
+    for layer in range(2):
+        with profiler.scope("prefill"):
+            with profiler.scope(f"layer_{layer}"):
+                with profiler.scope("attention"):
+                    pass
+                with profiler.scope("moe"):
+                    pass
+
+    aggregated = profiler.aggregate()
+    assert aggregated["attention"].count == 2
+    assert aggregated["moe"].count == 2
+    assert "attention" in profiler.aggregate_report()
+    assert "moe" in profiler.aggregate_report()
+
+
+def test_aggregate_keeps_external_attention_phases() -> None:
+    profiler = Profiler()
+    with profiler.scope("prefill"):
+        with profiler.scope("layer_3"):
+            profiler.add_external("attention_core", 0.125)
+
+    aggregated = profiler.aggregate()
+    assert aggregated["attention_core"].count == 1
+    assert aggregated["attention_core"].total_s == 0.125

--- a/tests/test_qwen4_exp_qsa_cuda.py
+++ b/tests/test_qwen4_exp_qsa_cuda.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.kernels.cuda_loader import load_cuda_kernel
+
+
+def _extension():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    ext = load_cuda_kernel()
+    if ext is None or not hasattr(ext, "qwen4_exp_qsa_bf16_forward"):
+        pytest.skip("Qwen4-Exp QSA CUDA extension is unavailable")
+    return ext
+
+
+def _reference(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    selected: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    batch, rows, query_heads, dim = query.shape
+    kv_heads = key.shape[1]
+    heads_per_kv = query_heads // kv_heads
+    safe = selected.clamp_min(0).to(torch.long)
+    batch_index = torch.arange(batch, device=query.device).view(batch, 1, 1).expand_as(safe)
+    key_tokens = key.transpose(1, 2)
+    value_tokens = value.transpose(1, 2)
+    gathered_key = key_tokens[batch_index, safe].repeat_interleave(heads_per_kv, dim=3)
+    gathered_value = value_tokens[batch_index, safe].repeat_interleave(heads_per_kv, dim=3)
+    scores = torch.einsum("bqhd,bqkhd->bqhk", query.float(), gathered_key.float()) * scale
+    scores = scores.masked_fill((selected < 0).unsqueeze(2), float("-inf"))
+    weights = torch.softmax(scores, dim=-1)
+    return torch.einsum("bqhk,bqkhd->bqhd", weights, gathered_value.float()).to(query.dtype)
+
+
+@pytest.mark.parametrize(
+    "rows,kv_len,selected_len,query_heads",
+    [
+        (1, 7, 9, 6),
+        (5, 23, 17, 6),
+        (19, 64, 33, 6),
+        (5, 23, 17, 12),
+    ],
+)
+def test_qsa_bf16_matches_reference(
+    rows: int,
+    kv_len: int,
+    selected_len: int,
+    query_heads: int,
+) -> None:
+    ext = _extension()
+    torch.manual_seed(20260830 + rows + query_heads)
+    query = torch.randn(
+        1,
+        rows,
+        query_heads,
+        256,
+        device="cuda",
+        dtype=torch.bfloat16,
+    ) * 0.1
+    key = torch.randn(1, 1, kv_len, 256, device="cuda", dtype=torch.bfloat16) * 0.1
+    value = torch.randn(1, 1, kv_len, 256, device="cuda", dtype=torch.bfloat16) * 0.1
+    selected = torch.randint(0, kv_len, (1, rows, selected_len), device="cuda", dtype=torch.int32)
+    selected[:, :, -2:] = -1
+    scale = 256**-0.5
+
+    got = ext.qwen4_exp_qsa_bf16_forward(query, key, value, selected, scale)
+    want = _reference(query, key, value, selected, scale)
+    torch.testing.assert_close(got, want, rtol=2e-2, atol=2e-3)
+
+
+def test_qsa_bf16_empty_padding_is_ignored() -> None:
+    ext = _extension()
+    query = torch.randn(1, 3, 6, 256, device="cuda", dtype=torch.bfloat16)
+    key = torch.randn(1, 1, 8, 256, device="cuda", dtype=torch.bfloat16)
+    value = torch.randn(1, 1, 8, 256, device="cuda", dtype=torch.bfloat16)
+    selected = torch.full((1, 3, 11), -1, device="cuda", dtype=torch.int32)
+    selected[:, :, 0] = torch.tensor([0, 3, 7], device="cuda", dtype=torch.int32)
+
+    got = ext.qwen4_exp_qsa_bf16_forward(query, key, value, selected, 256**-0.5)
+    want = value[:, :, [0, 3, 7]].transpose(1, 2).expand(-1, -1, 6, -1)
+    torch.testing.assert_close(got, want, rtol=0, atol=0)

--- a/tests/test_qwen4_exp_qsa_fallback.py
+++ b/tests/test_qwen4_exp_qsa_fallback.py
@@ -1,0 +1,69 @@
+"""Correctness tests for the memory-bounded QSA Python fallback."""
+
+from __future__ import annotations
+
+import copy
+
+import torch
+
+from src.models.qwen4_exp.attention import QSAAttention
+from src.models.qwen4_exp.config import Qwen4ExpTextConfig
+
+
+def _weights(config: Qwen4ExpTextConfig) -> dict[str, torch.Tensor]:
+    hidden = config.hidden_size
+    query = config.num_attention_heads * config.head_dim * 2
+    kv = config.num_key_value_heads * config.head_dim
+    index = (
+        (config.indexer_n_heads or 0) * (config.indexer_head_dim or 0)
+        + (config.indexer_kv_heads or 0) * (config.indexer_head_dim or 0)
+    )
+    return {
+        "q_proj": torch.randn(query, hidden, dtype=torch.bfloat16) * 0.02,
+        "k_proj": torch.randn(kv, hidden, dtype=torch.bfloat16) * 0.02,
+        "v_proj": torch.randn(kv, hidden, dtype=torch.bfloat16) * 0.02,
+        "o_proj": torch.randn(hidden, config.num_attention_heads * config.head_dim, dtype=torch.bfloat16) * 0.02,
+        "q_norm": torch.randn(config.head_dim, dtype=torch.bfloat16) * 0.02,
+        "k_norm": torch.randn(config.head_dim, dtype=torch.bfloat16) * 0.02,
+        "index_qk_proj": torch.randn(index, hidden, dtype=torch.bfloat16) * 0.02,
+        "q_layernorm": torch.randn(config.indexer_head_dim, dtype=torch.bfloat16) * 0.02,
+        "k_layernorm": torch.randn(config.indexer_head_dim, dtype=torch.bfloat16) * 0.02,
+    }
+
+
+def test_qsa_chunked_fallback_matches_dense_reference(monkeypatch) -> None:
+    config = Qwen4ExpTextConfig(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=16,
+        indexer_budget=32,
+        indexer_compress_ratio=4,
+    )
+    weights = _weights(config)
+    hidden = torch.randn(1, 29, config.hidden_size, dtype=torch.bfloat16)
+    cos = torch.ones(1, 29, config.rotary_dim, dtype=torch.bfloat16)
+    sin = torch.zeros_like(cos)
+
+    monkeypatch.setenv("DSV4_QWEN4_QSA_CUDA", "0")
+    monkeypatch.setenv("DSV4_QWEN4_QSA_FALLBACK_ROWS", "5")
+    chunked = QSAAttention(config, copy.deepcopy(weights))(
+        hidden,
+        cos,
+        sin,
+        None,
+        past_len=0,
+    )
+    monkeypatch.setenv("DSV4_QWEN4_QSA_FALLBACK_ROWS", "29")
+    dense = QSAAttention(config, copy.deepcopy(weights))(
+        hidden,
+        cos,
+        sin,
+        None,
+        past_len=0,
+    )
+
+    torch.testing.assert_close(chunked, dense, rtol=0, atol=0)

--- a/tests/test_qwen4_exp_qsa_indexer.py
+++ b/tests/test_qwen4_exp_qsa_indexer.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from src.models.qwen4_exp.attention import QSAIndexer
+
+
+@pytest.fixture
+def config() -> SimpleNamespace:
+    return SimpleNamespace(
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=8,
+        indexer_budget=8,
+        indexer_compress_ratio=4,
+        rms_norm_eps=1e-6,
+    )
+
+
+def _indexer(config: SimpleNamespace) -> QSAIndexer:
+    qk_rows = (config.indexer_n_heads + config.indexer_kv_heads) * config.indexer_head_dim
+    weights = {
+        "index_qk_proj": torch.randn(qk_rows, 16),
+        "q_layernorm": torch.ones(config.indexer_head_dim),
+        "k_layernorm": torch.ones(config.indexer_head_dim),
+    }
+    return QSAIndexer(config, weights)
+
+
+def _rope(length: int, dim: int) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.ones(1, length, dim), torch.zeros(1, length, dim)
+
+
+def _assert_valid_causal_indices(
+    selected: torch.Tensor,
+    *,
+    past_len: int,
+    kv_len: int,
+) -> None:
+    assert selected.dtype == torch.int32
+    for row in range(selected.shape[1]):
+        valid = selected[0, row][selected[0, row] >= 0]
+        assert torch.all(valid < past_len + row + 1)
+        assert torch.all(valid < kv_len)
+        assert valid.unique().numel() == valid.numel()
+
+
+def test_all_visible_context_uses_dynamic_width(config: SimpleNamespace) -> None:
+    torch.manual_seed(20260830)
+    indexer = _indexer(config)
+    hidden = torch.randn(1, 5, 16)
+    cos, sin = _rope(5, config.indexer_head_dim)
+
+    selected = indexer(hidden, cos, sin, None, past_len=0)
+
+    assert selected.shape == (1, 5, 5)
+    expected = torch.tensor(
+        [
+            [0, -1, -1, -1, -1],
+            [0, 1, -1, -1, -1],
+            [0, 1, 2, -1, -1],
+            [0, 1, 2, 3, -1],
+            [0, 1, 2, 3, 4],
+        ],
+        dtype=torch.int32,
+    ).unsqueeze(0)
+    torch.testing.assert_close(selected, expected)
+
+
+def test_sparse_indices_are_causal_unique_and_compact(config: SimpleNamespace) -> None:
+    torch.manual_seed(20260831)
+    indexer = _indexer(config)
+    hidden = torch.randn(1, 19, 16)
+    cos, sin = _rope(19, config.indexer_head_dim)
+
+    selected = indexer(hidden, cos, sin, None, past_len=0)
+
+    assert selected.shape == (1, 19, 11)
+    _assert_valid_causal_indices(selected, past_len=0, kv_len=19)
+    last_valid = selected[0, -1][selected[0, -1] >= 0]
+    assert last_valid.numel() <= config.indexer_budget + config.indexer_compress_ratio - 1
+    assert 16 in last_valid.tolist()
+    assert 17 in last_valid.tolist()
+    assert 18 in last_valid.tolist()
+
+
+def test_cached_non_aligned_tail_stays_causal(config: SimpleNamespace) -> None:
+    torch.manual_seed(20260901)
+    indexer = _indexer(config)
+    hidden = torch.randn(1, 3, 16)
+    raw_prefix = torch.randn(1, 10, config.indexer_head_dim)
+    cos, sin = _rope(13, config.indexer_head_dim)
+
+    selected = indexer(
+        hidden,
+        cos,
+        sin,
+        None,
+        past_len=10,
+        raw_keys_override=raw_prefix,
+    )
+
+    assert selected.shape == (1, 3, 11)
+    _assert_valid_causal_indices(selected, past_len=10, kv_len=13)

--- a/tests/test_qwen4_exp_runtime.py
+++ b/tests/test_qwen4_exp_runtime.py
@@ -1,0 +1,41 @@
+"""Runtime topology helpers for Qwen4-Exp heterogeneous inference."""
+
+from __future__ import annotations
+
+import io
+import os
+
+import torch
+
+from src.models.qwen4_exp import runtime
+
+
+def test_parse_cpu_list() -> None:
+    assert runtime._parse_cpu_list("0-2,5,8-9\n") == [0, 1, 2, 5, 8, 9]
+
+
+def test_cpu_affinity_splits_ranks_on_same_numa_node(monkeypatch) -> None:
+    monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(16)))
+    monkeypatch.setattr(runtime, "_cuda_numa_node", lambda device: int(device.index or 0) // 2)
+    monkeypatch.setattr(
+        runtime,
+        "_physical_core_groups",
+        lambda cpus: [[cpu] for cpu in sorted(cpus)],
+    )
+
+    real_open = open
+
+    def fake_open(path, *args, **kwargs):
+        if path.endswith("node0/cpulist"):
+            return io.StringIO("0-7")
+        if path.endswith("node1/cpulist"):
+            return io.StringIO("8-15")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 4)
+
+    assert runtime._cpu_affinity_for_device(torch.device("cuda:0"), 0, 4) == [0, 1, 2, 3]
+    assert runtime._cpu_affinity_for_device(torch.device("cuda:1"), 1, 4) == [4, 5, 6, 7]
+    assert runtime._cpu_affinity_for_device(torch.device("cuda:2"), 2, 4) == [8, 9, 10, 11]
+    assert runtime._cpu_affinity_for_device(torch.device("cuda:3"), 3, 4) == [12, 13, 14, 15]

--- a/tests/test_qwen4_exp_tp_sharding.py
+++ b/tests/test_qwen4_exp_tp_sharding.py
@@ -210,3 +210,166 @@ def test_host_expert_rows_match_dense(checkpoint_dir):
         gate_up, down = checkpoint.expert_rows(0, expert_id)
         torch.testing.assert_close(gate_up, gate_up_all[expert_id], rtol=0, atol=0)
         torch.testing.assert_close(down, down_all[expert_id], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("world_size", [1, 2, 4])
+def test_resident_shard_partitions_experts(checkpoint_dir, world_size):
+    """Preloaded shards must cover every expert exactly once, sized to their share."""
+    config = Qwen4ExpConfig.from_pretrained(checkpoint_dir).text_config
+    num_experts = config.num_experts
+    owned: list[int] = []
+    for rank in range(world_size):
+        checkpoint = Qwen4ExpCheckpoint(checkpoint_dir, store=MmapSafetensors(checkpoint_dir))
+        shard = checkpoint.preload_experts(
+            config.num_hidden_layers, rank=rank, world_size=world_size, pin=False
+        )
+        ids = shard.local_expert_ids(num_experts)
+        owned.extend(ids)
+        assert shard.num_local_experts == len(ids)
+        assert shard.stats()["layers"] == config.num_hidden_layers
+        gate_up, down = shard.rows(0, ids[0])
+        assert gate_up.shape == (2 * config.moe_intermediate_size, config.hidden_size)
+        assert down.shape == (config.hidden_size, config.moe_intermediate_size)
+        per_expert = (
+            gate_up.numel() * gate_up.element_size() + down.numel() * down.element_size()
+        )
+        assert shard.resident_bytes == per_expert * len(ids) * config.num_hidden_layers
+        # Local indices are dense: the last owned expert sits at len(ids) - 1.
+        assert shard.local_index(ids[-1]) == len(ids) - 1
+    assert sorted(owned) == list(range(num_experts))
+
+
+def test_release_mapping_keeps_rows_readable(checkpoint_dir):
+    """MADV_DONTNEED must free pages without changing what the mapping returns.
+
+    The advice only drops this process's resident pages; touching the view again
+    faults them back, so both the resident copy and a later mmap read of the same
+    tensor must still be bit-exact.
+    """
+    from safetensors import safe_open
+
+    config = Qwen4ExpConfig.from_pretrained(checkpoint_dir).text_config
+    checkpoint = Qwen4ExpCheckpoint(checkpoint_dir, store=MmapSafetensors(checkpoint_dir))
+    key = checkpoint.expert_key(0, "gate_up_proj")
+    reference = checkpoint.store.view(key).clone()
+
+    checkpoint.preload_experts(
+        config.num_hidden_layers, rank=0, world_size=1, pin=False, release_mapping=True
+    )
+    torch.testing.assert_close(checkpoint.store.view(key), reference, rtol=0, atol=0)
+    with safe_open(
+        os.path.join(checkpoint_dir, checkpoint.store.entries[key].file_name), framework="pt"
+    ) as f:
+        torch.testing.assert_close(checkpoint.store.view(key), f.get_tensor(key), rtol=0, atol=0)
+
+
+def test_resident_shard_rows_match_mmap(checkpoint_dir):
+    """Rows served from host RAM must be bit-identical to the mapped rows."""
+    config = Qwen4ExpConfig.from_pretrained(checkpoint_dir).text_config
+    world_size = 4
+    for rank in range(world_size):
+        mapped = Qwen4ExpCheckpoint(checkpoint_dir, store=MmapSafetensors(checkpoint_dir))
+        resident = Qwen4ExpCheckpoint(checkpoint_dir, store=MmapSafetensors(checkpoint_dir))
+        resident.preload_experts(
+            config.num_hidden_layers, rank=rank, world_size=world_size, pin=False
+        )
+        for layer_idx in range(config.num_hidden_layers):
+            for expert_id in range(config.num_experts):
+                if expert_id % world_size != rank:
+                    continue
+                got_gate_up, got_down = resident.expert_rows(layer_idx, expert_id)
+                want_gate_up, want_down = mapped.expert_rows(layer_idx, expert_id)
+                torch.testing.assert_close(got_gate_up, want_gate_up, rtol=0, atol=0)
+                torch.testing.assert_close(got_down, want_down, rtol=0, atol=0)
+        # The shard is a copy, not a view into the mapping.
+        owned = rank
+        row, _ = resident.expert_rows(0, owned)
+        assert row.data_ptr() != mapped.expert_rows(0, owned)[0].data_ptr()
+
+
+def test_resident_shard_matches_mmap_logits(checkpoint_dir, golden):
+    """A TP forward over resident experts must reproduce the mmap-path logits."""
+    config = Qwen4ExpConfig.from_pretrained(checkpoint_dir)
+    world_size = 4
+    models = []
+    for rank in range(world_size):
+        checkpoint = Qwen4ExpCheckpoint(checkpoint_dir, store=MmapSafetensors(checkpoint_dir))
+        checkpoint.preload_experts(
+            config.text_config.num_hidden_layers, rank=rank, world_size=world_size, pin=False
+        )
+        models.append(
+            build_heterogeneous(
+                config.text_config,
+                checkpoint,
+                device="cpu",
+                dtype=torch.float32,
+                rank=rank,
+                world_size=world_size,
+                all_reduce=lambda t: t,
+            )
+        )
+    logits = _lockstep_forward(models, golden["input_ids"], world_size)
+    torch.testing.assert_close(logits, golden["prefill_logits"].float(), rtol=1e-4, atol=1e-4)
+
+
+def test_host_expert_moe_resident_matches_mmap(checkpoint_dir):
+    """`HostExpertMoE` output must not depend on where the rows came from."""
+    from src.models.qwen4_exp.moe import HostExpertMoE
+
+    config = Qwen4ExpConfig.from_pretrained(checkpoint_dir).text_config
+    mapped = Qwen4ExpCheckpoint(checkpoint_dir, store=MmapSafetensors(checkpoint_dir))
+    resident = Qwen4ExpCheckpoint(checkpoint_dir, store=MmapSafetensors(checkpoint_dir))
+    resident.preload_experts(config.num_hidden_layers, rank=0, world_size=1, pin=False)
+
+    device = torch.device("cpu")
+    backends = [
+        HostExpertMoE(reader, config.num_experts, device, torch.float32)
+        for reader in (mapped, resident)
+    ]
+
+    torch.manual_seed(0)
+    tokens = 6
+    hidden = torch.randn(tokens, config.hidden_size)
+    indices = torch.randint(0, config.num_experts, (tokens, config.num_experts_per_tok))
+    weights = torch.rand(tokens, config.num_experts_per_tok)
+
+    out_mapped = backends[0](1, hidden, indices, weights)
+    out_resident = backends[1](1, hidden, indices, weights)
+    torch.testing.assert_close(out_resident, out_mapped, rtol=0, atol=0)
+
+
+def test_resident_shard_pin_fallback_is_uniform():
+    """A mid-load pin failure must leave no pinned tensors behind."""
+    from src.models.qwen4_exp.weights import HostExpertShard
+
+    shard = HostExpertShard(num_layers=2, rank=0, world_size=1, pin_memory=True)
+    gate_up_all = torch.randn(4, 6, 8)
+    down_all = torch.randn(4, 8, 3)
+    shard.load_layer(0, gate_up_all, down_all)
+    if not shard.pinned:
+        pytest.skip("pinned host memory unavailable in this environment")
+
+    real_empty = torch.empty
+    # Fail on the *second* pinned allocation of the layer, which is the case that
+    # could otherwise leave one layer with a pinned gate_up and a pageable down.
+    remaining = [1]
+
+    def failing_empty(*args, **kwargs):
+        if kwargs.get("pin_memory"):
+            if remaining[0] <= 0:
+                raise RuntimeError("simulated memlock limit")
+            remaining[0] -= 1
+        return real_empty(*args, **kwargs)
+
+    torch.empty = failing_empty
+    try:
+        shard.load_layer(1, gate_up_all, down_all)
+    finally:
+        torch.empty = real_empty
+
+    assert not shard.pinned
+    for layer_idx in (0, 1):
+        gate_up, down = shard.rows(layer_idx, 0)
+        assert not gate_up.is_pinned() and not down.is_pinned()
+        torch.testing.assert_close(gate_up, gate_up_all[0], rtol=0, atol=0)
+        torch.testing.assert_close(down, down_all[0], rtol=0, atol=0)


### PR DESCRIPTION
## Summary

Qwen3.8-Flash-Next (Qwen4-Exp) runs as a heterogeneous TP4 model on 4x RTX 2080 Ti: routed experts live in host RAM, active experts are staged to the GPU per layer, and all MoE arithmetic runs on the GPU. This PR works on the prefill side of that runtime.

**Host-resident experts and staging**
- The per-rank expert shard is an explicit host-RAM copy, not an mmap page-cache hit: round-robin ownership (`expert_id % world_size == rank`), 128 experts per layer per rank, 56.25 GiB/rank, disjoint across ranks so the four shards hold exactly one copy of the 225 GiB expert set. Pinned by default with an all-or-nothing pageable fallback.
- Prefill tokens are grouped per expert with a stable argsort and experts are visited in ascending id, so MoE output is reproducible run to run.
- The next expert is prefetched on a copy stream while the current one computes.

**CUDA kernels for the Qwen4-Exp specific blocks**
- `qwen4_exp_gated_delta.cu` — BF16 gated DeltaNet recurrence
- `qwen4_exp_qsa.cu` — sparse-attention indexer and indexed core
- `qwen4_exp_hyper_connection.cu` — hyper-connection SiLU, inject gate, inject, grouped RMSNorm
- `qwen4_exp_moe.cu` — BF16 prefill MoE

**Prefill paths**
- `prefill_linear` routes wide prefill GEMMs through SM75 FP16 tensor cores and falls back to BF16 below the row threshold, so single-row decode is untouched.
- `last_token_only` trims the prefill tail to the token that is actually sampled.
- Each rank's CPU threads are pinned to the physical cores on its GPU's NUMA node.

**Profiling** — scope aggregation plus `add_external` folds per-layer attention timings into one report; the tree view stays behind `DSV4_QWEN4_PROFILE_TREE`.

## Measured

Conditions: 8192 real tokenizer tokens, one 8192-token chunk, TP4, expert cache capacity 1024, pinned 56.25 GiB host shard per rank, global warmup applied, host preload (~53 s/rank, one-time) excluded. All rows produced token 97792.

| Path | Mean wall | Mean throughput |
|---|---:|---:|
| BF16 baseline | 10.419 s | 786.27 tok/s |
| FP16 dense + CUDA hyper-connection | 8.629 s | 949.41 tok/s |
| BF16 baseline recheck | 10.653 s | 769.01 tok/s |

Separately, replacing all expert H2D with GPU-resident dummy experts gives 909.07 tok/s / 9.011 s against the real path's 779.93 tok/s / 10.504 s. Exposed staging is therefore 1.492 s, 14.2% of wall — perfect staging overlap alone cannot reach 1000 tok/s, because the compute floor itself exceeds the 8.192 s that 1000 tok/s requires on 8192 tokens.

## Caveats

- **The 1061.46 tok/s FP32-output dense variant is not enabled and is not claimed as correct.** It changes a non-tie greedy decision (decision 23, baseline margin 0.1875), so it is an experimental precision arm, not a default.
- The hyper-connection SiLU and inject-gate kernels are bit-exact against PyTorch. The grouped RMSNorm kernel is near-parity, not bit-exact (`equal=0.99999541`, `max_abs=0.0625`), so `DSV4_QWEN4_HC_CUDA=1` should be read as accuracy-tested near-parity.
- `DSV4_QWEN4_MOE_GROUPED` stays default `0`; the FP16 dense and FP16 hyper-connection gates are also off by default.
- `DSV4_QWEN4_CPU_AFFINITY` defaults to **on** — this is the one change here that alters default runtime behavior.
- All prefill precision gates require at least 128 rows, so rows=1 decode keeps the BF16 path.

## Testing

- `pytest tests/ -k qwen4_exp` — 69 passed (237 deselected), including the CUDA gated-delta / QSA / MoE / hyper-connection kernel tests, the QSA fallback tests, TP sharding, parity, runtime, and profiler tests.
- Rebased onto `master` at c0de331 (PR #100); that PR only touches `cpp_engine/`, so there is no overlap with this change set.
- Not run: the full repository test suite.
