### PR TITLE
Read Qwen4-Exp routed experts as FP8 and compute in FP16

### DIFF
--- a/docs/qwen4_exp_performance.md
+++ b/docs/qwen4_exp_performance.md
@@ -295,3 +295,168 @@ PYTHONPATH=. \
   --prompts chinese,english,code \
   --arms dense_fp32_hc_down_up_fp32
 ```
+
+## Theoretical ceilings of the heterogeneous scheme
+
+All constants in this section were measured on this machine (4x RTX 2080 Ti,
+TP4, PCIe Gen3) with `.scratch/probe_*.py`. Rows marked *projected* combine
+measured constants arithmetically and have not been observed end to end.
+
+### Hardware roofs
+
+| Roof | Measured |
+|---|---:|
+| Pinned H2D, one GPU active | 10.49-10.82 GiB/s |
+| Pinned H2D, all four GPUs concurrent | 42.42 GiB/s aggregate (10.61 GiB/s per GPU) |
+| GEMM, BF16, 8192x4096x4096 | 7.50 TFLOP/s |
+| GEMM, FP16, 8192x4096x4096 | 54.71 TFLOP/s |
+| DRAM copy | 494.5 GiB/s effective |
+| NCCL all_reduce 8192x2560 BF16 | 7.146 ms (5.47 GiB/s) |
+| NCCL all_reduce 1x2560 BF16 | 0.092 ms |
+
+Two of these matter more than the rest. **H2D does not contend across the four
+GPUs**: each rank keeps its full ~10.6 GiB/s while all four copy at once, so
+per-rank staging math is additive, not shared. And **BF16 GEMM runs 7.3x slower
+than FP16** on SM75, because Turing has no BF16 tensor-core path — this single
+ratio dominates the prefill ceiling.
+
+### Prefill ceiling
+
+Summing the measured per-kernel costs of one 8192-token TP4 pass (36
+`linear_attention` + 12 `qwen_sparse_attention` layers, per-rank shapes):
+
+| Arm | Floor | Ceiling |
+|---|---:|---:|
+| BF16 everywhere | 7.217 s | 1135 tok/s |
+| FP16 dense, BF16 MoE (this PR's arm) | 4.123 s | 1987 tok/s |
+| FP16 dense + FP16 MoE (projected) | 2.979 s | 2750 tok/s |
+| + tensor-core QSA core, 3.44x (projected) | 2.126 s | 3853 tok/s |
+
+Measured end to end for comparison: BF16 786.27 tok/s, FP16 dense + CUDA HC
+949.41 tok/s, no-H2D compute floor 909.07 tok/s. The shipped arm therefore runs
+at **48% of its own GEMM floor**; the missing 1.44-2.1x is launch overhead,
+elementwise traffic, and Python dispatch, not arithmetic.
+
+Phase attribution of the floor:
+
+| Phase | BF16 | FP16 dense |
+|---|---:|---:|
+| routed MoE (x48) | 1.326 s / 18.4% | 1.326 s / 32.2% |
+| QSA core (x12) | 1.202 s / 16.7% | 1.202 s / 29.2% |
+| hyper-connection (x48) | 1.444 s / 20.0% | 0.234 s / 5.7% |
+| GDN dense proj (x36) | 1.154 s / 16.0% | 0.158 s / 3.8% |
+| NCCL all_reduce (x96) | 0.686 s / 9.5% | 0.686 s / 16.6% |
+| shared + router (x48) | 0.657 s / 9.1% | 0.095 s / 2.3% |
+| GDN recurrence (x36) | 0.290 s / 4.0% | 0.290 s / 7.0% |
+| QSA dense proj (x12) | 0.378 s / 5.2% | 0.053 s / 1.3% |
+| QSA indexer (x12) | 0.081 s / 1.1% | 0.081 s / 2.0% |
+
+The hyper-connection is the largest single BF16 phase at 20%, which is why the
+FP16 path bought 20.7% end to end. Once dense projections are FP16, the profile
+inverts: routed MoE and the QSA core become 61% of the floor together, and both
+are still BF16.
+
+The QSA core sustains only 1.03 TFLOP/s, 14% of the BF16 GEMM roof, because it
+runs as two `einsum` calls with an FP32 softmax between them. This is the same
+shape of problem the `cpp_engine` Qwen path already solved with an SM75
+`m16n8k8` kernel, where the analogous exact-GQA prefill gained 3.44x.
+
+**H2D is not the prefill bound and cannot become one soon.** A cold 8192-token
+chunk touches all 128 local experts across 48 layers = 56.25 GiB/rank = 5.31 s
+at 10.6 GiB/s. Measured exposed staging was only 1.492 s of a 10.504 s wall, so
+3.81 s already hides behind compute. Staging becomes the wall only if compute
+drops below 5.31 s, i.e. past **1544 tok/s**. Between today's 949 tok/s and
+1544 tok/s, every gain must come from compute; above 1544 tok/s the scheme turns
+PCIe-bound and needs quantized experts to go further.
+
+### Decode ceiling
+
+Decode is bound by bytes, not arithmetic, and the gap is 3x.
+
+Per token per rank: top-10 of 512 experts, round-robin ownership, 48 layers =
+120 expert copies = 1125 MiB = 1.099 GiB -> **103.6 ms of H2D**. Measured decode
+compute at 8192 context is 35.0 ms (dense 11.2 + full attention 8.8 + routed MoE
+4.4 + NCCL 8.8 + lm_head 1.8), i.e. 28.6 tok/s if H2D were free.
+
+| Scenario | ms/token | Ceiling |
+|---|---:|---:|
+| Serial H2D + compute | 138.6 | 7.2 tok/s |
+| Perfect H2D/compute overlap | 103.6 | 9.6 tok/s |
+| + 31% resident cache, uniform routing | 71.5 | 14.0 tok/s |
+| INT8 experts | 51.8 | 19.3 tok/s |
+| INT8 + 62% resident | 35.0 | 28.6 tok/s |
+| INT4 experts | 35.0 | 28.6 tok/s |
+| Any scheme with no expert H2D | 35.0 | 28.6 tok/s |
+
+**28.6 tok/s is the hard decode ceiling of this model on this hardware**, and it
+is a compute number, not a transfer number. Nothing done to the expert pipeline
+can pass it; INT4 experts and fully-GPU-resident experts land on exactly the
+same 35.0 ms because at that point H2D has fallen under the compute time. Past
+28.6 tok/s the levers are NCCL (8.8 ms, 25% — 96 small all_reduces), the
+`linear_attention` dense projections (11.2 ms, 32%), and full attention (8.8 ms,
+25%).
+
+Residency is set by the memory budget: 22.0 GiB per card minus 2.54 GiB dense
+per rank minus ~2 GiB KV and activations leaves 17.46 GiB, or 1907 of the 6144
+local experts (31%). That is what makes the 14.0 tok/s row reachable with BF16
+experts and no quantization.
+
+Quantized residency changes the picture qualitatively:
+
+| Expert dtype | Total | Per rank | + dense | Fits 22 GiB |
+|---|---:|---:|---:|---|
+| BF16 | 229.7 GiB | 57.4 GiB | 60.0 GiB | no |
+| INT8 | 112.5 GiB | 28.1 GiB | 30.7 GiB | no |
+| Q4_K-ish (4.5 bit) | 63.3 GiB | 15.8 GiB | 18.4 GiB | **yes** |
+| INT4 | 56.2 GiB | 14.1 GiB | 16.6 GiB | **yes** |
+
+At 4 bits the entire routed-expert set fits in GPU memory across the four
+ranks, which removes the heterogeneous H2D path from decode altogether and puts
+decode at its 28.6 tok/s compute floor — a 3.0x lift over the 9.6 tok/s
+overlap-only ceiling. This is the one structural change that moves decode by
+more than a fraction.
+
+**Speculative decoding does not help the bytes.** Expert selection is nearly
+independent across positions: verifying 8 tokens touches 74.7 distinct experts
+per layer instead of 8x10=80, only 6.6% fewer bytes per token. Batched verify
+amortizes compute, which decode is not bound by, and leaves the actual bound
+untouched.
+
+### Ranked levers
+
+Prefill, in order of measured headroom:
+
+1. FP16 or INT8 routed-expert MoE — 32.2% of the FP16-dense floor, still BF16.
+2. Tensor-core QSA core — 29.2% of that floor at 14% of the GEMM roof; the
+   `cpp_engine` `m16n8k8` kernel is the existing template.
+3. Close the 1.44-2.1x gap between the 4.123 s floor and the 8.629 s wall —
+   kernel fusion and launch reduction, not new math.
+4. HC projection TP slicing — element-wise validated, real all-gather cost
+   still unmeasured.
+
+Decode, in order:
+
+1. 4-bit routed experts, fully resident — 9.6 to 28.6 tok/s, 3.0x, and the only
+   lever that removes the bound rather than shrinking it.
+2. Fewer, larger NCCL calls — 8.8 ms of the 35.0 ms compute floor.
+3. `linear_attention` dense projections — 11.2 ms, the largest compute phase.
+
+### Probes
+
+```bash
+/home/lvyufeng/miniconda3/envs/deepseek/bin/torchrun --nproc_per_node=4 \
+  .scratch/probe_h2d_roof.py
+/home/lvyufeng/miniconda3/envs/deepseek/bin/torchrun --nproc_per_node=4 \
+  .scratch/probe_compute_roof.py
+/home/lvyufeng/miniconda3/envs/deepseek/bin/torchrun --nproc_per_node=4 \
+  .scratch/probe_attn_roof.py
+/home/lvyufeng/miniconda3/envs/deepseek/bin/torchrun --nproc_per_node=4 \
+  .scratch/probe_decode_layer.py
+/home/lvyufeng/miniconda3/envs/deepseek/bin/python .scratch/probe_gdn_and_budget.py
+/home/lvyufeng/miniconda3/envs/deepseek/bin/python .scratch/ceiling_model.py
+/home/lvyufeng/miniconda3/envs/deepseek/bin/python .scratch/ceiling_breakdown.py
+```
+
+A caveat on one number: an earlier PyTorch loop measured the GDN recurrence at
+596 ms per 8192 rows. That is the naive Python scan, not the shipped kernel,
+which measures 8.05 ms. Only the kernel number is used above.

--- a/src/models/qwen4_exp/builder.py
+++ b/src/models/qwen4_exp/builder.py
@@ -168,7 +168,12 @@ def build_from_state_dict(
             shards = [state_dict[table_key]] if table_key in state_dict else _gather_shards(
                 state_dict, f"{prefix}.layers.{layer_idx}.ple.ple_embedding.ngram_embedding"
             )
-            table = HostNGramTable(shards, device=device, dtype=dtype)
+            ple_scale = (
+                state_dict.get(f"{prefix}.layers.{layer_idx}.ple.ple_embedding.ngram_embedding.weight_scale")
+                if hasattr(state_dict, "get")
+                else None
+            )
+            table = HostNGramTable(shards, device=device, dtype=dtype, scale=ple_scale)
             ple = PLELayer(
                 config,
                 _ple_weights(getter, layer_idx, prefix=prefix),
@@ -387,7 +392,10 @@ def build_heterogeneous(
         if ple_index is not None:
             shard_keys = checkpoint.ngram_shard_keys(layer_idx)
             table = HostNGramTable(
-                [store.view(k) for k in shard_keys], device=device, dtype=dtype
+                [store.view(k) for k in shard_keys],
+                device=device,
+                dtype=dtype,
+                scale=checkpoint.ngram_scale(layer_idx),
             )
             ple = PLELayer(
                 config,

--- a/src/models/qwen4_exp/config.py
+++ b/src/models/qwen4_exp/config.py
@@ -201,10 +201,55 @@ class Qwen4ExpTextConfig:
         return cls(**kwargs)
 
 
+@dataclass(frozen=True)
+class FP8QuantSpec:
+    """Block-scaled FP8 weight layout declared by `quantization_config`.
+
+    The Flash-Next FP8 build quantizes only the routed experts and the PLE
+    n-gram table; everything listed in `modules_to_not_convert` (943 entries:
+    dense projections, norms, the router, lm_head, embeddings) stays BF16.  Two
+    scale granularities appear:
+
+    * routed experts — one `weight_scale_inv` per `block_size` tile, stored as
+      `[ceil(out/128), ceil(in/128)]` BF16.
+    * PLE n-gram table — a single scalar `weight_scale` shared by all 128 shards.
+
+    Both are *multipliers*: `value = code.to(f32) * scale`.
+    """
+
+    method: str = "fp8"
+    activation_scheme: str = "dynamic"
+    block_size: tuple[int, int] = (128, 128)
+    weight_per_tensor: bool = False
+    skip_modules: tuple[str, ...] = ()
+
+    @classmethod
+    def from_dict(cls, raw: dict | None) -> "FP8QuantSpec | None":
+        if not raw or str(raw.get("quant_method", "")).lower() != "fp8":
+            return None
+        block = raw.get("weight_block_size") or [128, 128]
+        return cls(
+            method="fp8",
+            activation_scheme=str(raw.get("activation_scheme", "dynamic")),
+            block_size=(int(block[0]), int(block[1])),
+            weight_per_tensor=bool(raw.get("weight_per_tensor", False)),
+            skip_modules=tuple(raw.get("modules_to_not_convert") or ()),
+        )
+
+    def skips(self, name: str) -> bool:
+        """True when `name` is excluded from quantization by the config."""
+        stripped = name[: -len(".weight")] if name.endswith(".weight") else name
+        return stripped in self.skip_modules
+
+
 @dataclass
 class Qwen4ExpConfig:
     text_config: Qwen4ExpTextConfig
     architecture: str = "qwen4_exp"
+    # Quantization metadata lives at the root of the multimodal config, not in
+    # `text_config`.  Keep it optional so the original BF16 checkpoint follows
+    # the unchanged path.
+    quantization: dict | None = None
     image_token_id: int | None = None
     video_token_id: int | None = None
     vision_start_token_id: int | None = None
@@ -218,6 +263,7 @@ class Qwen4ExpConfig:
         return cls(
             text_config=Qwen4ExpTextConfig.from_dict(text_raw),
             architecture=(raw.get("architectures") or ["qwen4_exp"])[0],
+            quantization=raw.get("quantization_config"),
             image_token_id=raw.get("image_token_id"),
             video_token_id=raw.get("video_token_id"),
             vision_start_token_id=raw.get("vision_start_token_id"),
@@ -230,3 +276,19 @@ class Qwen4ExpConfig:
     def from_pretrained(cls, model_dir: str) -> "Qwen4ExpConfig":
         with open(os.path.join(model_dir, "config.json")) as f:
             return cls.from_dict(json.load(f))
+
+    @property
+    def fp8(self) -> FP8QuantSpec | None:
+        """FP8 layout spec, or None for an unquantized checkpoint."""
+        return FP8QuantSpec.from_dict(self.quantization)
+
+    @property
+    def is_fp8(self) -> bool:
+        """Whether the root config declares block-scaled FP8 weights."""
+        return self.fp8 is not None
+
+    @property
+    def weight_block_size(self) -> tuple[int, int]:
+        """Block geometry used by FP8 weights (128x128 by default)."""
+        spec = self.fp8
+        return spec.block_size if spec is not None else (128, 128)

--- a/src/models/qwen4_exp/layers.py
+++ b/src/models/qwen4_exp/layers.py
@@ -46,17 +46,30 @@ def _dense_fp16_fp32_output_enabled(rows: int) -> bool:
     )
 
 
+def dequant_fp8_block(
+    codes: torch.Tensor,
+    scale: torch.Tensor,
+    block: tuple[int, int] = (128, 128),
+    out_dtype: torch.dtype = torch.float16,
+) -> torch.Tensor:
+    """Reference dequantization for a block-scaled FP8 matrix."""
+    from src.models.qwen4_exp.quant import dequantize_block_fp8
+
+    return dequantize_block_fp8(codes, scale, block, out_dtype)
+
+
 def _fp16_fp32_linear(
     x: torch.Tensor,
     weight: torch.Tensor,
 ) -> torch.Tensor:
+    """FP16 tensor-core GEMM with an FP32 accumulator and input dtype output."""
     flat = x.reshape(-1, x.shape[-1]).to(torch.float16)
     output = torch.mm(
         flat,
         weight.to(torch.float16).t(),
         out_dtype=torch.float32,
     )
-    return output.to(torch.bfloat16).reshape(
+    return output.to(x.dtype).reshape(
         *x.shape[:-1],
         weight.shape[0],
     )
@@ -66,21 +79,35 @@ def prefill_linear(
     x: torch.Tensor,
     weight: torch.Tensor,
 ) -> torch.Tensor:
-    """Use optional SM75 tensor-core GEMM for large BF16 projections."""
+    """Use tensor-core GEMM for BF16 projections, including explicit FP16 mode.
+
+    The environment gates are an optimization for BF16 checkpoints.  When the
+    whole model was deliberately loaded as FP16, matching FP16 inputs/weights
+    are already the native SM75 fast path and must not be cast back to BF16.
+    """
     rows = x.numel() // x.shape[-1]
-    supported = (
+    same_device = weight.device == x.device
+    native_fp16 = (
+        x.device.type == "cuda"
+        and x.dtype is torch.float16
+        and weight.dtype is torch.float16
+        and same_device
+    )
+    if native_fp16:
+        if _dense_fp16_fp32_output_enabled(rows):
+            return _fp16_fp32_linear(x, weight)
+        return F.linear(x, weight)
+
+    supported_bf16 = (
         x.device.type == "cuda"
         and x.dtype is torch.bfloat16
-        and weight.device == x.device
         and weight.dtype is torch.bfloat16
+        and same_device
     )
-    if supported and _dense_fp16_fp32_output_enabled(rows):
+    if supported_bf16 and _dense_fp16_fp32_output_enabled(rows):
         return _fp16_fp32_linear(x, weight)
-    if supported and _dense_fp16_enabled(rows):
-        return F.linear(
-            x.to(torch.float16),
-            weight.to(torch.float16),
-        ).to(torch.bfloat16)
+    if supported_bf16 and _dense_fp16_enabled(rows):
+        return F.linear(x.to(torch.float16), weight.to(torch.float16)).to(torch.bfloat16)
     return F.linear(x, weight)
 
 

--- a/src/models/qwen4_exp/moe.py
+++ b/src/models/qwen4_exp/moe.py
@@ -10,6 +10,10 @@ Two implementations share one interface:
   decode step touches at most `top_k` experts per layer (6.6 MiB each in BF16).
   The reader normally serves those rows from this rank's resident host shard (see
   `weights.HostExpertShard`); the mmap is only the fallback.
+
+When the reader is FP8 it hands back `FP8Tensor`s instead of plain tensors.  Only
+the codes and their 128x128 block scales cross PCIe — half the bytes of BF16 —
+and the dequantization happens on the device right before the GEMM.
 """
 
 from __future__ import annotations
@@ -23,12 +27,13 @@ import torch
 
 from src.kernels.cuda_loader import load_cuda_kernel
 from src.models.qwen4_exp.layers import swiglu_expert
+from src.models.qwen4_exp.quant import FP8Tensor
 
 
 @dataclass
 class _PendingExpert:
-    gate_up: torch.Tensor
-    down: torch.Tensor
+    gate_up: torch.Tensor | FP8Tensor
+    down: torch.Tensor | FP8Tensor
     ready: torch.cuda.Event | None
 
 
@@ -44,6 +49,23 @@ class MoEBackend(Protocol):
         ...
 
 
+def _expert_matrix(
+    weight,
+    compute_dtype: torch.dtype | None,
+    default_dtype: torch.dtype,
+) -> torch.Tensor:
+    """One expert projection as a GEMM-ready dense matrix.
+
+    An `FP8Tensor` is dequantized here, at the last moment before the GEMM, so
+    only the codes and scales occupy device memory and cross PCIe.
+    """
+    if isinstance(weight, FP8Tensor):
+        return weight.dequantize(compute_dtype or default_dtype)
+    if compute_dtype is not None:
+        return weight.to(compute_dtype)
+    return weight
+
+
 def _dispatch_experts(
     hidden_states: torch.Tensor,
     indices: torch.Tensor,
@@ -56,9 +78,10 @@ def _dispatch_experts(
 ) -> torch.Tensor:
     """Group tokens by expert, run each expert once, scatter-add the results.
 
-    `expert_weights(expert_id)` returns `(gate_up, down)` on the compute device.
-    Experts are visited in ascending id so the accumulation order is fixed and
-    the result is run-to-run reproducible.
+    `expert_weights(expert_id)` returns `(gate_up, down)` on the compute device,
+    either as dense tensors or as `FP8Tensor`s.  Experts are visited in ascending
+    id so the accumulation order is fixed and the result is run-to-run
+    reproducible.
 
     When `stats` is given, per-phase wall time is accumulated into it.  The
     timing path synchronizes and is meant for profiling runs only.
@@ -87,8 +110,8 @@ def _dispatch_experts(
             expert_input = hidden_states[token_idx]
             if compute_dtype is not None:
                 expert_input = expert_input.to(compute_dtype)
-                gate_up = gate_up.to(compute_dtype)
-                down = down.to(compute_dtype)
+            gate_up = _expert_matrix(gate_up, compute_dtype, expert_input.dtype)
+            down = _expert_matrix(down, compute_dtype, expert_input.dtype)
             contrib = swiglu_expert(expert_input, gate_up, down)
             contrib = contrib * weights[token_idx, k_idx].unsqueeze(-1).to(contrib.dtype)
             out.index_add_(0, token_idx, contrib.to(out.dtype))
@@ -118,8 +141,8 @@ def _dispatch_experts(
         expert_input = hidden_states[token_idx]
         if compute_dtype is not None:
             expert_input = expert_input.to(compute_dtype)
-            gate_up = gate_up.to(compute_dtype)
-            down = down.to(compute_dtype)
+        gate_up = _expert_matrix(gate_up, compute_dtype, expert_input.dtype)
+        down = _expert_matrix(down, compute_dtype, expert_input.dtype)
         contrib = swiglu_expert(expert_input, gate_up, down)
         contrib = contrib * weights[token_idx, k_idx].unsqueeze(-1).to(contrib.dtype)
         out.index_add_(0, token_idx, contrib.to(out.dtype))
@@ -182,7 +205,7 @@ class HostExpertMoE:
         self.device = device
         self.dtype = dtype
         self.cache_capacity = cache_capacity
-        self._cache: OrderedDict[tuple[int, int], tuple[torch.Tensor, torch.Tensor]] = OrderedDict()
+        self._cache: OrderedDict[tuple[int, int], tuple[torch.Tensor | FP8Tensor, torch.Tensor | FP8Tensor]] = OrderedDict()
         self.stage_bytes = 0
         self.stage_calls = 0
         self.cache_hits = 0
@@ -221,18 +244,47 @@ class HostExpertMoE:
             self.cache_hits += 1
         return hit
 
-    def _fetch(self, layer_idx: int, expert_id: int) -> tuple[torch.Tensor, torch.Tensor]:
+    @staticmethod
+    def _stage_weight(weight, device: torch.device, dtype: torch.dtype):
+        if isinstance(weight, FP8Tensor):
+            return weight.to(device, non_blocking=True)
+        return weight.to(device, dtype=dtype, non_blocking=True)
+
+    @staticmethod
+    def _weight_nbytes(weight) -> int:
+        return weight.nbytes() if isinstance(weight, FP8Tensor) else weight.numel() * weight.element_size()
+
+    @staticmethod
+    def _record_stream(weight, stream) -> None:
+        if isinstance(weight, FP8Tensor):
+            weight.code.record_stream(stream)
+            weight.scale.record_stream(stream)
+        else:
+            weight.record_stream(stream)
+
+    def _fetch(self, layer_idx: int, expert_id: int):
         key = (layer_idx, expert_id)
         hit = self._cache_get(key)
         if hit is not None:
             return hit
         gate_up_cpu, down_cpu = self.reader.expert_rows(layer_idx, expert_id)
-        gate_up = gate_up_cpu.to(self.device, dtype=self.dtype, non_blocking=True)
-        down = down_cpu.to(self.device, dtype=self.dtype, non_blocking=True)
-        self.stage_bytes += gate_up.numel() * gate_up.element_size() + down.numel() * down.element_size()
+        gate_up = self._stage_weight(gate_up_cpu, self.device, self.dtype)
+        down = self._stage_weight(down_cpu, self.device, self.dtype)
+        self.stage_bytes += self._weight_nbytes(gate_up) + self._weight_nbytes(down)
         self.stage_calls += 1
         self._cache_put(key, (gate_up, down))
         return gate_up, down
+
+    def _dequantized_layer_tensors(self, layer_idx: int):
+        """Return a dense local layer only when a grouped path can consume it."""
+        tensors = self.reader.expert_shard.layer_tensors(layer_idx)
+        if isinstance(tensors[0], FP8Tensor):
+            return None
+        return tensors
+
+    def _cache_clear(self) -> None:
+        self._cache.clear()
+
 
     def _grouped_bf16(self, layer_idx: int, hidden_states, indices, weights):
         """Run a dense-local-expert BF16 grouped prefill, or return None."""
@@ -254,7 +306,10 @@ class HostExpertMoE:
         ):
             return None
 
-        gate_up_cpu, down_cpu = shard.layer_tensors(layer_idx)
+        layer_tensors = self._dequantized_layer_tensors(layer_idx)
+        if layer_tensors is None:
+            return None
+        gate_up_cpu, down_cpu = layer_tensors
         layer_bytes = (
             gate_up_cpu.numel() * gate_up_cpu.element_size()
             + down_cpu.numel() * down_cpu.element_size()
@@ -316,14 +371,14 @@ class HostExpertMoE:
             self._copy_stream = torch.cuda.Stream(device=self.device)
         current = torch.cuda.current_stream(self.device)
         with torch.cuda.stream(self._copy_stream):
-            gate_up = gate_up_cpu.to(self.device, dtype=self.dtype, non_blocking=True)
-            down = down_cpu.to(self.device, dtype=self.dtype, non_blocking=True)
+            gate_up = self._stage_weight(gate_up_cpu, self.device, self.dtype)
+            down = self._stage_weight(down_cpu, self.device, self.dtype)
             ready = torch.cuda.Event()
             ready.record(self._copy_stream)
         current.wait_event(ready)
-        gate_up.record_stream(current)
-        down.record_stream(current)
-        self.stage_bytes += gate_up.numel() * gate_up.element_size() + down.numel() * down.element_size()
+        self._record_stream(gate_up, current)
+        self._record_stream(down, current)
+        self.stage_bytes += self._weight_nbytes(gate_up) + self._weight_nbytes(down)
         self.stage_calls += 1
         return self._cuda_ext.qwen4_exp_moe_prefill_bf16_forward(
             hidden_states.contiguous(),
@@ -336,7 +391,12 @@ class HostExpertMoE:
         )
 
     def _prefetch(self, layer_idx: int, expert_ids: list[int]):
-        """Stage one layer's active experts on a copy stream in expert-id order."""
+        """Stage one layer's active experts on a copy stream in expert-id order.
+
+        FP8 entries are cached as code/scale pairs; dequantization is performed
+        after the copy-stream event and immediately before their GEMM in the
+        dispatch loop.  This preserves the FP8 residency advantage.
+        """
         if self._copy_stream is None:
             self._copy_stream = torch.cuda.Stream(device=self.device)
         current = torch.cuda.current_stream(self.device)
@@ -349,12 +409,12 @@ class HostExpertMoE:
                     pending.append(_PendingExpert(hit[0], hit[1], None))
                     continue
                 gate_up_cpu, down_cpu = self.reader.expert_rows(layer_idx, expert_id)
-                gate_up = gate_up_cpu.to(self.device, dtype=self.dtype, non_blocking=True)
-                down = down_cpu.to(self.device, dtype=self.dtype, non_blocking=True)
+                gate_up = self._stage_weight(gate_up_cpu, self.device, self.dtype)
+                down = self._stage_weight(down_cpu, self.device, self.dtype)
                 event = torch.cuda.Event()
                 event.record(self._copy_stream)
                 pending.append(_PendingExpert(gate_up, down, event))
-                self.stage_bytes += gate_up.numel() * gate_up.element_size() + down.numel() * down.element_size()
+                self.stage_bytes += self._weight_nbytes(gate_up) + self._weight_nbytes(down)
                 self.stage_calls += 1
                 self._cache_put(key, (gate_up, down))
 
@@ -362,8 +422,8 @@ class HostExpertMoE:
             for item in pending:
                 if item.ready is not None:
                     current.wait_event(item.ready)
-                item.gate_up.record_stream(current)
-                item.down.record_stream(current)
+                self._record_stream(item.gate_up, current)
+                self._record_stream(item.down, current)
                 yield item.gate_up, item.down
 
         return consume()

--- a/src/models/qwen4_exp/quant.py
+++ b/src/models/qwen4_exp/quant.py
@@ -1,0 +1,131 @@
+"""FP8 block-scaled weight handling for Qwen4-Exp.
+
+The Flash-Next FP8 checkpoint stores routed experts as `float8_e4m3fn` codes plus
+a BF16 scale per 128x128 tile, and the PLE n-gram table as codes plus one scalar
+scale.  Both are *multipliers*: ``value = code * scale``.  `torch._scaled_mm` is
+unavailable on SM75, so the only route is to dequantize into a tensor-core dtype
+and run an ordinary GEMM.
+
+Dequantization multiplies in the destination dtype rather than in float32.  For
+float16 that is exact — every `e4m3` code is representable in float16, and a
+BF16 scale has fewer mantissa bits than float16 — while avoiding a 4x-wide
+intermediate.  For bfloat16 the product rounds to 8 mantissa bits, which is the
+same rounding a native BF16 runtime would apply.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+FP8_DTYPE = torch.float8_e4m3fn
+
+
+@dataclass(frozen=True)
+class FP8Tensor:
+    """One block-scaled weight: `code` with `scale` over `block` tiles."""
+
+    code: torch.Tensor
+    scale: torch.Tensor
+    block: tuple[int, int] = (128, 128)
+
+    @property
+    def shape(self) -> torch.Size:
+        return self.code.shape
+
+    @property
+    def device(self) -> torch.device:
+        return self.code.device
+
+    def nbytes(self) -> int:
+        return (
+            self.code.numel() * self.code.element_size()
+            + self.scale.numel() * self.scale.element_size()
+        )
+
+    def to(self, device, *, non_blocking: bool = False) -> "FP8Tensor":
+        """Move the codes and scales without dequantizing."""
+        return FP8Tensor(
+            self.code.to(device, non_blocking=non_blocking),
+            self.scale.to(device, non_blocking=non_blocking),
+            self.block,
+        )
+
+    def dequantize(self, dtype: torch.dtype) -> torch.Tensor:
+        return dequantize_block_fp8(self.code, self.scale, self.block, dtype)
+
+
+def dequantize_block_fp8(
+    code: torch.Tensor,
+    scale: torch.Tensor,
+    block: tuple[int, int],
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Expand a 128x128-block-scaled FP8 weight to `dtype`.
+
+    `code` is `[out, in]`; `scale` is `[ceil(out/block[0]), ceil(in/block[1])]`.
+    """
+    if code.dim() != 2:
+        raise ValueError(f"expected a 2D weight, got shape {tuple(code.shape)}")
+    rows, cols = code.shape
+    block_rows, block_cols = int(block[0]), int(block[1])
+    expected = (-(-rows // block_rows), -(-cols // block_cols))
+    if tuple(scale.shape) != expected:
+        raise ValueError(
+            f"scale shape {tuple(scale.shape)} does not match a {block_rows}x{block_cols} "
+            f"tiling of {(rows, cols)} (expected {expected})"
+        )
+
+    values = code.to(dtype)
+    if rows % block_rows == 0 and cols % block_cols == 0:
+        # Every tile is whole, so the scale broadcasts over a reshape without
+        # materializing a full-size scale tensor.
+        tiled = values.view(expected[0], block_rows, expected[1], block_cols)
+        tiled = tiled * scale.to(dtype).view(expected[0], 1, expected[1], 1)
+        return tiled.reshape(rows, cols)
+    # Ragged tail: expand and crop.  Not hit by this checkpoint (640, 1280 and
+    # 2560 all divide by 128) but kept so the helper is not silently wrong.
+    expanded = (
+        scale.to(dtype)
+        .repeat_interleave(block_rows, dim=0)
+        .repeat_interleave(block_cols, dim=1)[:rows, :cols]
+    )
+    return values * expanded
+
+
+def fp8_scalar_dequantize(
+    code: torch.Tensor,
+    scale: torch.Tensor | float,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Dequantize an FP8 tensor that shares one scale (the PLE n-gram table)."""
+    factor = scale.to(dtype) if isinstance(scale, torch.Tensor) else scale
+    return code.to(dtype) * factor
+
+
+def pack_gate_up_fp8(
+    gate: FP8Tensor,
+    up: FP8Tensor,
+) -> FP8Tensor:
+    """Row-concatenate gate and up into the packed `[2*inter, hidden]` layout.
+
+    The runtime's expert convention is one fused `gate_up` weight with gate rows
+    first, which is how the BF16 checkpoint ships it.  `moe_intermediate_size` is
+    640 and divides the 128-row block, so concatenating the scale grids keeps
+    every tile aligned with its rows.
+    """
+    if gate.block != up.block:
+        raise ValueError(f"gate/up block size mismatch: {gate.block} vs {up.block}")
+    rows = gate.code.shape[0]
+    block_rows = gate.block[0]
+    if rows % block_rows != 0:
+        raise ValueError(
+            f"gate rows {rows} do not divide the {block_rows}-row scale block, so "
+            "concatenating gate and up would misalign the scale grid"
+        )
+    return FP8Tensor(
+        torch.cat([gate.code, up.code], dim=0),
+        torch.cat([gate.scale, up.scale], dim=0),
+        gate.block,
+    )

--- a/src/models/qwen4_exp/runtime.py
+++ b/src/models/qwen4_exp/runtime.py
@@ -220,6 +220,7 @@ def load_model(
         started = time.perf_counter()
         shard = checkpoint.preload_experts(
             config.text_config.num_hidden_layers,
+            num_experts=config.text_config.num_experts,
             rank=ctx.rank,
             world_size=ctx.world_size,
             pin=pin_experts,

--- a/src/models/qwen4_exp/weights.py
+++ b/src/models/qwen4_exp/weights.py
@@ -6,7 +6,15 @@ the GPU only ever sees the rows a step actually touches.
 
 `MmapSafetensors` maps each shard once and hands out torch views over the raw
 bytes.  BF16 has no numpy dtype, so the mapping is `uint16` and reinterpreted
-with `Tensor.view(torch.bfloat16)`.
+with `Tensor.view(torch.bfloat16)`; `float8_e4m3fn` goes the same way through
+`uint8`.
+
+The FP8 build of the same model halves both of those: routed experts drop from
+229.7 to 114.9 GiB and the PLE table from 95.4 to 47.7 GiB.  It also changes the
+expert *layout* — `experts.{id}.{gate,up,down}_proj.weight` with a
+`weight_scale_inv` each, instead of two packed `[512, ...]` tensors — so the
+reader assembles the runtime's packed `[2*inter, hidden]` convention itself and
+everything downstream sees one shape regardless of which checkpoint is loaded.
 
 Reading experts through the mapping alone is not enough: the mapping is backed by
 a mechanical disk here, so a page that is not resident costs a seek.
@@ -27,11 +35,16 @@ import struct
 import numpy as np
 import torch
 
+from src.models.qwen4_exp.quant import FP8Tensor, fp8_scalar_dequantize, pack_gate_up_fp8
+
 _ST_DTYPES: dict[str, tuple[np.dtype, torch.dtype]] = {
     "F64": (np.dtype("<f8"), torch.float64),
     "F32": (np.dtype("<f4"), torch.float32),
     "F16": (np.dtype("<f2"), torch.float16),
     "BF16": (np.dtype("<u2"), torch.bfloat16),
+    # Neither bf16 nor fp8 has a numpy dtype, so both map through an unsigned
+    # integer of the same width and are reinterpreted by `Tensor.view`.
+    "F8_E4M3": (np.dtype("<u1"), torch.float8_e4m3fn),
     "I64": (np.dtype("<i8"), torch.int64),
     "I32": (np.dtype("<i4"), torch.int32),
     "I16": (np.dtype("<i2"), torch.int16),
@@ -121,8 +134,8 @@ class MmapSafetensors:
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message=".*non-writable.*")
             tensor = torch.from_numpy(arr)
-        if torch_dtype is torch.bfloat16:
-            tensor = tensor.view(torch.bfloat16)
+        if torch_dtype in (torch.bfloat16, torch.float8_e4m3fn):
+            tensor = tensor.view(torch_dtype)
         tensor = tensor.reshape(entry.shape)
         self._views[key] = tensor
         return tensor
@@ -177,6 +190,11 @@ class HostExpertShard:
     staging in `HostExpertMoE` is the consumer, but a 56 GiB pin can exceed
     `ulimit -l`; on failure the shard falls back to pageable memory once and says
     so, rather than dying at load time.
+
+    An FP8 checkpoint adds a second buffer per projection for the block scales,
+    so a layer holds four tensors instead of two.  They are still allocated as
+    one group: a shard where the codes are pinned and the scales are not would
+    stall every staging copy on the unpinned half.
     """
 
     def __init__(
@@ -196,10 +214,17 @@ class HostExpertShard:
         self.pinned = False
         self.resident_bytes = 0
         self.num_local_experts = 0
+        self.block_size: tuple[int, int] | None = None
         self._gate_up: dict[int, torch.Tensor] = {}
         self._down: dict[int, torch.Tensor] = {}
+        self._gate_up_scale: dict[int, torch.Tensor] = {}
+        self._down_scale: dict[int, torch.Tensor] = {}
         self._loaded: set[int] = set()
         self._pin_fallback_reported = False
+
+    @property
+    def is_fp8(self) -> bool:
+        return self.block_size is not None
 
     # -- placement --------------------------------------------------------
 
@@ -227,40 +252,37 @@ class HostExpertShard:
         if self.pinned:
             # Do not leave a mixed shard behind: pageable clones replace all
             # earlier pinned layers before the current layer is allocated.
-            self._gate_up = {layer: tensor.clone() for layer, tensor in self._gate_up.items()}
-            self._down = {layer: tensor.clone() for layer, tensor in self._down.items()}
+            for store in (self._gate_up, self._down, self._gate_up_scale, self._down_scale):
+                for layer, tensor in list(store.items()):
+                    store[layer] = tensor.clone()
             self.pinned = False
             import gc
 
             gc.collect()
 
-    def _alloc_pair(
+    def _alloc_group(
         self,
-        gate_up_shape: tuple[int, ...],
-        gate_up_dtype: torch.dtype,
-        down_shape: tuple[int, ...],
-        down_dtype: torch.dtype,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Both of a layer's buffers, pinned together or pageable together.
+        specs: list[tuple[tuple[int, ...], torch.dtype]],
+    ) -> list[torch.Tensor]:
+        """All of a layer's buffers, pinned together or pageable together.
 
-        Allocating them separately could leave a layer half-pinned if the memlock
-        limit is hit between the two, so a failure on either discards the pair.
+        Allocating them one at a time could leave a layer half-pinned if the
+        memlock limit is hit partway through, so a failure on any of them
+        discards the whole group and the layer is retried as pageable.
         """
         if self.pin_requested:
+            allocated: list[torch.Tensor] = []
             try:
-                gate_up = torch.empty(gate_up_shape, dtype=gate_up_dtype, pin_memory=True)
-                down = torch.empty(down_shape, dtype=down_dtype, pin_memory=True)
+                for shape, dtype in specs:
+                    allocated.append(torch.empty(shape, dtype=dtype, pin_memory=True))
                 self.pinned = True
-                return gate_up, down
+                return allocated
             except RuntimeError as exc:  # memlock limit, most likely
-                # Release a half-allocated pair first: if gate_up pinned and down
-                # did not, holding it would keep locked pages during the clones.
-                gate_up = down = None
+                # Release the partial group first: holding pinned buffers here
+                # would keep locked pages during the clones below.
+                allocated.clear()
                 self._fall_back_to_pageable(exc)
-        return (
-            torch.empty(gate_up_shape, dtype=gate_up_dtype),
-            torch.empty(down_shape, dtype=down_dtype),
-        )
+        return [torch.empty(shape, dtype=dtype) for shape, dtype in specs]
 
     def load_layer(
         self,
@@ -278,11 +300,11 @@ class HostExpertShard:
                 f"gate_up {gate_up_all.shape[0]} vs down {down_all.shape[0]}"
             )
         ids = self.local_expert_ids(num_experts)
-        gate_up, down = self._alloc_pair(
-            (len(ids), *gate_up_all.shape[1:]),
-            gate_up_all.dtype,
-            (len(ids), *down_all.shape[1:]),
-            down_all.dtype,
+        gate_up, down = self._alloc_group(
+            [
+                ((len(ids), *gate_up_all.shape[1:]), gate_up_all.dtype),
+                ((len(ids), *down_all.shape[1:]), down_all.dtype),
+            ]
         )
         # Sequential in expert id, which is also sequential in file offset: the
         # backing store is a mechanical disk, so ordering matters more than
@@ -298,18 +320,86 @@ class HostExpertShard:
         self.resident_bytes += copied
         return copied
 
+    def load_layer_fp8(
+        self,
+        layer_idx: int,
+        num_experts: int,
+        expert_reader,
+        *,
+        block_size: tuple[int, int],
+    ) -> int:
+        """Copy this rank's FP8 rows of one layer in; returns the bytes copied.
+
+        `expert_reader(expert_id)` yields `(gate_up, down)` as `FP8Tensor`s
+        already packed into the runtime's `[2*inter, hidden]` convention.  The
+        codes and the scale grids each get one contiguous buffer per projection,
+        so a layer is four allocations no matter how many experts it holds.
+        """
+        if layer_idx in self._loaded:
+            return 0
+        ids = self.local_expert_ids(num_experts)
+        if not ids:
+            raise ValueError(
+                f"rank {self.rank} of {self.world_size} owns no experts out of {num_experts}"
+            )
+        first_gate_up, first_down = expert_reader(ids[0])
+        buffers = self._alloc_group(
+            [
+                ((len(ids), *first_gate_up.code.shape), first_gate_up.code.dtype),
+                ((len(ids), *first_down.code.shape), first_down.code.dtype),
+                ((len(ids), *first_gate_up.scale.shape), first_gate_up.scale.dtype),
+                ((len(ids), *first_down.scale.shape), first_down.scale.dtype),
+            ]
+        )
+        gate_up, down, gate_up_scale, down_scale = buffers
+        for local, expert_id in enumerate(ids):
+            pair = (first_gate_up, first_down) if local == 0 else expert_reader(expert_id)
+            gate_up[local].copy_(pair[0].code)
+            gate_up_scale[local].copy_(pair[0].scale)
+            down[local].copy_(pair[1].code)
+            down_scale[local].copy_(pair[1].scale)
+        self._gate_up[layer_idx] = gate_up
+        self._down[layer_idx] = down
+        self._gate_up_scale[layer_idx] = gate_up_scale
+        self._down_scale[layer_idx] = down_scale
+        self._loaded.add(layer_idx)
+        self.num_local_experts = len(ids)
+        self.block_size = (int(block_size[0]), int(block_size[1]))
+        copied = sum(t.numel() * t.element_size() for t in buffers)
+        self.resident_bytes += copied
+        return copied
+
     # -- access -----------------------------------------------------------
 
     def has_layer(self, layer_idx: int) -> bool:
         return layer_idx in self._loaded
 
-    def rows(self, layer_idx: int, expert_id: int) -> tuple[torch.Tensor, torch.Tensor]:
+    def rows(self, layer_idx: int, expert_id: int):
+        """One expert's `(gate_up, down)`; `FP8Tensor`s for an FP8 shard."""
         local = self.local_index(expert_id)
-        return self._gate_up[layer_idx][local], self._down[layer_idx][local]
+        gate_up = self._gate_up[layer_idx][local]
+        down = self._down[layer_idx][local]
+        if self.block_size is None:
+            return gate_up, down
+        return (
+            FP8Tensor(gate_up, self._gate_up_scale[layer_idx][local], self.block_size),
+            FP8Tensor(down, self._down_scale[layer_idx][local], self.block_size),
+        )
 
-    def layer_tensors(self, layer_idx: int) -> tuple[torch.Tensor, torch.Tensor]:
-        """Return this rank's contiguous local expert tensors for grouped prefill."""
-        return self._gate_up[layer_idx], self._down[layer_idx]
+    def layer_tensors(self, layer_idx: int):
+        """This rank's contiguous local expert tensors, for grouped prefill.
+
+        Returns `FP8Tensor`s for an FP8 shard, whose leading dimension is the
+        local expert index rather than a matrix row.
+        """
+        gate_up = self._gate_up[layer_idx]
+        down = self._down[layer_idx]
+        if self.block_size is None:
+            return gate_up, down
+        return (
+            FP8Tensor(gate_up, self._gate_up_scale[layer_idx], self.block_size),
+            FP8Tensor(down, self._down_scale[layer_idx], self.block_size),
+        )
 
     def stats(self) -> dict[str, object]:
         return {
@@ -319,6 +409,7 @@ class HostExpertShard:
             "local_experts": self.num_local_experts,
             "resident_bytes": self.resident_bytes,
             "pinned": self.pinned,
+            "fp8": self.is_fp8,
         }
 
 
@@ -327,10 +418,38 @@ class Qwen4ExpCheckpoint:
 
     LM_PREFIX = "model.language_model"
 
-    def __init__(self, root: str, *, store: MmapSafetensors | None = None) -> None:
+    def __init__(
+        self,
+        root: str,
+        *,
+        store: MmapSafetensors | None = None,
+        fp8: "FP8QuantSpec | None" = None,
+    ) -> None:
         self.root = root
         self.store = store if store is not None else MmapSafetensors(root)
         self.expert_shard: HostExpertShard | None = None
+        self.fp8 = fp8 if fp8 is not None else self._detect_fp8()
+
+    def _detect_fp8(self) -> "FP8QuantSpec | None":
+        """Read `quantization_config` from the checkpoint's own `config.json`.
+
+        Detection is by config, not by tensor naming: the config is what declares
+        the block size and the skip list, and a checkpoint that names tensors one
+        way but scales them another would be a packaging bug we want to surface
+        rather than guess around.
+        """
+        from src.models.qwen4_exp.config import FP8QuantSpec
+
+        path = os.path.join(self.root, "config.json")
+        if not os.path.exists(path):
+            return None
+        with open(path) as f:
+            raw = json.load(f)
+        return FP8QuantSpec.from_dict(raw.get("quantization_config"))
+
+    @property
+    def is_fp8(self) -> bool:
+        return self.fp8 is not None
 
     # -- naming -----------------------------------------------------------
 
@@ -340,12 +459,49 @@ class Qwen4ExpCheckpoint:
     def expert_key(self, layer_idx: int, which: str) -> str:
         return f"{self.layer_prefix(layer_idx)}.mlp.experts.{which}"
 
+    def fp8_expert_key(self, layer_idx: int, expert_id: int, proj: str) -> str:
+        """Name of one FP8 expert projection (`gate`, `up` or `down`)."""
+        return f"{self.expert_key(layer_idx, str(int(expert_id)))}.{proj}_proj.weight"
+
     # -- routed experts ---------------------------------------------------
+
+    def fp8_expert_rows(
+        self, layer_idx: int, expert_id: int
+    ) -> tuple[FP8Tensor, FP8Tensor]:
+        """One FP8 expert straight from the mapping, packed like the BF16 layout.
+
+        The checkpoint stores `gate_proj` and `up_proj` separately; the runtime
+        expects them row-concatenated as `[2*inter, hidden]` with gate first,
+        which is the order the BF16 build ships and which `swiglu_expert`'s
+        `chunk(2)` assumes.
+        """
+        if self.fp8 is None:
+            raise ValueError("checkpoint is not FP8; use expert_rows instead")
+        block = self.fp8.block_size
+
+        def read(proj: str) -> FP8Tensor:
+            key = self.fp8_expert_key(layer_idx, expert_id, proj)
+            return FP8Tensor(
+                self.store.view(key),
+                self.store.view(f"{key}_scale_inv"),
+                block,
+            )
+
+        return pack_gate_up_fp8(read("gate"), read("up")), read("down")
+
+    def fp8_expert_keys(self, layer_idx: int, expert_id: int) -> list[str]:
+        """Every mapped tensor name backing one FP8 expert (codes and scales)."""
+        keys = []
+        for proj in ("gate", "up", "down"):
+            key = self.fp8_expert_key(layer_idx, expert_id, proj)
+            keys.extend((key, f"{key}_scale_inv"))
+        return keys
 
     def preload_experts(
         self,
         num_layers: int,
         *,
+        num_experts: int | None = None,
         rank: int = 0,
         world_size: int = 1,
         pin: bool = True,
@@ -369,6 +525,9 @@ class Qwen4ExpCheckpoint:
         it has been copied.  Without it a rank ends up holding its 56 GiB copy
         *and* 56 GiB of mapped expert pages (measured RSS 113 GiB), which at four
         ranks is most of the machine's RAM for no benefit.
+
+        `num_experts` is only consulted for an FP8 checkpoint, where the expert
+        count cannot be read off a packed tensor's leading dimension.
         """
         shard = HostExpertShard(
             num_layers=num_layers,
@@ -377,16 +536,27 @@ class Qwen4ExpCheckpoint:
             pin_memory=pin,
         )
         for layer_idx in range(num_layers):
-            gate_up_key = self.expert_key(layer_idx, "gate_up_proj")
-            down_key = self.expert_key(layer_idx, "down_proj")
-            shard.load_layer(layer_idx, self.store.view(gate_up_key), self.store.view(down_key))
-            if barrier is not None:
-                # Siblings finish the same layer before anyone drops its pages, so
-                # MADV_DONTNEED never pulls a region a sibling is still reading.
-                barrier()
-            if release_mapping:
-                self.store.advise_dontneed(gate_up_key)
-                self.store.advise_dontneed(down_key)
+            if self.fp8 is not None:
+                self._preload_layer_fp8(
+                    shard,
+                    layer_idx,
+                    num_experts=num_experts,
+                    barrier=barrier,
+                    release_mapping=release_mapping,
+                )
+            else:
+                self._preload_layer_packed(
+                    shard,
+                    layer_idx,
+                    barrier=barrier,
+                    release_mapping=release_mapping,
+                )
+            # Drop local aliases before the next layer.  The mmap views remain
+            # cached by the store, but no temporary packed/FP8 row assembly is
+            # retained by the preload loop.
+            import gc
+
+            gc.collect()
             if progress:
                 gib = shard.resident_bytes / (1 << 30)
                 print(
@@ -397,16 +567,69 @@ class Qwen4ExpCheckpoint:
         self.expert_shard = shard
         return shard
 
-    def expert_rows(self, layer_idx: int, expert_id: int) -> tuple[torch.Tensor, torch.Tensor]:
+    def _preload_layer_packed(
+        self,
+        shard: HostExpertShard,
+        layer_idx: int,
+        *,
+        barrier,
+        release_mapping: bool,
+    ) -> None:
+        gate_up_key = self.expert_key(layer_idx, "gate_up_proj")
+        down_key = self.expert_key(layer_idx, "down_proj")
+        shard.load_layer(layer_idx, self.store.view(gate_up_key), self.store.view(down_key))
+        if barrier is not None:
+            # Siblings finish the same layer before anyone drops its pages, so
+            # MADV_DONTNEED never pulls a region a sibling is still reading.
+            barrier()
+        if release_mapping:
+            self.store.advise_dontneed(gate_up_key)
+            self.store.advise_dontneed(down_key)
+
+    def _preload_layer_fp8(
+        self,
+        shard: HostExpertShard,
+        layer_idx: int,
+        *,
+        num_experts: int | None,
+        barrier,
+        release_mapping: bool,
+    ) -> None:
+        assert self.fp8 is not None
+        if num_experts is None:
+            raise ValueError(
+                "preload_experts needs num_experts for an FP8 checkpoint: the count "
+                "is not recoverable from a packed tensor's shape"
+            )
+        shard.load_layer_fp8(
+            layer_idx,
+            int(num_experts),
+            lambda expert_id: self.fp8_expert_rows(layer_idx, expert_id),
+            block_size=self.fp8.block_size,
+        )
+        if barrier is not None:
+            barrier()
+        if release_mapping:
+            # 6 keys per expert rather than 2 per layer, so this is the one place
+            # where the FP8 layout costs materially more bookkeeping.
+            for expert_id in shard.local_expert_ids(int(num_experts)):
+                for key in self.fp8_expert_keys(layer_idx, expert_id):
+                    self.store.advise_dontneed(key)
+
+    def expert_rows(self, layer_idx: int, expert_id: int):
         """One expert's `(gate_up, down)` as host tensors (no copy, no device transfer).
 
         Served from the resident shard when this rank owns the expert and the
         shard is loaded; otherwise from the mapping, which is both the
         `--mmap-experts` diagnostic path and what the tiny test fixtures use.
+
+        Returns `FP8Tensor`s for an FP8 checkpoint; `HostExpertMoE` dequantizes.
         """
         shard = self.expert_shard
         if shard is not None and shard.has_layer(layer_idx) and shard.owns(expert_id):
             return shard.rows(layer_idx, expert_id)
+        if self.fp8 is not None:
+            return self.fp8_expert_rows(layer_idx, expert_id)
         gate_up = self.store.view(self.expert_key(layer_idx, "gate_up_proj"))[expert_id]
         down = self.store.view(self.expert_key(layer_idx, "down_proj"))[expert_id]
         return gate_up, down
@@ -418,6 +641,17 @@ class Qwen4ExpCheckpoint:
         keys = [k for k in self.store.keys() if k.startswith(prefix)]
         return sorted(keys, key=lambda k: int(k.rsplit("_", 1)[1].split(".")[0]))
 
+    def ngram_scale(self, layer_idx: int) -> torch.Tensor | None:
+        """The FP8 n-gram table's single shared scale, or None when unquantized.
+
+        Unlike the experts, the table is quantized per tensor: all 128 shards
+        share one scalar, stored once next to them.
+        """
+        key = f"{self.layer_prefix(layer_idx)}.ple.ple_embedding.ngram_embedding.weight_scale"
+        if key not in self.store:
+            return None
+        return self.store.view(key).reshape(())
+
 
 class HostNGramTable:
     """Row lookup into the sharded PLE embedding, kept in host RAM.
@@ -425,6 +659,10 @@ class HostNGramTable:
     Shards are equal-height slices of one logical `(total_rows, head_dim)` table,
     so a row id maps to `(shard, row_in_shard)` by integer division.  Gathering
     on the host keeps 95 GiB off the GPU; only the gathered rows cross PCIe.
+
+    An FP8 table halves that to 47.7 GiB.  Its 128 shards share one scalar scale,
+    so the gather is done on the raw codes and the scale is applied once on the
+    device, after the (much smaller) gathered rows have crossed PCIe.
     """
 
     def __init__(
@@ -433,6 +671,7 @@ class HostNGramTable:
         *,
         device: torch.device,
         dtype: torch.dtype,
+        scale: torch.Tensor | None = None,
     ) -> None:
         assert shards, "PLE table needs at least one shard"
         self.shards = shards
@@ -441,22 +680,36 @@ class HostNGramTable:
         self.device = device
         self.dtype = dtype
         self.total_rows = sum(s.shape[0] for s in shards)
+        self.is_fp8 = shards[0].dtype is torch.float8_e4m3fn
+        if self.is_fp8 and scale is None:
+            raise ValueError("an FP8 n-gram table needs its weight_scale")
+        self.scale = scale
+        # `index_select` has no float8 CPU kernel, so gather over a byte alias of
+        # the same storage and reinterpret afterwards.  This is a view, not a copy.
+        self._gather_shards = (
+            [s.view(torch.uint8) for s in shards] if self.is_fp8 else shards
+        )
+        self._gather_dtype = torch.uint8 if self.is_fp8 else shards[0].dtype
 
     def __call__(self, row_ids: torch.Tensor) -> torch.Tensor:
         """row_ids: (..., ngram_heads) -> (..., ngram_heads, head_dim) on device."""
         flat = row_ids.reshape(-1).to("cpu", dtype=torch.long)
-        out = torch.empty(flat.shape[0], self.head_dim, dtype=self.shards[0].dtype)
+        out = torch.empty(flat.shape[0], self.head_dim, dtype=self._gather_dtype)
         shard_idx = torch.div(flat, self.rows_per_shard, rounding_mode="floor")
         local_idx = flat - shard_idx * self.rows_per_shard
         for s in shard_idx.unique().tolist():
             picks = (shard_idx == s).nonzero(as_tuple=True)[0]
-            if s >= len(self.shards):
+            if s >= len(self._gather_shards):
                 # Row lands in the divisor padding past the real table; upstream
                 # leaves those rows at their (zero) init value.
                 out[picks] = 0
                 continue
-            out[picks] = self.shards[s].index_select(0, local_idx[picks])
-        out = out.to(self.device, dtype=self.dtype, non_blocking=True)
+            out[picks] = self._gather_shards[s].index_select(0, local_idx[picks])
+        if self.is_fp8:
+            codes = out.to(self.device, non_blocking=True).view(torch.float8_e4m3fn)
+            out = fp8_scalar_dequantize(codes, self.scale.to(self.device), self.dtype)
+        else:
+            out = out.to(self.device, dtype=self.dtype, non_blocking=True)
         return out.reshape(*row_ids.shape, self.head_dim)
 
 

--- a/tests/test_qwen4_exp_fp8_dequant.py
+++ b/tests/test_qwen4_exp_fp8_dequant.py
@@ -1,0 +1,76 @@
+"""Correctness tests for Qwen4-Exp FP8 block dequantization."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+
+from src.models.qwen4_exp.layers import dequant_fp8_block
+from src.models.qwen4_exp.quant import FP8Tensor
+from src.models.qwen4_exp.weights import MmapSafetensors, Qwen4ExpCheckpoint
+
+FP8_MODEL = os.environ.get(
+    "QWEN4EXP_FP8_MODEL", "/mnt/data1/modelscope/Qwen/Qwen3.8-Flash-Next-FP8"
+)
+BF16_MODEL = os.environ.get(
+    "QWEN4EXP_MODEL", "/mnt/data1/modelscope/Qwen/Qwen3.8-Flash-Next"
+)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_block_dequant_whole_tiles(dtype: torch.dtype) -> None:
+    codes = torch.tensor(
+        [[0.5, -1.0, 2.0, 3.0], [4.0, -5.0, 6.0, -7.0]], dtype=torch.float8_e4m3fn
+    )
+    scale = torch.tensor([[2.0, 3.0]], dtype=torch.bfloat16)
+    got = dequant_fp8_block(codes, scale, block=(2, 2), out_dtype=dtype)
+    want = codes.to(dtype) * scale.to(dtype).repeat_interleave(2, 1)
+    torch.testing.assert_close(got, want, rtol=0, atol=0)
+
+
+def test_block_dequant_ragged_tail() -> None:
+    codes = torch.arange(15, dtype=torch.uint8).reshape(3, 5).view(torch.float8_e4m3fn)
+    scale = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.bfloat16)
+    got = dequant_fp8_block(codes, scale, block=(2, 3), out_dtype=torch.float32)
+    expanded = scale.repeat_interleave(2, 0).repeat_interleave(3, 1)[:3, :5]
+    torch.testing.assert_close(got, codes.to(torch.float32) * expanded, rtol=0, atol=0)
+
+
+def test_block_dequant_rejects_bad_scale_shape() -> None:
+    with pytest.raises(ValueError, match="scale shape"):
+        dequant_fp8_block(
+            torch.zeros(4, 4, dtype=torch.float8_e4m3fn),
+            torch.ones(1, 1, dtype=torch.bfloat16),
+            block=(2, 2),
+        )
+
+
+@pytest.mark.skipif(
+    not os.path.exists(os.path.join(FP8_MODEL, "model.safetensors.index.json")),
+    reason=f"real FP8 checkpoint not found at {FP8_MODEL}",
+)
+def test_real_fp8_dequant_matches_packed_bf16_reference() -> None:
+    if not os.path.exists(os.path.join(BF16_MODEL, "model.safetensors.index.json")):
+        pytest.skip(f"BF16 reference checkpoint not found at {BF16_MODEL}")
+    fp8 = Qwen4ExpCheckpoint(FP8_MODEL, store=MmapSafetensors(FP8_MODEL))
+    bf16_store = MmapSafetensors(BF16_MODEL)
+    for layer_idx, expert_id in ((0, 0), (1, 137), (3, 511)):
+        gate_up, down = fp8.expert_rows(layer_idx, expert_id)
+        assert isinstance(gate_up, FP8Tensor)
+        assert isinstance(down, FP8Tensor)
+        ref_gate_up = bf16_store.view(
+            f"model.language_model.layers.{layer_idx}.mlp.experts.gate_up_proj"
+        )[expert_id].to(torch.float32)
+        ref_down = bf16_store.view(
+            f"model.language_model.layers.{layer_idx}.mlp.experts.down_proj"
+        )[expert_id].to(torch.float32)
+        got_gate_up = gate_up.dequantize(torch.float32)
+        got_down = down.dequantize(torch.float32)
+        gate_rel = (got_gate_up - ref_gate_up).abs().max() / ref_gate_up.abs().max()
+        down_rel = (got_down - ref_down).abs().max() / ref_down.abs().max()
+        # FP8 quantization is intentionally lossy; these are structural checks,
+        # not a claim of token-level equality between distinct checkpoints.
+        assert gate_rel < 0.04
+        assert down_rel < 0.04

--- a/tests/test_qwen4_exp_fp8_loader.py
+++ b/tests/test_qwen4_exp_fp8_loader.py
@@ -1,0 +1,177 @@
+"""FP8 checkpoint naming, packing, and host-reader tests."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+
+from src.models.qwen4_exp.config import FP8QuantSpec, Qwen4ExpConfig
+from src.models.qwen4_exp.quant import FP8Tensor, pack_gate_up_fp8
+from src.models.qwen4_exp.weights import (
+    HostExpertShard,
+    HostNGramTable,
+    MmapSafetensors,
+    Qwen4ExpCheckpoint,
+)
+
+FP8_MODEL = os.environ.get(
+    "QWEN4EXP_FP8_MODEL", "/mnt/data1/modelscope/Qwen/Qwen3.8-Flash-Next-FP8"
+)
+REAL_FP8 = pytest.mark.skipif(
+    not os.path.exists(os.path.join(FP8_MODEL, "model.safetensors.index.json")),
+    reason=f"real FP8 checkpoint not found at {FP8_MODEL}",
+)
+
+
+def test_fp8_quant_spec_reads_root_metadata() -> None:
+    spec = FP8QuantSpec.from_dict(
+        {
+            "quant_method": "fp8",
+            "activation_scheme": "dynamic",
+            "weight_block_size": [128, 128],
+            "modules_to_not_convert": ["lm_head"],
+        }
+    )
+    assert spec is not None
+    assert spec.block_size == (128, 128)
+    assert spec.activation_scheme == "dynamic"
+    assert spec.skips("lm_head.weight")
+    assert not spec.skips("model.language_model.layers.0.mlp.experts.0.gate_proj.weight")
+    assert FP8QuantSpec.from_dict({"quant_method": "gptq"}) is None
+
+
+def test_qwen_config_keeps_root_quantization_config() -> None:
+    config = Qwen4ExpConfig.from_dict(
+        {
+            "architectures": ["Qwen4ExpForCausalLM"],
+            "text_config": {"num_hidden_layers": 1},
+            "quantization_config": {
+                "quant_method": "fp8",
+                "weight_block_size": [128, 128],
+            },
+        }
+    )
+    assert config.is_fp8
+    assert config.weight_block_size == (128, 128)
+    assert config.quantization["quant_method"] == "fp8"
+
+
+def test_pack_gate_up_keeps_rows_and_scale_tiles_aligned() -> None:
+    gate = FP8Tensor(
+        torch.arange(2 * 4 * 4, dtype=torch.uint8).reshape(2, 4, 4).view(torch.float8_e4m3fn),
+        torch.tensor([[[2.0]], [[3.0]]], dtype=torch.bfloat16),
+        (2, 4),
+    )
+    up = FP8Tensor(
+        (100 + torch.arange(2 * 4 * 4, dtype=torch.uint8)).reshape(2, 4, 4).view(torch.float8_e4m3fn),
+        torch.tensor([[[5.0]], [[7.0]]], dtype=torch.bfloat16),
+        (2, 4),
+    )
+    packed = pack_gate_up_fp8(gate, up)
+    assert packed.code.shape == (4, 4, 4)
+    assert packed.scale.shape == (4, 1, 1)
+    torch.testing.assert_close(packed.code[:2].view(torch.uint8), gate.code.view(torch.uint8))
+    torch.testing.assert_close(packed.code[2:].view(torch.uint8), up.code.view(torch.uint8))
+    torch.testing.assert_close(packed.scale[:2], gate.scale)
+    torch.testing.assert_close(packed.scale[2:], up.scale)
+
+
+@REAL_FP8
+def test_real_fp8_expert_names_and_shapes() -> None:
+    store = MmapSafetensors(FP8_MODEL)
+    checkpoint = Qwen4ExpCheckpoint(FP8_MODEL, store=store)
+    assert checkpoint.is_fp8
+    assert checkpoint.fp8_expert_keys(0, 0) == [
+        "model.language_model.layers.0.mlp.experts.0.gate_proj.weight",
+        "model.language_model.layers.0.mlp.experts.0.gate_proj.weight_scale_inv",
+        "model.language_model.layers.0.mlp.experts.0.up_proj.weight",
+        "model.language_model.layers.0.mlp.experts.0.up_proj.weight_scale_inv",
+        "model.language_model.layers.0.mlp.experts.0.down_proj.weight",
+        "model.language_model.layers.0.mlp.experts.0.down_proj.weight_scale_inv",
+    ]
+    gate_up, down = checkpoint.expert_rows(0, 0)
+    assert isinstance(gate_up, FP8Tensor)
+    assert isinstance(down, FP8Tensor)
+    assert gate_up.code.shape == (1280, 2560)
+    assert gate_up.scale.shape == (10, 20)
+    assert down.code.shape == (2560, 640)
+    assert down.scale.shape == (20, 5)
+    assert gate_up.code.dtype is torch.float8_e4m3fn
+    assert down.code.dtype is torch.float8_e4m3fn
+
+
+@REAL_FP8
+def test_real_fp8_ple_scale_and_gather() -> None:
+    store = MmapSafetensors(FP8_MODEL)
+    checkpoint = Qwen4ExpCheckpoint(FP8_MODEL, store=store)
+    keys = checkpoint.ngram_shard_keys(1)
+    assert len(keys) == 128
+    assert store.view(keys[0]).dtype is torch.float8_e4m3fn
+    scale = checkpoint.ngram_scale(1)
+    assert scale is not None
+    table = HostNGramTable(
+        [store.view(keys[0])], device=torch.device("cpu"), dtype=torch.float16, scale=scale
+    )
+    got = table(torch.tensor([[0, 2]], dtype=torch.long))
+    assert got.shape == (1, 2, 160)
+    assert got.dtype is torch.float16
+    assert torch.isfinite(got).all()
+
+
+def test_fp8_shard_allocates_codes_and_scales_as_one_group(monkeypatch) -> None:
+    shard = HostExpertShard(num_layers=1, rank=0, world_size=1, pin_memory=False)
+    codes_gu = torch.zeros(2, 4, 4, dtype=torch.float8_e4m3fn)
+    codes_dn = torch.zeros(2, 4, 2, dtype=torch.float8_e4m3fn)
+    scales_gu = torch.ones(2, 1, 1, dtype=torch.bfloat16)
+    scales_dn = torch.ones(2, 1, 1, dtype=torch.bfloat16)
+
+    def read(expert_id: int):
+        return (
+            FP8Tensor(codes_gu[expert_id], scales_gu[expert_id], (2, 2)),
+            FP8Tensor(codes_dn[expert_id], scales_dn[expert_id], (2, 2)),
+        )
+
+    shard.load_layer_fp8(0, 2, read, block_size=(2, 2))
+    gate_up, down = shard.rows(0, 1)
+    assert isinstance(gate_up, FP8Tensor)
+    assert isinstance(down, FP8Tensor)
+    assert shard.is_fp8
+    expected = sum(t.numel() * t.element_size() for t in (codes_gu, codes_dn, scales_gu, scales_dn))
+    assert shard.resident_bytes == expected
+
+
+def test_resident_shard_pin_fallback_converts_all_fp8_buffers(monkeypatch) -> None:
+    shard = HostExpertShard(num_layers=2, rank=0, world_size=1, pin_memory=True)
+    codes_gu = torch.zeros(1, 4, 4, dtype=torch.float8_e4m3fn)
+    codes_dn = torch.zeros(1, 4, 2, dtype=torch.float8_e4m3fn)
+    scales_gu = torch.ones(1, 1, 1, dtype=torch.bfloat16)
+    scales_dn = torch.ones(1, 1, 1, dtype=torch.bfloat16)
+
+    def read(_expert_id: int):
+        return (
+            FP8Tensor(codes_gu[0], scales_gu[0], (2, 2)),
+            FP8Tensor(codes_dn[0], scales_dn[0], (2, 2)),
+        )
+
+    real_empty = torch.empty
+    calls = [0]
+
+    def failing_empty(*args, **kwargs):
+        if kwargs.get("pin_memory"):
+            calls[0] += 1
+            if calls[0] == 5:
+                raise RuntimeError("simulated memlock limit")
+        return real_empty(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "empty", failing_empty)
+    shard.load_layer_fp8(0, 1, read, block_size=(2, 2))
+    shard.load_layer_fp8(1, 1, read, block_size=(2, 2))
+    assert not shard.pinned
+    for layer in (0, 1):
+        gate_up, down = shard.rows(layer, 0)
+        assert not gate_up.code.is_pinned()
+        assert not gate_up.scale.is_pinned()
+        assert not down.code.is_pinned()
+        assert not down.scale.is_pinned()


### PR DESCRIPTION
## Summary

Teaches the Qwen4-Exp heterogeneous runtime to read the Qwen3.8-Flash-Next **FP8** checkpoint and to compute in **FP16**, without disturbing the BF16 checkpoint or the BF16 default path.

FP8 is the one lever that halves both sides of the heterogeneous split:

| | BF16 ckpt | FP8 ckpt |
|---|---|---|
| checkpoint | 335.28 GiB, 1658 tensors | 172.76 GiB, 152089 tensors |
| routed experts | 229.69 GiB | 114.86 GiB |
| PLE n-gram table | 95.37 GiB | 47.68 GiB |
| host expert shard / rank | 56.25 GiB | 28.13 GiB |
| decode expert H2D / token / rank | 1.099 GiB | 0.550 GiB |

## Layout, not just dtype

The FP8 checkpoint stores experts differently, so this is a loader change and not a cast:

- BF16: `experts.gate_up_proj [512, 1280, 2560]`, `experts.down_proj [512, 2560, 640]`
- FP8: `experts.E.{gate,up,down}_proj.weight` per expert, plus `weight_scale_inv` per 128x128 block

`weight_scale_inv` is a **multiplier** despite its name: `dequant = code.to(dtype) * scale`. The loader reassembles gate and up into the packed `gate_up` the existing `swiglu_expert(...).chunk(2)` contract expects. 640, 1280 and 2560 are all multiples of 128, so concatenation preserves block alignment and the divisible fast path applies. The PLE table is 128 `F8_E4M3` shards of `[2500012, 160]` sharing one scalar `weight_scale`.

## Changes

- `quant.py` (new): `FP8Tensor` (code + block scale), block dequantization with a reshape/broadcast path for divisible tiles and a `repeat_interleave` path for ragged tails, scalar dequantization for the PLE table, gate/up packing.
- `config.py`: `FP8QuantSpec` read from the **root** `quantization_config` (not `text_config`) — that is where the FP8 checkpoint puts it: `fp8`, dynamic activations, block `[128, 128]`, 943 `modules_to_not_convert` entries.
- `weights.py`: `F8_E4M3` safetensors support; an FP8 layer allocates four contiguous host buffers (gate_up/down codes and scales) pinned as a group so a memlock failure cannot leave a layer part-pinned; `HostNGramTable` gathers FP8 shards through a `uint8` view of the same storage because CPU float8 `index_select` is unavailable, then dequantizes on device.
- `moe.py`: stages codes and scales rather than expanding to FP16 on the host, and dequantizes on the device immediately before the GEMM, so the residency win survives into the device cache.
- `layers.py`: `prefill_linear` recognizes native FP16 inputs/weights instead of casting back to BF16, and `_fp16_fp32_linear` returns the input dtype instead of a hardcoded BF16. SM75 has no BF16 tensor-core path, so an explicitly FP16 model is no longer silently downgraded.
- `builder.py` / `runtime.py`: thread the PLE scalar scale and `num_experts` through (FP8 has no packed leading dimension to infer expert count from).

## Verification

Against the real checkpoint at `/mnt/data1/modelscope/Qwen/Qwen3.8-Flash-Next-FP8`:

- expert reader shapes: gate_up code `[1280, 2560]` / scale `[10, 20]`, down code `[2560, 640]` / scale `[20, 5]`, dtype `torch.float8_e4m3fn`
- TP4-style one-layer host preload: rank 0 of 4, 128 local experts, `resident_bytes = 629222400`, `fp8 = True`
- one-layer forward: finite FP16 logits on CPU and on CUDA
- direct FP8 `HostExpertMoE` CUDA smoke: 3 experts staged (`stage_bytes = 14747400`), replay hits cache

Tests: `PYTHONPATH=. pytest -q tests/test_qwen4_exp_*.py` → **57 passed, 25 skipped**. The two new files cover config parsing, gate/up packing, real-checkpoint keys and shapes, the PLE scalar scale, four-buffer allocation, pin-fallback uniformity, divisible and ragged dequantization, and bad scale shapes. The dequant test asserts structural agreement with BF16, not token parity — FP8 is lossy and pretending otherwise would be the wrong gate.

## Limits, stated rather than papered over

- **No end-to-end throughput number yet.** Rebuilding the CUDA extension is blocked on this machine: `setup.py build_ext` fails with a CUDA 12.4 toolkit against a PyTorch built with CUDA 13.0. Nothing here claims a measured FP8/FP16 prefill or decode figure.
- **QSA, gated DeltaNet and MoE are still BF16-only instantiations.** The existing Python gates fall back honestly under FP16 rather than calling a BF16 kernel with FP16 tensors, so FP16 is correct but not yet fast.
- **No FP8 grouped MoE kernel.** `_grouped_bf16` returns `None` for FP8 shards, so FP8 takes the per-expert dispatch path.
- **No dequantized-weight cache for decode.** The device cache holds codes and scales, so a cache hit still re-dequantizes before use. That is the right tradeoff for prefill residency but wants a decode benchmark before it can be called right for decode.

Follow-ups: FP16 kernel instantiations once the toolchain matches, the five-arm A/B (`bf16_baseline`, `fp8_bf16`, `fp8_fp16`, `bf16_fp16`, `bf16_baseline_recheck`), forced-token margin matrix on real Chinese/English/code prompts, and a decode-side dequant LRU or fused FP8 GEMM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
