### PR TITLE
Optimize Qwen TP2 decode paths

### DIFF
--- a/cpp_engine/backends/cuda/kernels/qwen_gqa_optimized.cu
+++ b/cpp_engine/backends/cuda/kernels/qwen_gqa_optimized.cu
@@ -98,11 +98,17 @@ int decode_sm_count() {
 }
 
 // The tensor-core split kernel reassociates both dot products, so it is not
-// bit-identical to the scalar kernel. Keep short contexts on the established
-// exact path by default, where its measured gain is small and near ties are more
-// visible; select the candidate automatically once the scan is long enough to
-// matter. `=1` forces it at every context for A/B, while `=0` forces scalar.
-constexpr int kDecodeMmaDefaultMinContext = 16384;
+// bit-identical to the scalar kernel. Its gain used to be small at short context,
+// where near ties are more visible, so the default kept those on the exact path.
+// Raising the CTA occupancy to three per SM removed that trade: the candidate now
+// wins from the minimum context the fused path accepts. Full-network TP2 decode
+// at 8192 and TG128, serial fresh processes, three repetitions each:
+//
+//   scalar   29.5123  29.3403  29.2454
+//   candidate 30.6626  30.4263  30.3284
+//
+// `=1` forces it at every context for A/B, while `=0` forces scalar.
+constexpr int kDecodeMmaDefaultMinContext = 0;
 bool decode_mma_enabled(int attended_positions) {
     static const int mode = [] {
         const char* env = std::getenv("DSV4_QWEN_DECODE_MMA");
@@ -159,13 +165,25 @@ int decode_target_splits(int attended_positions, bool mma) {
         //     32768   0.1742     0.1107  0.1024    0.0986  0.1194 0.1142 0.1362
         //     65536   0.3149     0.2052  0.1832    0.1784  0.1999 0.1939 0.2239
         //
-        // Long contexts want both waves because the slice is long enough to
-        // amortise the per-CTA partial write; short ones do not. The split at
-        // 16384 takes the better column on both sides. Anything that is not a
-        // whole wave (119, 153, 170) is strictly worse than the wave below it.
+        // Cutting the shared footprint to 18632 bytes raised the CTA occupancy
+        // from two to three per SM, which moved the optimum. Re-measured at the
+        // TP4 shape, fused milliseconds, medians of the second and third
+        // repetitions:
+        //
+        //   context   scalar   68 (1 wave)  136 (2)   204 (3)   272 (4)
+        //      4096   0.2728      0.0598     0.0413    0.0413    0.0412
+        //      8192   0.8359      0.0889     0.0633    0.0633    0.0633
+        //     16384   1.6727      0.0550     0.0546    0.0629    0.0699
+        //     32768   3.3562      0.0973     0.0904    0.1009    0.1088
+        //     65536   6.7720      0.1788     0.1589    0.1648    0.1822
+        //
+        // Two waves now win at every context, so the short-context exception
+        // that the one-CTA geometry needed is gone. Past two waves the per-CTA
+        // partial write stops being amortised and the long contexts regress.
+        // The TP2 shape agrees: with 68 splits per KV group, 65536 costs
+        // 0.2844 ms against 0.3204 ms for twice as many.
         if (override_value <= 0) {
-            const int per_sm = attended_positions < kDecodeShortContext ? 1 : 2;
-            return decode_sm_count() * per_sm;
+            return decode_sm_count() * 2;
         }
     }
     if (override_value > 0) return override_value;
@@ -1752,8 +1770,8 @@ __global__ void gqa_decode_split_f16_kernel(
     }
 }
 
-// The real TP4 decode shape has six Q rows sharing one KV head. This candidate
-// maps those rows to the M dimension of SM75's m16n8k8 instruction, padding ten
+// The decode tensor-core shape has six Q rows sharing each KV head. This candidate
+// maps one group to the M dimension of SM75's m16n8k8 instruction, padding ten
 // inactive rows, and maps four warps to four eight-position N tiles. The same
 // 32-position tile is then used for P*V. Unlike the scalar split kernel, a CTA
 // scans a longer slice and performs the two 256-wide products on tensor cores.
@@ -1761,21 +1779,39 @@ __global__ void gqa_decode_split_f16_kernel(
 // rounded to half before P*V, matching the proven prefill MMA path. Consequently
 // this is numerically close rather than bit-identical and is opt-in.
 constexpr int kDecodeMmaThreads = 128;
-constexpr int kDecodeMmaWarps = kDecodeMmaThreads / 32;
 constexpr int kDecodeMmaRows = 16;
 constexpr int kDecodeMmaValidRows = 6;
+// The tile stays at 32 positions. Halving it to 16 cuts shared memory to 9864
+// bytes but the CTA still needs 133 registers, so 4 * 128 * 133 = 68096 exceeds
+// the 65536-register file and occupancy stays at three CTAs per SM either way.
+// The same register wall blocks `__launch_bounds__(128, 4)`: capping registers at
+// 128 fits the file but 4 * 18632 bytes of shared memory does not, and the
+// microbenchmark confirmed no change (65536: 0.3068 ms against 0.3066 ms).
 constexpr int kDecodeMmaKvTile = 32;
 constexpr int kDecodeMmaDim = 256;
 constexpr int kDecodeMmaSteps = kDecodeMmaDim / 8;
 constexpr int kDecodeMmaKsStride = kDecodeMmaDim + 8;
 constexpr int kDecodeMmaVtStride = kDecodeMmaKvTile + 2;
 
-__global__ __launch_bounds__(kDecodeMmaThreads, 1)
+// Six valid rows all fall in the first half of the MMA M dimension, so the
+// second row a lane owns (`gid + 8`) is never active at this shape. Only the
+// first half of every accumulator fragment is therefore consumed, and the
+// per-lane output set is small enough to live in registers.
+static_assert(kDecodeMmaValidRows <= 8,
+              "the decode MMA epilogue assumes the padded row half is inactive");
+
+// Shared memory is what limits this kernel's occupancy: the register budget
+// admits four CTAs per SM but every byte above 21845 costs a resident CTA. So
+// the score and probability tiles are cut to the valid rows and the output
+// accumulator is held in registers, where each element already had exactly one
+// writer.
+__global__ __launch_bounds__(kDecodeMmaThreads, 3)
 void gqa_decode_split_mma_f16_kernel(
     const uint16_t* __restrict__ q,
     const uint16_t* __restrict__ k_cache,
     const uint16_t* __restrict__ v_cache,
     float* __restrict__ partial_output,
+    int kv_groups,
     int context_len,
     int splits,
     int positions_per_split) {
@@ -1785,12 +1821,11 @@ void gqa_decode_split_mma_f16_kernel(
         reinterpret_cast<uint16_t (*)[kDecodeMmaKsStride]>(kv_stage);
     uint16_t (*vt)[kDecodeMmaVtStride] =
         reinterpret_cast<uint16_t (*)[kDecodeMmaVtStride]>(kv_stage);
-    __shared__ float scores[kDecodeMmaRows][kDecodeMmaKvTile];
-    __shared__ uint16_t probability[kDecodeMmaRows][kDecodeMmaKvTile];
+    __shared__ float scores[kDecodeMmaValidRows][kDecodeMmaKvTile];
+    __shared__ uint16_t probability[kDecodeMmaValidRows][kDecodeMmaKvTile];
     __shared__ float running_max[kDecodeMmaValidRows];
     __shared__ float running_sum[kDecodeMmaValidRows];
     __shared__ float rescale[kDecodeMmaValidRows];
-    __shared__ float accumulator[kDecodeMmaValidRows][kDecodeMmaDim];
 
     const int tid = static_cast<int>(threadIdx.x);
     const int warp = tid >> 5;
@@ -1800,13 +1835,25 @@ void gqa_decode_split_mma_f16_kernel(
     const int lrow0 = gid;
     const int lrow1 = gid + 8;
     const int split = static_cast<int>(blockIdx.x);
+    const int kv_group = static_cast<int>(blockIdx.y);
+    if (kv_group >= kv_groups) return;
+    const size_t q_offset =
+        static_cast<size_t>(kv_group) * kDecodeMmaValidRows * kDecodeMmaDim;
+    const size_t kv_offset = static_cast<size_t>(kv_group) * kDecodeMmaDim;
+    const size_t partial_group_offset =
+        static_cast<size_t>(kv_group) * kDecodeMmaValidRows * splits *
+        (kDecodeMmaDim + 2);
     const int start = split * positions_per_split;
     const int end = min(context_len, start + positions_per_split);
 
-    for (int index = tid;
-         index < kDecodeMmaValidRows * kDecodeMmaDim;
-         index += kDecodeMmaThreads) {
-        accumulator[index / kDecodeMmaDim][index % kDecodeMmaDim] = 0.0f;
+    // The eight P*V fragments a lane accumulates. Lane `lane` owns row `gid` and
+    // channels `slice * 64 + j * 8 + tig * 2` for j in [0, 8), which is a
+    // disjoint set across the CTA.
+    float accumulator[8][2];
+#pragma unroll
+    for (int j = 0; j < 8; ++j) {
+        accumulator[j][0] = 0.0f;
+        accumulator[j][1] = 0.0f;
     }
     if (tid < kDecodeMmaValidRows) {
         running_max[tid] = -INFINITY;
@@ -1825,11 +1872,11 @@ void gqa_decode_split_mma_f16_kernel(
         uint32_t first = 0u;
         uint32_t second = 0u;
         if (lrow0 < kDecodeMmaValidRows) {
-            first = *reinterpret_cast<const uint32_t*>(q +
+            first = *reinterpret_cast<const uint32_t*>(q + q_offset +
                 static_cast<size_t>(lrow0) * kDecodeMmaDim + col);
         }
         if (lrow1 < kDecodeMmaValidRows) {
-            second = *reinterpret_cast<const uint32_t*>(q +
+            second = *reinterpret_cast<const uint32_t*>(q + q_offset +
                 static_cast<size_t>(lrow1) * kDecodeMmaDim + col);
         }
         qfrag[k][0] = first;
@@ -1848,7 +1895,8 @@ void gqa_decode_split_mma_f16_kernel(
             uint4 key = make_uint4(0u, 0u, 0u, 0u);
             if (slot < count) {
                 key = *reinterpret_cast<const uint4*>(k_cache +
-                    static_cast<size_t>(base + slot) * kv_stride + chunk * 8);
+                    static_cast<size_t>(base + slot) * kv_groups * kv_stride +
+                    kv_offset + chunk * 8);
             }
             *reinterpret_cast<uint4*>(&ks[slot][chunk * 8]) = key;
         }
@@ -1886,8 +1934,10 @@ void gqa_decode_split_mma_f16_kernel(
 #pragma unroll
             for (int i = 0; i < 4; ++i) {
                 const int col = col0 + i;
-                const float value = col < count
-                    ? scores[row][col] * attention_scale : -INFINITY;
+                const float value = valid_row && col < count
+                    ? scores[row < kDecodeMmaValidRows ? row : 0][col] *
+                          attention_scale
+                    : -INFINITY;
                 values[i] = value;
                 local_max = fmaxf(local_max, value);
             }
@@ -1905,7 +1955,9 @@ void gqa_decode_split_mma_f16_kernel(
                     bits = float_to_half(expf(values[i] - new_max));
                     local_sum += half_to_float(bits);
                 }
-                probability[row][col0 + i] = bits;
+                if (valid_row) {
+                    probability[row][col0 + i] = bits;
+                }
             }
 #pragma unroll
             for (int offset = 1; offset < 8; offset <<= 1) {
@@ -1931,7 +1983,8 @@ void gqa_decode_split_mma_f16_kernel(
             uint4 value = make_uint4(0u, 0u, 0u, 0u);
             if (slot < count) {
                 value = *reinterpret_cast<const uint4*>(v_cache +
-                    static_cast<size_t>(base + slot) * kv_stride + chunk * 8);
+                    static_cast<size_t>(base + slot) * kv_groups * kv_stride +
+                    kv_offset + chunk * 8);
             }
             const uint16_t* source = reinterpret_cast<const uint16_t*>(&value);
 #pragma unroll
@@ -1953,32 +2006,23 @@ void gqa_decode_split_mma_f16_kernel(
             float value_fragment[4] = {0.0f, 0.0f, 0.0f, 0.0f};
 #pragma unroll
             for (int kt = 0; kt < kDecodeMmaKvTile / 8; ++kt) {
+                // The second row half is inactive, so its A fragment stays zero
+                // and is never read out of the six-row probability tile.
                 uint32_t a[2] = {0u, 0u};
                 if (lrow0 < kDecodeMmaValidRows) {
                     a[0] = *reinterpret_cast<const uint32_t*>(
                         &probability[lrow0][kt * 8 + tig * 2]);
-                }
-                if (lrow1 < kDecodeMmaValidRows) {
-                    a[1] = *reinterpret_cast<const uint32_t*>(
-                        &probability[lrow1][kt * 8 + tig * 2]);
                 }
                 const uint32_t b = *reinterpret_cast<const uint32_t*>(
                     &vt[channel + gid][kt * 8 + tig * 2]);
                 mma_m16n8k8_f16_f32(value_fragment, a, b);
             }
             if (lrow0 < kDecodeMmaValidRows) {
-                const int d0 = channel + tig * 2;
-                accumulator[lrow0][d0] =
-                    accumulator[lrow0][d0] * rescale[lrow0] + value_fragment[0];
-                accumulator[lrow0][d0 + 1] =
-                    accumulator[lrow0][d0 + 1] * rescale[lrow0] + value_fragment[1];
-            }
-            if (lrow1 < kDecodeMmaValidRows) {
-                const int d1 = channel + tig * 2;
-                accumulator[lrow1][d1] =
-                    accumulator[lrow1][d1] * rescale[lrow1] + value_fragment[2];
-                accumulator[lrow1][d1 + 1] =
-                    accumulator[lrow1][d1 + 1] * rescale[lrow1] + value_fragment[3];
+                const float row_rescale = rescale[lrow0];
+                accumulator[j][0] =
+                    accumulator[j][0] * row_rescale + value_fragment[0];
+                accumulator[j][1] =
+                    accumulator[j][1] * row_rescale + value_fragment[1];
             }
         }
         __syncthreads();
@@ -1986,18 +2030,20 @@ void gqa_decode_split_mma_f16_kernel(
 
     const int partial_stride = kDecodeMmaDim + 2;
     if (tid < kDecodeMmaValidRows) {
-        float* destination = partial_output +
+        float* destination = partial_output + partial_group_offset +
             (static_cast<size_t>(tid) * splits + split) * partial_stride;
         destination[0] = running_max[tid];
         destination[1] = running_sum[tid];
     }
-    for (int index = tid;
-         index < kDecodeMmaValidRows * kDecodeMmaDim;
-         index += kDecodeMmaThreads) {
-        const int head = index / kDecodeMmaDim;
-        const int d = index - head * kDecodeMmaDim;
-        partial_output[(static_cast<size_t>(head) * splits + split) *
-                           partial_stride + 2 + d] = accumulator[head][d];
+    if (lrow0 < kDecodeMmaValidRows) {
+        float* destination = partial_output + partial_group_offset +
+            (static_cast<size_t>(lrow0) * splits + split) * partial_stride + 2;
+#pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            const int d0 = warp * 64 + j * 8 + tig * 2;
+            *reinterpret_cast<float2*>(destination + d0) =
+                make_float2(accumulator[j][0], accumulator[j][1]);
+        }
     }
 }
 
@@ -2425,16 +2471,25 @@ bool valid_shape(int q_heads, int kv_heads, int head_dim) {
 }
 
 // Never splits finer than one position per split, so short contexts fall back to
-// however many splits they can actually fill.
+// however many splits they can actually fill. The automatic tensor-core target
+// is expressed as a total grid size: one CTA covers one KV head, so divide that
+// target across KV heads instead of launching an extra full wave for every head.
+// The MMA-specific environment override and the explicit test override remain
+// per KV head for reproducible A/B sweeps.
 int decode_split_count_for_variant(int attended_positions, bool mma,
-                                    int split_count_override) {
+                                    int split_count_override, int kv_heads = 1) {
     if (attended_positions <= 0) return 1;
     const int forced = decode_forced_positions();
+    const int total_target = decode_target_splits(attended_positions, mma);
+    const int mma_override = mma ? decode_mma_target_splits() : 0;
+    const int shape_target = mma && mma_override <= 0
+        ? (total_target + std::max(kv_heads, 1) - 1) / std::max(kv_heads, 1)
+        : total_target;
     const int requested = split_count_override > 0
         ? split_count_override
         : forced > 0
             ? (attended_positions + forced - 1) / forced
-            : std::min(decode_target_splits(attended_positions, mma), attended_positions);
+            : std::min(shape_target, attended_positions);
     const int splits = std::max(std::min(decode_max_splits(), requested), 1);
     // Correctness tests may deliberately preserve an oversized split count to
     // exercise the neutral partial written by an empty CTA. Production geometry
@@ -2449,9 +2504,11 @@ int decode_split_count_for_variant(int attended_positions, bool mma,
     return std::max((attended_positions + positions - 1) / positions, 1);
 }
 
-int decode_split_count(int attended_positions) {
+int decode_split_count(int attended_positions, int kv_heads,
+                       bool tensor_core_shape) {
+    const bool mma = tensor_core_shape && decode_mma_enabled(attended_positions);
     return decode_split_count_for_variant(
-        attended_positions, decode_mma_enabled(attended_positions), 0);
+        attended_positions, mma, 0, kv_heads);
 }
 
 struct GqaCublasWorkspace {
@@ -2886,8 +2943,9 @@ bool qwen_gqa_verify_attention_f16_cuda(
     return cudaGetLastError() == cudaSuccess;
 }
 
-int qwen_gqa_decode_split_count(int attended_positions) {
-    return decode_split_count(attended_positions);
+int qwen_gqa_decode_split_count(int attended_positions, int kv_heads,
+                                bool tensor_core_shape) {
+    return decode_split_count(attended_positions, kv_heads, tensor_core_shape);
 }
 
 int qwen_gqa_decode_split_count_variant(
@@ -2897,12 +2955,12 @@ int qwen_gqa_decode_split_count_variant(
         ? decode_mma_enabled(attended_positions)
         : variant == QwenGqaDecodeVariant::TensorCore;
     return decode_split_count_for_variant(attended_positions, mma,
-                                          split_count_override);
+                                          split_count_override, 1);
 }
 
-// Widest Q group the decode split kernel is instantiated for. Six covers the
-// TP4 full-attention shape (q_heads 6, kv_heads 1) in a single CTA, which is
-// what removes the duplicate KV stream.
+// Widest Q group the decode split kernel is instantiated for. Six covers one
+// full-attention KV group in both TP4 (6/1) and TP2 (12/2), which is what removes
+// the duplicate KV stream.
 constexpr int kDecodeMaxHeadsPerGroup = 6;
 
 // Zero keeps the automatic choice: cover the whole KV group so its cache line is
@@ -2948,7 +3006,7 @@ bool launch_decode_fused(
     // Geometry follows the variant being launched, and the same query is public
     // so the engine's scratch sizing cannot disagree with the grid.
     const int splits = decode_split_count_for_variant(
-        attended, want_mma, split_count_override);
+        attended, want_mma, split_count_override, kv_heads);
     const int positions_per_split = (attended + splits - 1) / splits;
     const int group_heads = decode_group_width(q_heads / kv_heads);
     const int groups_per_kv =
@@ -2956,8 +3014,8 @@ bool launch_decode_fused(
     const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
     const bool mma_supported = decode_mma_device_supported() &&
         attention_window <= 0 && sink_tokens == 0 &&
-        q_heads == 6 && kv_heads == 1 && head_dim == kDecodeMmaDim &&
-        splits <= kDecodeSplitCeiling;
+        q_heads == kv_heads * kDecodeMmaValidRows &&
+        head_dim == kDecodeMmaDim && splits <= kDecodeSplitCeiling;
     // An explicit tensor-core request on an unsupported shape is an error, not a
     // silent fallback: a test that asked for the candidate must not measure the
     // scalar kernel instead.
@@ -2966,10 +3024,12 @@ bool launch_decode_fused(
     }
     const bool use_decode_mma = want_mma && mma_supported;
     if (use_decode_mma) {
-        gqa_decode_split_mma_f16_kernel<<<splits, kDecodeMmaThreads, 0,
-                                           cuda_stream>>>(
-            q, k_cache, v_cache, partial_scratch, context_len, splits,
-            positions_per_split);
+        const dim3 grid(static_cast<unsigned>(splits),
+                        static_cast<unsigned>(kv_heads), 1);
+        gqa_decode_split_mma_f16_kernel<<<
+            grid, kDecodeMmaThreads, 0, cuda_stream>>>(
+            q, k_cache, v_cache, partial_scratch, kv_heads, context_len,
+            splits, positions_per_split);
         if (cudaGetLastError() != cudaSuccess) return false;
         gqa_decode_merge_f16_kernel<<<q_heads, kThreads, 0, cuda_stream>>>(
             partial_scratch, output, q_heads, head_dim, splits);

--- a/cpp_engine/backends/cuda/kernels/qwen_half_ops.cu
+++ b/cpp_engine/backends/cuda/kernels/qwen_half_ops.cu
@@ -3,6 +3,7 @@
 #include <cublas_v2.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#include <cub/block/block_reduce.cuh>
 
 #include <algorithm>
 #include <cmath>
@@ -237,6 +238,92 @@ __global__ void fp8_matvec_f16_multirow_kernel(
         }
         if (lane == 0) y[row_base + r] = float_to_half(sum);
     }
+}
+
+// Decode-only row concatenation without concatenating the stored matrices.
+// Every projection consumes the same activation but lives in an independent
+// checkpoint tensor. One grid selects its source per output row and preserves
+// the established wide-8 arithmetic within each row.
+template <int kWarps, int kColsPerLane, int kGroups>
+__global__ void fp8_matvec_f16_grouped_kernel(
+    const uint16_t* __restrict__ x,
+    const uint8_t* __restrict__ first_weight,
+    const uint16_t* __restrict__ first_scale,
+    uint16_t* __restrict__ first_y, int first_rows, int first_weight_stride,
+    int first_scale_stride,
+    const uint8_t* __restrict__ second_weight,
+    const uint16_t* __restrict__ second_scale,
+    uint16_t* __restrict__ second_y, int second_rows, int second_weight_stride,
+    int second_scale_stride,
+    const uint8_t* __restrict__ third_weight,
+    const uint16_t* __restrict__ third_scale,
+    uint16_t* __restrict__ third_y, int third_rows, int third_weight_stride,
+    int third_scale_stride, int cols) {
+    const int warp = static_cast<int>(threadIdx.x) >> 5;
+    const int lane = static_cast<int>(threadIdx.x) & 31;
+    const int combined_row = static_cast<int>(blockIdx.x) * kWarps + warp;
+    const int first_end = first_rows;
+    const int second_end = first_end + second_rows;
+    const int total_rows = second_end + (kGroups == 3 ? third_rows : 0);
+    if (combined_row >= total_rows) return;
+
+    const bool use_second = combined_row >= first_end && combined_row < second_end;
+    const bool use_third = combined_row >= second_end;
+    const int row = use_third ? combined_row - second_end
+                              : use_second ? combined_row - first_end
+                                           : combined_row;
+    const int weight_stride = use_third ? third_weight_stride
+        : use_second ? second_weight_stride : first_weight_stride;
+    const int scale_stride = use_third ? third_scale_stride
+        : use_second ? second_scale_stride : first_scale_stride;
+    const uint8_t* weight = (use_third ? third_weight
+        : use_second ? second_weight : first_weight) +
+        static_cast<size_t>(row) * weight_stride;
+    const uint16_t* scale = (use_third ? third_scale
+        : use_second ? second_scale : first_scale) +
+        static_cast<size_t>(row / kFp8WeightBlock) * scale_stride;
+    uint16_t* output = use_third ? third_y : use_second ? second_y : first_y;
+
+    float sum = 0.0f;
+    constexpr int kQuads = kColsPerLane / 4;
+    constexpr int kStride = 32 * kColsPerLane;
+    const int vec_cols = cols & ~(kColsPerLane - 1);
+    for (int col = lane * kColsPerLane; col < vec_cols; col += kStride) {
+        float xv[kColsPerLane];
+#pragma unroll
+        for (int q = 0; q < kQuads; ++q) {
+            const uint2 packed = *reinterpret_cast<const uint2*>(x + col + q * 4);
+            xv[q * 4 + 0] = half_to_float(static_cast<uint16_t>(packed.x));
+            xv[q * 4 + 1] = half_to_float(static_cast<uint16_t>(packed.x >> 16));
+            xv[q * 4 + 2] = half_to_float(static_cast<uint16_t>(packed.y));
+            xv[q * 4 + 3] = half_to_float(static_cast<uint16_t>(packed.y >> 16));
+        }
+        Fp8x4AsHalf2 w[kQuads];
+#pragma unroll
+        for (int q = 0; q < kQuads; ++q) {
+            w[q] = fp8x4_as_half2_scaled(
+                *reinterpret_cast<const uchar4*>(weight + col + q * 4));
+        }
+        float span = 0.0f;
+#pragma unroll
+        for (int q = 0; q < kQuads; ++q) {
+            span +=
+                xv[q * 4 + 0] * half_to_float(static_cast<uint16_t>(w[q].lo)) +
+                xv[q * 4 + 1] * half_to_float(static_cast<uint16_t>(w[q].lo >> 16)) +
+                xv[q * 4 + 2] * half_to_float(static_cast<uint16_t>(w[q].hi)) +
+                xv[q * 4 + 3] * half_to_float(static_cast<uint16_t>(w[q].hi >> 16));
+        }
+        sum += span * half_to_float(scale[col / kFp8WeightBlock]);
+    }
+    sum *= kFp8E4m3HalfFixup;
+    for (int col = vec_cols + lane; col < cols; col += 32) {
+        sum += half_to_float(x[col]) * fp8_e4m3_to_float(weight[col]) *
+               half_to_float(scale[col / kFp8WeightBlock]);
+    }
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        sum += __shfl_xor_sync(0xffffffffu, sum, offset);
+    }
+    if (lane == 0) output[row] = float_to_half(sum);
 }
 
 // Small speculative batches are weight-bandwidth bound. One warp owns one
@@ -1792,6 +1879,175 @@ __global__ void concat_rows_f16_kernel(const uint16_t* left, const uint16_t* rig
     }
 }
 
+template <int kBlockThreads>
+__global__ void rmsnorm_f16_vector_kernel(
+    const uint16_t* __restrict__ x, const uint16_t* __restrict__ gamma,
+    uint16_t* __restrict__ y, int rows, int cols, float eps) {
+    using BlockReduce = cub::BlockReduce<float, kBlockThreads>;
+    __shared__ typename BlockReduce::TempStorage reduce_storage;
+    __shared__ float inverse_rms;
+    const int row = static_cast<int>(blockIdx.x);
+    if (row >= rows) return;
+    const uint16_t* src = x + static_cast<size_t>(row) * cols;
+    uint16_t* dst = y + static_cast<size_t>(row) * cols;
+    const int quads = cols / 8;
+    float sum = 0.0f;
+    for (int quad = threadIdx.x; quad < quads; quad += kBlockThreads) {
+        const uint4 values = reinterpret_cast<const uint4*>(src)[quad];
+        const uint32_t halves[4] = {values.x, values.y, values.z, values.w};
+#pragma unroll
+        for (int pair = 0; pair < 4; ++pair) {
+            const float first = half_to_float(static_cast<uint16_t>(halves[pair]));
+            const float second =
+                half_to_float(static_cast<uint16_t>(halves[pair] >> 16));
+            sum += first * first;
+            sum += second * second;
+        }
+    }
+    for (int col = quads * 8 + threadIdx.x; col < cols;
+         col += kBlockThreads) {
+        const float value = half_to_float(src[col]);
+        sum += value * value;
+    }
+    const float total = BlockReduce(reduce_storage).Sum(sum);
+    if (threadIdx.x == 0) {
+        inverse_rms = rsqrtf(total / static_cast<float>(cols) + eps);
+    }
+    __syncthreads();
+    for (int quad = threadIdx.x; quad < quads; quad += kBlockThreads) {
+        const uint4 values = reinterpret_cast<const uint4*>(src)[quad];
+        const uint4 weights = reinterpret_cast<const uint4*>(gamma)[quad];
+        const uint32_t input_halves[4] = {
+            values.x, values.y, values.z, values.w};
+        const uint32_t weight_halves[4] = {
+            weights.x, weights.y, weights.z, weights.w};
+        uint32_t output_halves[4];
+#pragma unroll
+        for (int pair = 0; pair < 4; ++pair) {
+            const float first = half_to_float(
+                static_cast<uint16_t>(input_halves[pair]));
+            const float second = half_to_float(
+                static_cast<uint16_t>(input_halves[pair] >> 16));
+            const float first_weight = 1.0f + half_to_float(
+                static_cast<uint16_t>(weight_halves[pair]));
+            const float second_weight = 1.0f + half_to_float(
+                static_cast<uint16_t>(weight_halves[pair] >> 16));
+            output_halves[pair] =
+                static_cast<uint32_t>(float_to_half(
+                    first * inverse_rms * first_weight)) |
+                (static_cast<uint32_t>(float_to_half(
+                    second * inverse_rms * second_weight)) << 16);
+        }
+        reinterpret_cast<uint4*>(dst)[quad] =
+            make_uint4(output_halves[0], output_halves[1],
+                       output_halves[2], output_halves[3]);
+    }
+    for (int col = quads * 8 + threadIdx.x; col < cols;
+         col += kBlockThreads) {
+        dst[col] = float_to_half(
+            half_to_float(src[col]) * inverse_rms *
+            (1.0f + half_to_float(gamma[col])));
+    }
+}
+
+template <int kBlockThreads>
+__global__ void residual_add_rmsnorm_f16_vector_kernel(
+    const uint16_t* __restrict__ hidden,
+    const uint16_t* __restrict__ delta,
+    const uint16_t* __restrict__ gamma,
+    uint16_t* __restrict__ residual,
+    uint16_t* __restrict__ normalized,
+    int rows, int cols, float eps) {
+    using BlockReduce = cub::BlockReduce<float, kBlockThreads>;
+    __shared__ typename BlockReduce::TempStorage reduce_storage;
+    __shared__ float inverse_rms;
+    const int row = static_cast<int>(blockIdx.x);
+    if (row >= rows) return;
+    const size_t row_offset = static_cast<size_t>(row) * cols;
+    const uint16_t* hidden_row = hidden + row_offset;
+    const uint16_t* delta_row = delta + row_offset;
+    uint16_t* residual_row = residual + row_offset;
+    uint16_t* normalized_row = normalized + row_offset;
+    const int quads = cols / 8;
+    float sum = 0.0f;
+    for (int quad = threadIdx.x; quad < quads; quad += kBlockThreads) {
+        const uint4 hidden_values =
+            reinterpret_cast<const uint4*>(hidden_row)[quad];
+        const uint4 delta_values =
+            reinterpret_cast<const uint4*>(delta_row)[quad];
+        const uint32_t hidden_halves[4] = {
+            hidden_values.x, hidden_values.y, hidden_values.z, hidden_values.w};
+        const uint32_t delta_halves[4] = {
+            delta_values.x, delta_values.y, delta_values.z, delta_values.w};
+        uint32_t residual_halves[4];
+#pragma unroll
+        for (int pair = 0; pair < 4; ++pair) {
+            const uint16_t first = float_to_half(
+                half_to_float(static_cast<uint16_t>(hidden_halves[pair])) +
+                half_to_float(static_cast<uint16_t>(delta_halves[pair])));
+            const uint16_t second = float_to_half(
+                half_to_float(static_cast<uint16_t>(hidden_halves[pair] >> 16)) +
+                half_to_float(static_cast<uint16_t>(delta_halves[pair] >> 16)));
+            residual_halves[pair] = static_cast<uint32_t>(first) |
+                (static_cast<uint32_t>(second) << 16);
+            const float first_value = half_to_float(first);
+            const float second_value = half_to_float(second);
+            sum += first_value * first_value;
+            sum += second_value * second_value;
+        }
+        reinterpret_cast<uint4*>(residual_row)[quad] =
+            make_uint4(residual_halves[0], residual_halves[1],
+                       residual_halves[2], residual_halves[3]);
+    }
+    for (int col = quads * 8 + threadIdx.x; col < cols;
+         col += kBlockThreads) {
+        const uint16_t value = float_to_half(
+            half_to_float(hidden_row[col]) + half_to_float(delta_row[col]));
+        residual_row[col] = value;
+        const float rounded = half_to_float(value);
+        sum += rounded * rounded;
+    }
+    const float total = BlockReduce(reduce_storage).Sum(sum);
+    if (threadIdx.x == 0) {
+        inverse_rms = rsqrtf(total / static_cast<float>(cols) + eps);
+    }
+    __syncthreads();
+    for (int quad = threadIdx.x; quad < quads; quad += kBlockThreads) {
+        const uint4 values = reinterpret_cast<const uint4*>(residual_row)[quad];
+        const uint4 weights = reinterpret_cast<const uint4*>(gamma)[quad];
+        const uint32_t residual_halves[4] = {
+            values.x, values.y, values.z, values.w};
+        const uint32_t weight_halves[4] = {
+            weights.x, weights.y, weights.z, weights.w};
+        uint32_t output_halves[4];
+#pragma unroll
+        for (int pair = 0; pair < 4; ++pair) {
+            const float first = half_to_float(
+                static_cast<uint16_t>(residual_halves[pair]));
+            const float second = half_to_float(
+                static_cast<uint16_t>(residual_halves[pair] >> 16));
+            const float first_weight = 1.0f + half_to_float(
+                static_cast<uint16_t>(weight_halves[pair]));
+            const float second_weight = 1.0f + half_to_float(
+                static_cast<uint16_t>(weight_halves[pair] >> 16));
+            output_halves[pair] =
+                static_cast<uint32_t>(float_to_half(
+                    first * inverse_rms * first_weight)) |
+                (static_cast<uint32_t>(float_to_half(
+                    second * inverse_rms * second_weight)) << 16);
+        }
+        reinterpret_cast<uint4*>(normalized_row)[quad] =
+            make_uint4(output_halves[0], output_halves[1],
+                       output_halves[2], output_halves[3]);
+    }
+    for (int col = quads * 8 + threadIdx.x; col < cols;
+         col += kBlockThreads) {
+        normalized_row[col] = float_to_half(
+            half_to_float(residual_row[col]) * inverse_rms *
+            (1.0f + half_to_float(gamma[col])));
+    }
+}
+
 __global__ void rmsnorm_f16_kernel(const uint16_t* x, const uint16_t* gamma,
                                    uint16_t* y, int rows, int cols, float eps) {
     const int row = static_cast<int>(blockIdx.x);
@@ -1804,9 +2060,12 @@ __global__ void rmsnorm_f16_kernel(const uint16_t* x, const uint16_t* gamma,
         sum += value * value;
     }
     extern __shared__ float scratch[];
-    const float inv = rsqrtf(block_reduce_sum(sum, scratch) / static_cast<float>(cols) + eps);
+    const float inv = rsqrtf(
+        block_reduce_sum(sum, scratch) / static_cast<float>(cols) + eps);
     for (int col = threadIdx.x; col < cols; col += blockDim.x) {
-        dst[col] = float_to_half(half_to_float(src[col]) * inv * (1.0f + half_to_float(gamma[col])));
+        dst[col] = float_to_half(
+            half_to_float(src[col]) * inv *
+            (1.0f + half_to_float(gamma[col])));
     }
 }
 
@@ -1835,6 +2094,69 @@ __global__ void residual_add_rmsnorm_f16_kernel(
         normalized_row[col] = float_to_half(
             half_to_float(residual_row[col]) * inv *
             (1.0f + half_to_float(gamma[col])));
+    }
+}
+
+template <int kBlockThreads>
+__global__ void gated_rmsnorm_f16_vector_kernel(
+    const uint16_t* __restrict__ x,
+    const uint16_t* __restrict__ gamma,
+    const uint16_t* __restrict__ gate,
+    uint16_t* __restrict__ y,
+    int rows, int cols, float eps) {
+    using BlockReduce = cub::BlockReduce<float, kBlockThreads>;
+    __shared__ typename BlockReduce::TempStorage reduce_storage;
+    __shared__ float inverse_rms;
+    const int row = static_cast<int>(blockIdx.x);
+    if (row >= rows) return;
+    const size_t row_offset = static_cast<size_t>(row) * cols;
+    const uint16_t* src = x + row_offset;
+    const uint16_t* gate_row = gate + row_offset;
+    uint16_t* dst = y + row_offset;
+    const int pairs = cols / 2;
+    float sum = 0.0f;
+    for (int pair = threadIdx.x; pair < pairs; pair += kBlockThreads) {
+        const uint32_t values = reinterpret_cast<const uint32_t*>(src)[pair];
+        const float first = half_to_float(static_cast<uint16_t>(values));
+        const float second = half_to_float(static_cast<uint16_t>(values >> 16));
+        sum += first * first;
+        sum += second * second;
+    }
+    for (int col = pairs * 2 + threadIdx.x; col < cols;
+         col += kBlockThreads) {
+        const float value = half_to_float(src[col]);
+        sum += value * value;
+    }
+    const float total = BlockReduce(reduce_storage).Sum(sum);
+    if (threadIdx.x == 0) {
+        inverse_rms = rsqrtf(total / static_cast<float>(cols) + eps);
+    }
+    __syncthreads();
+    for (int pair = threadIdx.x; pair < pairs; pair += kBlockThreads) {
+        const uint32_t values = reinterpret_cast<const uint32_t*>(src)[pair];
+        const uint32_t weights = reinterpret_cast<const uint32_t*>(gamma)[pair];
+        const uint32_t gates = reinterpret_cast<const uint32_t*>(gate_row)[pair];
+        const float first = half_to_float(static_cast<uint16_t>(values));
+        const float second = half_to_float(static_cast<uint16_t>(values >> 16));
+        const float first_weight = half_to_float(static_cast<uint16_t>(weights));
+        const float second_weight =
+            half_to_float(static_cast<uint16_t>(weights >> 16));
+        const float first_gate = half_to_float(static_cast<uint16_t>(gates));
+        const float second_gate =
+            half_to_float(static_cast<uint16_t>(gates >> 16));
+        const uint16_t first_output = float_to_half(
+            first * inverse_rms * first_weight * silu(first_gate));
+        const uint16_t second_output = float_to_half(
+            second * inverse_rms * second_weight * silu(second_gate));
+        reinterpret_cast<uint32_t*>(dst)[pair] =
+            static_cast<uint32_t>(first_output) |
+            (static_cast<uint32_t>(second_output) << 16);
+    }
+    for (int col = pairs * 2 + threadIdx.x; col < cols;
+         col += kBlockThreads) {
+        const float value = half_to_float(src[col]) * inverse_rms *
+            half_to_float(gamma[col]);
+        dst[col] = float_to_half(value * silu(half_to_float(gate_row[col])));
     }
 }
 
@@ -2726,6 +3048,82 @@ bool qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
     return cudaGetLastError() == cudaSuccess;
 }
 
+bool qwen_fp8_e4m3_fp16scale_matvec_dual_f16_cuda(
+    const uint16_t* x,
+    const uint8_t* first_weight, const uint16_t* first_scale,
+    uint16_t* first_y, int first_rows, int first_weight_stride,
+    int first_scale_stride,
+    const uint8_t* second_weight, const uint16_t* second_scale,
+    uint16_t* second_y, int second_rows, int second_weight_stride,
+    int second_scale_stride, int cols, void* stream) {
+    const int minimum_scale_stride =
+        (cols + kFp8WeightBlock - 1) / kFp8WeightBlock;
+    if (!x || !first_weight || !first_scale || !first_y || first_rows <= 0 ||
+        first_weight_stride < cols || first_scale_stride < minimum_scale_stride ||
+        !second_weight || !second_scale || !second_y || second_rows <= 0 ||
+        second_weight_stride < cols ||
+        second_scale_stride < minimum_scale_stride || cols <= 0) {
+        return false;
+    }
+    if (cols % 8 != 0 || first_weight_stride % 8 != 0 ||
+        second_weight_stride % 8 != 0 || kFp8WeightBlock % 8 != 0 ||
+        reinterpret_cast<uintptr_t>(x) % 8 != 0) {
+        return false;
+    }
+    constexpr int kWarps = 8;
+    const int blocks =
+        (first_rows + second_rows + kWarps - 1) / kWarps;
+    fp8_matvec_f16_grouped_kernel<kWarps, 8, 2>
+        <<<blocks, kWarps * 32, 0, static_cast<cudaStream_t>(stream)>>>(
+            x, first_weight, first_scale, first_y, first_rows,
+            first_weight_stride, first_scale_stride, second_weight,
+            second_scale, second_y, second_rows, second_weight_stride,
+            second_scale_stride, nullptr, nullptr, nullptr, 0, 0, 0, cols);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_fp8_e4m3_fp16scale_matvec_triple_f16_cuda(
+    const uint16_t* x,
+    const uint8_t* first_weight, const uint16_t* first_scale,
+    uint16_t* first_y, int first_rows, int first_weight_stride,
+    int first_scale_stride,
+    const uint8_t* second_weight, const uint16_t* second_scale,
+    uint16_t* second_y, int second_rows, int second_weight_stride,
+    int second_scale_stride,
+    const uint8_t* third_weight, const uint16_t* third_scale,
+    uint16_t* third_y, int third_rows, int third_weight_stride,
+    int third_scale_stride, int cols, void* stream) {
+    const int minimum_scale_stride =
+        (cols + kFp8WeightBlock - 1) / kFp8WeightBlock;
+    if (!x || !first_weight || !first_scale || !first_y || first_rows <= 0 ||
+        first_weight_stride < cols || first_scale_stride < minimum_scale_stride ||
+        !second_weight || !second_scale || !second_y || second_rows <= 0 ||
+        second_weight_stride < cols ||
+        second_scale_stride < minimum_scale_stride ||
+        !third_weight || !third_scale || !third_y || third_rows <= 0 ||
+        third_weight_stride < cols ||
+        third_scale_stride < minimum_scale_stride || cols <= 0) {
+        return false;
+    }
+    if (cols % 8 != 0 || first_weight_stride % 8 != 0 ||
+        second_weight_stride % 8 != 0 || third_weight_stride % 8 != 0 ||
+        kFp8WeightBlock % 8 != 0 ||
+        reinterpret_cast<uintptr_t>(x) % 8 != 0) {
+        return false;
+    }
+    constexpr int kWarps = 8;
+    const int blocks =
+        (first_rows + second_rows + third_rows + kWarps - 1) / kWarps;
+    fp8_matvec_f16_grouped_kernel<kWarps, 8, 3>
+        <<<blocks, kWarps * 32, 0, static_cast<cudaStream_t>(stream)>>>(
+            x, first_weight, first_scale, first_y, first_rows,
+            first_weight_stride, first_scale_stride, second_weight,
+            second_scale, second_y, second_rows, second_weight_stride,
+            second_scale_stride, third_weight, third_scale, third_y, third_rows,
+            third_weight_stride, third_scale_stride, cols);
+    return cudaGetLastError() == cudaSuccess;
+}
+
 bool qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
     const uint16_t* x, const uint8_t* gate_weight,
     const uint16_t* gate_scale, const uint8_t* up_weight,
@@ -3275,8 +3673,31 @@ bool qwen_rmsnorm_fp16_gamma_rows_f16_cuda(
     const uint16_t* x, const uint16_t* gamma, uint16_t* y,
     int rows, int cols, float eps, void* stream) {
     if (!x || !gamma || !y || rows <= 0 || cols <= 0 || eps < 0.0f) return false;
-    rmsnorm_f16_kernel<<<rows, kThreads, kThreads * sizeof(float),
-        static_cast<cudaStream_t>(stream)>>>(x, gamma, y, rows, cols, eps);
+    static const bool vectorized = [] {
+        const char* raw = std::getenv("QWEN_RMSNORM_VECTOR");
+        return raw != nullptr && raw[0] != '\0' && raw[0] != '0';
+    }();
+    const bool aligned_16 =
+        (reinterpret_cast<uintptr_t>(x) & 15u) == 0 &&
+        (reinterpret_cast<uintptr_t>(gamma) & 15u) == 0 &&
+        (reinterpret_cast<uintptr_t>(y) & 15u) == 0;
+    if (vectorized && rows == 1 && cols == 5120 && aligned_16) {
+        constexpr int kVectorThreads = 640;
+        rmsnorm_f16_vector_kernel<kVectorThreads><<<
+            rows, kVectorThreads, 0, static_cast<cudaStream_t>(stream)>>>(
+            x, gamma, y, rows, cols, eps);
+    // Decode Q/K norm over the full-attention head width. One warp covers the
+    // row through 8-wide loads, so the CTA carries no idle threads and the
+    // reduction stays inside a single warp.
+    } else if (vectorized && rows <= 64 && cols == 256 && aligned_16) {
+        constexpr int kVectorThreads = 32;
+        rmsnorm_f16_vector_kernel<kVectorThreads><<<
+            rows, kVectorThreads, 0, static_cast<cudaStream_t>(stream)>>>(
+            x, gamma, y, rows, cols, eps);
+    } else {
+        rmsnorm_f16_kernel<<<rows, kThreads, kThreads * sizeof(float),
+            static_cast<cudaStream_t>(stream)>>>(x, gamma, y, rows, cols, eps);
+    }
     return cudaGetLastError() == cudaSuccess;
 }
 
@@ -3289,10 +3710,26 @@ bool qwen_residual_add_rmsnorm_fp16_gamma_rows_f16_cuda(
         normalized == hidden || normalized == delta || normalized == residual) {
         return false;
     }
-    residual_add_rmsnorm_f16_kernel<<<
-        rows, kThreads, kThreads * sizeof(float),
-        static_cast<cudaStream_t>(stream)>>>(
-        hidden, delta, gamma, residual, normalized, rows, cols, eps);
+    static const bool vectorized = [] {
+        const char* raw = std::getenv("QWEN_RMSNORM_VECTOR");
+        return raw != nullptr && raw[0] != '\0' && raw[0] != '0';
+    }();
+    if (vectorized && rows == 1 && cols == 5120 &&
+        (reinterpret_cast<uintptr_t>(hidden) & 15u) == 0 &&
+        (reinterpret_cast<uintptr_t>(delta) & 15u) == 0 &&
+        (reinterpret_cast<uintptr_t>(gamma) & 15u) == 0 &&
+        (reinterpret_cast<uintptr_t>(residual) & 15u) == 0 &&
+        (reinterpret_cast<uintptr_t>(normalized) & 15u) == 0) {
+        constexpr int kVectorThreads = 640;
+        residual_add_rmsnorm_f16_vector_kernel<kVectorThreads><<<
+            rows, kVectorThreads, 0, static_cast<cudaStream_t>(stream)>>>(
+            hidden, delta, gamma, residual, normalized, rows, cols, eps);
+    } else {
+        residual_add_rmsnorm_f16_kernel<<<
+            rows, kThreads, kThreads * sizeof(float),
+            static_cast<cudaStream_t>(stream)>>>(
+            hidden, delta, gamma, residual, normalized, rows, cols, eps);
+    }
     return cudaGetLastError() == cudaSuccess;
 }
 
@@ -3300,8 +3737,27 @@ bool qwen_gated_rmsnorm_fp16_gamma_rows_f16_cuda(
     const uint16_t* x, const uint16_t* gamma, const uint16_t* gate,
     uint16_t* y, int rows, int cols, float eps, void* stream) {
     if (!x || !gamma || !gate || !y || rows <= 0 || cols <= 0 || eps < 0.0f) return false;
-    gated_rmsnorm_f16_kernel<<<rows, kThreads, kThreads * sizeof(float),
-        static_cast<cudaStream_t>(stream)>>>(x, gamma, gate, y, rows, cols, eps);
+    static const bool vectorized = [] {
+        const char* raw = std::getenv("QWEN_RMSNORM_VECTOR");
+        return raw != nullptr && raw[0] != '\0' && raw[0] != '0';
+    }();
+    // The DeltaNet head width is 128, so one lane per FP16 pair covers a row
+    // exactly. The scalar path spends a 256-thread shared-memory tree on it and
+    // leaves half the block idle.
+    if (vectorized && cols == 128 &&
+        (reinterpret_cast<uintptr_t>(x) & 3u) == 0 &&
+        (reinterpret_cast<uintptr_t>(gamma) & 3u) == 0 &&
+        (reinterpret_cast<uintptr_t>(gate) & 3u) == 0 &&
+        (reinterpret_cast<uintptr_t>(y) & 3u) == 0) {
+        constexpr int kVectorThreads = 64;
+        gated_rmsnorm_f16_vector_kernel<kVectorThreads><<<
+            rows, kVectorThreads, 0, static_cast<cudaStream_t>(stream)>>>(
+            x, gamma, gate, y, rows, cols, eps);
+    } else {
+        gated_rmsnorm_f16_kernel<<<rows, kThreads, kThreads * sizeof(float),
+            static_cast<cudaStream_t>(stream)>>>(x, gamma, gate, y, rows, cols,
+                                                 eps);
+    }
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -84,7 +84,6 @@ struct DeviceLinear {
     // Optional dense FP16 expansion used only by batched target verification.
     // The raw FP8 matrix remains canonical and serves decode/prefill.
     QwenDeviceTensor verify_weight;
-    bool fp8 = false;
     // NVFP4 tensor-level scaling. The factor is reciprocal(weight_global_scale);
     // input_global_scale is calibration metadata the SM75 path does not apply.
     float weight_global_factor = 1.0f;
@@ -167,8 +166,7 @@ DeviceLinear fuse_linear_rows(const DeviceLinear& first,
     if (first.weight.data == nullptr || second.weight.data == nullptr) return fused;
     if (first.weight.shape.size() != 2 || second.weight.shape.size() != 2) return fused;
     if (first.weight.shape[1] != second.weight.shape[1] ||
-        first.weight.device_dtype != second.weight.device_dtype ||
-        first.fp8 != second.fp8) {
+        first.weight.device_dtype != second.weight.device_dtype) {
         return fused;
     }
     // The two operands must dispatch to the same kernel family, and both must
@@ -177,12 +175,17 @@ DeviceLinear fuse_linear_rows(const DeviceLinear& first,
     // pick the wrong kernel or throw. NVFP4 is never fused because its packed
     // rows and per-tensor factors do not concatenate.
     if (first.kind != second.kind ||
-        first.kind == QwenLinearKind::NvFp4Group16 ||
+        (first.kind != QwenLinearKind::DenseF16 &&
+         first.kind != QwenLinearKind::Fp8Block128) ||
         first.logical_shape.size() != 2 || second.logical_shape.size() != 2 ||
         first.logical_shape[1] != second.logical_shape[1]) {
         return fused;
     }
-    if (first.fp8 &&
+    // Block-128 FP8 scale rows track output-row blocks and therefore concatenate
+    // with the weight rows. Other compressed formats have different layouts and
+    // are rejected above until a fused consumer for them is validated.
+    const bool has_fp8_scale = first.kind == QwenLinearKind::Fp8Block128;
+    if (has_fp8_scale &&
         (first.scale.data == nullptr || second.scale.data == nullptr ||
          first.scale.shape.size() != 2 || second.scale.shape.size() != 2 ||
          first.scale.shape[1] != second.scale.shape[1] ||
@@ -198,18 +201,19 @@ DeviceLinear fuse_linear_rows(const DeviceLinear& first,
     const uint64_t columns = first.weight.shape[1];
     allocate(fused.weight, first.weight.nbytes + second.weight.nbytes,
              {first_rows + second_rows, columns}, first.weight.device_dtype);
-    check_device(memcpy_d2d(fused.weight.data, first.weight.data, first.weight.nbytes),
+    check_device(memcpy_d2d(fused.weight.data, first.weight.data,
+                            first.weight.nbytes),
                  "Qwen fused projection first weight copy");
     check_device(memcpy_d2d(static_cast<uint8_t*>(fused.weight.data) + first.weight.nbytes,
                             second.weight.data, second.weight.nbytes),
                  "Qwen fused projection second weight copy");
-    fused.fp8 = first.fp8;
-    if (first.fp8) {
+    if (has_fp8_scale) {
         const uint64_t scale_columns = first.scale.shape[1];
         allocate(fused.scale, first.scale.nbytes + second.scale.nbytes,
                  {first.scale.shape[0] + second.scale.shape[0], scale_columns},
                  first.scale.device_dtype);
-        check_device(memcpy_d2d(fused.scale.data, first.scale.data, first.scale.nbytes),
+        check_device(memcpy_d2d(fused.scale.data, first.scale.data,
+                                first.scale.nbytes),
                      "Qwen fused projection first scale copy");
         check_device(memcpy_d2d(static_cast<uint8_t*>(fused.scale.data) + first.scale.nbytes,
                                 second.scale.data, second.scale.nbytes),
@@ -823,8 +827,8 @@ struct QwenEngine::Impl {
             qwen_env_enabled_default("QWEN_VERIFY_RESIDENT_FP16");
         if (verify_resident_weights) {
             auto materialize_verify_weight = [this](DeviceLinear& linear) {
-                if (!linear.fp8 || linear.weight.data == nullptr ||
-                    linear.weight.shape.size() != 2 ||
+                if (linear.kind != QwenLinearKind::Fp8Block128 ||
+                    linear.weight.data == nullptr || linear.weight.shape.size() != 2 ||
                     linear.scale.data == nullptr || linear.scale.shape.size() != 2) {
                     return;
                 }
@@ -1896,7 +1900,25 @@ struct QwenEngine::Impl {
             k_normalized = &workspace_float(key_elements, q_normalized->shape);
         }
 
-        projection(layer.linear.qkv, hidden, packed.f16_data(), rows, "lin.qkv");
+        const bool dual_qkvz = rows == 1 &&
+            layer.linear.qkv.kind == QwenLinearKind::Fp8Block128 &&
+            layer.linear.z.kind == QwenLinearKind::Fp8Block128 &&
+            qwen_env_enabled("QWEN_FUSE_QKVZ_DECODE");
+        if (dual_qkvz) {
+            PhaseScope dual_scope(this, "pd.lin.qkvz");
+            require_launch(qwen_fp8_e4m3_fp16scale_matvec_dual_f16_cuda(
+                hidden,
+                layer.linear.qkv.weight.fp8_data(),
+                layer.linear.qkv.scale.f16_data(), packed.f16_data(), packed_dim,
+                hidden_size, static_cast<int>(layer.linear.qkv.scale.shape[1]),
+                layer.linear.z.weight.fp8_data(),
+                layer.linear.z.scale.f16_data(), z.f16_data(), value_dim,
+                hidden_size, static_cast<int>(layer.linear.z.scale.shape[1]),
+                hidden_size), "dual FP8 QKV/Z decode projection");
+        } else {
+            projection(layer.linear.qkv, hidden, packed.f16_data(), rows,
+                       "lin.qkv");
+        }
         require_launch(qwen_causal_depthwise_conv_silu_f16(
             packed.f16_data(), layer.linear.conv.f16_data(),
             layer.linear.conv_tail.f16_data(), convolved.f16_data(), rows,
@@ -2006,7 +2028,9 @@ struct QwenEngine::Impl {
                 "FP16 linear recurrent state");
         }
         delta_scope.reset();
-        projection(layer.linear.z, hidden, z.f16_data(), rows, "lin.z");
+        if (!dual_qkvz) {
+            projection(layer.linear.z, hidden, z.f16_data(), rows, "lin.z");
+        }
         require_launch(qwen_gated_rmsnorm_fp16_gamma_rows_f16(
             core.f16_data(), layer.linear.norm.f16_data(), z.f16_data(),
             normalized.f16_data(), rows * value_heads,
@@ -2069,17 +2093,39 @@ struct QwenEngine::Impl {
         QwenDeviceTensor& attention = workspace_half(attention_elements, q.shape);
         QwenDeviceTensor& merged = workspace_half(attention_elements, q.shape);
 
-        { PhaseScope sub(this, "full.q_proj"); projection(layer.full.q, hidden, q_projection.f16_data(), rows, "full.q"); }
-        if (fused_kv) {
-            { PhaseScope sub(this, "full.kv_proj"); projection(
-                layer.full.kv, hidden, kv_projection->f16_data(), rows,
-                "full.kv"); }
-            require_launch(qwen_split_rows_pair_f16(
-                kv_projection->f16_data(), k.f16_data(), v.f16_data(), rows,
-                kv_heads * head_dim), "FP16 fused full K/V split");
+        const int hidden_size = static_cast<int>(config.hidden_size);
+        const bool grouped_qkv = rows == 1 && !fused_kv &&
+            layer.full.q.kind == QwenLinearKind::Fp8Block128 &&
+            layer.full.k.kind == QwenLinearKind::Fp8Block128 &&
+            layer.full.v.kind == QwenLinearKind::Fp8Block128 &&
+            qwen_env_enabled("QWEN_FUSE_FULL_QKV_DECODE");
+        if (grouped_qkv) {
+            PhaseScope sub(this, "pd.full.qkv");
+            require_launch(qwen_fp8_e4m3_fp16scale_matvec_triple_f16_cuda(
+                hidden, layer.full.q.weight.fp8_data(),
+                layer.full.q.scale.f16_data(), q_projection.f16_data(),
+                q_projection_dim, hidden_size,
+                static_cast<int>(layer.full.q.scale.shape[1]),
+                layer.full.k.weight.fp8_data(), layer.full.k.scale.f16_data(),
+                k.f16_data(), kv_heads * head_dim, hidden_size,
+                static_cast<int>(layer.full.k.scale.shape[1]),
+                layer.full.v.weight.fp8_data(), layer.full.v.scale.f16_data(),
+                v.f16_data(), kv_heads * head_dim, hidden_size,
+                static_cast<int>(layer.full.v.scale.shape[1]), hidden_size),
+                "triple FP8 full Q/K/V decode projection");
         } else {
-            { PhaseScope sub(this, "full.k_proj"); projection(layer.full.k, hidden, k.f16_data(), rows, "full.k"); }
-            { PhaseScope sub(this, "full.v_proj"); projection(layer.full.v, hidden, v.f16_data(), rows, "full.v"); }
+            { PhaseScope sub(this, "full.q_proj"); projection(layer.full.q, hidden, q_projection.f16_data(), rows, "full.q"); }
+            if (fused_kv) {
+                { PhaseScope sub(this, "full.kv_proj"); projection(
+                    layer.full.kv, hidden, kv_projection->f16_data(), rows,
+                    "full.kv"); }
+                require_launch(qwen_split_rows_pair_f16(
+                    kv_projection->f16_data(), k.f16_data(), v.f16_data(), rows,
+                    kv_heads * head_dim), "FP16 fused full K/V split");
+            } else {
+                { PhaseScope sub(this, "full.k_proj"); projection(layer.full.k, hidden, k.f16_data(), rows, "full.k"); }
+                { PhaseScope sub(this, "full.v_proj"); projection(layer.full.v, hidden, v.f16_data(), rows, "full.v"); }
+            }
         }
         require_launch(qwen_split_q_gate_f16(
             q_projection.f16_data(), q.f16_data(), gate.f16_data(), rows,
@@ -2144,8 +2190,10 @@ struct QwenEngine::Impl {
                 attended_positions = sink_count + (context_length - window_start);
             }
             // Must match the launch exactly; it sizes the partial scratch.
-            const int optimized_splits =
-                qwen_gqa_decode_split_count(attended_positions);
+            const bool tensor_core_decode_shape = attention_window <= 0 &&
+                sink_tokens == 0 && q_heads == kv_heads * 6 && head_dim == 256;
+            const int optimized_splits = qwen_gqa_decode_split_count(
+                attended_positions, kv_heads, tensor_core_decode_shape);
             const size_t score_elements = optimized_decode
                 ? static_cast<size_t>(q_heads) * optimized_splits *
                       static_cast<size_t>(head_dim + 2)

--- a/cpp_engine/include/qwen_cuda_ops.hpp
+++ b/cpp_engine/include/qwen_cuda_ops.hpp
@@ -220,6 +220,46 @@ bool qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
     int scale_stride,
     void* stream = nullptr);
 
+bool qwen_fp8_e4m3_fp16scale_matvec_dual_f16_cuda(
+    const uint16_t* d_x_fp16,
+    const uint8_t* d_first_weight,
+    const uint16_t* d_first_scale_fp16,
+    uint16_t* d_first_y_fp16,
+    int first_rows,
+    int first_weight_stride,
+    int first_scale_stride,
+    const uint8_t* d_second_weight,
+    const uint16_t* d_second_scale_fp16,
+    uint16_t* d_second_y_fp16,
+    int second_rows,
+    int second_weight_stride,
+    int second_scale_stride,
+    int cols,
+    void* stream = nullptr);
+
+bool qwen_fp8_e4m3_fp16scale_matvec_triple_f16_cuda(
+    const uint16_t* d_x_fp16,
+    const uint8_t* d_first_weight,
+    const uint16_t* d_first_scale_fp16,
+    uint16_t* d_first_y_fp16,
+    int first_rows,
+    int first_weight_stride,
+    int first_scale_stride,
+    const uint8_t* d_second_weight,
+    const uint16_t* d_second_scale_fp16,
+    uint16_t* d_second_y_fp16,
+    int second_rows,
+    int second_weight_stride,
+    int second_scale_stride,
+    const uint8_t* d_third_weight,
+    const uint16_t* d_third_scale_fp16,
+    uint16_t* d_third_y_fp16,
+    int third_rows,
+    int third_weight_stride,
+    int third_scale_stride,
+    int cols,
+    void* stream = nullptr);
+
 bool qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
     const uint16_t* d_x_fp16,
     const uint8_t* d_gate_weight,
@@ -793,7 +833,8 @@ bool qwen_gqa_decode_attention_f16_fused_cuda(
 // Splits the fused decode kernel will use for this many attended positions. The
 // caller must size `d_partial_scratch` as q_heads * splits * (head_dim + 2), so
 // this has to be the same number the launch computes.
-int qwen_gqa_decode_split_count(int attended_positions);
+int qwen_gqa_decode_split_count(int attended_positions, int kv_heads = 1,
+                                bool tensor_core_shape = false);
 
 // Which split kernel the fused decode path runs. Production selects this from
 // the environment once per process, which makes an in-process comparison of the
@@ -813,8 +854,8 @@ int qwen_gqa_decode_split_count_variant(
     int split_count_override = 0);
 
 // Fused decode with the split kernel chosen explicitly. Returns false when the
-// requested variant does not support the shape (the tensor-core kernel is
-// specialized for q_heads=6, kv_heads=1, head_dim=256, full causal attention),
+// requested variant does not support the shape (the tensor-core kernel requires
+// six Q heads per KV head, head_dim=256, and full causal attention),
 // so a test cannot silently measure a fallback. A positive split override is a
 // correctness-test seam: unlike production geometry, it preserves the requested
 // count so trailing empty splits reach the kernel and merge.

--- a/cpp_engine/tests/bench_qwen_delta_f16.cpp
+++ b/cpp_engine/tests/bench_qwen_delta_f16.cpp
@@ -55,13 +55,17 @@ int main(int argc, char** argv) {
     int iters = 1000;
     if (argc > 1) rows = std::atoi(argv[1]);
     if (argc > 2) iters = std::atoi(argv[2]);
-    constexpr int kHeads = 12;
-    constexpr int kKeyHeads = 4;
+    const int heads = argc > 3 ? std::atoi(argv[3]) : 12;
+    const int key_heads = argc > 4 ? std::atoi(argv[4]) : 4;
     constexpr int kDim = 128;
-    const size_t state_elements = static_cast<size_t>(kHeads) * kDim * kDim;
-    const size_t key_elements = static_cast<size_t>(rows) * kKeyHeads * kDim;
-    const size_t value_elements = static_cast<size_t>(rows) * kHeads * kDim;
-    const size_t gate_elements = static_cast<size_t>(rows) * kHeads;
+    if (heads <= 0 || key_heads <= 0 || heads % key_heads != 0) {
+        std::fprintf(stderr, "invalid heads=%d key_heads=%d\n", heads, key_heads);
+        return 1;
+    }
+    const size_t state_elements = static_cast<size_t>(heads) * kDim * kDim;
+    const size_t key_elements = static_cast<size_t>(rows) * key_heads * kDim;
+    const size_t value_elements = static_cast<size_t>(rows) * heads * kDim;
+    const size_t gate_elements = static_cast<size_t>(rows) * heads;
 
     float* state = nullptr;
     uint16_t* q = nullptr;
@@ -101,23 +105,23 @@ int main(int argc, char** argv) {
 
     auto sequence = [&]() {
         return dsv4::qwen_gated_delta_sequence_f16(
-            state, q, k, v, g, beta, output, rows, kHeads, kKeyHeads,
+            state, q, k, v, g, beta, output, rows, heads, key_heads,
             kDim, kDim, 1.0f / 11.3137085f);
     };
     auto normalized = [&]() {
         return dsv4::qwen_normalize_gated_delta_qk_f16(
-                   q, k, q_normalized, k_normalized, rows, kKeyHeads, kDim) &&
+                   q, k, q_normalized, k_normalized, rows, key_heads, kDim) &&
                dsv4::qwen_gated_delta_sequence_normalized_f16(
                    state, q_normalized, k_normalized, v, g, beta, output,
-                   rows, kHeads, kKeyHeads, kDim, kDim,
+                   rows, heads, key_heads, kDim, kDim,
                    1.0f / 11.3137085f);
     };
     auto shared_state_variant = [&]() {
         return dsv4::qwen_normalize_gated_delta_qk_f16(
-                   q, k, q_normalized, k_normalized, rows, kKeyHeads, kDim) &&
+                   q, k, q_normalized, k_normalized, rows, key_heads, kDim) &&
                dsv4::qwen_gated_delta_sequence_normalized_shared_f16(
                    state, q_normalized, k_normalized, v, g, beta, output,
-                   rows, kHeads, kKeyHeads, kDim, kDim,
+                   rows, heads, key_heads, kDim, kDim,
                    1.0f / 11.3137085f);
     };
     // FlashQLA SM75 subgroup-sharded kernel: WIDTH=16 lanes hold COLS=4 state
@@ -125,22 +129,22 @@ int main(int argc, char** argv) {
     // thread per value dimension. Same serial recurrence, different sharding.
     auto flashqla = [&]() {
         return dsv4::qwen_normalize_gated_delta_qk_f16(
-                   q, k, q_normalized, k_normalized, rows, kKeyHeads, kDim) &&
+                   q, k, q_normalized, k_normalized, rows, key_heads, kDim) &&
                dsv4::qwen_gated_delta_flashqla_sm75_f16_cuda(
                    state, q_normalized, k_normalized, v, g, beta, output,
-                   rows, kHeads, kKeyHeads, kDim, kDim,
+                   rows, heads, key_heads, kDim, kDim,
                    1.0f / 11.3137085f);
     };
     auto steps = [&]() {
         for (int row = 0; row < rows; ++row) {
             if (!dsv4::qwen_gated_delta_step_f16(
-                    state, q + static_cast<size_t>(row) * kKeyHeads * kDim,
-                    k + static_cast<size_t>(row) * kKeyHeads * kDim,
-                    v + static_cast<size_t>(row) * kHeads * kDim,
-                    g + static_cast<size_t>(row) * kHeads,
-                    beta + static_cast<size_t>(row) * kHeads,
-                    output + static_cast<size_t>(row) * kHeads * kDim,
-                    kHeads, kKeyHeads, kDim, kDim,
+                    state, q + static_cast<size_t>(row) * key_heads * kDim,
+                    k + static_cast<size_t>(row) * key_heads * kDim,
+                    v + static_cast<size_t>(row) * heads * kDim,
+                    g + static_cast<size_t>(row) * heads,
+                    beta + static_cast<size_t>(row) * heads,
+                    output + static_cast<size_t>(row) * heads * kDim,
+                    heads, key_heads, kDim, kDim,
                     1.0f / 11.3137085f)) return false;
         }
         return true;
@@ -159,7 +163,7 @@ int main(int argc, char** argv) {
                 "flashqla=%.6f ms steps=%.6f ms normalized_speedup=%.3f "
                 "shared_speedup=%.3f flashqla_speedup=%.3f "
                 "sequence_speedup=%.3f\n",
-                rows, kHeads, kKeyHeads, kDim, seq_ms, normalized_ms, shared_ms,
+                rows, heads, key_heads, kDim, seq_ms, normalized_ms, shared_ms,
                 flashqla_ms, step_ms, seq_ms / normalized_ms,
                 normalized_ms / shared_ms, normalized_ms / flashqla_ms,
                 step_ms / seq_ms);

--- a/cpp_engine/tests/bench_qwen_fp8_swiglu_decode.cpp
+++ b/cpp_engine/tests/bench_qwen_fp8_swiglu_decode.cpp
@@ -97,6 +97,7 @@ int main() {
     // Qwen3.8-27B-FP8 TP4: hidden 5120, intermediate 17408 sharded to 4352.
     const std::vector<Case> cases = {
         {4352, 5120, "tp4 mlp gate/up"},
+        {8704, 5120, "tp2 mlp gate/up"},
         {17408, 5120, "tp1 mlp gate/up"},
     };
     const char* iters_env = std::getenv("BENCH_ITERS");
@@ -261,11 +262,20 @@ int main() {
     };
     const std::vector<MatvecCase> matvec_cases = {
         {5120, 4352, "tp4 mlp down"},
-        {1536, 5120, "tp4 attn qkv-ish"},
+        {5120, 8704, "tp2 mlp down"},
+        {1536, 5120, "tp4 full q"},
+        {3072, 5120, "tp2 full q"},
+        {256, 5120, "tp4 full kv"},
+        {512, 5120, "tp2 full kv"},
+        {2560, 5120, "tp4 linear qkv"},
+        {5120, 5120, "tp2 linear qkv"},
+        {5120, 2560, "tp4 linear out"},
+        {5120, 5120, "tp2 linear out"},
     };
-    std::printf("\n%-18s %6s %6s %10s %10s %8s %8s %9s\n", "matvec case",
-                "rows", "cols", "vec4_ms", "vec8_ms", "v4_GB/s", "v8_GB/s",
-                "worst_err");
+    std::printf("\n%-18s %6s %6s %10s %10s %10s %10s %8s %8s %8s %8s %9s\n",
+                "matvec case", "rows", "cols", "vec4_ms", "vec8_ms",
+                "rows2_ms", "rows4_ms", "v4_GB/s", "v8_GB/s", "r2_GB/s",
+                "r4_GB/s", "worst_err");
     for (const MatvecCase& c : matvec_cases) {
         const int scale_rows = (c.rows + kBlock - 1) / kBlock;
         const int scale_cols = (c.cols + kBlock - 1) / kBlock;
@@ -303,10 +313,19 @@ int main() {
             ref[row] = sum;
         }
 
-        auto run = [&](int cols_per_lane, double* ms, double* err) {
+        auto run = [&](int cols_per_lane, int rows_per_warp, double* ms,
+                       double* err) {
             setenv("QWEN_FP8_F16_VECTORIZE", "1", 1);
             setenv("QWEN_FP8_F16_COLS_PER_LANE",
                    cols_per_lane == 4 ? "4" : "8", 1);
+            if (rows_per_warp > 1) {
+                setenv("QWEN_FP8_F16_MULTIROW", "1", 1);
+                setenv("QWEN_FP8_F16_MULTIROW_ROWS",
+                       rows_per_warp == 2 ? "2" : "4", 1);
+            } else {
+                unsetenv("QWEN_FP8_F16_MULTIROW");
+                unsetenv("QWEN_FP8_F16_MULTIROW_ROWS");
+            }
             auto launch = [&] {
                 return dsv4::qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
                     d_x, d_w, d_s, d_y, c.rows, c.cols, c.cols, scale_cols,
@@ -344,25 +363,325 @@ int main() {
 
         double vec4_ms = 0.0;
         double vec8_ms = 0.0;
+        double rows2_ms = 0.0;
+        double rows4_ms = 0.0;
         double vec4_err = 0.0;
         double vec8_err = 0.0;
-        run(4, &vec4_ms, &vec4_err);
-        run(8, &vec8_ms, &vec8_err);
+        double rows2_err = 0.0;
+        double rows4_err = 0.0;
+        run(4, 1, &vec4_ms, &vec4_err);
+        run(8, 1, &vec8_ms, &vec8_err);
+        run(8, 2, &rows2_ms, &rows2_err);
+        run(8, 4, &rows4_ms, &rows4_err);
+        unsetenv("QWEN_FP8_F16_MULTIROW");
+        unsetenv("QWEN_FP8_F16_MULTIROW_ROWS");
         unsetenv("QWEN_FP8_F16_COLS_PER_LANE");
         unsetenv("QWEN_FP8_F16_VECTORIZE");
 
         const double bytes = static_cast<double>(c.rows) * c.cols;
-        std::printf("%-18s %6d %6d %10.4f %10.4f %8.1f %8.1f %9.2e\n", c.label,
-                    c.rows, c.cols, vec4_ms, vec8_ms,
+        std::printf("%-18s %6d %6d %10.4f %10.4f %10.4f %10.4f "
+                    "%8.1f %8.1f %8.1f %8.1f %9.2e\n", c.label, c.rows,
+                    c.cols, vec4_ms, vec8_ms, rows2_ms, rows4_ms,
                     bytes / (vec4_ms * 1e-3) / 1e9,
                     bytes / (vec8_ms * 1e-3) / 1e9,
-                    std::max(vec4_err, vec8_err));
+                    bytes / (rows2_ms * 1e-3) / 1e9,
+                    bytes / (rows4_ms * 1e-3) / 1e9,
+                    std::max(std::max(vec4_err, vec8_err),
+                             std::max(rows2_err, rows4_err)));
 
         cudaFree(d_x);
         cudaFree(d_w);
         cudaFree(d_s);
         cudaFree(d_y);
     }
+    // TP2 DeltaNet qkv+z: compare the established two launches with the
+    // two-weight single-grid candidate. Both read the same 5120-element
+    // activation and preserve each output row's wide-8 reduction order.
+    {
+        constexpr int cols = 5120;
+        constexpr int qkv_rows = 5120;
+        constexpr int z_rows = 3072;
+        constexpr int scale_cols = cols / kBlock;
+        const int qkv_scale_rows = (qkv_rows + kBlock - 1) / kBlock;
+        const int z_scale_rows = (z_rows + kBlock - 1) / kBlock;
+        std::vector<uint16_t> x(cols);
+        std::vector<uint8_t> qkv_weight(
+            static_cast<size_t>(qkv_rows) * cols);
+        std::vector<uint8_t> z_weight(static_cast<size_t>(z_rows) * cols);
+        std::vector<uint16_t> qkv_scale(
+            static_cast<size_t>(qkv_scale_rows) * scale_cols);
+        std::vector<uint16_t> z_scale(
+            static_cast<size_t>(z_scale_rows) * scale_cols);
+        std::uniform_real_distribution<float> x_dist(-0.5f, 0.5f);
+        std::uniform_real_distribution<float> s_dist(0.01f, 0.05f);
+        for (uint16_t& value : x) value = float_to_half_host(x_dist(rng));
+        for (uint8_t& value : qkv_weight) value = sample_code(rng);
+        for (uint8_t& value : z_weight) value = sample_code(rng);
+        for (uint16_t& value : qkv_scale) value = float_to_half_host(s_dist(rng));
+        for (uint16_t& value : z_scale) value = float_to_half_host(s_dist(rng));
+
+        uint16_t* d_x = nullptr;
+        uint8_t* d_qkv_weight = nullptr;
+        uint8_t* d_z_weight = nullptr;
+        uint16_t* d_qkv_scale = nullptr;
+        uint16_t* d_z_scale = nullptr;
+        uint16_t* d_qkv_reference = nullptr;
+        uint16_t* d_z_reference = nullptr;
+        uint16_t* d_qkv_dual = nullptr;
+        uint16_t* d_z_dual = nullptr;
+        if (cudaMalloc(&d_x, x.size() * 2) != cudaSuccess ||
+            cudaMalloc(&d_qkv_weight, qkv_weight.size()) != cudaSuccess ||
+            cudaMalloc(&d_z_weight, z_weight.size()) != cudaSuccess ||
+            cudaMalloc(&d_qkv_scale, qkv_scale.size() * 2) != cudaSuccess ||
+            cudaMalloc(&d_z_scale, z_scale.size() * 2) != cudaSuccess ||
+            cudaMalloc(&d_qkv_reference,
+                       static_cast<size_t>(qkv_rows) * 2) != cudaSuccess ||
+            cudaMalloc(&d_z_reference,
+                       static_cast<size_t>(z_rows) * 2) != cudaSuccess ||
+            cudaMalloc(&d_qkv_dual,
+                       static_cast<size_t>(qkv_rows) * 2) != cudaSuccess ||
+            cudaMalloc(&d_z_dual,
+                       static_cast<size_t>(z_rows) * 2) != cudaSuccess) {
+            std::printf("[FAIL] dual projection alloc\n");
+            return 1;
+        }
+        cudaMemcpy(d_x, x.data(), x.size() * 2, cudaMemcpyHostToDevice);
+        cudaMemcpy(d_qkv_weight, qkv_weight.data(), qkv_weight.size(),
+                   cudaMemcpyHostToDevice);
+        cudaMemcpy(d_z_weight, z_weight.data(), z_weight.size(),
+                   cudaMemcpyHostToDevice);
+        cudaMemcpy(d_qkv_scale, qkv_scale.data(), qkv_scale.size() * 2,
+                   cudaMemcpyHostToDevice);
+        cudaMemcpy(d_z_scale, z_scale.data(), z_scale.size() * 2,
+                   cudaMemcpyHostToDevice);
+        setenv("QWEN_FP8_F16_VECTORIZE", "1", 1);
+        setenv("QWEN_FP8_F16_COLS_PER_LANE", "8", 1);
+        unsetenv("QWEN_FP8_F16_MULTIROW");
+        auto separate = [&] {
+            return dsv4::qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+                       d_x, d_qkv_weight, d_qkv_scale, d_qkv_reference,
+                       qkv_rows, cols, cols, scale_cols) &&
+                   dsv4::qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+                       d_x, d_z_weight, d_z_scale, d_z_reference, z_rows, cols,
+                       cols, scale_cols);
+        };
+        auto dual = [&] {
+            return dsv4::qwen_fp8_e4m3_fp16scale_matvec_dual_f16_cuda(
+                d_x, d_qkv_weight, d_qkv_scale, d_qkv_dual, qkv_rows, cols,
+                scale_cols, d_z_weight, d_z_scale, d_z_dual, z_rows, cols,
+                scale_cols, cols);
+        };
+        if (!separate() || !dual() || cudaDeviceSynchronize() != cudaSuccess) {
+            std::printf("[FAIL] dual projection launch\n");
+            return 1;
+        }
+        std::vector<uint16_t> qkv_reference(qkv_rows), qkv_dual(qkv_rows);
+        std::vector<uint16_t> z_reference(z_rows), z_dual(z_rows);
+        cudaMemcpy(qkv_reference.data(), d_qkv_reference,
+                   qkv_reference.size() * 2, cudaMemcpyDeviceToHost);
+        cudaMemcpy(qkv_dual.data(), d_qkv_dual, qkv_dual.size() * 2,
+                   cudaMemcpyDeviceToHost);
+        cudaMemcpy(z_reference.data(), d_z_reference, z_reference.size() * 2,
+                   cudaMemcpyDeviceToHost);
+        cudaMemcpy(z_dual.data(), d_z_dual, z_dual.size() * 2,
+                   cudaMemcpyDeviceToHost);
+        const bool exact = qkv_reference == qkv_dual && z_reference == z_dual;
+
+        auto time = [&](auto&& launch) {
+            for (int i = 0; i < 20; ++i) launch();
+            cudaDeviceSynchronize();
+            cudaEvent_t start;
+            cudaEvent_t stop;
+            cudaEventCreate(&start);
+            cudaEventCreate(&stop);
+            cudaEventRecord(start);
+            for (int i = 0; i < iters; ++i) launch();
+            cudaEventRecord(stop);
+            cudaEventSynchronize(stop);
+            float elapsed = 0.0f;
+            cudaEventElapsedTime(&elapsed, start, stop);
+            cudaEventDestroy(start);
+            cudaEventDestroy(stop);
+            return static_cast<double>(elapsed) / iters;
+        };
+        const double separate_ms = time(separate);
+        const double dual_ms = time(dual);
+        const double bytes =
+            static_cast<double>(qkv_rows + z_rows) * cols;
+        std::printf("\n%-18s %10s %10s %9s %9s %10s\n",
+                    "dual projection", "separate_ms", "dual_ms",
+                    "sep_GB/s", "dual_GB/s", "bit_exact");
+        std::printf("%-18s %10.4f %10.4f %9.1f %9.1f %10s\n",
+                    "tp2 qkv+z", separate_ms, dual_ms,
+                    bytes / (separate_ms * 1e-3) / 1e9,
+                    bytes / (dual_ms * 1e-3) / 1e9,
+                    exact ? "yes" : "no");
+        unsetenv("QWEN_FP8_F16_COLS_PER_LANE");
+        unsetenv("QWEN_FP8_F16_VECTORIZE");
+        cudaFree(d_x);
+        cudaFree(d_qkv_weight);
+        cudaFree(d_z_weight);
+        cudaFree(d_qkv_scale);
+        cudaFree(d_z_scale);
+        cudaFree(d_qkv_reference);
+        cudaFree(d_z_reference);
+        cudaFree(d_qkv_dual);
+        cudaFree(d_z_dual);
+        if (!exact) {
+            std::printf("[FAIL] dual projection mismatch\n");
+            return 1;
+        }
+    }
+
+    // TP2 full attention projects Q/gate, K, and V from the same hidden row.
+    // Grouping them removes the two underfilled 512-row grids.
+    {
+        constexpr int cols = 5120;
+        constexpr int q_rows = 6144;
+        constexpr int kv_rows = 512;
+        constexpr int scale_cols = cols / 128;
+        std::mt19937 rng(20260830);
+        std::vector<uint16_t> x(cols);
+        std::vector<uint8_t> q_weight(static_cast<size_t>(q_rows) * cols);
+        std::vector<uint8_t> k_weight(static_cast<size_t>(kv_rows) * cols);
+        std::vector<uint8_t> v_weight(static_cast<size_t>(kv_rows) * cols);
+        std::vector<uint16_t> q_scale(
+            static_cast<size_t>((q_rows + 127) / 128) * scale_cols);
+        std::vector<uint16_t> k_scale(
+            static_cast<size_t>((kv_rows + 127) / 128) * scale_cols);
+        std::vector<uint16_t> v_scale(
+            static_cast<size_t>((kv_rows + 127) / 128) * scale_cols);
+        std::uniform_real_distribution<float> x_dist(-0.5f, 0.5f);
+        std::uniform_real_distribution<float> s_dist(0.01f, 0.05f);
+        for (uint16_t& value : x) value = float_to_half_host(x_dist(rng));
+        for (uint8_t& value : q_weight) value = sample_code(rng);
+        for (uint8_t& value : k_weight) value = sample_code(rng);
+        for (uint8_t& value : v_weight) value = sample_code(rng);
+        for (uint16_t& value : q_scale) value = float_to_half_host(s_dist(rng));
+        for (uint16_t& value : k_scale) value = float_to_half_host(s_dist(rng));
+        for (uint16_t& value : v_scale) value = float_to_half_host(s_dist(rng));
+
+        uint16_t* d_x = nullptr;
+        uint8_t *d_q_weight = nullptr, *d_k_weight = nullptr,
+                *d_v_weight = nullptr;
+        uint16_t *d_q_scale = nullptr, *d_k_scale = nullptr, *d_v_scale = nullptr;
+        uint16_t *d_q_reference = nullptr, *d_k_reference = nullptr,
+                 *d_v_reference = nullptr, *d_q_triple = nullptr,
+                 *d_k_triple = nullptr, *d_v_triple = nullptr;
+        if (cudaMalloc(&d_x, x.size() * 2) != cudaSuccess ||
+            cudaMalloc(&d_q_weight, q_weight.size()) != cudaSuccess ||
+            cudaMalloc(&d_k_weight, k_weight.size()) != cudaSuccess ||
+            cudaMalloc(&d_v_weight, v_weight.size()) != cudaSuccess ||
+            cudaMalloc(&d_q_scale, q_scale.size() * 2) != cudaSuccess ||
+            cudaMalloc(&d_k_scale, k_scale.size() * 2) != cudaSuccess ||
+            cudaMalloc(&d_v_scale, v_scale.size() * 2) != cudaSuccess ||
+            cudaMalloc(&d_q_reference, static_cast<size_t>(q_rows) * 2) != cudaSuccess ||
+            cudaMalloc(&d_k_reference, static_cast<size_t>(kv_rows) * 2) != cudaSuccess ||
+            cudaMalloc(&d_v_reference, static_cast<size_t>(kv_rows) * 2) != cudaSuccess ||
+            cudaMalloc(&d_q_triple, static_cast<size_t>(q_rows) * 2) != cudaSuccess ||
+            cudaMalloc(&d_k_triple, static_cast<size_t>(kv_rows) * 2) != cudaSuccess ||
+            cudaMalloc(&d_v_triple, static_cast<size_t>(kv_rows) * 2) != cudaSuccess) {
+            std::printf("[FAIL] triple projection alloc\n");
+            return 1;
+        }
+        cudaMemcpy(d_x, x.data(), x.size() * 2, cudaMemcpyHostToDevice);
+        cudaMemcpy(d_q_weight, q_weight.data(), q_weight.size(), cudaMemcpyHostToDevice);
+        cudaMemcpy(d_k_weight, k_weight.data(), k_weight.size(), cudaMemcpyHostToDevice);
+        cudaMemcpy(d_v_weight, v_weight.data(), v_weight.size(), cudaMemcpyHostToDevice);
+        cudaMemcpy(d_q_scale, q_scale.data(), q_scale.size() * 2, cudaMemcpyHostToDevice);
+        cudaMemcpy(d_k_scale, k_scale.data(), k_scale.size() * 2, cudaMemcpyHostToDevice);
+        cudaMemcpy(d_v_scale, v_scale.data(), v_scale.size() * 2, cudaMemcpyHostToDevice);
+        setenv("QWEN_FP8_F16_VECTORIZE", "1", 1);
+        setenv("QWEN_FP8_F16_COLS_PER_LANE", "8", 1);
+        unsetenv("QWEN_FP8_F16_MULTIROW");
+        auto separate = [&] {
+            return dsv4::qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+                       d_x, d_q_weight, d_q_scale, d_q_reference, q_rows, cols,
+                       cols, scale_cols) &&
+                   dsv4::qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+                       d_x, d_k_weight, d_k_scale, d_k_reference, kv_rows, cols,
+                       cols, scale_cols) &&
+                   dsv4::qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+                       d_x, d_v_weight, d_v_scale, d_v_reference, kv_rows, cols,
+                       cols, scale_cols);
+        };
+        auto triple = [&] {
+            return dsv4::qwen_fp8_e4m3_fp16scale_matvec_triple_f16_cuda(
+                d_x, d_q_weight, d_q_scale, d_q_triple, q_rows, cols,
+                scale_cols, d_k_weight, d_k_scale, d_k_triple, kv_rows, cols,
+                scale_cols, d_v_weight, d_v_scale, d_v_triple, kv_rows, cols,
+                scale_cols, cols);
+        };
+        if (!separate() || !triple() || cudaDeviceSynchronize() != cudaSuccess) {
+            std::printf("[FAIL] triple projection launch\n");
+            return 1;
+        }
+        std::vector<uint16_t> q_reference(q_rows), q_triple(q_rows);
+        std::vector<uint16_t> k_reference(kv_rows), k_triple(kv_rows);
+        std::vector<uint16_t> v_reference(kv_rows), v_triple(kv_rows);
+        cudaMemcpy(q_reference.data(), d_q_reference, q_reference.size() * 2,
+                   cudaMemcpyDeviceToHost);
+        cudaMemcpy(q_triple.data(), d_q_triple, q_triple.size() * 2,
+                   cudaMemcpyDeviceToHost);
+        cudaMemcpy(k_reference.data(), d_k_reference, k_reference.size() * 2,
+                   cudaMemcpyDeviceToHost);
+        cudaMemcpy(k_triple.data(), d_k_triple, k_triple.size() * 2,
+                   cudaMemcpyDeviceToHost);
+        cudaMemcpy(v_reference.data(), d_v_reference, v_reference.size() * 2,
+                   cudaMemcpyDeviceToHost);
+        cudaMemcpy(v_triple.data(), d_v_triple, v_triple.size() * 2,
+                   cudaMemcpyDeviceToHost);
+        const bool exact = q_reference == q_triple && k_reference == k_triple &&
+                           v_reference == v_triple;
+        auto time = [&](auto&& launch) {
+            for (int i = 0; i < 20; ++i) launch();
+            cudaDeviceSynchronize();
+            cudaEvent_t start;
+            cudaEvent_t stop;
+            cudaEventCreate(&start);
+            cudaEventCreate(&stop);
+            cudaEventRecord(start);
+            for (int i = 0; i < iters; ++i) launch();
+            cudaEventRecord(stop);
+            cudaEventSynchronize(stop);
+            float elapsed = 0.0f;
+            cudaEventElapsedTime(&elapsed, start, stop);
+            cudaEventDestroy(start);
+            cudaEventDestroy(stop);
+            return static_cast<double>(elapsed) / iters;
+        };
+        const double separate_ms = time(separate);
+        const double triple_ms = time(triple);
+        const double bytes = static_cast<double>(q_rows + 2 * kv_rows) * cols;
+        std::printf("\n%-18s %10s %10s %9s %9s %10s\n",
+                    "triple projection", "separate_ms", "triple_ms",
+                    "sep_GB/s", "triple_GB/s", "bit_exact");
+        std::printf("%-18s %10.4f %10.4f %9.1f %9.1f %10s\n",
+                    "tp2 full q/k/v", separate_ms, triple_ms,
+                    bytes / (separate_ms * 1e-3) / 1e9,
+                    bytes / (triple_ms * 1e-3) / 1e9,
+                    exact ? "yes" : "NO");
+        if (!exact) {
+            std::printf("[FAIL] triple projection bit exactness\n");
+            return 1;
+        }
+        unsetenv("QWEN_FP8_F16_COLS_PER_LANE");
+        unsetenv("QWEN_FP8_F16_VECTORIZE");
+        cudaFree(d_x);
+        cudaFree(d_q_weight);
+        cudaFree(d_k_weight);
+        cudaFree(d_v_weight);
+        cudaFree(d_q_scale);
+        cudaFree(d_k_scale);
+        cudaFree(d_v_scale);
+        cudaFree(d_q_reference);
+        cudaFree(d_k_reference);
+        cudaFree(d_v_reference);
+        cudaFree(d_q_triple);
+        cudaFree(d_k_triple);
+        cudaFree(d_v_triple);
+    }
+
     std::printf("[PASS] bench_qwen_fp8_swiglu_decode\n");
     return 0;
 }

--- a/cpp_engine/tests/bench_qwen_gqa_decode.cpp
+++ b/cpp_engine/tests/bench_qwen_gqa_decode.cpp
@@ -106,7 +106,8 @@ void run_fused(void* raw) {
 }  // namespace
 
 int main(int argc, char** argv) {
-    // Real TP4 rank shape unless overridden.
+    // Real six-Q-heads-per-KV-group shape unless overridden. TP4 uses 6/1;
+    // TP2 uses 12/2 with the same per-group kernel geometry.
     const int q_heads = argc > 1 ? std::atoi(argv[1]) : 6;
     const int kv_heads = argc > 2 ? std::atoi(argv[2]) : 1;
     const int head_dim = argc > 3 ? std::atoi(argv[3]) : 256;
@@ -139,10 +140,14 @@ int main(int argc, char** argv) {
     // Large enough for either layout: q_heads*context for the reference path,
     // q_heads*splits*(head_dim+2) for the fused one. The split count is tunable,
     // so ask the kernel rather than assuming it.
+    const bool tensor_core_shape =
+        q_heads == kv_heads * 6 && head_dim == 256;
     const size_t scratch_elements =
         static_cast<size_t>(q_heads) * max_context +
         static_cast<size_t>(q_heads) *
-            dsv4::qwen_gqa_decode_split_count(max_context) * (head_dim + 2);
+            dsv4::qwen_gqa_decode_split_count(
+                max_context, kv_heads, tensor_core_shape) *
+            (head_dim + 2);
     check(cudaMalloc(&scratch, scratch_elements * sizeof(float)), "malloc scratch");
     check(cudaMemcpy(q, host_q.data(), host_q.size() * sizeof(uint16_t),
                      cudaMemcpyHostToDevice), "copy q");

--- a/cpp_engine/tests/test_qwen_gqa_attention.cpp
+++ b/cpp_engine/tests/test_qwen_gqa_attention.cpp
@@ -478,16 +478,18 @@ bool run_prefill_tiled(int rows, int q_heads, int kv_heads, int head_dim,
 // splits scan nothing at all: an early return there left scratch uninitialized
 // and produced -inf logits from the second decode step onward.
 bool run_decode_mma(int context_len, int target_splits,
-                    int split_override = 0, bool expect_empty_splits = false) {
-    constexpr int q_heads = 6;
-    constexpr int kv_heads = 1;
+                    int split_override = 0, bool expect_empty_splits = false,
+                    int kv_heads = 1, bool check_variant_geometry = true,
+                    float minimum_value = -0.1f,
+                    float maximum_value = 0.1f) {
+    const int q_heads = kv_heads * 6;
     constexpr int head_dim = 256;
     const int max_context = context_len + 16;
     const size_t q_elements = static_cast<size_t>(q_heads) * head_dim;
     const size_t kv_elements =
         static_cast<size_t>(max_context) * kv_heads * head_dim;
     std::mt19937 rng(24681 + context_len * 31 + target_splits);
-    std::uniform_real_distribution<float> dist(-0.1f, 0.1f);
+    std::uniform_real_distribution<float> dist(minimum_value, maximum_value);
     std::vector<uint16_t> q(q_elements), k(kv_elements, 0), v(kv_elements, 0);
     for (uint16_t& value : q) value = to_half(dist(rng));
     for (size_t i = 0;
@@ -496,11 +498,17 @@ bool run_decode_mma(int context_len, int target_splits,
         v[i] = to_half(dist(rng));
     }
 
-    const int mma_splits = dsv4::qwen_gqa_decode_split_count_variant(
-        context_len, dsv4::QwenGqaDecodeVariant::TensorCore, split_override);
+    const int mma_splits = split_override > 0
+        ? dsv4::qwen_gqa_decode_split_count_variant(
+              context_len, dsv4::QwenGqaDecodeVariant::TensorCore,
+              split_override)
+        : dsv4::qwen_gqa_decode_split_count_variant(
+              context_len, dsv4::QwenGqaDecodeVariant::TensorCore);
     const int scalar_splits = dsv4::qwen_gqa_decode_split_count_variant(
         context_len, dsv4::QwenGqaDecodeVariant::Scalar, split_override);
-    if (split_override == 0 && mma_splits != target_splits) {
+    if (check_variant_geometry && split_override == 0 &&
+        std::getenv("DSV4_QWEN_DECODE_MMA_TARGET_SPLITS") == nullptr &&
+        mma_splits != target_splits) {
         fail("gqa decode candidate split count ctx=" +
              std::to_string(context_len) + " got=" +
              std::to_string(mma_splits) + " want=" +
@@ -819,14 +827,45 @@ int main() {
     // this process against the same inputs, so every case checks scalar against
     // the CPU reference, the candidate against the CPU reference, and the two
     // against each other, regardless of what DSV4_QWEN_DECODE_MMA selects.
+    // The candidate targets two CTA waves (136 on this host) at every context.
+    // 4096 and 8199 land below that because the count is re-derived from the
+    // rounded slice length: 31 positions cover 4096 in 133 splits and 61 cover
+    // 8199 in 135, so the dead trailing CTAs are dropped.
     const int decode_cases[][2] = {
-        {4096, 68}, {8199, 68}, {16384, 136}, {65537, 136},
+        {4096, 133}, {8199, 135}, {16384, 136}, {65537, 136},
     };
     for (const auto& decode_case : decode_cases) {
         if (!run_decode_mma(decode_case[0], decode_case[1])) {
             std::printf("[SKIP] device allocation failed\n");
             return 0;
         }
+    }
+    // TP2 has two independent 6Q:1KV groups in each rank. The same kernel grid
+    // must address the interleaved [position, kv_head, channel] cache correctly
+    // and publish both groups into the q-head-major partial layout.
+    if (!run_decode_mma(8199, 135, 0, false, 2)) {
+        std::printf("[SKIP] device allocation failed\n");
+        return 0;
+    }
+    // Positive-only inputs expose stale scores from the ten padded MMA rows. Their
+    // shared score slots are never written, so they must be masked before reduction;
+    // otherwise a previous valid row can survive and make a full-mask shuffle group
+    // use an arbitrary maximum. This was invisible to symmetric random fixtures.
+    if (!run_decode_mma(4096, 133, 0, false, 2, true, 0.01f, 0.1f)) {
+        std::printf("[SKIP] device allocation failed\n");
+        return 0;
+    }
+    const int tp2_long_splits = dsv4::qwen_gqa_decode_split_count(65537, 2, true);
+    const char* mma_split_env =
+        std::getenv("DSV4_QWEN_DECODE_MMA_TARGET_SPLITS");
+    const int mma_split_override =
+        mma_split_env != nullptr ? std::atoi(mma_split_env) : 0;
+    const int expected_tp2_long_splits =
+        mma_split_override > 0 ? mma_split_override : 68;
+    if (tp2_long_splits != expected_tp2_long_splits) {
+        fail("gqa decode TP2 shape-aware split count got=" +
+             std::to_string(tp2_long_splits) + " want=" +
+             std::to_string(expected_tp2_long_splits));
     }
     // Empty trailing splits. 4100 positions over 200 splits is 21 each, which 196
     // splits already cover, so the last four CTAs scan nothing and must still

--- a/cpp_engine/tests/test_qwen_half_ops.cpp
+++ b/cpp_engine/tests/test_qwen_half_ops.cpp
@@ -667,6 +667,171 @@ bool check_fp8_f16_projection() {
                     decode_vector_dispatch_error, decode_multi_dispatch_error);
     }
 
+    // The DeltaNet decode path can issue QKV and Z as one grid without copying
+    // their raw FP8 tensors into permanent concatenated storage. The dual grid
+    // must remain bit exact against the two established wide-8 launches.
+    {
+        constexpr int dual_cols = 512;
+        constexpr int first_rows = 640;
+        constexpr int second_rows = 384;
+        constexpr int third_rows = 256;
+        constexpr int first_scale_stride = dual_cols / 128;
+        constexpr int second_scale_stride = dual_cols / 128;
+        std::vector<uint16_t> dual_x(dual_cols);
+        std::vector<uint8_t> first_weight(
+            static_cast<size_t>(first_rows) * dual_cols);
+        std::vector<uint8_t> second_weight(
+            static_cast<size_t>(second_rows) * dual_cols);
+        std::vector<uint16_t> first_scale(
+            static_cast<size_t>((first_rows + 127) / 128) *
+            first_scale_stride);
+        std::vector<uint16_t> second_scale(
+            static_cast<size_t>((second_rows + 127) / 128) *
+            second_scale_stride);
+        std::vector<uint8_t> third_weight(
+            static_cast<size_t>(third_rows) * dual_cols);
+        std::vector<uint16_t> third_scale(
+            static_cast<size_t>((third_rows + 127) / 128) *
+            second_scale_stride);
+        for (uint16_t& value : dual_x) value = to_half(x_dist(rng));
+        for (uint8_t& value : first_weight) value = random_code();
+        for (uint8_t& value : second_weight) value = random_code();
+        for (uint8_t& value : third_weight) value = random_code();
+        for (uint16_t& value : first_scale) value = to_half(scale_dist(rng));
+        for (uint16_t& value : second_scale) value = to_half(scale_dist(rng));
+        for (uint16_t& value : third_scale) value = to_half(scale_dist(rng));
+
+        DeviceBuffer d_dual_x, d_first_weight, d_second_weight, d_first_scale,
+            d_second_scale, d_first_reference, d_second_reference,
+            d_first_dual, d_second_dual, d_third_weight, d_third_scale,
+            d_third_reference, d_third_grouped;
+        uint16_t* dual_px = d_dual_x.allocate<uint16_t>(dual_x.size());
+        uint8_t* first_pw = d_first_weight.allocate<uint8_t>(
+            first_weight.size());
+        uint8_t* second_pw = d_second_weight.allocate<uint8_t>(
+            second_weight.size());
+        uint16_t* first_ps = d_first_scale.allocate<uint16_t>(
+            first_scale.size());
+        uint16_t* second_ps = d_second_scale.allocate<uint16_t>(
+            second_scale.size());
+        uint16_t* first_reference =
+            d_first_reference.allocate<uint16_t>(first_rows);
+        uint16_t* second_reference =
+            d_second_reference.allocate<uint16_t>(second_rows);
+        uint16_t* first_dual = d_first_dual.allocate<uint16_t>(first_rows);
+        uint16_t* second_dual = d_second_dual.allocate<uint16_t>(second_rows);
+        uint8_t* third_pw = d_third_weight.allocate<uint8_t>(
+            third_weight.size());
+        uint16_t* third_ps = d_third_scale.allocate<uint16_t>(
+            third_scale.size());
+        uint16_t* third_reference =
+            d_third_reference.allocate<uint16_t>(third_rows);
+        uint16_t* third_grouped =
+            d_third_grouped.allocate<uint16_t>(third_rows);
+        if (!dual_px || !first_pw || !second_pw || !first_ps || !second_ps ||
+            !first_reference || !second_reference || !first_dual ||
+            !second_dual || !third_pw || !third_ps || !third_reference ||
+            !third_grouped ||
+            cudaMemcpy(dual_px, dual_x.data(), dual_x.size() * sizeof(uint16_t),
+                       cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(first_pw, first_weight.data(), first_weight.size(),
+                       cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(second_pw, second_weight.data(), second_weight.size(),
+                       cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(first_ps, first_scale.data(),
+                       first_scale.size() * sizeof(uint16_t),
+                       cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(second_ps, second_scale.data(),
+                       second_scale.size() * sizeof(uint16_t),
+                       cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(third_pw, third_weight.data(), third_weight.size(),
+                       cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(third_ps, third_scale.data(),
+                       third_scale.size() * sizeof(uint16_t),
+                       cudaMemcpyHostToDevice) != cudaSuccess) {
+            fail("FP16 FP8 dual projection allocation/copy");
+            return false;
+        }
+        setenv("QWEN_FP8_F16_VECTORIZE", "1", 1);
+        setenv("QWEN_FP8_F16_COLS_PER_LANE", "8", 1);
+        unsetenv("QWEN_FP8_F16_MULTIROW");
+        bool dual_ok = true;
+        for (int pass = 0; pass < 3 && dual_ok; ++pass) {
+            dual_ok =
+                dsv4::qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+                    dual_px, first_pw, first_ps, first_reference, first_rows,
+                    dual_cols, dual_cols, first_scale_stride) &&
+                dsv4::qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+                    dual_px, second_pw, second_ps, second_reference,
+                    second_rows, dual_cols, dual_cols, second_scale_stride) &&
+                dsv4::qwen_fp8_e4m3_fp16scale_matvec_dual_f16_cuda(
+                    dual_px, first_pw, first_ps, first_dual, first_rows,
+                    dual_cols, first_scale_stride, second_pw, second_ps,
+                    second_dual, second_rows, dual_cols, second_scale_stride,
+                    dual_cols) &&
+                cudaDeviceSynchronize() == cudaSuccess;
+        }
+        unsetenv("QWEN_FP8_F16_COLS_PER_LANE");
+        unsetenv("QWEN_FP8_F16_VECTORIZE");
+        if (!dual_ok) {
+            fail("FP16 FP8 dual projection launch");
+            return false;
+        }
+        std::vector<uint16_t> first_got(first_rows), first_want(first_rows);
+        std::vector<uint16_t> second_got(second_rows), second_want(second_rows);
+        cudaMemcpy(first_got.data(), first_dual,
+                   first_got.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+        cudaMemcpy(first_want.data(), first_reference,
+                   first_want.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+        cudaMemcpy(second_got.data(), second_dual,
+                   second_got.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+        cudaMemcpy(second_want.data(), second_reference,
+                   second_want.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+        if (first_got != first_want || second_got != second_want) {
+            fail("FP16 FP8 dual projection bit exactness");
+        } else {
+            std::printf("  FP16 FP8 dual projection first=%d second=%d "
+                        "cols=%d bit exact\n",
+                        first_rows, second_rows, dual_cols);
+        }
+
+        bool triple_ok = true;
+        for (int pass = 0; pass < 3 && triple_ok; ++pass) {
+            triple_ok =
+                dsv4::qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+                    dual_px, third_pw, third_ps, third_reference, third_rows,
+                    dual_cols, dual_cols, second_scale_stride) &&
+                dsv4::qwen_fp8_e4m3_fp16scale_matvec_triple_f16_cuda(
+                    dual_px, first_pw, first_ps, first_dual, first_rows,
+                    dual_cols, first_scale_stride, second_pw, second_ps,
+                    second_dual, second_rows, dual_cols, second_scale_stride,
+                    third_pw, third_ps, third_grouped, third_rows, dual_cols,
+                    second_scale_stride, dual_cols) &&
+                cudaDeviceSynchronize() == cudaSuccess;
+        }
+        if (!triple_ok) {
+            fail("FP16 FP8 triple projection launch");
+            return false;
+        }
+        std::vector<uint16_t> third_got(third_rows), third_want(third_rows);
+        cudaMemcpy(first_got.data(), first_dual,
+                   first_got.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+        cudaMemcpy(second_got.data(), second_dual,
+                   second_got.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+        cudaMemcpy(third_got.data(), third_grouped,
+                   third_got.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+        cudaMemcpy(third_want.data(), third_reference,
+                   third_want.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+        if (first_got != first_want || second_got != second_want ||
+            third_got != third_want) {
+            fail("FP16 FP8 triple projection bit exactness");
+        } else {
+            std::printf("  FP16 FP8 triple projection rows=%d+%d+%d "
+                        "cols=%d bit exact\n",
+                        first_rows, second_rows, third_rows, dual_cols);
+        }
+    }
+
     // Small speculative batches reuse each FP8 weight across all input rows.
     constexpr int small_batch = 5;
     constexpr int small_rows = 130;

--- a/scripts/bench_qwen_long_context.py
+++ b/scripts/bench_qwen_long_context.py
@@ -328,6 +328,10 @@ def environment_metadata() -> dict[str, str]:
         "QWEN_FP16_LOGITS_MATVEC",
         "QWEN_FUSE_ATTN_RESID_NORM",
         "QWEN_GATED_DELTA_FLASHQLA_SM75",
+        "QWEN_RMSNORM_HYBRID_REDUCTION",
+        "QWEN_RMSNORM_VECTOR",
+        "QWEN_FUSE_QKVZ_DECODE",
+        "QWEN_FUSE_FULL_QKV_DECODE",
     )
     return {name: os.environ[name] for name in names if name in os.environ}
 


### PR DESCRIPTION
## Summary

- optimize the SM75 Qwen tensor-core GQA decode path for the TP2 6Q:1KV-per-group shape
- reduce decode MMA shared-memory usage by storing the valid six-row score/probability tiles and keeping the uniquely-owned P*V accumulator in registers
- raise the MMA decode occupancy from two to three CTAs per SM and use the optimized path at all supported decode contexts
- add grouped FP8 matvec paths for TP2 projections and extend focused benchmarks/tests for the new shapes
- record TP2 benchmark provenance and environment metadata

## Validation

- `cpp_engine/build/tests/test_qwen_gqa_attention` — PASS
- `cpp_engine/build/tests/test_qwen_half_ops` — PASS
- decode MMA resource check on RTX 2080 Ti SM75: 132 registers, 18,632 B shared memory, no spills
- standalone TP2 GQA decode at context 65,536: 0.3279 ms -> 0.2842 ms (13.3% faster)
- full-network TP2, physical GPUs 2/3, FP16 KV, chunk 8192, greedy TG128, rank token parity PASS
  - 8K decode: 30.51–30.91 tok/s vs vLLM reference 30.068 tok/s
  - 64K decode: 24.74–26.23 tok/s vs vLLM reference 26.743 tok/s; sustained-load clock/throughput drift remains under investigation

The 64K end-to-end vLLM parity target is not claimed as complete by this PR. The remaining gap is documented so follow-up work can focus on the FP8 decode matvec paths rather than the already-optimized attention kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
