### PR TITLE
Ascend 910 (first-gen) baseline: AscendC kernels with TP4 support

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -47,9 +47,17 @@ set(POCKET_CORE_SOURCES
 set(POCKET_ENGINE_SOURCES
     engine/qwen_weights.cpp
     engine/qwen_target_head.cpp
+    engine/qwen_engine.cpp
+)
+
+# Engines that still call CUDA kernels by name. A runtime guard cannot help here:
+# a CUDA symbol referenced from any object in the link must resolve even when its
+# branch is unreachable, so these are excluded from a non-CUDA target and
+# engine/backend_unimplemented_ascend.cpp supplies throwing definitions for the
+# entry points their remaining callers name.
+set(POCKET_CUDA_ONLY_ENGINE_SOURCES
     engine/qwen_dspark.cpp
     engine/qwen_dflash2.cpp
-    engine/qwen_engine.cpp
     engine/dsv4_engine.cpp
     engine/dspark_engine.cpp
 )
@@ -62,6 +70,11 @@ set(POCKET_RUNTIME_SOURCES)
 set(POCKET_BACKEND_LIBS)
 set(POCKET_BACKEND_INCLUDES)
 set(POCKET_BACKEND_DEFINES)
+# AscendC's generated device library is consumed by the engine, but must not be
+# linked into pocket_runtime: the latter is intentionally kernel-free so the
+# runtime conformance test can exercise ACL without any device binary.
+set(POCKET_ASCEND_KERNEL_LIBS)
+set(POCKET_ASCEND_KERNEL_INCLUDES)
 
 if(POCKET_BACKEND STREQUAL "cuda")
     set(CMAKE_CUDA_STANDARD 17)
@@ -99,6 +112,7 @@ if(POCKET_BACKEND STREQUAL "cuda")
         message(STATUS "NCCL not found; distributed C++ TP helpers disabled")
     endif()
 
+    list(APPEND POCKET_ENGINE_SOURCES ${POCKET_CUDA_ONLY_ENGINE_SOURCES})
     list(APPEND POCKET_RUNTIME_SOURCES backends/cuda/runtime/device_runtime_cuda.cpp)
     list(APPEND POCKET_BACKEND_SOURCES
         backends/cuda/collective/tp_comm.cpp
@@ -138,9 +152,8 @@ if(POCKET_BACKEND STREQUAL "cuda")
     endif()
 else()
     # Ascend: ACL runtime, AscendC kernels and HCCL collectives under
-    # backends/ascend. The device runtime is implemented; kernels are not, so the
-    # full engine still does not link. What does link and run today is anything
-    # that needs only pocket_core plus the device runtime.
+    # backends/ascend. The dense-FP16 Qwen path is complete through the linked
+    # engine; CUDA-only engines and quantized Qwen modes stay outside this build.
     set(DSV4_HAVE_TP_COMM OFF)
 
     # CANN layout: $ASCEND_TOOLKIT_HOME/<arch>-linux/{include,lib64}. The arch
@@ -216,11 +229,42 @@ else()
         "${ASCEND_NNOPBASE_LIBRARY}")
     list(APPEND POCKET_BACKEND_DEFINES POCKET_BACKEND_ASCEND=1)
 
+    # Stands in for POCKET_CUDA_ONLY_ENGINE_SOURCES, which is not built here.
+    list(APPEND POCKET_ENGINE_SOURCES engine/backend_unimplemented_ascend.cpp)
+
     # aclnn-backed operators: matrix products, normalizations, elementwise
     # activations and the reshape-shaped ops. The recurrent and attention kernels
-    # have no aclnn equivalent on this install and are hand-written AscendC, which
-    # is not in this list yet.
+    # have no aclnn equivalent on this install and are hand-written AscendC below.
     list(APPEND POCKET_BACKEND_SOURCES backends/ascend/kernels/aclnn_ops.cpp)
+
+    # Hand-written AscendC device code. These are the operators with no aclnn
+    # equivalent: the gated-delta recurrence, its gates and normalizations, the
+    # causal depthwise convolution, partial RoPE, KV-cache append and GQA
+    # attention.
+    set(POCKET_ASCEND_KERNEL_SOURCES
+        backends/ascend/kernels/qwen_gated_delta_f16.cpp
+        backends/ascend/kernels/qwen_linear_f16.cpp
+        backends/ascend/kernels/qwen_attention_f16.cpp
+        backends/ascend/kernels/qwen_argmax_f32.cpp
+    )
+    # ascendc.cmake reads these three variables by name out of the enclosing
+    # scope and fails unhelpfully if any is unset, so set them here rather than
+    # making every caller pass -D flags.
+    set(SOC_VERSION "${ASCEND_SOC_VERSION}")
+    set(RUN_MODE "npu")
+    set(ASCEND_CANN_PACKAGE_PATH "${ASCEND_TOOLKIT_HOME}")
+    include(${ASCEND_TOOLKIT_HOME}/compiler/tikcpp/ascendc_kernel_cmake/ascendc.cmake)
+    ascendc_library(pocket_ascend_kernels STATIC ${POCKET_ASCEND_KERNEL_SOURCES})
+
+    # ascendc_library() emits one aclrtlaunch_<kernel>.h per
+    # `extern "C" __global__ __aicore__` entry point into
+    # ${CMAKE_BINARY_DIR}/include/<target>. The launcher below is the only file
+    # that includes them, but the directory has to be on the include path of
+    # whatever compiles it, which is dsv4_cpp_core.
+    list(APPEND POCKET_BACKEND_SOURCES backends/ascend/kernels/qwen_ascend_ops_launch.cpp)
+    list(APPEND POCKET_ASCEND_KERNEL_INCLUDES
+        "${CMAKE_BINARY_DIR}/include/pocket_ascend_kernels")
+    list(APPEND POCKET_ASCEND_KERNEL_LIBS pocket_ascend_kernels)
 
     if(DSV4_HAVE_TP_COMM)
         list(APPEND POCKET_BACKEND_SOURCES backends/ascend/collective/tp_comm.cpp)
@@ -228,11 +272,11 @@ else()
         list(APPEND POCKET_BACKEND_DEFINES DSV4_HAVE_TP_COMM=1)
     endif()
 
-    message(WARNING
-        "POCKET_BACKEND=ascend has a device runtime and HCCL collectives but not "
-        "yet a full operator set. pocket_core, pocket_runtime, every engine object "
-        "file and the host-only tools and tests build; linking dsv4_cpp_engine "
-        "still fails on the unimplemented operator contracts.")
+    message(STATUS
+        "POCKET_BACKEND=ascend builds the Qwen FP16 path: device runtime, HCCL "
+        "collectives, the neutral operator set and dsv4_cpp_engine. Quantized "
+        "weights and KV caches, external drafters, device sampling and the DSV4 "
+        "engine are rejected at runtime, not implemented.")
 endif()
 
 # Device-agnostic core as its own library. Anything that links only this target
@@ -280,11 +324,24 @@ endif()
 if(POCKET_BACKEND_LIBS)
     target_link_libraries(dsv4_cpp_core PUBLIC ${POCKET_BACKEND_LIBS})
 endif()
+if(POCKET_ASCEND_KERNEL_INCLUDES)
+    target_include_directories(dsv4_cpp_core PUBLIC ${POCKET_ASCEND_KERNEL_INCLUDES})
+endif()
+if(POCKET_ASCEND_KERNEL_LIBS)
+    target_link_libraries(dsv4_cpp_core PUBLIC ${POCKET_ASCEND_KERNEL_LIBS})
+endif()
 if(POCKET_BACKEND_DEFINES)
     target_compile_definitions(dsv4_cpp_core PUBLIC ${POCKET_BACKEND_DEFINES})
 endif()
 if(POCKET_BACKEND STREQUAL "cuda")
     set_target_properties(dsv4_cpp_core PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+else()
+    # Keep legacy CUDA-heavy methods in discardable sections while the Ascend
+    # executable uses only the dense FP16 Qwen path. This prevents unused GGUF,
+    # DSpark and DFlash2 methods from imposing link-time CUDA dependencies; all
+    # reachable unsupported paths still reject their formats at runtime.
+    target_compile_options(dsv4_cpp_core PRIVATE -ffunction-sections -fdata-sections)
+    target_link_options(dsv4_cpp_core INTERFACE -Wl,--gc-sections)
 endif()
 
 # Fail the build if a vendor SDK leaks into the shared layers. This is the
@@ -532,6 +589,14 @@ set_target_properties(test_tp_comm_smoke PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${C
 add_executable(test_qwen_ascend_ops tests/test_qwen_ascend_ops.cpp)
 target_link_libraries(test_qwen_ascend_ops PRIVATE dsv4_cpp_core)
 set_target_properties(test_qwen_ascend_ops PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+# The twelve operators with no aclnn equivalent, i.e. the hand-written AscendC
+# kernels. Same neutral-name discipline as test_qwen_ascend_ops; it is a separate
+# binary because these are the kernels most likely to fault the device, and a fault
+# there should not take the aclnn coverage with it.
+add_executable(test_qwen_ascend_group_b tests/test_qwen_ascend_group_b.cpp)
+target_link_libraries(test_qwen_ascend_group_b PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_ascend_group_b PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 # The (1 + weight) gamma fold is host arithmetic on the staged bytes, so this needs
 # no device. It still links dsv4_cpp_core because the policy body is backend-gated.

--- a/cpp_engine/backends/ascend/kernels/qwen_argmax_f32.cpp
+++ b/cpp_engine/backends/ascend/kernels/qwen_argmax_f32.cpp
@@ -1,0 +1,111 @@
+// AscendC row-wise argmax over FP32 logits for first-generation 910.
+//
+// This is the greedy selection at the end of every forward. aclnnArgMax exists on
+// this install, but it returns only the index: the engine needs the winning logit
+// too (it reports it, and the TP top-1 merge compares logits across ranks), and it
+// needs the global token id rather than the shard-local one. Chaining aclnnArgMax
+// with a gather to recover the value costs two more ops and an index tensor, so
+// this is written directly.
+//
+// Tie-break is the lower token id, matching argmax_fp32_rows_cuda. That is not
+// cosmetic: under TP the ranks must agree on the same token, and a tie inside one
+// shard resolved differently from the CUDA reference would make a cross-backend
+// comparison diverge on exactly the inputs that look most benign.
+//
+// One block owns up to eight consecutive rows. Vector ReduceMax is float16-only
+// on this SoC (see the note in qwen_ascend_kernel_common.hpp), so the scan is
+// scalar over UB-resident tiles:
+// MTE2 brings a tile in, the scalar unit walks it. At a 62,080-wide vocab slice
+// that is one pass over 243 KiB per row, bandwidth-bound and comfortably cheaper
+// than the lm_head GEMM that produced it.
+
+#include "qwen_ascend_kernel_common.hpp"
+
+namespace {
+
+using namespace pocket;
+
+// Floats per tile. 2048 * 4 = 8 KiB, small enough to double-buffer later without
+// restructuring, large enough that the per-tile MTE2 issue cost disappears.
+constexpr uint32_t kScanTile = 2048;
+
+// Rows per block. Both results are 4 bytes wide and one per row, so a block that
+// owned a single row would write 4 bytes of a 32-byte GM cache line that seven
+// other blocks also write. Scalar GM stores are not coherent between cores at
+// sub-line granularity: whichever core's line lands last wins and the other seven
+// results are silently lost. Giving each block eight consecutive rows makes its two
+// output spans exactly one cache line each, so no two blocks share a line and the
+// row parallelism survives.
+constexpr uint32_t kRowsPerBlock = kBlockBytes / sizeof(float);
+
+}  // namespace
+
+// logits: [rows, count] FP32. tokens: [rows] int32, count-relative index plus
+// token_offset. values: [rows] FP32, the winning logit.
+extern "C" __global__ __aicore__ void qwen_argmax_f32_rows_kernel(
+    GM_ADDR logits, GM_ADDR tokens, GM_ADDR values, uint32_t rows,
+    uint32_t count, int32_t token_offset) {
+    AscendC::GlobalTensor<float> logits_gm;
+    logits_gm.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(logits));
+    AscendC::GlobalTensor<int32_t> tokens_gm;
+    tokens_gm.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t*>(tokens));
+    AscendC::GlobalTensor<float> values_gm;
+    values_gm.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(values));
+
+    AscendC::TPipe pipe;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> tile_buf;
+    pipe.InitBuffer(tile_buf, kScanTile * sizeof(float));
+    AscendC::LocalTensor<float> tile = tile_buf.Get<float>();
+
+    const uint32_t block = AscendC::GetBlockIdx();
+    const uint32_t block_count = AscendC::GetBlockNum();
+
+    const uint32_t groups = (rows + kRowsPerBlock - 1) / kRowsPerBlock;
+    for (uint32_t group = block; group < groups; group += block_count) {
+        const uint32_t group_end =
+            min_u32(rows, (group + 1) * kRowsPerBlock);
+        for (uint32_t row = group * kRowsPerBlock; row < group_end; ++row) {
+        const uint64_t base = static_cast<uint64_t>(row) * count;
+        float best = 0.0f;
+        uint32_t best_index = 0;
+        bool have_best = false;
+
+        for (uint32_t start = 0; start < count; start += kScanTile) {
+            const uint32_t width = min_u32(kScanTile, count - start);
+            // A row is not 8-float aligned in general, and the scan reads only
+            // `width` lanes, so the aligned bulk plus a scalar tail is exact.
+            const uint32_t bulk = align_down_u32(width, kAlignFloat);
+            if (bulk > 0) {
+                AscendC::DataCopy(tile, logits_gm[base + start], bulk);
+                wait_load_before_scalar();
+            }
+            for (uint32_t i = 0; i < bulk; ++i) {
+                const float value = tile.GetValue(i);
+                // Strict greater-than keeps the first maximum, which is the
+                // lowest index, which is the lowest token id.
+                if (!have_best || value > best) {
+                    best = value;
+                    best_index = start + i;
+                    have_best = true;
+                }
+            }
+            for (uint32_t i = bulk; i < width; ++i) {
+                const float value = logits_gm.GetValue(base + start + i);
+                if (!have_best || value > best) {
+                    best = value;
+                    best_index = start + i;
+                    have_best = true;
+                }
+            }
+            if (bulk > 0) {
+                // The next iteration refills the same tile, and nothing but the
+                // scalar unit read it, so this is S_MTE2 rather than MTE3_MTE2.
+                wait_scalar_before_load();
+            }
+        }
+
+        tokens_gm.SetValue(row, static_cast<int32_t>(best_index) + token_offset);
+        values_gm.SetValue(row, best);
+    }
+    }
+}

--- a/cpp_engine/backends/ascend/kernels/qwen_ascend_kernel_common.hpp
+++ b/cpp_engine/backends/ascend/kernels/qwen_ascend_kernel_common.hpp
@@ -1,0 +1,249 @@
+// Shared device-side helpers for the hand-written AscendC kernels.
+//
+// Everything here is first-generation 910 specific (Short_SoC_version=Ascend910:
+// 30 AI cores, 32 MB L2, 256 KiB UB, no BF16). Three constraints shape every
+// kernel in this directory and are worth stating once:
+//
+//   1. TBuf inserts no synchronization. Every hand-off between hardware pipes has
+//      to be written out. Omitting one does not crash: the kernel returns success
+//      with numbers that are simply wrong, because Vector read UB before MTE2's
+//      copy landed.
+//   2. There are no scalar transcendentals. `expf`, `cosf`, `rsqrtf` and friends
+//      exist in the CANN headers but are gated behind the SIMT API and are not
+//      visible from a classic __aicore__ kernel. Scalar `sqrt`, `+ - * /` are, and
+//      they are fully precise. Anything else has to run as a vector op over a tile,
+//      even when only one value is wanted.
+//   3. Vector `Reciprocal` and `Rsqrt` are ~2e-3 hardware approximations, not FP32.
+//      Where a reciprocal has to be exact, take it as a scalar division instead.
+//
+// FP32 `ReduceSum` is also unavailable: its generic path instantiates vcmax, which
+// this SoC supports for float16 only (`Intrinsic_vcmax|float16` in Ascend910B.ini),
+// so it does not compile. The halving folds below use nothing but vadd.
+
+#ifndef POCKET_QWEN_ASCEND_KERNEL_COMMON_HPP
+#define POCKET_QWEN_ASCEND_KERNEL_COMMON_HPP
+
+#include "kernel_operator.h"
+
+namespace pocket {
+
+// Vector ops want 32-byte alignment: 16 halfs or 8 floats.
+constexpr uint32_t kAlignHalf = 16;
+constexpr uint32_t kAlignFloat = 8;
+
+// Bytes per 32-byte DataCopy block, the unit DataCopyParams counts in.
+constexpr uint32_t kBlockBytes = 32;
+
+__aicore__ inline uint32_t pocket_align_up(uint32_t value, uint32_t multiple) {
+    return (value + multiple - 1) / multiple * multiple;
+}
+
+__aicore__ inline uint32_t align_down_u32(uint32_t value, uint32_t multiple) {
+    return value / multiple * multiple;
+}
+
+__aicore__ inline uint32_t min_u32(uint32_t a, uint32_t b) { return a < b ? a : b; }
+
+// Pipe hand-offs. Named for what they guard rather than for the event, because the
+// event names alone read as noise at the call site.
+__aicore__ inline void wait_load_before_compute() {
+    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+}
+
+__aicore__ inline void wait_compute_before_scalar() {
+    AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID0);
+    AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID0);
+}
+
+__aicore__ inline void wait_scalar_before_compute() {
+    AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+    AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+}
+
+__aicore__ inline void wait_compute_before_store() {
+    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+}
+
+__aicore__ inline void wait_scalar_before_store() {
+    AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(EVENT_ID0);
+    AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(EVENT_ID0);
+}
+
+// A store has to land before the same buffer is refilled on the next iteration.
+__aicore__ inline void wait_store_before_load() {
+    AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+}
+
+// A store has to drain before Vector reuses the same UB. This differs from the
+// MTE3->MTE2 hand-off above: the next producer is Vector, not another load.
+__aicore__ inline void wait_store_before_compute() {
+    AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
+    AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
+}
+
+// Same lifetime rule when the scalar unit is the next user of the stored tile.
+__aicore__ inline void wait_store_before_scalar() {
+    AscendC::SetFlag<AscendC::HardEvent::MTE3_S>(EVENT_ID0);
+    AscendC::WaitFlag<AscendC::HardEvent::MTE3_S>(EVENT_ID0);
+}
+
+// A load has to land before a scalar unit reads the same UB.
+__aicore__ inline void wait_load_before_scalar() {
+    AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(EVENT_ID0);
+    AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(EVENT_ID0);
+}
+
+// A scalar read has to finish before a load refills the same UB. This is the
+// counterpart to wait_load_before_scalar for a tile the scalar unit consumes
+// directly, where wait_store_before_load would name a store that never happened.
+__aicore__ inline void wait_scalar_before_load() {
+    AscendC::SetFlag<AscendC::HardEvent::S_MTE2>(EVENT_ID0);
+    AscendC::WaitFlag<AscendC::HardEvent::S_MTE2>(EVENT_ID0);
+}
+
+// A Vector read has to finish before a load refills the same UB.
+//
+// This is the anti-dependency of wait_load_before_compute and it is easy to miss: a
+// staging tile that is loaded, consumed by Vector, then loaded again needs a hand-off
+// in *both* directions. MTE2 is free the instant its previous copy retires, so
+// without this the next copy lands on top of a tile the Vector pipe is still reading,
+// and the consumer silently sees the following iteration's data.
+__aicore__ inline void wait_compute_before_load() {
+    AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+}
+
+// Exact-length fp16 transfers.
+//
+// DataCopy moves whole 32-byte blocks, so a tile whose length is not a multiple of
+// 16 halfs cannot be moved by DataCopy alone without reading or writing past the
+// payload. Rounding the length up is what the first draft of these kernels did, and
+// it is an out-of-bounds access on both directions at the end of a plane.
+// DataCopyPad would be the answer on a second-generation part, but every GM<->UB
+// overload of it reports "not support" on dav_c100. So the tail moves on the scalar
+// unit: at most 15 elements, once per tile.
+//
+// Both helpers own their pipe hand-offs. Callers must not add their own
+// wait_load_before_compute / wait_compute_before_store around them, or the flag
+// pairs will nest and deadlock.
+
+__aicore__ inline void load_half_exact(const AscendC::LocalTensor<half>& dst,
+                                       const AscendC::GlobalTensor<half>& src,
+                                       uint32_t offset, uint32_t count) {
+    const uint32_t bulk = align_down_u32(count, kAlignHalf);
+    if (bulk > 0) {
+        AscendC::DataCopy(dst, src[offset], bulk);
+    }
+    for (uint32_t i = bulk; i < count; ++i) {
+        dst.SetValue(i, src.GetValue(offset + i));
+    }
+    if (bulk > 0) {
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+    }
+    if (bulk < count) {
+        AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+    }
+}
+
+__aicore__ inline void store_half_exact(AscendC::GlobalTensor<half>& dst,
+                                        uint32_t offset,
+                                        const AscendC::LocalTensor<half>& src,
+                                        uint32_t count) {
+    const uint32_t bulk = align_down_u32(count, kAlignHalf);
+    if (bulk < count) {
+        AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID0);
+        for (uint32_t i = bulk; i < count; ++i) {
+            dst.SetValue(offset + i, src.GetValue(i));
+        }
+    }
+    if (bulk > 0) {
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+        AscendC::DataCopy(dst[offset], src, bulk);
+    }
+}
+
+// Sum of `width` contiguous floats, where `width` is a power of two and at least
+// kAlignFloat. Folds the buffer in half repeatedly with vadd, then finishes the
+// last 8 lanes on the scalar unit. Destroys `work`.
+//
+// Costs log2(width/8) vector instructions: 4 for a 128-wide key row.
+__aicore__ inline float fold_sum(const AscendC::LocalTensor<float>& work,
+                                 uint32_t width) {
+    for (uint32_t half = width / 2; half >= kAlignFloat; half /= 2) {
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Add(work, work, work[half], half);
+    }
+    wait_compute_before_scalar();
+    float sum = 0.0f;
+    const uint32_t tail = min_u32(width, kAlignFloat);
+    for (uint32_t i = 0; i < tail; ++i) sum += work.GetValue(i);
+    return sum;
+}
+
+// Column-wise sum of a [rows, width] tile, leaving the result in the first `width`
+// lanes. `rows` must be a power of two; `width` a multiple of kAlignFloat. Same
+// halving fold as fold_sum, but folding whole rows so all `width` columns reduce at
+// once. Destroys `work`.
+__aicore__ inline void fold_rows(const AscendC::LocalTensor<float>& work,
+                                 uint32_t rows, uint32_t width) {
+    for (uint32_t half = rows / 2; half >= 1; half /= 2) {
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Add(work, work, work[half * width], half * width);
+    }
+}
+
+// exp() of a single scalar. There is no scalar exp on this part, so this runs the
+// vector unit over one 8-lane tile. Used where a per-token gate is needed and
+// batching the whole sequence is not worth the buffer.
+__aicore__ inline float scalar_exp(const AscendC::LocalTensor<float>& work,
+                                   float value) {
+    wait_scalar_before_compute();
+    AscendC::Duplicate(work, value, kAlignFloat);
+    AscendC::PipeBarrier<PIPE_V>();
+    AscendC::Exp(work, work, kAlignFloat);
+    wait_compute_before_scalar();
+    return work.GetValue(0);
+}
+
+// Broadcast `src[i]` across a row of `width` lanes, for i in [0, rows).
+//
+// This is the shape a scalar-per-key-row multiply needs, and it is the hot spot of
+// the recurrence: one Duplicate per row. The dsts do not overlap, so no barrier is
+// needed between them, but it is still `rows` instruction issues. Brcb plus four
+// strided doublings would do the same job in five ops and is the known next
+// optimization here; it is left out until the numbers are trusted.
+__aicore__ inline void broadcast_rows(const AscendC::LocalTensor<float>& dst,
+                                      const AscendC::LocalTensor<float>& src,
+                                      uint32_t rows, uint32_t width) {
+    for (uint32_t i = 0; i < rows; ++i) {
+        AscendC::Duplicate(dst[i * width], src.GetValue(i), width);
+    }
+}
+
+// Copy a [rows, width] column window out of a [rows, stride] GM tile.
+//
+// DataCopyParams counts in 32-byte blocks, so this needs width*sizeof(T) and
+// (stride-width)*sizeof(T) to both be block multiples. Callers validate that on
+// the host rather than silently truncating here.
+template <typename T>
+__aicore__ inline AscendC::DataCopyParams window_params(uint32_t rows,
+                                                        uint32_t width,
+                                                        uint32_t stride) {
+    AscendC::DataCopyParams params;
+    params.blockCount = static_cast<uint16_t>(rows);
+    params.blockLen = static_cast<uint16_t>(width * sizeof(T) / kBlockBytes);
+    params.srcStride = static_cast<uint16_t>((stride - width) * sizeof(T) / kBlockBytes);
+    params.dstStride = 0;
+    return params;
+}
+
+}  // namespace pocket
+
+#endif  // POCKET_QWEN_ASCEND_KERNEL_COMMON_HPP

--- a/cpp_engine/backends/ascend/kernels/qwen_ascend_ops_launch.cpp
+++ b/cpp_engine/backends/ascend/kernels/qwen_ascend_ops_launch.cpp
@@ -1,0 +1,510 @@
+// Host launchers for the hand-written AscendC kernels.
+//
+// These are the twelve operators with no aclnn equivalent on this install: the
+// gated-delta recurrence and its gates/normalization, the causal depthwise
+// convolution, partial RoPE, the KV-cache append and the three GQA attention
+// forms. The device code lives beside this file; everything here is argument
+// validation, block-count selection and the launch itself.
+//
+// ascendc_library() generates one host stub per `extern "C" __global__ __aicore__`
+// entry point:
+//
+//     extern "C" uint32_t aclrtlaunch_<kernel>(uint32_t numBlocks,
+//                                              aclrtStream stream, <args...>);
+//
+// It returns 0 on success and allocates/frees its own 8-byte overflow-status
+// buffer per launch. The generated headers land in
+// ${CMAKE_BINARY_DIR}/include/pocket_ascend_kernels, which is on this target's
+// include path.
+//
+// Two things are worth knowing before changing anything here:
+//
+//   1. Validation is not defensive decoration. The kernels index GM with
+//      unsigned arithmetic and no bounds checks, so a bad `max_context` or a
+//      `heads % key_heads != 0` is an out-of-bounds device write, not a wrong
+//      number. Every contract the device code assumes is checked here, and the
+//      checks mirror the CUDA launchers so a caller cannot tell the backends
+//      apart by which arguments they reject.
+//   2. There is no device sin/cos reachable from a classic __aicore__ kernel, so
+//      partial RoPE takes precomputed FP32 tables. The first correctness path builds
+//      the requested tables per call on the host and uploads them synchronously; it
+//      deliberately makes no retained per-device or per-geometry cache claim.
+
+#include "aclnn_common.hpp"
+
+#include "qwen_ascend_ops.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <map>
+#include <mutex>
+#include <vector>
+
+#include "aclrtlaunch_qwen_append_kv_cache_kernel.h"
+#include "aclrtlaunch_qwen_argmax_f32_rows_kernel.h"
+#include "aclrtlaunch_qwen_causal_depthwise_conv_silu_kernel.h"
+#include "aclrtlaunch_qwen_gated_delta_sequence_kernel.h"
+#include "aclrtlaunch_qwen_gated_delta_sequence_normalized_kernel.h"
+#include "aclrtlaunch_qwen_gated_delta_step_kernel.h"
+#include "aclrtlaunch_qwen_gqa_decode_attention_kernel.h"
+#include "aclrtlaunch_qwen_gqa_prefill_attention_kernel.h"
+#include "aclrtlaunch_qwen_gqa_verify_attention_kernel.h"
+#include "aclrtlaunch_qwen_linear_attn_gates_kernel.h"
+#include "aclrtlaunch_qwen_normalize_gated_delta_qk_kernel.h"
+#include "aclrtlaunch_qwen_partial_rope_rows_kernel.h"
+
+namespace dsv4 {
+namespace {
+
+using ascend::resolve;
+
+// The generated stubs return 0 for success.
+constexpr uint32_t kLaunchOk = 0;
+
+// The recurrence kernels hard-code a [128, 128] state tile, so the host has to
+// reject any other head geometry rather than launch a kernel that would read the
+// wrong stride. The CUDA launchers reject the same values.
+constexpr int kRecurrentKeyDim = 128;
+constexpr int kRecurrentValueDim = 128;
+
+// Convolution tail capacity, matching kMaxKernel in the device code and kMaxTail
+// on the CUDA side.
+constexpr int kMaxConvKernel = 8;
+
+// First-generation 910 has 30 AI cores. Every kernel here is a grid-stride loop
+// over independent work items, so more blocks than cores would only add launch
+// overhead; fewer than the work available would leave cores idle.
+constexpr uint32_t kMaxBlocks = 30;
+
+// Query the AI core count once per device and fall back to the known
+// first-generation value. Reading it rather than hard-coding it means a run on
+// second-generation silicon (20 or 24 cores) still launches a legal grid, even
+// though the kernels are not tuned for it.
+uint32_t core_count() {
+    static std::mutex mutex;
+    static std::map<int32_t, uint32_t> cache;
+    int32_t device = 0;
+    if (aclrtGetDevice(&device) != ACL_SUCCESS) return kMaxBlocks;
+    std::lock_guard<std::mutex> guard(mutex);
+    auto found = cache.find(device);
+    if (found != cache.end()) return found->second;
+    int64_t cores = 0;
+    uint32_t resolved = kMaxBlocks;
+    if (aclrtGetDeviceInfo(static_cast<uint32_t>(device),
+                           ACL_DEV_ATTR_AICORE_CORE_NUM,
+                           &cores) == ACL_SUCCESS &&
+        cores > 0) {
+        // Clamped rather than trusted. A reported count above 30 means this is
+        // not the SoC these kernels were written for, and launching that grid
+        // would size the loop for hardware whose UB budget has not been checked.
+        resolved = static_cast<uint32_t>(cores);
+        if (resolved > kMaxBlocks) resolved = kMaxBlocks;
+    }
+    cache.emplace(device, resolved);
+    return resolved;
+}
+
+// Blocks for `work` independent items: never more than there is work for, never
+// more than there are cores, never zero.
+uint32_t blocks_for(uint64_t work) {
+    const uint32_t cores = core_count();
+    if (work == 0) return 1;
+    if (work < static_cast<uint64_t>(cores)) return static_cast<uint32_t>(work);
+    return cores;
+}
+
+// Shared attention preconditions, mirroring valid_attention() in the CUDA
+// launcher so both backends reject the same shapes.
+bool valid_attention(int q_heads, int kv_heads, int head_dim, int context_len,
+                     int max_context) {
+    return q_heads > 0 && kv_heads > 0 && q_heads % kv_heads == 0 &&
+           head_dim > 0 && context_len > 0 && context_len <= max_context;
+}
+
+// The softmax scale. Passed to the kernel as a float because aicore cannot cast
+// an unsigned integer to floating point, and its integer sqrt overload truncates
+// (head_dim 128 would give 11 instead of 11.3137).
+float attention_scale(int head_dim) {
+    return 1.0f / std::sqrt(static_cast<float>(head_dim));
+}
+
+bool valid_recurrent(int heads, int key_heads, int key_dim, int value_dim,
+                     float q_scale) {
+    return heads > 0 && key_heads > 0 && heads % key_heads == 0 &&
+           key_dim == kRecurrentKeyDim && value_dim == kRecurrentValueDim &&
+           q_scale > 0.0f;
+}
+
+// Per-call FP32 cos/sin tables for partial RoPE.
+//
+// The table is [rows, rotary_dim / 2] and contains the absolute positions starting
+// at `start_position`. Angles are computed in double and rounded once to float;
+// the CUDA device implementation's float powf/cosf path is therefore not copied
+// into this first-generation kernel, which has no classic-aicore trig primitive.
+//
+// The device allocation comes from WorkspacePool's Intermediate slot rather than
+// aclrtMalloc. The copy is queued on the same stream as the kernel, so the table
+// remains live until the launch consumes it and can be reused by the next
+// serialized operator without a stream-wide synchronization.
+class RopeTables {
+public:
+    static bool acquire(int rotary_dim, float theta, int start_position, int rows,
+                        aclrtStream stream, const float** cos_rows,
+                        const float** sin_rows) {
+        const size_t half = static_cast<size_t>(rotary_dim / 2);
+        const size_t elements = static_cast<size_t>(rows) * half;
+        const size_t bytes = elements * sizeof(float);
+        std::vector<float> host_cos(elements);
+        std::vector<float> host_sin(elements);
+        std::vector<double> inv_freq(half);
+        for (size_t i = 0; i < half; ++i) {
+            inv_freq[i] = std::pow(
+                static_cast<double>(theta),
+                -2.0 * static_cast<double>(i) /
+                    static_cast<double>(rotary_dim));
+        }
+        for (int row = 0; row < rows; ++row) {
+            const double position = static_cast<double>(start_position + row);
+            const size_t base = static_cast<size_t>(row) * half;
+            for (size_t i = 0; i < half; ++i) {
+                const double angle = position * inv_freq[i];
+                host_cos[base + i] = static_cast<float>(std::cos(angle));
+                host_sin[base + i] = static_cast<float>(std::sin(angle));
+            }
+        }
+
+        bool pool_ok = true;
+        void* storage = ascend::WorkspacePool::acquire(
+            bytes * 2, stream, pool_ok,
+            ascend::WorkspacePool::Purpose::Intermediate);
+        if (!pool_ok || storage == nullptr) return false;
+        auto* device = static_cast<float*>(storage);
+        // The host vectors are temporary. A synchronous copy keeps their lifetime
+        // explicit; enqueueing an async H2D and destroying them at return races the
+        // DMA engine and produces position-dependent RoPE corruption.
+        if (aclrtMemcpy(device, bytes, host_cos.data(), bytes,
+                        ACL_MEMCPY_HOST_TO_DEVICE) != ACL_SUCCESS ||
+            aclrtMemcpy(device + elements, bytes, host_sin.data(), bytes,
+                        ACL_MEMCPY_HOST_TO_DEVICE) != ACL_SUCCESS) {
+            return false;
+        }
+        *cos_rows = device;
+        *sin_rows = device + elements;
+        return true;
+    }
+};
+
+bool valid_rope(int start_position, int rows, int rotary_dim, float theta,
+                int q_heads, int kv_heads, int head_dim) {
+    return start_position >= 0 && rows > 0 && rotary_dim > 0 &&
+           (rotary_dim & 1) == 0 && rotary_dim <= head_dim &&
+           std::isfinite(theta) && theta > 0.0f && q_heads > 0 &&
+           kv_heads > 0 && head_dim > 0;
+}
+
+// The kernels take GM_ADDR, which the generated stubs expose as void*. Const is
+// dropped at the boundary because the launch ABI has no const form; the device
+// code only reads these.
+template <typename T>
+void* gm(const T* pointer) {
+    return const_cast<void*>(static_cast<const void*>(pointer));
+}
+
+}  // namespace
+
+bool qwen_normalize_gated_delta_qk_f16_ascend(
+    const uint16_t* d_q_fp16, const uint16_t* d_k_fp16, float* d_q_normalized,
+    float* d_k_normalized, int rows, int key_heads, int key_dim, void* stream) {
+    if (d_q_fp16 == nullptr || d_k_fp16 == nullptr ||
+        d_q_normalized == nullptr || d_k_normalized == nullptr || rows <= 0 ||
+        key_heads <= 0 || key_dim != kRecurrentKeyDim) {
+        return false;
+    }
+    const uint64_t pairs = static_cast<uint64_t>(rows) * key_heads;
+    return aclrtlaunch_qwen_normalize_gated_delta_qk_kernel(
+               blocks_for(pairs), resolve(stream), gm(d_q_fp16), gm(d_k_fp16),
+               gm(d_q_normalized), gm(d_k_normalized),
+               static_cast<uint32_t>(rows),
+               static_cast<uint32_t>(key_heads)) == kLaunchOk;
+}
+
+bool qwen_gated_delta_sequence_f16_ascend(
+    float* d_state, const uint16_t* d_q_fp16, const uint16_t* d_k_fp16,
+    const uint16_t* d_v_fp16, const uint16_t* d_g_fp16,
+    const uint16_t* d_beta_fp16, uint16_t* d_out_fp16, int rows, int heads,
+    int key_heads, int key_dim, int value_dim, float q_scale, void* stream) {
+    if (d_state == nullptr || d_q_fp16 == nullptr || d_k_fp16 == nullptr ||
+        d_v_fp16 == nullptr || d_g_fp16 == nullptr || d_beta_fp16 == nullptr ||
+        d_out_fp16 == nullptr || rows <= 0 ||
+        !valid_recurrent(heads, key_heads, key_dim, value_dim, q_scale)) {
+        return false;
+    }
+    return aclrtlaunch_qwen_gated_delta_sequence_kernel(
+               blocks_for(static_cast<uint64_t>(heads)), resolve(stream),
+               gm(d_state), gm(d_q_fp16), gm(d_k_fp16), gm(d_v_fp16),
+               gm(d_g_fp16), gm(d_beta_fp16), gm(d_out_fp16),
+               static_cast<uint32_t>(rows), static_cast<uint32_t>(heads),
+               static_cast<uint32_t>(key_heads), q_scale) == kLaunchOk;
+}
+
+bool qwen_gated_delta_sequence_normalized_f16_ascend(
+    float* d_state, const float* d_q_normalized, const float* d_k_normalized,
+    const uint16_t* d_v_fp16, const uint16_t* d_g_fp16,
+    const uint16_t* d_beta_fp16, uint16_t* d_out_fp16, int rows, int heads,
+    int key_heads, int key_dim, int value_dim, float q_scale, void* stream) {
+    if (d_state == nullptr || d_q_normalized == nullptr ||
+        d_k_normalized == nullptr || d_v_fp16 == nullptr ||
+        d_g_fp16 == nullptr || d_beta_fp16 == nullptr ||
+        d_out_fp16 == nullptr || rows <= 0 ||
+        !valid_recurrent(heads, key_heads, key_dim, value_dim, q_scale)) {
+        return false;
+    }
+    return aclrtlaunch_qwen_gated_delta_sequence_normalized_kernel(
+               blocks_for(static_cast<uint64_t>(heads)), resolve(stream),
+               gm(d_state), gm(d_q_normalized), gm(d_k_normalized),
+               gm(d_v_fp16), gm(d_g_fp16), gm(d_beta_fp16), gm(d_out_fp16),
+               static_cast<uint32_t>(rows), static_cast<uint32_t>(heads),
+               static_cast<uint32_t>(key_heads), q_scale) == kLaunchOk;
+}
+
+// The CUDA `_shared` variant shards one head's state across a block so several
+// value columns progress together in shared memory. That is a launch-geometry
+// choice, not a different recurrence: it is bit-comparable to the normalized
+// kernel by construction. This part has no equivalent to shard onto (a head's
+// state already lives entirely in UB and tokens are strictly sequential), so the
+// contract is satisfied by the normalized kernel itself rather than by a second
+// device implementation.
+bool qwen_gated_delta_sequence_normalized_shared_f16_ascend(
+    float* d_state, const float* d_q_normalized, const float* d_k_normalized,
+    const uint16_t* d_v_fp16, const uint16_t* d_g_fp16,
+    const uint16_t* d_beta_fp16, uint16_t* d_out_fp16, int rows, int heads,
+    int key_heads, int key_dim, int value_dim, float q_scale, void* stream) {
+    return qwen_gated_delta_sequence_normalized_f16_ascend(
+        d_state, d_q_normalized, d_k_normalized, d_v_fp16, d_g_fp16,
+        d_beta_fp16, d_out_fp16, rows, heads, key_heads, key_dim, value_dim,
+        q_scale, stream);
+}
+
+bool qwen_gated_delta_step_f16_ascend(
+    float* d_state, const uint16_t* d_q_fp16, const uint16_t* d_k_fp16,
+    const uint16_t* d_v_fp16, const uint16_t* d_g_fp16,
+    const uint16_t* d_beta_fp16, uint16_t* d_out_fp16, int heads,
+    int key_heads, int key_dim, int value_dim, float q_scale, void* stream) {
+    if (d_state == nullptr || d_q_fp16 == nullptr || d_k_fp16 == nullptr ||
+        d_v_fp16 == nullptr || d_g_fp16 == nullptr || d_beta_fp16 == nullptr ||
+        d_out_fp16 == nullptr ||
+        !valid_recurrent(heads, key_heads, key_dim, value_dim, q_scale)) {
+        return false;
+    }
+    return aclrtlaunch_qwen_gated_delta_step_kernel(
+               blocks_for(static_cast<uint64_t>(heads)), resolve(stream),
+               gm(d_state), gm(d_q_fp16), gm(d_k_fp16), gm(d_v_fp16),
+               gm(d_g_fp16), gm(d_beta_fp16), gm(d_out_fp16),
+               static_cast<uint32_t>(heads), static_cast<uint32_t>(key_heads),
+               q_scale) == kLaunchOk;
+}
+
+bool qwen_linear_attn_gates_f16_ascend(
+    const uint16_t* d_a_fp16, const uint16_t* d_b_fp16,
+    const uint16_t* d_a_log_fp16, const uint16_t* d_dt_bias_fp16,
+    uint16_t* d_g_fp16, uint16_t* d_beta_fp16, int rows, int heads,
+    void* stream) {
+    if (d_a_fp16 == nullptr || d_b_fp16 == nullptr ||
+        d_a_log_fp16 == nullptr || d_dt_bias_fp16 == nullptr ||
+        d_g_fp16 == nullptr || d_beta_fp16 == nullptr || rows <= 0 ||
+        heads <= 0) {
+        return false;
+    }
+    // The kernel tiles the flat [rows*heads] plane in 512-lane chunks.
+    const uint64_t total = static_cast<uint64_t>(rows) * heads;
+    const uint64_t tiles = (total + 511) / 512;
+    return aclrtlaunch_qwen_linear_attn_gates_kernel(
+               blocks_for(tiles), resolve(stream), gm(d_a_fp16), gm(d_b_fp16),
+               gm(d_a_log_fp16), gm(d_dt_bias_fp16), gm(d_g_fp16),
+               gm(d_beta_fp16), static_cast<uint32_t>(rows),
+               static_cast<uint32_t>(heads)) == kLaunchOk;
+}
+
+bool qwen_causal_depthwise_conv_silu_f16_ascend(
+    const uint16_t* d_x_fp16, const uint16_t* d_weight_fp16,
+    uint16_t* d_tail_fp16, uint16_t* d_y_fp16, int seq_len, int channels,
+    int kernel, bool update_tail, void* stream) {
+    // d_tail_fp16 is allowed to be null: that signals zero convolution history,
+    // and the device code branches on it. Everything else is required.
+    if (d_x_fp16 == nullptr || d_weight_fp16 == nullptr || d_y_fp16 == nullptr ||
+        seq_len <= 0 || channels <= 0 || kernel <= 0 ||
+        kernel > kMaxConvKernel) {
+        return false;
+    }
+    // The kernel walks 512-channel tiles for the whole sequence.
+    const uint64_t tiles = (static_cast<uint64_t>(channels) + 511) / 512;
+    return aclrtlaunch_qwen_causal_depthwise_conv_silu_kernel(
+               blocks_for(tiles), resolve(stream), gm(d_x_fp16),
+               gm(d_weight_fp16), gm(d_tail_fp16), gm(d_y_fp16),
+               static_cast<uint32_t>(seq_len), static_cast<uint32_t>(channels),
+               static_cast<uint32_t>(kernel),
+               update_tail ? 1u : 0u) == kLaunchOk;
+}
+
+bool qwen_partial_rope_rows_f16_ascend(
+    uint16_t* d_q_fp16, uint16_t* d_k_fp16, int start_position, int rows,
+    int rotary_dim, float theta, int q_heads, int kv_heads, int head_dim,
+    void* stream) {
+    if (d_q_fp16 == nullptr || d_k_fp16 == nullptr || start_position < 0 ||
+        rows <= 0 || rotary_dim <= 0 || (rotary_dim & 1) != 0 ||
+        rotary_dim > head_dim || theta <= 0.0f || q_heads <= 0 ||
+        kv_heads <= 0 || head_dim <= 0) {
+        return false;
+    }
+    const aclrtStream s = resolve(stream);
+    const float* cos_rows = nullptr;
+    const float* sin_rows = nullptr;
+    if (!RopeTables::acquire(rotary_dim, theta, start_position, rows, s,
+                             &cos_rows, &sin_rows)) {
+        return false;
+    }
+    const uint64_t pairs = static_cast<uint64_t>(rows) * (rotary_dim / 2);
+    return aclrtlaunch_qwen_partial_rope_rows_kernel(
+               blocks_for(pairs), s, gm(d_q_fp16), gm(d_k_fp16), gm(cos_rows),
+               gm(sin_rows), static_cast<uint32_t>(rows),
+               static_cast<uint32_t>(rotary_dim),
+               static_cast<uint32_t>(q_heads), static_cast<uint32_t>(kv_heads),
+               static_cast<uint32_t>(head_dim)) == kLaunchOk;
+}
+
+bool qwen_append_kv_cache_f16_ascend(
+    const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
+    uint16_t* d_k_cache_fp16, uint16_t* d_v_cache_fp16, int seq_len,
+    int kv_heads, int head_dim, int start_pos, int max_context, void* stream) {
+    if (d_k_rows_fp16 == nullptr || d_v_rows_fp16 == nullptr ||
+        d_k_cache_fp16 == nullptr || d_v_cache_fp16 == nullptr ||
+        seq_len <= 0 || kv_heads <= 0 || head_dim <= 0 || start_pos < 0 ||
+        max_context <= 0 || start_pos + seq_len > max_context) {
+        return false;
+    }
+    const uint64_t elements = static_cast<uint64_t>(seq_len) * kv_heads * head_dim;
+    const uint64_t tiles = (elements + 511) / 512;
+    // Scalar handling of an unaligned tail is serialized to avoid two cores
+    // updating different halfs in the same cache line. Qwen's 128-wide rows take
+    // the aligned parallel path.
+    const bool aligned = head_dim % 16 == 0;
+    return aclrtlaunch_qwen_append_kv_cache_kernel(
+               aligned ? blocks_for(tiles) : 1u, resolve(stream), gm(d_k_rows_fp16),
+               gm(d_v_rows_fp16), gm(d_k_cache_fp16), gm(d_v_cache_fp16),
+               static_cast<uint32_t>(seq_len), static_cast<uint32_t>(kv_heads),
+               static_cast<uint32_t>(head_dim),
+               static_cast<uint32_t>(start_pos),
+               static_cast<uint32_t>(max_context)) == kLaunchOk;
+}
+
+bool qwen_gqa_decode_attention_f16_ascend(
+    const uint16_t* d_q_fp16, const uint16_t* d_k_cache_fp16,
+    const uint16_t* d_v_cache_fp16, uint16_t* d_out_fp16,
+    float* d_score_scratch, int q_heads, int kv_heads, int head_dim,
+    int context_len, int max_context, void* stream) {
+    if (d_q_fp16 == nullptr || d_k_cache_fp16 == nullptr ||
+        d_v_cache_fp16 == nullptr || d_out_fp16 == nullptr ||
+        d_score_scratch == nullptr ||
+        !valid_attention(q_heads, kv_heads, head_dim, context_len,
+                         max_context)) {
+        return false;
+    }
+    // The device baseline writes both output and score scratch with scalar GM
+    // stores. Their neutral layouts need not be 32-byte aligned per head (the
+    // score row is only `context_len` floats), and scalar stores from adjacent
+    // blocks can then lose one another in a shared GM cache line. Use one block
+    // for this correctness-first implementation; the whole head loop remains
+    // grid-stride-ready for a future block-owned, aligned fast path.
+    return aclrtlaunch_qwen_gqa_decode_attention_kernel(
+               1u, resolve(stream), gm(d_q_fp16), gm(d_k_cache_fp16),
+               gm(d_v_cache_fp16), gm(d_out_fp16), gm(d_score_scratch),
+               static_cast<uint32_t>(q_heads), static_cast<uint32_t>(kv_heads),
+               static_cast<uint32_t>(head_dim),
+               static_cast<uint32_t>(context_len),
+               static_cast<uint32_t>(max_context), attention_scale(head_dim)) ==
+           kLaunchOk;
+}
+
+bool qwen_gqa_prefill_attention_f16_ascend(
+    const uint16_t* d_q_rows_fp16, const uint16_t* d_k_cache_fp16,
+    const uint16_t* d_v_cache_fp16, uint16_t* d_out_rows_fp16, int seq_len,
+    int q_heads, int kv_heads, int head_dim, int position_offset,
+    int max_context, void* stream) {
+    if (d_q_rows_fp16 == nullptr || d_k_cache_fp16 == nullptr ||
+        d_v_cache_fp16 == nullptr || d_out_rows_fp16 == nullptr ||
+        seq_len <= 0 || position_offset < 0 ||
+        position_offset + seq_len > max_context ||
+        !valid_attention(q_heads, kv_heads, head_dim, position_offset + seq_len,
+                         max_context)) {
+        return false;
+    }
+    const uint64_t work = static_cast<uint64_t>(seq_len) * q_heads;
+    return aclrtlaunch_qwen_gqa_prefill_attention_kernel(
+               blocks_for(work), resolve(stream), gm(d_q_rows_fp16),
+               gm(d_k_cache_fp16), gm(d_v_cache_fp16), gm(d_out_rows_fp16),
+               static_cast<uint32_t>(seq_len), static_cast<uint32_t>(q_heads),
+               static_cast<uint32_t>(kv_heads),
+               static_cast<uint32_t>(head_dim),
+               static_cast<uint32_t>(position_offset),
+               static_cast<uint32_t>(max_context),
+               attention_scale(head_dim)) == kLaunchOk;
+}
+
+bool qwen_gqa_verify_attention_f16_ascend(
+    const uint16_t* d_q_rows_fp16, const uint16_t* d_k_cache_fp16,
+    const uint16_t* d_v_cache_fp16, uint16_t* d_out_rows_fp16,
+    float* d_partial_scratch, int rows, int q_heads, int kv_heads,
+    int head_dim, int position_offset, int max_context, int splits,
+    void* stream) {
+    // splits is also the scratch geometry the caller sized
+    // [rows, q_heads, splits, head_dim + 2] against, so a mismatch here is an
+    // out-of-bounds write rather than a wrong answer.
+    if (d_q_rows_fp16 == nullptr || d_k_cache_fp16 == nullptr ||
+        d_v_cache_fp16 == nullptr || d_out_rows_fp16 == nullptr ||
+        d_partial_scratch == nullptr || rows <= 0 || position_offset < 0 ||
+        position_offset + rows > max_context || splits <= 0 ||
+        splits > position_offset + rows ||
+        !valid_attention(q_heads, kv_heads, head_dim, position_offset + rows,
+                         max_context)) {
+        return false;
+    }
+    // Partial records are also scalar-written and a record is not necessarily an
+    // integral number of 32-byte cache lines (`splits * (head_dim + 2)` floats).
+    // Serialize ownership until the kernel has a block-owned aligned store path.
+    return aclrtlaunch_qwen_gqa_verify_attention_kernel(
+               1u, resolve(stream), gm(d_q_rows_fp16), gm(d_k_cache_fp16),
+               gm(d_v_cache_fp16), gm(d_out_rows_fp16), gm(d_partial_scratch),
+               static_cast<uint32_t>(rows), static_cast<uint32_t>(q_heads),
+               static_cast<uint32_t>(kv_heads), static_cast<uint32_t>(head_dim),
+               static_cast<uint32_t>(position_offset),
+               static_cast<uint32_t>(max_context),
+               static_cast<uint32_t>(splits), attention_scale(head_dim)) ==
+           kLaunchOk;
+}
+
+// Greedy top-1 per logits row. aclnn has ArgMax, but it returns only the index
+// and the caller needs the winning logit as well to merge vocabulary shards
+// across TP ranks; running an aclnn Max beside it would scan the row twice and
+// would not guarantee the two agree on which duplicate maximum won.
+bool qwen_argmax_fp32_rows_ascend(const float* d_logits, int* d_tokens,
+                                  float* d_logits_out, int rows, int count,
+                                  int token_offset, void* stream) {
+    // Exactly the CUDA launcher's preconditions, including requiring
+    // d_logits_out and accepting a negative token_offset, so a caller cannot
+    // tell the two backends apart by what they reject.
+    if (d_logits == nullptr || d_tokens == nullptr || d_logits_out == nullptr ||
+        rows <= 0 || count <= 0) {
+        return false;
+    }
+    // The kernel gives each block eight consecutive rows so its two 4-byte-per-row
+    // output spans are whole 32-byte cache lines; block count follows that grouping,
+    // not the row count, or the extra blocks would idle.
+    const uint64_t groups = (static_cast<uint64_t>(rows) + 7) / 8;
+    return aclrtlaunch_qwen_argmax_f32_rows_kernel(
+               blocks_for(groups), resolve(stream),
+               gm(d_logits), gm(d_tokens), gm(d_logits_out),
+               static_cast<uint32_t>(rows), static_cast<uint32_t>(count),
+               static_cast<int32_t>(token_offset)) == kLaunchOk;
+}
+
+}  // namespace dsv4

--- a/cpp_engine/backends/ascend/kernels/qwen_attention_f16.cpp
+++ b/cpp_engine/backends/ascend/kernels/qwen_attention_f16.cpp
@@ -1,0 +1,435 @@
+// First-generation Ascend 910 full-attention kernels.
+//
+// Attention vectors stay in UB and vector instructions perform the QK dot,
+// softmax, and weighted-V accumulation. This is especially important on the
+// first-generation scalar unit: recomputing one QK dot per output dimension made
+// the correctness baseline O(head_dim^2 * context) and dominated the whole model.
+// Cache padding, causal limits, and split ownership remain explicit.
+
+#include "qwen_ascend_kernel_common.hpp"
+
+namespace {
+
+using namespace pocket;
+
+constexpr uint32_t kMaxRotaryDim = 128;
+constexpr uint32_t kMaxHeadsPerBlock = 1;
+
+__aicore__ inline float half_value(const AscendC::GlobalTensor<half>& tensor,
+                                   uint32_t index) {
+    return static_cast<float>(tensor.GetValue(index));
+}
+
+__aicore__ inline void set_half(AscendC::GlobalTensor<half>& tensor,
+                                uint32_t index, float value) {
+    tensor.SetValue(index, static_cast<half>(value));
+}
+
+__aicore__ inline float dot_query_key(
+    const AscendC::GlobalTensor<half>& q,
+    const AscendC::GlobalTensor<half>& k_cache,
+    uint32_t q_offset, uint32_t k_offset, uint32_t head_dim) {
+    float result = 0.0f;
+    for (uint32_t d = 0; d < head_dim; ++d) {
+        result += half_value(q, q_offset + d) * half_value(k_cache, k_offset + d);
+    }
+    return result;
+}
+
+// The softmax scale is a kernel argument rather than 1/sqrt(head_dim) computed
+// here: aicore rejects a cast between a floating and an unsigned integer
+// variable, and the integer sqrt overload that does compile truncates (head_dim
+// 128 would give 11 instead of 11.3137). The host already knows the exact value.
+
+// The scalar Exp helper needs an event pair around the scalar write and vector
+// read. It is called repeatedly by the scalar attention baseline, so keep the
+// eight-lane temporary in the worker's TBuf rather than allocating one per score.
+__aicore__ inline float exp_score(const AscendC::LocalTensor<float>& exp_buf,
+                                  float score) {
+    AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+    AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+    AscendC::Duplicate(exp_buf, score, kAlignFloat);
+    AscendC::PipeBarrier<PIPE_V>();
+    AscendC::Exp(exp_buf, exp_buf, kAlignFloat);
+    AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID0);
+    AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID0);
+    return exp_buf.GetValue(0);
+}
+
+}  // namespace
+
+// In-place partial RoPE. The host launcher supplies FP32 sin/cos tables with shape
+// [rows, rotary_dim / 2], because this CANN release has no classic-aicore Sin/Cos
+// or Pow implementation. Every q and KV head shares the row's angle table. The
+// absolute start position is already folded into those per-call table values.
+extern "C" __global__ __aicore__ void qwen_partial_rope_rows_kernel(
+    GM_ADDR q, GM_ADDR k, GM_ADDR cos_table, GM_ADDR sin_table,
+    uint32_t rows, uint32_t rotary_dim,
+    uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim) {
+    AscendC::TPipe pipe;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> q_buf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> k_buf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> cos_buf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> sin_buf;
+    pipe.InitBuffer(q_buf, kMaxRotaryDim * sizeof(half));
+    pipe.InitBuffer(k_buf, kMaxRotaryDim * sizeof(half));
+    pipe.InitBuffer(cos_buf, (kMaxRotaryDim / 2) * sizeof(float));
+    pipe.InitBuffer(sin_buf, (kMaxRotaryDim / 2) * sizeof(float));
+
+    const uint32_t half_rotary = rotary_dim / 2;
+    const uint32_t table_stride = half_rotary;
+    AscendC::GlobalTensor<half> q_gm;
+    AscendC::GlobalTensor<half> k_gm;
+    AscendC::GlobalTensor<float> cos_gm;
+    AscendC::GlobalTensor<float> sin_gm;
+    q_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(q),
+                         rows * q_heads * head_dim);
+    k_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(k),
+                         rows * kv_heads * head_dim);
+    cos_gm.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(cos_table),
+                           rows * table_stride);
+    sin_gm.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(sin_table),
+                           rows * table_stride);
+
+    AscendC::LocalTensor<half> q_local = q_buf.Get<half>();
+    AscendC::LocalTensor<half> k_local = k_buf.Get<half>();
+    AscendC::LocalTensor<float> cos_local = cos_buf.Get<float>();
+    AscendC::LocalTensor<float> sin_local = sin_buf.Get<float>();
+    for (uint32_t row = AscendC::GetBlockIdx(); row < rows;
+         row += AscendC::GetBlockNum()) {
+        AscendC::DataCopy(cos_local, cos_gm[row * table_stride], table_stride);
+        AscendC::DataCopy(sin_local, sin_gm[row * table_stride], table_stride);
+        wait_load_before_scalar();
+
+        const uint32_t q_row = row * q_heads * head_dim;
+        for (uint32_t head = 0; head < q_heads; ++head) {
+            const uint32_t base = q_row + head * head_dim;
+            load_half_exact(q_local, q_gm, base, rotary_dim);
+            wait_load_before_scalar();
+            for (uint32_t index = 0; index < half_rotary; ++index) {
+                const float a = static_cast<float>(q_local.GetValue(index));
+                const float b = static_cast<float>(q_local.GetValue(index + half_rotary));
+                const float c = cos_local.GetValue(index);
+                const float s = sin_local.GetValue(index);
+                q_local.SetValue(index, static_cast<half>(a * c - b * s));
+                q_local.SetValue(index + half_rotary,
+                                 static_cast<half>(b * c + a * s));
+            }
+            wait_scalar_before_store();
+            store_half_exact(q_gm, base, q_local, rotary_dim);
+            wait_store_before_load();
+        }
+
+        const uint32_t k_row = row * kv_heads * head_dim;
+        for (uint32_t head = 0; head < kv_heads; ++head) {
+            const uint32_t base = k_row + head * head_dim;
+            load_half_exact(k_local, k_gm, base, rotary_dim);
+            wait_load_before_scalar();
+            for (uint32_t index = 0; index < half_rotary; ++index) {
+                const float a = static_cast<float>(k_local.GetValue(index));
+                const float b = static_cast<float>(k_local.GetValue(index + half_rotary));
+                const float c = cos_local.GetValue(index);
+                const float s = sin_local.GetValue(index);
+                k_local.SetValue(index, static_cast<half>(a * c - b * s));
+                k_local.SetValue(index + half_rotary,
+                                 static_cast<half>(b * c + a * s));
+            }
+            wait_scalar_before_store();
+            store_half_exact(k_gm, base, k_local, rotary_dim);
+            wait_store_before_load();
+        }
+        wait_scalar_before_load();
+    }
+}
+
+// Copy [seq_len, kv_heads, head_dim] rows into their cache positions. The real
+// Qwen row is 128 halfs; a 512-half tile covers four rows and keeps every GM
+// transfer block-aligned. The launcher uses one block for the unaligned fallback
+// so two scalar tails can never race on the same 32-byte cache line.
+extern "C" __global__ __aicore__ void qwen_append_kv_cache_kernel(
+    GM_ADDR k_rows, GM_ADDR v_rows, GM_ADDR k_cache, GM_ADDR v_cache,
+    uint32_t seq_len, uint32_t kv_heads, uint32_t head_dim,
+    uint32_t start_pos, uint32_t max_context) {
+    constexpr uint32_t kCopyTile = 512;
+    AscendC::TPipe pipe;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> k_buf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> v_buf;
+    pipe.InitBuffer(k_buf, kCopyTile * sizeof(half));
+    pipe.InitBuffer(v_buf, kCopyTile * sizeof(half));
+
+    const uint32_t rows = seq_len * kv_heads;
+    const uint32_t total = rows * head_dim;
+    const uint32_t destination_base = start_pos * kv_heads * head_dim;
+    AscendC::GlobalTensor<half> k_src;
+    AscendC::GlobalTensor<half> v_src;
+    AscendC::GlobalTensor<half> k_dst;
+    AscendC::GlobalTensor<half> v_dst;
+    k_src.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(k_rows), total);
+    v_src.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(v_rows), total);
+    k_dst.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(k_cache),
+                          max_context * kv_heads * head_dim);
+    v_dst.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(v_cache),
+                          max_context * kv_heads * head_dim);
+
+    AscendC::LocalTensor<half> k_local = k_buf.Get<half>();
+    AscendC::LocalTensor<half> v_local = v_buf.Get<half>();
+    const uint32_t tiles = (total + kCopyTile - 1) / kCopyTile;
+    for (uint32_t tile = AscendC::GetBlockIdx(); tile < tiles;
+         tile += AscendC::GetBlockNum()) {
+        const uint32_t offset = tile * kCopyTile;
+        const uint32_t count = min_u32(kCopyTile, total - offset);
+        load_half_exact(k_local, k_src, offset, count);
+        store_half_exact(k_dst, destination_base + offset, k_local, count);
+        wait_store_before_load();
+        load_half_exact(v_local, v_src, offset, count);
+        store_half_exact(v_dst, destination_base + offset, v_local, count);
+        wait_store_before_load();
+    }
+}
+
+// Decode GQA baseline. A block owns one query head and writes its score line and
+// output row. The score scratch remains normalized probabilities after this call,
+// matching the useful behavior of the CUDA baseline.
+extern "C" __global__ __aicore__ void qwen_gqa_decode_attention_kernel(
+    GM_ADDR q, GM_ADDR k_cache, GM_ADDR v_cache, GM_ADDR out,
+    GM_ADDR score_scratch, uint32_t q_heads, uint32_t kv_heads,
+    uint32_t head_dim, uint32_t context_len, uint32_t max_context,
+    float scale) {
+    AscendC::TPipe pipe;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> exp_buf;
+    pipe.InitBuffer(exp_buf, kAlignFloat * sizeof(float));
+    AscendC::LocalTensor<float> exp_tile = exp_buf.Get<float>();
+
+    AscendC::GlobalTensor<half> q_gm;
+    AscendC::GlobalTensor<half> k_gm;
+    AscendC::GlobalTensor<half> v_gm;
+    AscendC::GlobalTensor<half> out_gm;
+    AscendC::GlobalTensor<float> scores;
+    q_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(q), q_heads * head_dim);
+    k_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(k_cache),
+                         max_context * kv_heads * head_dim);
+    v_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(v_cache),
+                         max_context * kv_heads * head_dim);
+    out_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(out), q_heads * head_dim);
+    scores.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(score_scratch),
+                           q_heads * context_len);
+
+    const uint32_t repeat = q_heads / kv_heads;
+    for (uint32_t head = AscendC::GetBlockIdx(); head < q_heads;
+         head += AscendC::GetBlockNum()) {
+        const uint32_t kv_head = head / repeat;
+        const uint32_t q_offset = head * head_dim;
+        float maximum = -3.402823466e+38F;
+        for (uint32_t pos = 0; pos < context_len; ++pos) {
+            const uint32_t cache_offset = (pos * kv_heads + kv_head) * head_dim;
+            const float score = dot_query_key(q_gm, k_gm, q_offset, cache_offset,
+                                              head_dim) * scale;
+            scores.SetValue(head * context_len + pos, score);
+            if (score > maximum) maximum = score;
+        }
+
+        float denominator = 0.0f;
+        for (uint32_t pos = 0; pos < context_len; ++pos) {
+            const uint32_t cache_offset = (pos * kv_heads + kv_head) * head_dim;
+            const float score = dot_query_key(q_gm, k_gm, q_offset, cache_offset,
+                                              head_dim) * scale;
+            denominator += exp_score(exp_tile, score - maximum);
+        }
+        const float inverse = denominator > 0.0f ? 1.0f / denominator : 0.0f;
+        for (uint32_t pos = 0; pos < context_len; ++pos) {
+            const uint32_t cache_offset = (pos * kv_heads + kv_head) * head_dim;
+            const float score = dot_query_key(q_gm, k_gm, q_offset, cache_offset,
+                                              head_dim) * scale;
+            scores.SetValue(head * context_len + pos,
+                            exp_score(exp_tile, score - maximum) * inverse);
+        }
+        for (uint32_t d = 0; d < head_dim; ++d) {
+            float value = 0.0f;
+            for (uint32_t pos = 0; pos < context_len; ++pos) {
+                const uint32_t cache_offset = (pos * kv_heads + kv_head) * head_dim;
+                const float score = dot_query_key(q_gm, k_gm, q_offset,
+                                                  cache_offset, head_dim) * scale;
+                value += exp_score(exp_tile, score - maximum) *
+                         half_value(v_gm, cache_offset + d);
+            }
+            set_half(out_gm, q_offset + d, value * inverse);
+        }
+    }
+}
+
+// Causal prefill baseline. One block owns a (row, query-head) pair. Recompute the
+// score in the normalization and value passes rather than allocating a scratch
+// plane: this keeps the neutral prefill signature scratch-free.
+extern "C" __global__ __aicore__ void qwen_gqa_prefill_attention_kernel(
+    GM_ADDR q_rows, GM_ADDR k_cache, GM_ADDR v_cache, GM_ADDR out_rows,
+    uint32_t seq_len, uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
+    uint32_t position_offset, uint32_t max_context, float scale) {
+    AscendC::TPipe pipe;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> exp_buf;
+    pipe.InitBuffer(exp_buf, kAlignFloat * sizeof(float));
+    AscendC::LocalTensor<float> exp_tile = exp_buf.Get<float>();
+
+    AscendC::GlobalTensor<half> q_gm;
+    AscendC::GlobalTensor<half> k_gm;
+    AscendC::GlobalTensor<half> v_gm;
+    AscendC::GlobalTensor<half> out_gm;
+    q_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(q_rows),
+                         seq_len * q_heads * head_dim);
+    k_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(k_cache),
+                         max_context * kv_heads * head_dim);
+    v_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(v_cache),
+                         max_context * kv_heads * head_dim);
+    out_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(out_rows),
+                           seq_len * q_heads * head_dim);
+
+    const uint32_t total = seq_len * q_heads;
+    const uint32_t repeat = q_heads / kv_heads;
+    for (uint32_t work = AscendC::GetBlockIdx(); work < total;
+         work += AscendC::GetBlockNum()) {
+        const uint32_t row = work / q_heads;
+        const uint32_t head = work % q_heads;
+        const uint32_t kv_head = head / repeat;
+        const uint32_t q_offset = (row * q_heads + head) * head_dim;
+        const uint32_t context_len = position_offset + row + 1;
+
+        float maximum = -3.402823466e+38F;
+        for (uint32_t pos = 0; pos < context_len; ++pos) {
+            const uint32_t cache_offset = (pos * kv_heads + kv_head) * head_dim;
+            const float score = dot_query_key(q_gm, k_gm, q_offset, cache_offset,
+                                              head_dim) * scale;
+            if (score > maximum) maximum = score;
+        }
+
+        float denominator = 0.0f;
+        for (uint32_t d = 0; d < head_dim; ++d) {
+            float value = 0.0f;
+            for (uint32_t pos = 0; pos < context_len; ++pos) {
+                const uint32_t cache_offset = (pos * kv_heads + kv_head) * head_dim;
+                const float score = dot_query_key(q_gm, k_gm, q_offset,
+                                                  cache_offset, head_dim) * scale;
+                const float probability = exp_score(exp_tile, score - maximum);
+                denominator += (d == 0 ? probability : 0.0f);
+                value += probability * half_value(v_gm, cache_offset + d);
+            }
+            set_half(out_gm, q_offset + d,
+                     denominator > 0.0f ? value / denominator : 0.0f);
+        }
+    }
+}
+
+// Verify split + merge. One block owns a (row, query-head) output and fills all
+// split partials in the caller-provided [rows,q_heads,splits,head_dim+2] plane.
+extern "C" __global__ __aicore__ void qwen_gqa_verify_attention_kernel(
+    GM_ADDR q_rows, GM_ADDR k_cache, GM_ADDR v_cache, GM_ADDR out_rows,
+    GM_ADDR partial_scratch, uint32_t rows, uint32_t q_heads, uint32_t kv_heads,
+    uint32_t head_dim, uint32_t position_offset, uint32_t max_context,
+    uint32_t splits, float scale) {
+    AscendC::TPipe pipe;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> exp_buf;
+    pipe.InitBuffer(exp_buf, kAlignFloat * sizeof(float));
+    AscendC::LocalTensor<float> exp_tile = exp_buf.Get<float>();
+
+    AscendC::GlobalTensor<half> q_gm;
+    AscendC::GlobalTensor<half> k_gm;
+    AscendC::GlobalTensor<half> v_gm;
+    AscendC::GlobalTensor<half> out_gm;
+    AscendC::GlobalTensor<float> partial;
+    q_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(q_rows),
+                         rows * q_heads * head_dim);
+    k_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(k_cache),
+                         max_context * kv_heads * head_dim);
+    v_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(v_cache),
+                         max_context * kv_heads * head_dim);
+    out_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(out_rows),
+                           rows * q_heads * head_dim);
+    partial.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(partial_scratch),
+                            rows * q_heads * splits * (head_dim + 2));
+
+    const uint32_t total = rows * q_heads;
+    const uint32_t repeat = q_heads / kv_heads;
+    const uint32_t context_len = position_offset + rows;
+    const uint32_t positions_per_split =
+        (context_len + splits - 1) / splits;
+
+    for (uint32_t work = AscendC::GetBlockIdx(); work < total;
+         work += AscendC::GetBlockNum()) {
+        const uint32_t row = work / q_heads;
+        const uint32_t head = work % q_heads;
+        const uint32_t kv_head = head / repeat;
+        const uint32_t q_offset = (row * q_heads + head) * head_dim;
+        const uint32_t context_limit = position_offset + row + 1;
+        const uint32_t output_base = (row * q_heads + head) *
+                                     splits * (head_dim + 2);
+
+        for (uint32_t split = 0; split < splits; ++split) {
+            const uint32_t split_start = split * positions_per_split;
+            const uint32_t split_end =
+                min_u32(context_len, split_start + positions_per_split);
+            const uint32_t begin = split_start;
+            const uint32_t end = min_u32(split_end, context_limit);
+            const uint32_t base = output_base + split * (head_dim + 2);
+            float maximum = -3.402823466e+38F;
+            if (begin < end) {
+                for (uint32_t pos = begin; pos < end; ++pos) {
+                    const uint32_t cache_offset = (pos * kv_heads + kv_head) * head_dim;
+                    const float score = dot_query_key(q_gm, k_gm, q_offset,
+                                                      cache_offset, head_dim) * scale;
+                    if (score > maximum) maximum = score;
+                }
+            }
+            partial.SetValue(base, maximum);
+            if (begin >= end) {
+                partial.SetValue(base + 1, 0.0f);
+                for (uint32_t d = 0; d < head_dim; ++d) partial.SetValue(base + 2 + d, 0.0f);
+                continue;
+            }
+
+            float denominator = 0.0f;
+            for (uint32_t pos = begin; pos < end; ++pos) {
+                const uint32_t cache_offset = (pos * kv_heads + kv_head) * head_dim;
+                const float score = dot_query_key(q_gm, k_gm, q_offset,
+                                                  cache_offset, head_dim) * scale;
+                denominator += exp_score(exp_tile, score - maximum);
+            }
+            partial.SetValue(base + 1, denominator);
+            for (uint32_t d = 0; d < head_dim; ++d) {
+                float value = 0.0f;
+                for (uint32_t pos = begin; pos < end; ++pos) {
+                    const uint32_t cache_offset = (pos * kv_heads + kv_head) * head_dim;
+                    const float score = dot_query_key(q_gm, k_gm, q_offset,
+                                                      cache_offset, head_dim) * scale;
+                    value += exp_score(exp_tile, score - maximum) *
+                             half_value(v_gm, cache_offset + d);
+                }
+                partial.SetValue(base + 2 + d, value);
+            }
+        }
+
+        float global_max = -3.402823466e+38F;
+        for (uint32_t split = 0; split < splits; ++split) {
+            const uint32_t base = output_base + split * (head_dim + 2);
+            const float maximum = partial.GetValue(base);
+            if (maximum > global_max) global_max = maximum;
+        }
+        float denominator = 0.0f;
+        for (uint32_t split = 0; split < splits; ++split) {
+            const uint32_t base = output_base + split * (head_dim + 2);
+            const float maximum = partial.GetValue(base);
+            const float weight = maximum == -3.402823466e+38F
+                ? 0.0f : exp_score(exp_tile, maximum - global_max);
+            denominator += weight * partial.GetValue(base + 1);
+        }
+        for (uint32_t d = 0; d < head_dim; ++d) {
+            float value = 0.0f;
+            for (uint32_t split = 0; split < splits; ++split) {
+                const uint32_t base = output_base + split * (head_dim + 2);
+                const float maximum = partial.GetValue(base);
+                const float weight = maximum == -3.402823466e+38F
+                    ? 0.0f : exp_score(exp_tile, maximum - global_max);
+                value += weight * partial.GetValue(base + 2 + d);
+            }
+            set_half(out_gm, q_offset + d,
+                     denominator > 0.0f ? value / denominator : 0.0f);
+        }
+    }
+}

--- a/cpp_engine/backends/ascend/kernels/qwen_gated_delta_f16.cpp
+++ b/cpp_engine/backends/ascend/kernels/qwen_gated_delta_f16.cpp
@@ -1,0 +1,429 @@
+// AscendC gated-delta recurrence for first-generation 910.
+//
+// The recurrence, per head, per token, over a [key_dim, value_dim] FP32 state S,
+// a normalized key row k, a normalized query row q, a value row v, a decay scalar
+// and a beta scalar:
+//
+//     S       <- S * decay                      (elementwise, whole matrix)
+//     kv_mem  <- k^T S                          (row vector, value_dim wide)
+//     delta   <- (v - kv_mem) * beta            (row vector)
+//     S       <- S + k delta^T                  (rank-1 update)
+//     out     <- q^T S * q_scale                (row vector)
+//
+// Why this maps onto the vector unit the way it does:
+//
+//   - One head per core iteration, not one value column per core. A head's state is
+//     128*128 FP32 = 64 KiB, which fits UB (256 KiB) alongside the row buffers, so
+//     the whole recurrence runs out of UB with two GM touches per head: load the
+//     state once, store it once. Splitting a head across cores would mean either
+//     re-reading the state per token or a cross-core reduction for kv_mem, and this
+//     part has no separate vector cores to win that back.
+//   - `k^T S` and `q^T S` are reductions down the key axis, i.e. across rows of the
+//     state tile. Broadcasting the key scalar over a value-wide row and folding rows
+//     pairwise keeps every instruction a full-width vadd/vmul. The alternative,
+//     one dot product per value column, is 128 narrow reductions.
+//   - The rank-1 update is `Axpy` per key row: S[i,:] += delta * k[i], which is
+//     exactly dst = src*scalar + dst.
+//
+// Numerical order differs from the CUDA kernel: CUDA accumulates kv_mem as a scalar
+// sequential sum down the key axis, this folds pairwise in a tree. Both are FP32,
+// neither is "the" reference, so the tests compare against a double-precision host
+// reference with a tolerance that covers both.
+//
+// The state is fp32 and stays fp32 the whole way through; only q/k/v/out are fp16.
+
+#include "qwen_ascend_kernel_common.hpp"
+
+namespace {
+
+using namespace pocket;
+
+// Qwen3.5's linear-attention head geometry. Both are 128, and the host rejects
+// anything else, so they are compile-time constants: the state tile size, the
+// number of Axpy rows and the fold depth all depend on them.
+constexpr uint32_t kKeyDim = 128;
+constexpr uint32_t kValueDim = 128;
+constexpr uint32_t kStateElems = kKeyDim * kValueDim;
+
+// Rows are folded pairwise, so the fold works on a power-of-two row count. 128 is
+// already one.
+constexpr uint32_t kFoldRows = kKeyDim;
+
+// One head's working set in UB:
+//   state      64 KiB   [kKeyDim, kValueDim] fp32
+//   scratch    64 KiB   broadcast/fold workspace, same shape
+//   rows        3 KiB   q, k (fp32, kKeyDim) and v, out, kv_mem, delta (fp32, kValueDim)
+//   halves      1 KiB   fp16 staging for v and out
+// which leaves better than half of UB free.
+class GatedDeltaHead {
+public:
+    __aicore__ inline void Init(AscendC::TPipe& pipe) {
+        pipe.InitBuffer(state_buf_, kStateElems * sizeof(float));
+        pipe.InitBuffer(scratch_buf_, kStateElems * sizeof(float));
+        pipe.InitBuffer(q_buf_, kKeyDim * sizeof(float));
+        pipe.InitBuffer(k_buf_, kKeyDim * sizeof(float));
+        pipe.InitBuffer(v_buf_, kValueDim * sizeof(float));
+        pipe.InitBuffer(acc_buf_, kValueDim * sizeof(float));
+        pipe.InitBuffer(half_buf_, kValueDim * sizeof(half));
+        pipe.InitBuffer(aux_buf_, kAlignFloat * sizeof(float));
+    }
+
+    // Load S for this head. State layout is [heads, key_dim, value_dim], so a head's
+    // slice is contiguous.
+    __aicore__ inline void LoadState(const AscendC::GlobalTensor<float>& state,
+                                     uint32_t head) {
+        AscendC::LocalTensor<float> st = state_buf_.Get<float>();
+        AscendC::DataCopy(st, state[head * kStateElems], kStateElems);
+        wait_load_before_compute();
+    }
+
+    __aicore__ inline void StoreState(const AscendC::GlobalTensor<float>& state,
+                                      uint32_t head) {
+        AscendC::LocalTensor<float> st = state_buf_.Get<float>();
+        wait_compute_before_store();
+        AscendC::DataCopy(state[head * kStateElems], st, kStateElems);
+    }
+
+    // Pull an fp32 key or query row straight out of a normalized GM buffer.
+    __aicore__ inline void LoadKeyRow(const AscendC::LocalTensor<float>& dst,
+                                      const AscendC::GlobalTensor<float>& src,
+                                      uint32_t offset) {
+        AscendC::DataCopy(dst, src[offset], kKeyDim);
+        wait_load_before_compute();
+    }
+
+    // Pull an fp16 row and widen it. Used for v, and for q/k on the unnormalized
+    // entry point.
+    __aicore__ inline void LoadHalfRow(const AscendC::LocalTensor<float>& dst,
+                                       const AscendC::GlobalTensor<half>& src,
+                                       uint32_t offset, uint32_t count) {
+        AscendC::LocalTensor<half> staging = half_buf_.Get<half>();
+        AscendC::DataCopy(staging, src[offset], count);
+        wait_load_before_compute();
+        AscendC::Cast(dst, staging, AscendC::RoundMode::CAST_NONE, count);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    // L2-normalize a row in place, matching the CUDA kernel's rsqrt(sum + 1e-6).
+    //
+    // The reciprocal square root is taken as a scalar `1/sqrt(x)`: scalar sqrt and
+    // scalar division are both exact here, whereas vector Rsqrt is a ~3e-3
+    // approximation that would show up directly in the output.
+    __aicore__ inline void NormalizeRow(const AscendC::LocalTensor<float>& row) {
+        AscendC::LocalTensor<float> work = scratch_buf_.Get<float>();
+        AscendC::Mul(work, row, row, kKeyDim);
+        const float sum = fold_sum(work, kKeyDim);
+        const float inv = 1.0f / sqrt(sum + 1.0e-6f);
+        wait_scalar_before_compute();
+        AscendC::Muls(row, row, inv, kKeyDim);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    // One token of the recurrence. `q` and `k` are already normalized fp32 rows,
+    // `v` an fp32 row, and the result lands back in `v`'s buffer scaled by q_scale.
+    __aicore__ inline void Step(const AscendC::LocalTensor<float>& q,
+                                const AscendC::LocalTensor<float>& k,
+                                const AscendC::LocalTensor<float>& v,
+                                float decay, float beta, float q_scale) {
+        AscendC::LocalTensor<float> st = state_buf_.Get<float>();
+        AscendC::LocalTensor<float> work = scratch_buf_.Get<float>();
+        AscendC::LocalTensor<float> acc = acc_buf_.Get<float>();
+
+        // S *= decay
+        AscendC::Muls(st, st, decay, kStateElems);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        // kv_mem = k^T S, as a row-wise fold of S scaled by broadcast k.
+        broadcast_rows(work, k, kKeyDim, kValueDim);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Mul(work, work, st, kStateElems);
+        AscendC::PipeBarrier<PIPE_V>();
+        fold_rows(work, kFoldRows, kValueDim);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        // delta = (v - kv_mem) * beta, held in acc.
+        AscendC::Muls(acc, work, -1.0f, kValueDim);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Add(acc, acc, v, kValueDim);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Muls(acc, acc, beta, kValueDim);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        // S += k delta^T, one Axpy per key row. Distinct dst rows, so the only
+        // barrier needed is the one before the next read of S.
+        for (uint32_t i = 0; i < kKeyDim; ++i) {
+            AscendC::Axpy(st[i * kValueDim], acc, k.GetValue(i), kValueDim);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+
+        // out = q^T S * q_scale, same fold as kv_mem.
+        broadcast_rows(work, q, kKeyDim, kValueDim);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Mul(work, work, st, kStateElems);
+        AscendC::PipeBarrier<PIPE_V>();
+        fold_rows(work, kFoldRows, kValueDim);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Muls(v, work, q_scale, kValueDim);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    // Narrow an fp32 result row to fp16 and store it.
+    __aicore__ inline void StoreHalfRow(const AscendC::GlobalTensor<half>& dst,
+                                        const AscendC::LocalTensor<float>& src,
+                                        uint32_t offset, uint32_t count) {
+        AscendC::LocalTensor<half> staging = half_buf_.Get<half>();
+        AscendC::Cast(staging, src, AscendC::RoundMode::CAST_NONE, count);
+        wait_compute_before_store();
+        AscendC::DataCopy(dst[offset], staging, count);
+        wait_store_before_load();
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float> Query() { return q_buf_.Get<float>(); }
+    __aicore__ inline AscendC::LocalTensor<float> Key() { return k_buf_.Get<float>(); }
+    __aicore__ inline AscendC::LocalTensor<float> Value() { return v_buf_.Get<float>(); }
+    __aicore__ inline AscendC::LocalTensor<float> Aux() { return aux_buf_.Get<float>(); }
+
+private:
+    AscendC::TBuf<AscendC::TPosition::VECCALC> state_buf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> scratch_buf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> q_buf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> k_buf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> v_buf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> acc_buf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> half_buf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> aux_buf_;
+};
+
+// Per-token gate scalars. g and beta are [rows, heads] fp16; a head walks a column
+// of stride `heads`, so reading them as a scalar per token beats staging a tile.
+// decay = exp(g), and exp is vector-only on this part, so it goes through an 8-lane
+// tile once per token.
+struct Gates {
+    __aicore__ inline void Read(GatedDeltaHead& head,
+                                const AscendC::GlobalTensor<half>& g,
+                                const AscendC::GlobalTensor<half>& beta,
+                                uint32_t index) {
+        const float g_value = static_cast<float>(g.GetValue(index));
+        beta_value = static_cast<float>(beta.GetValue(index));
+        decay = scalar_exp(head.Aux(), g_value);
+    }
+
+    float decay;
+    float beta_value;
+};
+
+}  // namespace
+
+// Whole-sequence recurrence over pre-normalized fp32 q/k.
+//
+// One head per core iteration, round-robin over the 30 cores. Heads are independent,
+// so there is no cross-core communication at all; tokens inside a head are strictly
+// sequential, which is what forces the loop to live on one core.
+extern "C" __global__ __aicore__ void qwen_gated_delta_sequence_normalized_kernel(
+    GM_ADDR state, GM_ADDR q_normalized, GM_ADDR k_normalized, GM_ADDR v,
+    GM_ADDR g, GM_ADDR beta, GM_ADDR out, uint32_t rows, uint32_t heads,
+    uint32_t key_heads, float q_scale) {
+    AscendC::TPipe pipe;
+    GatedDeltaHead worker;
+    worker.Init(pipe);
+
+    AscendC::GlobalTensor<float> state_gm;
+    AscendC::GlobalTensor<float> q_gm;
+    AscendC::GlobalTensor<float> k_gm;
+    AscendC::GlobalTensor<half> v_gm;
+    AscendC::GlobalTensor<half> g_gm;
+    AscendC::GlobalTensor<half> beta_gm;
+    AscendC::GlobalTensor<half> out_gm;
+    state_gm.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(state), heads * kStateElems);
+    q_gm.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(q_normalized), rows * key_heads * kKeyDim);
+    k_gm.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(k_normalized), rows * key_heads * kKeyDim);
+    v_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(v), rows * heads * kValueDim);
+    g_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(g), rows * heads);
+    beta_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(beta), rows * heads);
+    out_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(out), rows * heads * kValueDim);
+
+    const uint32_t repeat = heads / key_heads;
+    const uint32_t key_stride = key_heads * kKeyDim;
+
+    for (uint32_t head = AscendC::GetBlockIdx(); head < heads;
+         head += AscendC::GetBlockNum()) {
+        const uint32_t key_head = head / repeat;
+        worker.LoadState(state_gm, head);
+        for (uint32_t token = 0; token < rows; ++token) {
+            const uint32_t key_offset = token * key_stride + key_head * kKeyDim;
+            const uint32_t value_offset = (token * heads + head) * kValueDim;
+            AscendC::LocalTensor<float> q = worker.Query();
+            AscendC::LocalTensor<float> k = worker.Key();
+            AscendC::LocalTensor<float> v = worker.Value();
+            worker.LoadKeyRow(q, q_gm, key_offset);
+            worker.LoadKeyRow(k, k_gm, key_offset);
+            worker.LoadHalfRow(v, v_gm, value_offset, kValueDim);
+            Gates gates;
+            gates.Read(worker, g_gm, beta_gm, token * heads + head);
+            worker.Step(q, k, v, gates.decay, gates.beta_value, q_scale);
+            worker.StoreHalfRow(out_gm, v, value_offset, kValueDim);
+        }
+        worker.StoreState(state_gm, head);
+    }
+}
+
+// Whole-sequence recurrence over raw fp16 q/k, normalizing each row on the fly.
+//
+// Same kernel as above with the normalization folded in. It exists because the
+// engine's default path (and every rows == 1 decode step) takes this entry point
+// without a separate normalization pass.
+extern "C" __global__ __aicore__ void qwen_gated_delta_sequence_kernel(
+    GM_ADDR state, GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR beta,
+    GM_ADDR out, uint32_t rows, uint32_t heads, uint32_t key_heads,
+    float q_scale) {
+    AscendC::TPipe pipe;
+    GatedDeltaHead worker;
+    worker.Init(pipe);
+
+    AscendC::GlobalTensor<float> state_gm;
+    AscendC::GlobalTensor<half> q_gm;
+    AscendC::GlobalTensor<half> k_gm;
+    AscendC::GlobalTensor<half> v_gm;
+    AscendC::GlobalTensor<half> g_gm;
+    AscendC::GlobalTensor<half> beta_gm;
+    AscendC::GlobalTensor<half> out_gm;
+    state_gm.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(state), heads * kStateElems);
+    q_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(q), rows * key_heads * kKeyDim);
+    k_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(k), rows * key_heads * kKeyDim);
+    v_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(v), rows * heads * kValueDim);
+    g_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(g), rows * heads);
+    beta_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(beta), rows * heads);
+    out_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(out), rows * heads * kValueDim);
+
+    const uint32_t repeat = heads / key_heads;
+    const uint32_t key_stride = key_heads * kKeyDim;
+
+    for (uint32_t head = AscendC::GetBlockIdx(); head < heads;
+         head += AscendC::GetBlockNum()) {
+        const uint32_t key_head = head / repeat;
+        worker.LoadState(state_gm, head);
+        for (uint32_t token = 0; token < rows; ++token) {
+            const uint32_t key_offset = token * key_stride + key_head * kKeyDim;
+            const uint32_t value_offset = (token * heads + head) * kValueDim;
+            AscendC::LocalTensor<float> q = worker.Query();
+            AscendC::LocalTensor<float> k = worker.Key();
+            AscendC::LocalTensor<float> v = worker.Value();
+            worker.LoadHalfRow(q, q_gm, key_offset, kKeyDim);
+            worker.NormalizeRow(q);
+            worker.LoadHalfRow(k, k_gm, key_offset, kKeyDim);
+            worker.NormalizeRow(k);
+            worker.LoadHalfRow(v, v_gm, value_offset, kValueDim);
+            Gates gates;
+            gates.Read(worker, g_gm, beta_gm, token * heads + head);
+            worker.Step(q, k, v, gates.decay, gates.beta_value, q_scale);
+            worker.StoreHalfRow(out_gm, v, value_offset, kValueDim);
+        }
+        worker.StoreState(state_gm, head);
+    }
+}
+
+// Single-token step. The gate, q, k and v buffers hold exactly one row, so the
+// indexing loses its token term; the recurrence itself is identical.
+extern "C" __global__ __aicore__ void qwen_gated_delta_step_kernel(
+    GM_ADDR state, GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR g, GM_ADDR beta,
+    GM_ADDR out, uint32_t heads, uint32_t key_heads, float q_scale) {
+    AscendC::TPipe pipe;
+    GatedDeltaHead worker;
+    worker.Init(pipe);
+
+    AscendC::GlobalTensor<float> state_gm;
+    AscendC::GlobalTensor<half> q_gm;
+    AscendC::GlobalTensor<half> k_gm;
+    AscendC::GlobalTensor<half> v_gm;
+    AscendC::GlobalTensor<half> g_gm;
+    AscendC::GlobalTensor<half> beta_gm;
+    AscendC::GlobalTensor<half> out_gm;
+    state_gm.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(state), heads * kStateElems);
+    q_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(q), key_heads * kKeyDim);
+    k_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(k), key_heads * kKeyDim);
+    v_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(v), heads * kValueDim);
+    g_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(g), heads);
+    beta_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(beta), heads);
+    out_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(out), heads * kValueDim);
+
+    const uint32_t repeat = heads / key_heads;
+
+    for (uint32_t head = AscendC::GetBlockIdx(); head < heads;
+         head += AscendC::GetBlockNum()) {
+        const uint32_t key_head = head / repeat;
+        AscendC::LocalTensor<float> q = worker.Query();
+        AscendC::LocalTensor<float> k = worker.Key();
+        AscendC::LocalTensor<float> v = worker.Value();
+        worker.LoadState(state_gm, head);
+        worker.LoadHalfRow(q, q_gm, key_head * kKeyDim, kKeyDim);
+        worker.NormalizeRow(q);
+        worker.LoadHalfRow(k, k_gm, key_head * kKeyDim, kKeyDim);
+        worker.NormalizeRow(k);
+        worker.LoadHalfRow(v, v_gm, head * kValueDim, kValueDim);
+        Gates gates;
+        gates.Read(worker, g_gm, beta_gm, head);
+        worker.Step(q, k, v, gates.decay, gates.beta_value, q_scale);
+        worker.StoreHalfRow(out_gm, v, head * kValueDim, kValueDim);
+        worker.StoreState(state_gm, head);
+    }
+}
+
+// Q/K L2 normalization on its own, fp16 in and fp32 out.
+//
+// Work is distributed over (token, key_head) pairs rather than tokens, so a decode
+// step with rows == 1 still spreads across cores.
+extern "C" __global__ __aicore__ void qwen_normalize_gated_delta_qk_kernel(
+    GM_ADDR q, GM_ADDR k, GM_ADDR q_normalized, GM_ADDR k_normalized,
+    uint32_t rows, uint32_t key_heads) {
+    AscendC::TPipe pipe;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> half_buf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> row_buf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> work_buf;
+    pipe.InitBuffer(half_buf, kKeyDim * sizeof(half));
+    pipe.InitBuffer(row_buf, kKeyDim * sizeof(float));
+    pipe.InitBuffer(work_buf, kKeyDim * sizeof(float));
+
+    const uint32_t total = rows * key_heads * kKeyDim;
+    AscendC::GlobalTensor<half> q_gm;
+    AscendC::GlobalTensor<half> k_gm;
+    AscendC::GlobalTensor<float> q_out;
+    AscendC::GlobalTensor<float> k_out;
+    q_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(q), total);
+    k_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(k), total);
+    q_out.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(q_normalized), total);
+    k_out.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(k_normalized), total);
+
+    AscendC::LocalTensor<half> staging = half_buf.Get<half>();
+    AscendC::LocalTensor<float> row = row_buf.Get<float>();
+    AscendC::LocalTensor<float> work = work_buf.Get<float>();
+
+    const uint32_t pairs = rows * key_heads;
+    for (uint32_t pair = AscendC::GetBlockIdx(); pair < pairs;
+         pair += AscendC::GetBlockNum()) {
+        const uint32_t offset = pair * kKeyDim;
+        // Q then K through the same buffers: the loads are independent but the
+        // buffers are not, so each pass ends with its store drained.
+        for (uint32_t which = 0; which < 2; ++which) {
+            if (which == 0) {
+                AscendC::DataCopy(staging, q_gm[offset], kKeyDim);
+            } else {
+                AscendC::DataCopy(staging, k_gm[offset], kKeyDim);
+            }
+            wait_load_before_compute();
+            AscendC::Cast(row, staging, AscendC::RoundMode::CAST_NONE, kKeyDim);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Mul(work, row, row, kKeyDim);
+            const float sum = fold_sum(work, kKeyDim);
+            const float inv = 1.0f / sqrt(sum + 1.0e-6f);
+            wait_scalar_before_compute();
+            AscendC::Muls(row, row, inv, kKeyDim);
+            wait_compute_before_store();
+            if (which == 0) {
+                AscendC::DataCopy(q_out[offset], row, kKeyDim);
+            } else {
+                AscendC::DataCopy(k_out[offset], row, kKeyDim);
+            }
+            wait_store_before_load();
+        }
+    }
+}

--- a/cpp_engine/backends/ascend/kernels/qwen_linear_f16.cpp
+++ b/cpp_engine/backends/ascend/kernels/qwen_linear_f16.cpp
@@ -1,0 +1,344 @@
+// AscendC linear-attention support kernels for first-generation 910: the gate
+// projection and the causal depthwise convolution with SiLU.
+
+#include "qwen_ascend_kernel_common.hpp"
+
+namespace {
+
+using namespace pocket;
+
+// Tile width for the elementwise gate math. 512 floats keeps every vector op at
+// full width while leaving room for the six live buffers.
+constexpr uint32_t kGateTile = 512;
+
+// Largest convolution kernel the tail buffer supports, matching kMaxTail on the
+// CUDA side.
+constexpr uint32_t kMaxKernel = 8;
+
+// Channel tile for the convolution. Each of the kernel's taps needs its own
+// float row, so kMaxKernel * kConvTile floats is the working set: 8 * 512 * 4 =
+// 16 KiB.
+constexpr uint32_t kConvTile = 512;
+
+// Above this input, softplus(x) and x agree to better than one FP32 ulp, because
+// exp(-x) < 2^-24. It is also far below where exp(x) overflows, which is what makes
+// the clamp below sufficient rather than merely helpful.
+constexpr float kSoftplusLinear = 20.0f;
+
+// softplus(x) = log1p(exp(x)), built from the two vector transcendentals that do
+// exist. Both Exp and Ln are near-exact here (~6e-8), so this is as accurate as the
+// CUDA log1pf for the magnitudes the gates see; log1p's advantage only shows for
+// exp(x) very close to zero, where g is dominated by -exp(a_log) anyway.
+//
+// The clamp is not optional. exp(x) overflows to inf above x = 88, and Ln(inf) is
+// inf, so an unclamped version returns inf for large positive x where the right
+// answer is x itself. Real dt_bias + a values do reach that range. The clamp caps
+// the exp argument and Max restores the identity branch afterwards, so both halves
+// of the domain come out of the same vector ops with no divergence. `work` is
+// clobbered.
+//
+// The clamp is a Duplicate plus a tensor-tensor Min rather than the one-instruction
+// `Mins`. First-generation 910 has no vmins/vmaxs: `Ascend910B.ini` lists
+// `Intrinsic_vmin` and `Intrinsic_vmax` but no scalar-operand form, and dav_c100
+// implements Mins/Maxs as ASCENDC_REPORT_NOT_SUPPORT stubs. Those stubs compile and
+// launch; they simply do not write `dst`, so the clamped value silently stays
+// whatever the buffer held before.
+__aicore__ inline void softplus(const AscendC::LocalTensor<float>& dst,
+                                const AscendC::LocalTensor<float>& src,
+                                const AscendC::LocalTensor<float>& work,
+                                uint32_t count) {
+    AscendC::Duplicate(work, kSoftplusLinear, count);
+    AscendC::PipeBarrier<PIPE_V>();
+    AscendC::Min(work, src, work, count);
+    AscendC::PipeBarrier<PIPE_V>();
+    AscendC::Exp(dst, work, count);
+    AscendC::PipeBarrier<PIPE_V>();
+    AscendC::Adds(dst, dst, 1.0f, count);
+    AscendC::PipeBarrier<PIPE_V>();
+    AscendC::Ln(dst, dst, count);
+    AscendC::PipeBarrier<PIPE_V>();
+    // For x <= kSoftplusLinear the Ln result already dominates x; above it the Ln
+    // result is the saturated constant and x is the answer.
+    AscendC::Max(dst, dst, src, count);
+    AscendC::PipeBarrier<PIPE_V>();
+}
+
+// sigmoid(x) = 1/(1 + exp(-x)).
+//
+// The reciprocal is a vector Reciprocal, which is only ~2e-3 accurate on this part.
+// That is acceptable here and nowhere else in this file: beta is immediately rounded
+// to fp16, whose own spacing near 1.0 is 4.9e-4, so a Newton step would buy less
+// than half a bit of the stored result.
+__aicore__ inline void sigmoid(const AscendC::LocalTensor<float>& dst,
+                               const AscendC::LocalTensor<float>& src,
+                               uint32_t count) {
+    AscendC::Muls(dst, src, -1.0f, count);
+    AscendC::PipeBarrier<PIPE_V>();
+    AscendC::Exp(dst, dst, count);
+    AscendC::PipeBarrier<PIPE_V>();
+    AscendC::Adds(dst, dst, 1.0f, count);
+    AscendC::PipeBarrier<PIPE_V>();
+    AscendC::Reciprocal(dst, dst, count);
+    AscendC::PipeBarrier<PIPE_V>();
+}
+
+// SiLU(x) = x * sigmoid(x). Same reciprocal argument as above: the result is stored
+// as fp16.
+__aicore__ inline void silu(const AscendC::LocalTensor<float>& dst,
+                            const AscendC::LocalTensor<float>& src,
+                            const AscendC::LocalTensor<float>& work,
+                            uint32_t count) {
+    sigmoid(work, src, count);
+    AscendC::Mul(dst, src, work, count);
+    AscendC::PipeBarrier<PIPE_V>();
+}
+
+}  // namespace
+
+// Gate projection: g = -exp(a_log[head]) * softplus(a + dt_bias[head]),
+// beta = sigmoid(b), over an [rows, heads] pair of fp16 planes.
+//
+// a_log and dt_bias are per-head, so a head's whole column shares two scalars. But
+// the natural tiling is the other way round: a and b are row-major [rows, heads], so
+// a contiguous tile spans heads, not rows. Rather than gather a strided column, this
+// walks contiguous tiles of the flat [rows*heads] plane and builds a per-lane
+// broadcast of the two head parameters once, since head = index % heads is periodic
+// with period `heads` and every tile is a whole number of head groups when
+// kGateTile is a multiple of heads. It is not in general, so the broadcast is
+// rebuilt per tile from the head index of each lane; `heads` is 32 or 64 in
+// practice, so that is at most kGateTile/heads Duplicates.
+extern "C" __global__ __aicore__ void qwen_linear_attn_gates_kernel(
+    GM_ADDR a, GM_ADDR b, GM_ADDR a_log, GM_ADDR dt_bias, GM_ADDR g,
+    GM_ADDR beta, uint32_t rows, uint32_t heads) {
+    AscendC::TPipe pipe;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> half_buf, val_buf, par_buf, work_buf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> head_half_buf, head_float_buf;
+    pipe.InitBuffer(half_buf, kGateTile * sizeof(half));
+    pipe.InitBuffer(val_buf, kGateTile * sizeof(float));
+    pipe.InitBuffer(par_buf, kGateTile * sizeof(float));
+    pipe.InitBuffer(work_buf, kGateTile * sizeof(float));
+    pipe.InitBuffer(head_half_buf, kGateTile * sizeof(half));
+    pipe.InitBuffer(head_float_buf, kGateTile * sizeof(float));
+
+    const uint32_t total = rows * heads;
+    AscendC::GlobalTensor<half> a_gm, b_gm, a_log_gm, dt_gm, g_gm, beta_gm;
+    a_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(a), total);
+    b_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(b), total);
+    a_log_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(a_log), heads);
+    dt_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(dt_bias), heads);
+    g_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(g), total);
+    beta_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(beta), total);
+
+    AscendC::LocalTensor<half> staging = half_buf.Get<half>();
+    AscendC::LocalTensor<float> value = val_buf.Get<float>();
+    AscendC::LocalTensor<float> param = par_buf.Get<float>();
+    AscendC::LocalTensor<float> work = work_buf.Get<float>();
+    AscendC::LocalTensor<half> head_staging = head_half_buf.Get<half>();
+    AscendC::LocalTensor<float> head_values = head_float_buf.Get<float>();
+
+    const uint32_t tiles = (total + kGateTile - 1) / kGateTile;
+    for (uint32_t tile = AscendC::GetBlockIdx(); tile < tiles;
+         tile += AscendC::GetBlockNum()) {
+        const uint32_t offset = tile * kGateTile;
+        const uint32_t count = min_u32(kGateTile, total - offset);
+        const uint32_t vector_count = pocket_align_up(count, kAlignFloat);
+
+        // beta = sigmoid(b): no per-head parameter, so it goes first and frees the
+        // parameter buffer for the g pass. Vector instructions operate on a complete
+        // eight-float block; zero the padding so a partial final tile is still safe.
+        load_half_exact(staging, b_gm, offset, count);
+        for (uint32_t i = count; i < vector_count; ++i) staging.SetValue(i, 0);
+        wait_scalar_before_compute();
+        AscendC::Cast(value, staging, AscendC::RoundMode::CAST_NONE, vector_count);
+        AscendC::PipeBarrier<PIPE_V>();
+        sigmoid(work, value, vector_count);
+        AscendC::Cast(staging, work, AscendC::RoundMode::CAST_NONE, vector_count);
+        store_half_exact(beta_gm, offset, staging, count);
+        // `staging` is overwritten by the following MTE2 load. `work` is not the
+        // source of the MTE3 transfer, so only the staging-buffer lifetime matters.
+        wait_store_before_load();
+
+        // g = -exp(a_log) * softplus(a + dt_bias). Lay dt_bias out per lane, add,
+        // softplus, then scale by the per-lane -exp(a_log).
+        load_half_exact(staging, a_gm, offset, count);
+        for (uint32_t i = count; i < vector_count; ++i) staging.SetValue(i, 0);
+        wait_scalar_before_compute();
+        AscendC::Cast(value, staging, AscendC::RoundMode::CAST_NONE, vector_count);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        load_half_exact(head_staging, dt_gm, 0, heads);
+        AscendC::Cast(head_values, head_staging, AscendC::RoundMode::CAST_NONE, heads);
+        AscendC::PipeBarrier<PIPE_V>();
+        wait_compute_before_scalar();
+        for (uint32_t lane = 0; lane < count; ++lane) {
+            const uint32_t head = (offset + lane) % heads;
+            param.SetValue(lane, head_values.GetValue(head));
+        }
+        for (uint32_t lane = count; lane < vector_count; ++lane) {
+            param.SetValue(lane, 0.0f);
+        }
+        wait_scalar_before_compute();
+        AscendC::Add(value, value, param, vector_count);
+        AscendC::PipeBarrier<PIPE_V>();
+        // param is free again once the sum is in `value`, so it doubles as the
+        // softplus clamp scratch.
+        softplus(work, value, param, vector_count);
+
+        load_half_exact(head_staging, a_log_gm, 0, heads);
+        AscendC::Cast(head_values, head_staging, AscendC::RoundMode::CAST_NONE, heads);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Exp(head_values, head_values, heads);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Muls(head_values, head_values, -1.0f, heads);
+        AscendC::PipeBarrier<PIPE_V>();
+        wait_compute_before_scalar();
+        for (uint32_t lane = 0; lane < count; ++lane) {
+            const uint32_t head = (offset + lane) % heads;
+            param.SetValue(lane, head_values.GetValue(head));
+        }
+        for (uint32_t lane = count; lane < vector_count; ++lane) {
+            param.SetValue(lane, 0.0f);
+        }
+        wait_scalar_before_compute();
+        AscendC::Mul(work, work, param, vector_count);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Cast(staging, work, AscendC::RoundMode::CAST_NONE, vector_count);
+        store_half_exact(g_gm, offset, staging, count);
+        wait_store_before_load();
+    }
+}
+
+// Causal depthwise convolution followed by SiLU, over an [seq_len, channels] fp16
+// plane with a per-channel [channels, kernel] weight and a [kernel-1, channels]
+// carried tail.
+//
+// The convolution is depthwise, so channels are independent and the tiling is over
+// channel tiles: each core owns kConvTile channels for the whole sequence. That
+// keeps the tap rows contiguous in the channel axis, which is the axis the data is
+// contiguous in, so every load is a straight DataCopy and the accumulation is a
+// plain Axpy against a broadcast weight.
+//
+// The weight is [channels, kernel], i.e. the taps of one channel are contiguous and
+// the channels of one tap are strided. A tile therefore needs a per-lane gather of
+// `kernel` values, done on the scalar unit once per tile rather than once per token.
+extern "C" __global__ __aicore__ void qwen_causal_depthwise_conv_silu_kernel(
+    GM_ADDR x, GM_ADDR weight, GM_ADDR tail, GM_ADDR y, uint32_t seq_len,
+    uint32_t channels, uint32_t kernel, uint32_t update_tail) {
+    AscendC::TPipe pipe;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> half_buf, acc_buf, work_buf, tap_buf, w_buf;
+    pipe.InitBuffer(half_buf, kConvTile * sizeof(half));
+    pipe.InitBuffer(acc_buf, kConvTile * sizeof(float));
+    pipe.InitBuffer(work_buf, kConvTile * sizeof(float));
+    pipe.InitBuffer(tap_buf, kMaxKernel * kConvTile * sizeof(float));
+    pipe.InitBuffer(w_buf, kMaxKernel * kConvTile * sizeof(float));
+
+    const uint32_t tail_len = kernel - 1;
+    AscendC::GlobalTensor<half> x_gm, w_gm, tail_gm, y_gm;
+    x_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(x), seq_len * channels);
+    w_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(weight), channels * kernel);
+    y_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(y), seq_len * channels);
+    if (tail != nullptr) {
+        tail_gm.SetGlobalBuffer(reinterpret_cast<__gm__ half*>(tail),
+                                tail_len * channels);
+    }
+
+    AscendC::LocalTensor<half> staging = half_buf.Get<half>();
+    AscendC::LocalTensor<float> acc = acc_buf.Get<float>();
+    AscendC::LocalTensor<float> work = work_buf.Get<float>();
+    AscendC::LocalTensor<float> taps = tap_buf.Get<float>();
+    AscendC::LocalTensor<float> weights = w_buf.Get<float>();
+
+    const uint32_t tiles = (channels + kConvTile - 1) / kConvTile;
+    for (uint32_t tile = AscendC::GetBlockIdx(); tile < tiles;
+         tile += AscendC::GetBlockNum()) {
+        const uint32_t base = tile * kConvTile;
+        const uint32_t count = min_u32(kConvTile, channels - base);
+
+        // Gather this tile's weights: weights[tap * kConvTile + lane] is channel
+        // (base + lane)'s tap `tap`.
+        for (uint32_t lane = 0; lane < count; ++lane) {
+            for (uint32_t tap = 0; tap < kernel; ++tap) {
+                weights.SetValue(tap * kConvTile + lane,
+                                 static_cast<float>(w_gm.GetValue((base + lane) * kernel + tap)));
+            }
+        }
+        wait_scalar_before_compute();
+
+        // Prime the tap window with the carried tail: taps[j] holds the input at
+        // relative position j - tail_len, so the first token's window is exactly
+        // the tail followed by x[0].
+        //
+        // Every iteration reloads the same `staging` tile, so the Cast that drains it
+        // has to be fenced against the next load. load_half_exact only supplies the
+        // forward MTE2->V hand-off; without the V->MTE2 anti-dependency here, MTE2
+        // issues copy j+1 while Vector is still reading copy j, and every tap slot
+        // ends up holding the following row. That shifts the whole primed window by
+        // one and is wrong only for the first output token, which is the one token
+        // whose window is entirely made of primed slots.
+        for (uint32_t j = 0; j < tail_len; ++j) {
+            if (tail != nullptr) {
+                load_half_exact(staging, tail_gm, j * channels + base, count);
+                AscendC::Cast(taps[j * kConvTile], staging,
+                              AscendC::RoundMode::CAST_NONE, count);
+                AscendC::PipeBarrier<PIPE_V>();
+                wait_compute_before_load();
+            } else {
+                AscendC::Duplicate(taps[j * kConvTile], 0.0f, count);
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+        }
+
+        for (uint32_t t = 0; t < seq_len; ++t) {
+            // Slide the window: the newest sample takes the last tap slot.
+            load_half_exact(staging, x_gm, t * channels + base, count);
+            AscendC::Cast(taps[tail_len * kConvTile], staging,
+                          AscendC::RoundMode::CAST_NONE, count);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            // Accumulate the taps oldest-first, matching the CUDA loop order so the
+            // FP32 rounding sequence is the same.
+            AscendC::Mul(acc, taps, weights, count);
+            AscendC::PipeBarrier<PIPE_V>();
+            for (uint32_t tap = 1; tap < kernel; ++tap) {
+                AscendC::Mul(work, taps[tap * kConvTile], weights[tap * kConvTile],
+                             count);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Add(acc, acc, work, count);
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+
+            silu(acc, acc, work, count);
+            AscendC::Cast(staging, acc, AscendC::RoundMode::CAST_NONE, count);
+            store_half_exact(y_gm, t * channels + base, staging, count);
+            // The output transfer reads only `staging`, which the next iteration
+            // refills. The FP32 window and accumulation buffers are independent.
+            wait_store_before_load();
+
+            // Shift the window down one slot for the next token. The source and
+            // destination overlap, so this must use memmove semantics. DataCopy does
+            // not guarantee that: `Adds(dst, src, 0.0f)` calls MTE, whose direction
+            // is undefined when the tensors overlap. Per-element copying permits a
+            // newest-to-oldest ordering that avoids clobbering, but staging a whole
+            // row is simpler than three Adds calls.
+            for (uint32_t j = 0; j + 1 < kernel; ++j) {
+                AscendC::Adds(work, taps[(j + 1) * kConvTile], 0.0f, count);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Adds(taps[j * kConvTile], work, 0.0f, count);
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+        }
+
+        // The carried tail is the last tail_len inputs, which the window already
+        // holds in slots 1..kernel-1 after the final shift.
+        if (update_tail != 0 && tail != nullptr && tail_len > 0) {
+            for (uint32_t j = 0; j < tail_len; ++j) {
+                AscendC::Cast(staging, taps[j * kConvTile],
+                              AscendC::RoundMode::CAST_NONE, count);
+                store_half_exact(tail_gm, j * channels + base, staging, count);
+                // Next writer of `staging` is the following Cast, not a load, so the
+                // store has to drain against Vector rather than against MTE2.
+                wait_store_before_compute();
+            }
+        }
+    }
+}

--- a/cpp_engine/backends/ascend/runtime/device_runtime_ascend.cpp
+++ b/cpp_engine/backends/ascend/runtime/device_runtime_ascend.cpp
@@ -77,8 +77,20 @@ aclrtEvent as_event(void* event) {
     return static_cast<aclrtEvent>(event);
 }
 
+// The blocking copy, and the third structural difference from CUDA. Nothing
+// reports an error when this one is missed, which is what makes it expensive.
+//
+// cudaMemcpy is ordered against the null stream: it waits for previously issued
+// work before it touches memory. aclrtMemcpy blocks only the *host* -- it does
+// not join the default stream -- so a read issued straight after a kernel launch
+// returns whatever the buffer held before the kernel ran. Engine code is written
+// to the CUDA contract (launch, then copy the result out) throughout, so the
+// ordering is restored at this one point rather than by auditing every call site.
+// The _async variants keep ACL's semantics untouched, so a caller that manages
+// its own stream ordering pays nothing for this.
 bool copy(void* dst, const void* src, size_t bytes, aclrtMemcpyKind kind) {
     if (bytes == 0) return true;
+    if (aclrtSynchronizeStream(nullptr) != ACL_SUCCESS) return false;
     return aclrtMemcpy(dst, bytes, src, bytes, kind) == ACL_SUCCESS;
 }
 
@@ -211,6 +223,8 @@ namespace {
 bool copy_2d(void* dst, size_t dst_pitch, const void* src, size_t src_pitch,
              size_t width, size_t height, aclrtMemcpyKind kind) {
     if (width == 0 || height == 0) return true;
+    // Stream-ordered for the same reason `copy` above is; see the note there.
+    if (aclrtSynchronizeStream(nullptr) != ACL_SUCCESS) return false;
     return aclrtMemcpy2d(dst, dst_pitch, src, src_pitch, width, height, kind) ==
            ACL_SUCCESS;
 }
@@ -249,6 +263,9 @@ bool memcpy_2d_d2h(void* dst, size_t dst_pitch, const void* src, size_t src_pitc
 
 bool device_memset(void* dst, int value, size_t bytes) {
     if (bytes == 0) return true;
+    // cudaMemset is ordered against the null stream, so a caller may legitimately
+    // clear a buffer that queued work still reads. Same fence as `copy`.
+    if (aclrtSynchronizeStream(nullptr) != ACL_SUCCESS) return false;
     return aclrtMemset(dst, bytes, value, bytes) == ACL_SUCCESS;
 }
 

--- a/cpp_engine/engine/backend_unimplemented_ascend.cpp
+++ b/cpp_engine/engine/backend_unimplemented_ascend.cpp
@@ -1,0 +1,268 @@
+// Definitions that stand in for the CUDA-only engines on the Ascend backend.
+//
+// Three subsystems are still CUDA-only: the DeepSeek-V4 forward engine
+// (engine/dsv4_engine.cpp, which also owns PersistentEngine), the DSpark draft
+// engine (engine/dspark_engine.cpp), and the two Qwen external drafters
+// (engine/qwen_dspark.cpp, engine/qwen_dflash2.cpp). Together they name ~120
+// CUDA kernels directly, so they are excluded from the Ascend target rather than
+// guarded line by line.
+//
+// A runtime guard would not be enough: a CUDA symbol referenced from any object
+// in the link has to resolve even when its branch is unreachable. Excluding the
+// sources removes those references, and this translation unit supplies the
+// handful of definitions the surviving callers still need -- main.cpp and
+// core/openai_server.cpp for the DSV4 entry points, and engine/qwen_engine.cpp
+// for the drafter runtime methods its shared bookkeeping calls.
+//
+// Every entry point throws. None of them is reachable from the Qwen FP16 path
+// that this backend does implement: QwenEngine's constructor rejects a drafter
+// checkpoint before any runtime is built, and the DSV4 model is a different
+// architecture altogether.
+
+#include "dsv4_engine.hpp"
+#include "persistent_engine.hpp"
+#include "qwen_dflash2.hpp"
+#include "qwen_dspark.hpp"
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace dsv4 {
+namespace {
+
+[[noreturn]] void unimplemented(const char* what) {
+    throw std::runtime_error(
+        std::string(what) + " is not implemented on the Ascend backend");
+}
+
+}  // namespace
+
+// --- DeepSeek-V4 forward entry points ---------------------------------------
+//
+// Dsv4Engine itself only parses GGUF metadata on the host, so it keeps its real
+// behaviour; the forward entry points below are what need the device.
+
+Dsv4Engine::Dsv4Engine(const std::string& model_path)
+    : gguf_(model_path), config_(ModelConfig::from_gguf(gguf_)) {}
+
+ForwardSmokeResult run_safetensors_min_layer_smoke(const std::string&) {
+    unimplemented("DSV4 safetensors forward");
+}
+
+ForwardSmokeResult run_safetensors_layer_loop_smoke(const std::string&, int) {
+    unimplemented("DSV4 safetensors forward");
+}
+
+ForwardSmokeResult run_safetensors_token_forward(const std::string&, int, int) {
+    unimplemented("DSV4 safetensors forward");
+}
+
+ForwardSmokeResult run_safetensors_token_forward_at_position(
+    const std::string&, int, int, int) {
+    unimplemented("DSV4 safetensors forward");
+}
+
+ForwardSmokeResult run_safetensors_token_forward_with_options(
+    const std::string&, int, int, int, const ForwardSmokeOptions&) {
+    unimplemented("DSV4 safetensors forward");
+}
+
+ForwardSmokeResult run_safetensors_prompt_forward(
+    const std::string&, const std::vector<int>&, int) {
+    unimplemented("DSV4 safetensors forward");
+}
+
+ForwardSmokeResult run_safetensors_prompt_forward_with_options(
+    const std::string&, const std::vector<int>&, int,
+    const ForwardSmokeOptions&) {
+    unimplemented("DSV4 safetensors forward");
+}
+
+std::vector<ForwardSmokeResult> run_safetensors_generate_tokens(
+    const std::string&, const std::vector<int>&, int, int) {
+    unimplemented("DSV4 safetensors generate");
+}
+
+std::vector<ForwardSmokeResult> run_safetensors_generate_tokens_with_options(
+    const std::string&, const std::vector<int>&, int, int,
+    const ForwardSmokeOptions&) {
+    unimplemented("DSV4 safetensors generate");
+}
+
+GenerateSmokeResult run_safetensors_generate_tokens_timed_with_options(
+    const std::string&, const std::vector<int>&, int, int,
+    const ForwardSmokeOptions&) {
+    unimplemented("DSV4 safetensors generate");
+}
+
+// --- PersistentEngine -------------------------------------------------------
+//
+// State is declared but never defined in the header, so the empty definition
+// here is what lets the unique_ptr member's destructor instantiate.
+
+struct PersistentEngine::State {};
+
+PersistentEngine::PersistentEngine(const std::string&,
+                                   const ForwardSmokeOptions&, int, int) {
+    unimplemented("DSV4 PersistentEngine");
+}
+
+PersistentEngine::~PersistentEngine() = default;
+
+void PersistentEngine::reset_session() {
+    unimplemented("DSV4 PersistentEngine");
+}
+
+int PersistentEngine::prefill(const std::vector<int>&, const SamplingParams&) {
+    unimplemented("DSV4 PersistentEngine");
+}
+
+int PersistentEngine::decode_step(int, int, const SamplingParams&) {
+    unimplemented("DSV4 PersistentEngine");
+}
+
+int PersistentEngine::eos_id() const {
+    unimplemented("DSV4 PersistentEngine");
+}
+
+int PersistentEngine::max_context() const {
+    unimplemented("DSV4 PersistentEngine");
+}
+
+const Tokenizer& PersistentEngine::tokenizer() const {
+    unimplemented("DSV4 PersistentEngine");
+}
+
+void PersistentEngine::run_worker_loop() {
+    unimplemented("DSV4 PersistentEngine");
+}
+
+void PersistentEngine::warmup_tp() {
+    unimplemented("DSV4 PersistentEngine");
+}
+
+void PersistentEngine::worker_command_prefill(const std::vector<int>&) {
+    unimplemented("DSV4 PersistentEngine");
+}
+
+void PersistentEngine::worker_command_decode(int32_t, int32_t) {
+    unimplemented("DSV4 PersistentEngine");
+}
+
+void PersistentEngine::worker_command_reset() {
+    unimplemented("DSV4 PersistentEngine");
+}
+
+void PersistentEngine::worker_command_shutdown() {
+    unimplemented("DSV4 PersistentEngine");
+}
+
+// --- Qwen external drafters -------------------------------------------------
+//
+// QwenEngine keeps the drafter members and their bookkeeping on every backend so
+// that run_chunk and the speculative steps stay backend-neutral. Construction is
+// rejected in QwenEngine's constructor, which is why none of these can be
+// entered: the owning unique_ptr is always null on this backend.
+
+struct QwenDSparkRuntime::Impl {};
+
+QwenDSparkRuntime::QwenDSparkRuntime(const std::string&,
+                                    const QwenDSparkConfig&,
+                                    const QwenDSparkWeightMap&,
+                                    const QwenDeviceTensor&,
+                                    QwenTargetHeadAdapter, int, int, int,
+                                    std::string, int) {
+    unimplemented("Qwen DSpark drafter");
+}
+
+QwenDSparkRuntime::~QwenDSparkRuntime() = default;
+
+void QwenDSparkRuntime::reset() { unimplemented("Qwen DSpark drafter"); }
+
+int QwenDSparkRuntime::committed_position() const {
+    unimplemented("Qwen DSpark drafter");
+}
+
+uint64_t QwenDSparkRuntime::resident_weight_bytes() const {
+    unimplemented("Qwen DSpark drafter");
+}
+
+uint64_t QwenDSparkRuntime::context_cache_bytes() const {
+    unimplemented("Qwen DSpark drafter");
+}
+
+uint64_t QwenDSparkRuntime::activation_workspace_bytes() const {
+    unimplemented("Qwen DSpark drafter");
+}
+
+void QwenDSparkRuntime::append_target_taps(const uint16_t*, int, int) {
+    unimplemented("Qwen DSpark drafter");
+}
+
+void QwenDSparkRuntime::crop_context(int) {
+    unimplemented("Qwen DSpark drafter");
+}
+
+QwenDSparkProposal QwenDSparkRuntime::propose(int) {
+    unimplemented("Qwen DSpark drafter");
+}
+
+struct QwenDFlash2Runtime::Impl {};
+
+QwenDFlash2Runtime::QwenDFlash2Runtime(const std::string&,
+                                      const QwenDFlash2Config&,
+                                      const QwenDFlash2WeightMap&,
+                                      const QwenDeviceTensor&,
+                                      QwenTargetHeadAdapter, int, int, int,
+                                      std::string, int) {
+    unimplemented("Qwen DFlash2 drafter");
+}
+
+QwenDFlash2Runtime::~QwenDFlash2Runtime() = default;
+
+void QwenDFlash2Runtime::reset() { unimplemented("Qwen DFlash2 drafter"); }
+
+int QwenDFlash2Runtime::committed_position() const {
+    unimplemented("Qwen DFlash2 drafter");
+}
+
+uint64_t QwenDFlash2Runtime::resident_weight_bytes() const {
+    unimplemented("Qwen DFlash2 drafter");
+}
+
+uint64_t QwenDFlash2Runtime::context_cache_bytes() const {
+    unimplemented("Qwen DFlash2 drafter");
+}
+
+uint64_t QwenDFlash2Runtime::activation_workspace_bytes() const {
+    unimplemented("Qwen DFlash2 drafter");
+}
+
+void QwenDFlash2Runtime::set_debug_callback(QwenDFlash2DebugCallback) {
+    unimplemented("Qwen DFlash2 drafter");
+}
+
+void QwenDFlash2Runtime::debug_load_target_taps(
+    const std::vector<uint16_t>&, int, int) {
+    unimplemented("Qwen DFlash2 drafter");
+}
+
+QwenDFlash2Proposal QwenDFlash2Runtime::debug_propose_from_host(
+    const std::vector<uint16_t>&, int, int, int) {
+    unimplemented("Qwen DFlash2 drafter");
+}
+
+void QwenDFlash2Runtime::append_target_taps(const uint16_t*, int, int) {
+    unimplemented("Qwen DFlash2 drafter");
+}
+
+void QwenDFlash2Runtime::crop_context(int) {
+    unimplemented("Qwen DFlash2 drafter");
+}
+
+QwenDFlash2Proposal QwenDFlash2Runtime::propose(int) {
+    unimplemented("Qwen DFlash2 drafter");
+}
+
+}  // namespace dsv4

--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -38,7 +38,10 @@ void check_device(bool ok, const char* what) {
 }
 
 void require_launch(bool ok, const char* what) {
-    if (!ok) throw std::runtime_error(std::string("Qwen CUDA launch failed: ") + what);
+    if (!ok) {
+        throw std::runtime_error(
+            std::string("Qwen ") + device_backend_name() + " launch failed: " + what);
+    }
 }
 
 bool qwen_env_enabled(const char* name) {
@@ -144,11 +147,22 @@ DeviceLinear upload_linear(const SafeTensorsIndex& index, const QwenLinearRef& r
     DeviceLinear output;
     output.kind = ref.kind;
     output.logical_shape = ref.logical_local_shape;
+#ifdef POCKET_BACKEND_ASCEND
+    // NVFP4 repacks into the SM75 WMMA block layout, and only the CUDA kernels
+    // read that layout. Reject the kind at load time so the Ascend build carries
+    // no reference to the repacking uploader.
+    if (ref.kind == QwenLinearKind::NvFp4Group16) {
+        throw std::runtime_error(
+            "Qwen NVFP4 weights are not implemented on the Ascend backend");
+    }
+    {
+#else
     if (ref.kind == QwenLinearKind::NvFp4Group16) {
         output.weight = qwen_upload_nvfp4_linear_cuda(
             index, ref, &output.weight_global_factor,
             &output.input_global_scale);
     } else {
+#endif
         output.weight = upload(index, ref.weight);
         if (ref.has_scale) output.scale = upload(index, ref.scale);
     }
@@ -365,6 +379,12 @@ struct QwenEngine::Impl {
     bool mtp_enabled = false;
     bool dspark_enabled = false;
     bool dflash2_enabled = false;
+    // The external drafters stay declared on every backend. Their bookkeeping is
+    // woven through run_chunk and the speculative steps, so compiling the members
+    // out fragments code that is otherwise backend-neutral; the Ascend build
+    // instead links throwing stubs for the two runtimes
+    // (engine/backend_unimplemented_ascend.cpp)
+    // and rejects a drafter checkpoint at construction.
     // Caps the verified draft block width. 0 verifies the full seven-draft
     // proposal, which is the upstream behaviour and stays the default.
     int dflash2_draft_width = qwen_env_int("DSV4_DFLASH2_DRAFT_WIDTH", 0);
@@ -821,6 +841,11 @@ struct QwenEngine::Impl {
         // cache unless this engine actually owns a speculative target.
         const bool verify_resident_weights = speculative_target &&
             qwen_env_enabled_default("QWEN_VERIFY_RESIDENT_FP16");
+#ifdef POCKET_BACKEND_ASCEND
+        // The resident cache only ever expands FP8 weights, and no FP8 kind is
+        // loadable on this backend, so there is nothing for it to materialize.
+        (void)verify_resident_weights;
+#else
         if (verify_resident_weights) {
             auto materialize_verify_weight = [this](DeviceLinear& linear) {
                 if (!linear.fp8 || linear.weight.data == nullptr ||
@@ -857,7 +882,16 @@ struct QwenEngine::Impl {
                 }
             }
         }
+#endif
 
+#ifdef POCKET_BACKEND_ASCEND
+        if (!options.dspark_checkpoint.empty() ||
+            !options.dflash2_checkpoint.empty()) {
+            throw std::runtime_error(
+                "Qwen DSpark and DFlash2 drafters are not implemented on the "
+                "Ascend backend");
+        }
+#else
         if (!options.dspark_checkpoint.empty()) {
             if (active_layers > 0 &&
                 active_layers != static_cast<int>(config.num_hidden_layers)) {
@@ -918,6 +952,7 @@ struct QwenEngine::Impl {
             uploaded_weight_bytes += dflash2->resident_weight_bytes();
             cache_data_bytes += dflash2->context_cache_bytes();
         }
+#endif
 
         if (options.mtp) {
             if (!map.mtp().found) {
@@ -1627,6 +1662,7 @@ struct QwenEngine::Impl {
         telemetry.active_linear_kinds = active_linear_kinds;
     }
 
+#ifndef POCKET_BACKEND_ASCEND
     void allocate_nvfp4_q8(int rows, int columns) {
         allocate(nvfp4_q8, static_cast<size_t>(rows) * columns,
                  {static_cast<uint64_t>(rows),
@@ -1723,6 +1759,7 @@ struct QwenEngine::Impl {
             up.weight_global_factor, output, rows, output_rows, columns,
             columns, output_rows, columns / 64);
     }
+#endif
 
     void projection(const DeviceLinear& linear, const uint16_t* input,
                     uint16_t* output, int rows, const char* site = "other") {
@@ -1732,6 +1769,22 @@ struct QwenEngine::Impl {
         }
         const int output_rows = static_cast<int>(linear.logical_shape[0]);
         const int columns = static_cast<int>(linear.logical_shape[1]);
+#ifdef POCKET_BACKEND_ASCEND
+        // Only the dense FP16 kind has an Ascend implementation. The quantized
+        // kinds are rejected here rather than left to a runtime branch: a
+        // reference to their CUDA kernels in this object would make the whole
+        // executable require the CUDA toolchain to link.
+        if (linear.kind != QwenLinearKind::DenseF16) {
+            throw std::runtime_error(
+                std::string("Qwen Ascend path is not implemented for ") +
+                qwen_linear_kind_name(linear.kind));
+        }
+        require_launch(qwen_fp16_matmul_rows_f16(
+            input, linear.weight.f16_data(), output, rows, output_rows,
+            columns, columns, output_rows, columns),
+            "FP16 activation/weight projection");
+        return;
+#else
         if (linear.kind == QwenLinearKind::Fp8Block128) {
             if (rows == 1) {
                 require_launch(qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
@@ -1820,6 +1873,7 @@ struct QwenEngine::Impl {
                 std::string("Qwen linear CUDA path is not implemented for ") +
                 qwen_linear_kind_name(linear.kind));
         }
+#endif
     }
 
     void norm(const QwenDeviceTensor& gamma, const uint16_t* input,
@@ -1885,6 +1939,11 @@ struct QwenEngine::Impl {
         QwenDeviceTensor& core = workspace_half(value_elements, v.shape);
         QwenDeviceTensor& z = workspace_half(value_elements, v.shape);
         QwenDeviceTensor& normalized = workspace_half(value_elements, v.shape);
+        // FlashQLA is an SM75 register/subgroup layout of the same recurrence,
+        // not a distinct operation, so the Ascend build simply does not have the
+        // selector: the normalized sequence kernel below produces the same
+        // result from the same FP32 normalized Q/K.
+#ifndef POCKET_BACKEND_ASCEND
         QwenDeviceTensor* q_normalized = nullptr;
         QwenDeviceTensor* k_normalized = nullptr;
         const bool flashqla = rows >= 8 &&
@@ -1895,6 +1954,7 @@ struct QwenEngine::Impl {
                 {static_cast<uint64_t>(rows), static_cast<uint64_t>(key_dim)});
             k_normalized = &workspace_float(key_elements, q_normalized->shape);
         }
+#endif
 
         projection(layer.linear.qkv, hidden, packed.f16_data(), rows, "lin.qkv");
         require_launch(qwen_causal_depthwise_conv_silu_f16(
@@ -1930,6 +1990,7 @@ struct QwenEngine::Impl {
         std::optional<PhaseScope> delta_scope;
         delta_scope.emplace(this, "gated_delta");
         bool sequenced = false;
+#ifndef POCKET_BACKEND_ASCEND
         if (flashqla) {
             // FlashQLA SM75 subgroup-sharded kernel. Still a serial recurrence,
             // but sharding the [128, 128] state over 16-lane subgroups replaces
@@ -1949,7 +2010,9 @@ struct QwenEngine::Impl {
                     static_cast<int>(config.linear_attention.key_head_dim),
                     static_cast<int>(config.linear_attention.value_head_dim),
                     q_scale);
-        } else if (rows >= 5 && key_heads < value_heads &&
+        } else
+#endif
+        if (rows >= 5 && key_heads < value_heads &&
             qwen_env_enabled_default("QWEN_GATED_DELTA_PRENORMALIZE")) {
             QwenDeviceTensor& q_normalized = workspace_float(
                 key_elements, {static_cast<uint64_t>(rows),
@@ -2097,6 +2160,59 @@ struct QwenEngine::Impl {
         const QwenKvCacheDType cache_dtype = options.kv_cache_dtype;
         const int attention_window = options.attention_window;
         const int sink_tokens = options.attention_sink_tokens;
+#ifdef POCKET_BACKEND_ASCEND
+        // The engine constructor rejects every non-FP16 cache dtype on this
+        // backend, so only the FP16 append and the three neutral attention
+        // launchers are compiled. The quantized caches are not merely disabled:
+        // naming their kernels here would put a CUDA dependency in this object.
+        require_launch(qwen_append_kv_cache_f16(
+            k_norm.f16_data(), v.f16_data(), layer.full.k_cache.f16_data(),
+            layer.full.v_cache.f16_data(), rows, kv_heads, head_dim,
+            position_offset, max_context), "append FP16 full KV cache");
+
+        if (rows == 1) {
+            const int context_length = position_offset + 1;
+            QwenDeviceTensor& scores = workspace_float(
+                static_cast<size_t>(q_heads) * context_length,
+                {static_cast<uint64_t>(q_heads),
+                 static_cast<uint64_t>(context_length)});
+            require_launch(qwen_gqa_decode_attention_f16(
+                q_norm.f16_data(), layer.full.k_cache.f16_data(),
+                layer.full.v_cache.f16_data(), attention.f16_data(),
+                scores.f32_data(), q_heads, kv_heads, head_dim,
+                context_length, max_context), "decode FP16-cache GQA");
+        } else if (rows <= 8) {
+            const int context_length = position_offset + rows;
+            // Same split geometry the CUDA verify path uses, so a verify block
+            // reduces its partials in the same order on both backends.
+            const int default_splits = context_length >= 1024 ? 64 : 32;
+            int target_splits = qwen_env_int(
+                "QWEN_GQA_VERIFY_SPLITS", default_splits);
+            if (target_splits <= 0) target_splits = default_splits;
+            const int verify_splits = std::max(
+                1, std::min(target_splits, context_length));
+            QwenDeviceTensor& partials = workspace_float(
+                static_cast<size_t>(rows) * q_heads * verify_splits *
+                    static_cast<size_t>(head_dim + 2),
+                {static_cast<uint64_t>(rows), static_cast<uint64_t>(q_heads),
+                 static_cast<uint64_t>(verify_splits),
+                 static_cast<uint64_t>(head_dim + 2)});
+            PhaseScope sub(this, "full.attn_kernel");
+            require_launch(qwen_gqa_verify_attention_f16(
+                q_norm.f16_data(), layer.full.k_cache.f16_data(),
+                layer.full.v_cache.f16_data(), attention.f16_data(),
+                partials.f32_data(), rows, q_heads, kv_heads, head_dim,
+                position_offset, max_context, verify_splits),
+                "verify split FP16-cache GQA");
+        } else {
+            require_launch(qwen_gqa_prefill_attention_f16(
+                q_norm.f16_data(), layer.full.k_cache.f16_data(),
+                layer.full.v_cache.f16_data(), attention.f16_data(), rows,
+                q_heads, kv_heads, head_dim, position_offset, max_context),
+                "prefill FP16-cache GQA");
+        }
+        (void)sink_tokens;
+#else
         if (cache_dtype == QwenKvCacheDType::Fp8) {
             require_launch(qwen_append_kv_cache_fp8_cuda(
                 k_norm.f16_data(), v.f16_data(), layer.full.k_cache.fp8_data(),
@@ -2381,6 +2497,7 @@ struct QwenEngine::Impl {
                 q_heads, kv_heads, head_dim, position_offset, max_context),
                 "prefill FP16-cache GQA");
         }
+#endif
         require_launch(qwen_sigmoid_mul_f16(
             attention.f16_data(), gate.f16_data(), merged.f16_data(),
             rows * attention_dim), "FP16 full attention output gate");
@@ -2409,6 +2526,15 @@ struct QwenEngine::Impl {
                               static_cast<uint64_t>(hidden_size)});
         QwenDeviceTensor& attention = workspace_half(hidden_elements, normalized.shape);
         QwenDeviceTensor& post = workspace_half(hidden_elements, normalized.shape);
+#ifdef POCKET_BACKEND_ASCEND
+        // Every fused SwiGLU variant below is a quantized-weight kernel, and no
+        // quantized kind loads on this backend. Keeping the flags as constants
+        // lets the shared control flow read identically on both backends while
+        // the dead arms are removed before codegen.
+        constexpr bool fused_decode_swiglu = false;
+        constexpr bool fused_small_batch_swiglu = false;
+        constexpr bool fused_nvfp4_swiglu = false;
+#else
         const bool compatible_fp8_swiglu =
             layer.gate.kind == QwenLinearKind::Fp8Block128 &&
             layer.up.kind == QwenLinearKind::Fp8Block128 &&
@@ -2437,6 +2563,7 @@ struct QwenEngine::Impl {
             layer.gate.kind == QwenLinearKind::NvFp4Group16 &&
             layer.up.kind == QwenLinearKind::NvFp4Group16 &&
             layer.gate.logical_shape == layer.up.logical_shape;
+#endif
         QwenDeviceTensor* gate = nullptr;
         QwenDeviceTensor* up = nullptr;
         if (!fused_decode_swiglu && !fused_small_batch_swiglu &&
@@ -2479,6 +2606,15 @@ struct QwenEngine::Impl {
             add(output, attention.f16_data(), rows * hidden_size);
             norm(layer.post_norm, output, post.f16_data(), rows, hidden_size);
         }
+#ifdef POCKET_BACKEND_ASCEND
+        {
+            projection(layer.gate, post.f16_data(), gate->f16_data(), rows, "mlp.gate");
+            projection(layer.up, post.f16_data(), up->f16_data(), rows, "mlp.up");
+            require_launch(qwen_silu_mul_rows_f16(
+                gate->f16_data(), up->f16_data(), intermediate.f16_data(), rows,
+                static_cast<int>(layer.gate.logical_shape[0])), "FP16 SwiGLU");
+        }
+#else
         if (fused_decode_swiglu) {
             PhaseScope scope(this, "swiglu.d");
             require_launch(qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
@@ -2520,6 +2656,7 @@ struct QwenEngine::Impl {
                 gate->f16_data(), up->f16_data(), intermediate.f16_data(), rows,
                 static_cast<int>(layer.gate.logical_shape[0])), "FP16 SwiGLU");
         }
+#endif
         // ar.mlp is the largest single collective (3.58 s of the 7.24 s
         // tp_all_reduce leaf at 32K), and down is a large GEMM, so this is the
         // best overlap candidate in the layer.
@@ -2553,6 +2690,10 @@ struct QwenEngine::Impl {
     // Under TP the vocabulary is sharded, so each rank emits its local top-k as
     // global ids, NCCL merges the candidates, and the draw happens over the
     // merged set with a uniform every rank already agrees on.
+    //
+    // The Ascend build has no device sampler yet, so the whole routine is
+    // compiled out and the constructor rejects a nonzero temperature up front.
+#ifndef POCKET_BACKEND_ASCEND
     QwenVerifyBatch sample_tokens_for(QwenDeviceTensor& local_logits, int rows,
                                       int local_vocab, int vocab_start,
                                       int position_after) {
@@ -2652,6 +2793,7 @@ struct QwenEngine::Impl {
         result.local_logits = result.top_logits;
         return result;
     }
+#endif
 
     QwenVerifyBatch top_tokens_for(const uint16_t* hidden, int rows,
                                    const QwenDeviceTensor* output_norm,
@@ -2679,6 +2821,23 @@ struct QwenEngine::Impl {
             static_cast<size_t>(rows) * local_vocab,
             {static_cast<uint64_t>(rows), static_cast<uint64_t>(local_vocab)});
         bool logits_ok = false;
+#ifdef POCKET_BACKEND_ASCEND
+        // The cuBLAS row variant is an alternative implementation of the same
+        // GEMM, so the Ascend build has only the neutral launcher. Fp8Channel is
+        // rejected for the same reason projection() rejects the quantized kinds.
+        if (lm_head.kind != QwenLinearKind::DenseF16) {
+            throw std::runtime_error(
+                std::string("Qwen Ascend target head is not implemented for ") +
+                qwen_linear_kind_name(lm_head.kind));
+        }
+        {
+            PhaseScope scope(this, rows == 1 ? "lmhead.d" : "lmhead.r");
+            logits_ok = qwen_fp16_matmul_rows_f16_f32(
+                normalized.f16_data(), lm_head.weight.f16_data(),
+                local_logits.f32_data(), rows, local_vocab, hidden_size,
+                hidden_size, local_vocab, hidden_size);
+        }
+#else
         if (lm_head.kind == QwenLinearKind::DenseF16) {
             // Decode. The warp-per-row matvec reorders the reduction, so it is a
             // separate entry point rather than a retune of the reference path;
@@ -2716,6 +2875,7 @@ struct QwenEngine::Impl {
                 std::string("Qwen target-head CUDA path is not implemented for ") +
                 qwen_linear_kind_name(lm_head.kind));
         }
+#endif
         require_launch(logits_ok, "Qwen batched FP32 logits");
         allocate(argmax_token, static_cast<size_t>(rows) * sizeof(int),
                  {static_cast<uint64_t>(rows)}, SafeDType::I64);
@@ -2726,19 +2886,20 @@ struct QwenEngine::Impl {
         // Sampled path. Kept ahead of the argmax launch so a sampled run does
         // not pay for a top-1 reduction it discards; greedy falls through to
         // the original code unchanged.
+#ifndef POCKET_BACKEND_ASCEND
         if (sampling_enabled()) {
             return sample_tokens_for(local_logits, rows, local_vocab,
                                      vocab_start, position_after);
         }
+#endif
 
         {
             PhaseScope scope(this, "argmax");
-            require_launch(argmax_fp32_rows_cuda(
+            require_launch(qwen_argmax_fp32_rows(
                 local_logits.f32_data(), static_cast<int*>(argmax_token.data),
                 argmax_logit.f32_data(), rows, local_vocab, vocab_start),
                 "Qwen batched local argmax");
         }
-
         QwenVerifyBatch result;
         result.top_tokens.resize(static_cast<size_t>(rows));
         result.top_logits.resize(static_cast<size_t>(rows));
@@ -3519,8 +3680,24 @@ QwenEngine::QwenEngine(const std::string& ckpt_dir,
         throw std::runtime_error(
             "Qwen sparse attention currently requires an FP16 KV cache");
     }
+#ifdef POCKET_BACKEND_ASCEND
+    // full_attention only compiles the FP16 cache path on this backend, so the
+    // rejection belongs here where the option is still reportable rather than
+    // deep inside a layer.
+    if (options_.kv_cache_dtype != QwenKvCacheDType::Fp16) {
+        throw std::runtime_error(
+            "Qwen Ascend backend currently supports only an FP16 KV cache");
+    }
+    if (options_.temperature > 1.0e-5f) {
+        throw std::runtime_error(
+            "Qwen sampling is not implemented on the Ascend backend; use greedy "
+            "decoding (--temperature 0)");
+    }
+#endif
     if (!device_set(options_.device)) {
-        throw std::runtime_error("failed to set Qwen CUDA device");
+        throw std::runtime_error(
+            std::string("failed to set Qwen ") + device_backend_name() +
+            " device");
     }
     if (layer_count <= 0) {
         active_layers_ = static_cast<int>(config_.num_hidden_layers);

--- a/cpp_engine/engine/qwen_target_head.cpp
+++ b/cpp_engine/engine/qwen_target_head.cpp
@@ -25,6 +25,14 @@ bool QwenTargetHeadAdapter::project_f16_to_f32(
         return false;
     }
     if (kind == QwenLinearKind::DenseF16) {
+#ifdef POCKET_BACKEND_ASCEND
+        // The portable Ascend path is the only dense implementation available
+        // here; cublas_fp32 is a CUDA tuning hint and must not affect it.
+        (void)cublas_fp32;
+        return qwen_fp16_matmul_rows_f16_f32(
+            hidden, weight->f16_data(), logits, rows, local_vocab,
+            hidden_size, hidden_size, local_vocab, hidden_size, stream);
+#else
         return cublas_fp32
             ? qwen_fp16_matmul_rows_f16_f32_cublas_cuda(
                   hidden, weight->f16_data(), logits, rows, local_vocab,
@@ -32,11 +40,18 @@ bool QwenTargetHeadAdapter::project_f16_to_f32(
             : qwen_fp16_matmul_rows_f16_f32(
                   hidden, weight->f16_data(), logits, rows, local_vocab,
                   hidden_size, hidden_size, local_vocab, hidden_size, stream);
+#endif
     }
+#ifdef POCKET_BACKEND_ASCEND
+    (void)stream;
+    // First-generation Ascend bring-up supports dense FP16 target heads only.
+    return false;
+#else
     return qwen_fp8_e4m3_channel_matmul_rows_f16_f32_cuda(
         hidden, weight->fp8_data(), scale->f16_data(), logits, rows,
         local_vocab, hidden_size, hidden_size, local_vocab, hidden_size,
         stream);
+#endif
 }
 
 }  // namespace dsv4

--- a/cpp_engine/include/qwen_ascend_ops.hpp
+++ b/cpp_engine/include/qwen_ascend_ops.hpp
@@ -23,6 +23,12 @@ namespace dsv4 {
 
 bool qwen_add_inplace_f16_ascend(uint16_t* d_y_fp16, const uint16_t* d_x_fp16, int count, void* stream);
 
+// Row-wise greedy top-1. Named for Qwen like the rest of this header even though
+// the CUDA counterpart lives in cuda_ops.hpp as argmax_fp32_rows_cuda: the neutral
+// forwarder in qwen_ops.hpp is what the engine calls, and it keeps the argmax with
+// the operators the Qwen forward actually uses.
+bool qwen_argmax_fp32_rows_ascend(const float* d_logits, int* d_tokens, float* d_logits_out, int rows, int count, int token_offset, void* stream);
+
 bool qwen_append_kv_cache_f16_ascend(const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16, uint16_t* d_k_cache_fp16, uint16_t* d_v_cache_fp16, int seq_len, int kv_heads, int head_dim, int start_pos, int max_context, void* stream);
 
 bool qwen_causal_depthwise_conv_silu_f16_ascend(const uint16_t* d_x_fp16, const uint16_t* d_weight_fp16, uint16_t* d_tail_fp16, uint16_t* d_y_fp16, int seq_len, int channels, int kernel, bool update_tail, void* stream);

--- a/cpp_engine/include/qwen_ops.hpp
+++ b/cpp_engine/include/qwen_ops.hpp
@@ -36,6 +36,17 @@ inline bool qwen_add_inplace_f16(uint16_t* d_y_fp16, const uint16_t* d_x_fp16, i
 #endif
 }
 
+// Greedy row-wise top-1 over FP32 logits. The CUDA symbol is spelled without the
+// qwen_ prefix because it predates the Qwen engine and is shared with the legacy
+// DSV4 path; the neutral name follows this header's convention.
+inline bool qwen_argmax_fp32_rows(const float* d_logits, int* d_tokens, float* d_logits_out, int rows, int count, int token_offset, void* stream = nullptr) {
+#ifdef POCKET_BACKEND_ASCEND
+    return qwen_argmax_fp32_rows_ascend(d_logits, d_tokens, d_logits_out, rows, count, token_offset, stream);
+#else
+    return argmax_fp32_rows_cuda(d_logits, d_tokens, d_logits_out, rows, count, token_offset, stream);
+#endif
+}
+
 inline bool qwen_append_kv_cache_f16(const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16, uint16_t* d_k_cache_fp16, uint16_t* d_v_cache_fp16, int seq_len, int kv_heads, int head_dim, int start_pos, int max_context, void* stream = nullptr) {
 #ifdef POCKET_BACKEND_ASCEND
     return qwen_append_kv_cache_f16_ascend(d_k_rows_fp16, d_v_rows_fp16, d_k_cache_fp16, d_v_cache_fp16, seq_len, kv_heads, head_dim, start_pos, max_context, stream);

--- a/cpp_engine/tests/test_qwen_ascend_group_b.cpp
+++ b/cpp_engine/tests/test_qwen_ascend_group_b.cpp
@@ -1,0 +1,1080 @@
+// Correctness tests for the hand-written Group B Qwen operators.
+//
+// Host references follow the operator definitions in double precision rather than
+// copying either vendor implementation. The calls use qwen_ops.hpp's neutral names,
+// so this also verifies that the engine-facing dispatch seam reaches the Ascend
+// launchers.
+//
+//   ./tests/test_qwen_ascend_group_b [--device N] [--only a,b,c]
+
+#include "device_runtime.hpp"
+#include "qwen_ops.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr int kKeyDim = 128;
+constexpr int kValueDim = 128;
+
+int failures = 0;
+int checks = 0;
+
+void expect(bool ok, const std::string& what) {
+    ++checks;
+    if (!ok) {
+        ++failures;
+        std::cout << "  FAIL " << what << "\n";
+    }
+}
+
+float half_to_float(uint16_t h) {
+    const uint32_t sign = static_cast<uint32_t>(h & 0x8000u) << 16;
+    const uint32_t exponent = (h >> 10) & 0x1fu;
+    const uint32_t mantissa = h & 0x3ffu;
+    uint32_t bits = 0;
+    if (exponent == 0) {
+        if (mantissa == 0) {
+            bits = sign;
+        } else {
+            uint32_t shifted = mantissa;
+            int shift = 0;
+            while ((shifted & 0x400u) == 0) {
+                shifted <<= 1;
+                ++shift;
+            }
+            bits = sign |
+                   ((127u - 15u - static_cast<uint32_t>(shift) + 1u) << 23) |
+                   ((shifted & 0x3ffu) << 13);
+        }
+    } else if (exponent == 31) {
+        bits = sign | 0x7f800000u | (mantissa << 13);
+    } else {
+        bits = sign | ((exponent + 127u - 15u) << 23) | (mantissa << 13);
+    }
+    float out = 0.0f;
+    std::memcpy(&out, &bits, sizeof(out));
+    return out;
+}
+
+uint16_t float_to_half(float f) {
+    uint32_t bits = 0;
+    std::memcpy(&bits, &f, sizeof(bits));
+    const uint32_t sign = (bits >> 16) & 0x8000u;
+    const int exponent = static_cast<int>((bits >> 23) & 0xffu) - 127 + 15;
+    uint32_t mantissa = bits & 0x7fffffu;
+    if (exponent <= 0) {
+        if (exponent < -10) return static_cast<uint16_t>(sign);
+        mantissa |= 0x800000u;
+        const int shift = 14 - exponent;
+        uint32_t half = mantissa >> shift;
+        const uint32_t remainder = mantissa & ((1u << shift) - 1u);
+        const uint32_t halfway = 1u << (shift - 1);
+        if (remainder > halfway || (remainder == halfway && (half & 1u))) ++half;
+        return static_cast<uint16_t>(sign | half);
+    }
+    if (exponent >= 31) return static_cast<uint16_t>(sign | 0x7c00u);
+    uint32_t half = mantissa >> 13;
+    const uint32_t remainder = mantissa & 0x1fffu;
+    if (remainder > 0x1000u || (remainder == 0x1000u && (half & 1u))) {
+        ++half;
+        if (half == 0x400u) {
+            half = 0;
+            if (exponent + 1 >= 31) return static_cast<uint16_t>(sign | 0x7c00u);
+            return static_cast<uint16_t>(
+                sign | (static_cast<uint32_t>(exponent + 1) << 10));
+        }
+    }
+    return static_cast<uint16_t>(
+        sign | (static_cast<uint32_t>(exponent) << 10) | half);
+}
+
+template <typename T>
+class DeviceBuffer {
+public:
+    explicit DeviceBuffer(size_t count) : count_(count) {
+        if (count == 0) return;
+        if (!dsv4::device_malloc_into(ptr_, count * sizeof(T))) {
+            throw std::runtime_error("device_malloc failed");
+        }
+        if (!dsv4::device_memset(ptr_, 0, count * sizeof(T))) {
+            throw std::runtime_error("device_memset failed");
+        }
+    }
+
+    explicit DeviceBuffer(const std::vector<T>& host) : DeviceBuffer(host.size()) {
+        upload(host);
+    }
+
+    ~DeviceBuffer() { dsv4::device_free(ptr_); }
+    DeviceBuffer(const DeviceBuffer&) = delete;
+    DeviceBuffer& operator=(const DeviceBuffer&) = delete;
+
+    T* get() const { return ptr_; }
+
+    void upload(const std::vector<T>& host) {
+        if (host.size() != count_) {
+            throw std::runtime_error("DeviceBuffer upload size mismatch");
+        }
+        if (count_ != 0 &&
+            !dsv4::memcpy_h2d(ptr_, host.data(), count_ * sizeof(T))) {
+            throw std::runtime_error("memcpy_h2d failed");
+        }
+    }
+
+    std::vector<T> download() const {
+        std::vector<T> host(count_);
+        if (count_ != 0 &&
+            !dsv4::memcpy_d2h(host.data(), ptr_, count_ * sizeof(T))) {
+            throw std::runtime_error("memcpy_d2h failed");
+        }
+        return host;
+    }
+
+private:
+    T* ptr_ = nullptr;
+    size_t count_ = 0;
+};
+
+std::vector<uint16_t> random_halves(size_t count, std::mt19937& rng,
+                                    float scale) {
+    std::uniform_real_distribution<float> dist(-scale, scale);
+    std::vector<uint16_t> out(count);
+    for (uint16_t& value : out) value = float_to_half(dist(rng));
+    return out;
+}
+
+std::vector<float> random_floats(size_t count, std::mt19937& rng, float scale) {
+    std::uniform_real_distribution<float> dist(-scale, scale);
+    std::vector<float> out(count);
+    for (float& value : out) value = dist(rng);
+    return out;
+}
+
+void sync_or_throw(const std::string& what) {
+    if (!dsv4::device_synchronize()) {
+        throw std::runtime_error("device_synchronize failed after " + what);
+    }
+}
+
+struct ErrorStats {
+    double worst = 0.0;
+    int mismatches = 0;
+};
+
+ErrorStats half_error(const std::vector<uint16_t>& got,
+                      const std::vector<double>& want, double relative,
+                      double absolute) {
+    if (got.size() != want.size()) {
+        return {1.0e30, static_cast<int>(std::max(got.size(), want.size()))};
+    }
+    ErrorStats stats;
+    for (size_t i = 0; i < want.size(); ++i) {
+        const double actual = half_to_float(got[i]);
+        const double error = std::fabs(actual - want[i]);
+        const double scale = std::max(std::fabs(want[i]), absolute);
+        stats.worst = std::max(stats.worst, error / scale);
+        if (error > absolute + relative * std::fabs(want[i])) ++stats.mismatches;
+    }
+    return stats;
+}
+
+ErrorStats float_error(const std::vector<float>& got,
+                       const std::vector<double>& want, double relative,
+                       double absolute) {
+    if (got.size() != want.size()) {
+        return {1.0e30, static_cast<int>(std::max(got.size(), want.size()))};
+    }
+    ErrorStats stats;
+    for (size_t i = 0; i < want.size(); ++i) {
+        const double error = std::fabs(static_cast<double>(got[i]) - want[i]);
+        const double scale = std::max(std::fabs(want[i]), absolute);
+        stats.worst = std::max(stats.worst, error / scale);
+        if (error > absolute + relative * std::fabs(want[i])) ++stats.mismatches;
+    }
+    return stats;
+}
+
+void expect_half_close(const std::vector<uint16_t>& got,
+                       const std::vector<double>& want, double relative,
+                       double absolute, const std::string& what) {
+    const ErrorStats stats = half_error(got, want, relative, absolute);
+    std::string detail;
+    if (stats.mismatches != 0 && got.size() == want.size()) {
+        for (size_t i = 0; i < want.size(); ++i) {
+            const double actual = half_to_float(got[i]);
+            const double error = std::fabs(actual - want[i]);
+            if (error > absolute + relative * std::fabs(want[i])) {
+                detail = " first=" + std::to_string(i) +
+                         " got=" + std::to_string(actual) +
+                         " want=" + std::to_string(want[i]);
+                break;
+            }
+        }
+    }
+    expect(stats.mismatches == 0,
+           what + " mismatches=" + std::to_string(stats.mismatches) +
+               " worst_relative=" + std::to_string(stats.worst) + detail);
+}
+
+void expect_half_exact(const std::vector<uint16_t>& got,
+                       const std::vector<uint16_t>& want,
+                       const std::string& what) {
+    int mismatches = 0;
+    size_t first = 0;
+    for (size_t i = 0; i < std::min(got.size(), want.size()); ++i) {
+        if (got[i] != want[i]) {
+            if (mismatches == 0) first = i;
+            ++mismatches;
+        }
+    }
+    if (got.size() != want.size()) {
+        mismatches += static_cast<int>(std::max(got.size(), want.size()) -
+                                       std::min(got.size(), want.size()));
+    }
+    std::string detail;
+    if (mismatches != 0 && first < got.size() && first < want.size()) {
+        detail = " first=" + std::to_string(first) +
+                 " got=" + std::to_string(half_to_float(got[first])) +
+                 " want=" + std::to_string(half_to_float(want[first]));
+    }
+    expect(mismatches == 0,
+           what + " mismatches=" + std::to_string(mismatches) + detail);
+}
+
+void expect_float_close(const std::vector<float>& got,
+                        const std::vector<double>& want, double relative,
+                        double absolute, const std::string& what) {
+    const ErrorStats stats = float_error(got, want, relative, absolute);
+    expect(stats.mismatches == 0,
+           what + " mismatches=" + std::to_string(stats.mismatches) +
+               " worst_relative=" + std::to_string(stats.worst));
+}
+
+std::vector<double> normalize_reference(const std::vector<uint16_t>& source,
+                                        int rows, int heads, int dim) {
+    std::vector<double> out(source.size());
+    for (int row = 0; row < rows; ++row) {
+        for (int head = 0; head < heads; ++head) {
+            const size_t base = (static_cast<size_t>(row) * heads + head) * dim;
+            double sum = 0.0;
+            for (int d = 0; d < dim; ++d) {
+                const double value = half_to_float(source[base + d]);
+                sum += value * value;
+            }
+            const double inverse = 1.0 / std::sqrt(sum + 1.0e-6);
+            for (int d = 0; d < dim; ++d) {
+                out[base + d] = half_to_float(source[base + d]) * inverse;
+            }
+        }
+    }
+    return out;
+}
+
+void test_normalize_qk(std::mt19937& rng) {
+    const int rows = 3;
+    const int key_heads = 7;
+    const size_t count = static_cast<size_t>(rows) * key_heads * kKeyDim;
+    const std::vector<uint16_t> q = random_halves(count, rng, 0.7f);
+    const std::vector<uint16_t> k = random_halves(count, rng, 0.7f);
+    DeviceBuffer<uint16_t> d_q(q);
+    DeviceBuffer<uint16_t> d_k(k);
+    DeviceBuffer<float> d_qn(count);
+    DeviceBuffer<float> d_kn(count);
+
+    expect(dsv4::qwen_normalize_gated_delta_qk_f16(
+               d_q.get(), d_k.get(), d_qn.get(), d_kn.get(), rows, key_heads,
+               kKeyDim),
+           "normalize qk launch");
+    sync_or_throw("normalize qk");
+
+    expect_float_close(d_qn.download(), normalize_reference(q, rows, key_heads,
+                                                             kKeyDim),
+                       3.0e-5, 2.0e-6, "normalized q");
+    expect_float_close(d_kn.download(), normalize_reference(k, rows, key_heads,
+                                                             kKeyDim),
+                       3.0e-5, 2.0e-6, "normalized k");
+}
+
+struct RecurrenceReference {
+    std::vector<double> output;
+    std::vector<double> state;
+};
+
+RecurrenceReference recurrence_reference(
+    const std::vector<float>& initial_state, const std::vector<double>& q,
+    const std::vector<double>& k, const std::vector<uint16_t>& v,
+    const std::vector<uint16_t>& g, const std::vector<uint16_t>& beta, int rows,
+    int heads, int key_heads, double q_scale) {
+    std::vector<double> state(initial_state.begin(), initial_state.end());
+    std::vector<double> output(static_cast<size_t>(rows) * heads * kValueDim);
+    const int repeat = heads / key_heads;
+    std::vector<double> memory(kValueDim);
+    std::vector<double> delta(kValueDim);
+    for (int head = 0; head < heads; ++head) {
+        const int key_head = head / repeat;
+        const size_t state_base = static_cast<size_t>(head) * kKeyDim * kValueDim;
+        for (int token = 0; token < rows; ++token) {
+            const size_t key_base =
+                (static_cast<size_t>(token) * key_heads + key_head) * kKeyDim;
+            const size_t value_base =
+                (static_cast<size_t>(token) * heads + head) * kValueDim;
+            const double decay =
+                std::exp(static_cast<double>(half_to_float(g[token * heads + head])));
+            const double gain = half_to_float(beta[token * heads + head]);
+            for (int i = 0; i < kKeyDim; ++i) {
+                for (int d = 0; d < kValueDim; ++d) {
+                    state[state_base + static_cast<size_t>(i) * kValueDim + d] *= decay;
+                }
+            }
+            for (int d = 0; d < kValueDim; ++d) {
+                double sum = 0.0;
+                for (int i = 0; i < kKeyDim; ++i) {
+                    sum += state[state_base + static_cast<size_t>(i) * kValueDim + d] *
+                           k[key_base + i];
+                }
+                memory[d] = sum;
+                delta[d] =
+                    (half_to_float(v[value_base + d]) - memory[d]) * gain;
+            }
+            for (int i = 0; i < kKeyDim; ++i) {
+                for (int d = 0; d < kValueDim; ++d) {
+                    state[state_base + static_cast<size_t>(i) * kValueDim + d] +=
+                        k[key_base + i] * delta[d];
+                }
+            }
+            for (int d = 0; d < kValueDim; ++d) {
+                double sum = 0.0;
+                for (int i = 0; i < kKeyDim; ++i) {
+                    sum += state[state_base + static_cast<size_t>(i) * kValueDim + d] *
+                           q[key_base + i];
+                }
+                output[value_base + d] = sum * q_scale;
+            }
+        }
+    }
+    return {std::move(output), std::move(state)};
+}
+
+std::vector<double> normalize_as_double(const std::vector<uint16_t>& source,
+                                        int rows, int heads) {
+    return normalize_reference(source, rows, heads, kKeyDim);
+}
+
+void test_gated_delta_recurrence(std::mt19937& rng) {
+    const int rows = 2;
+    const int heads = 4;
+    const int key_heads = 2;
+    const float q_scale = 0.125f;
+    const size_t key_count = static_cast<size_t>(rows) * key_heads * kKeyDim;
+    const size_t value_count = static_cast<size_t>(rows) * heads * kValueDim;
+    const size_t state_count = static_cast<size_t>(heads) * kKeyDim * kValueDim;
+    const std::vector<uint16_t> q = random_halves(key_count, rng, 0.6f);
+    const std::vector<uint16_t> k = random_halves(key_count, rng, 0.6f);
+    const std::vector<uint16_t> v = random_halves(value_count, rng, 0.35f);
+    const std::vector<uint16_t> g = random_halves(static_cast<size_t>(rows) * heads,
+                                                  rng, 0.06f);
+    std::vector<uint16_t> beta(static_cast<size_t>(rows) * heads);
+    std::uniform_real_distribution<float> beta_dist(0.15f, 0.75f);
+    for (uint16_t& value : beta) value = float_to_half(beta_dist(rng));
+    const std::vector<float> initial_state = random_floats(state_count, rng, 0.002f);
+    const std::vector<double> qn = normalize_as_double(q, rows, key_heads);
+    const std::vector<double> kn = normalize_as_double(k, rows, key_heads);
+    const RecurrenceReference reference = recurrence_reference(
+        initial_state, qn, kn, v, g, beta, rows, heads, key_heads, q_scale);
+
+    DeviceBuffer<float> d_state(initial_state);
+    DeviceBuffer<uint16_t> d_q(q);
+    DeviceBuffer<uint16_t> d_k(k);
+    DeviceBuffer<uint16_t> d_v(v);
+    DeviceBuffer<uint16_t> d_g(g);
+    DeviceBuffer<uint16_t> d_beta(beta);
+    DeviceBuffer<uint16_t> d_out(value_count);
+    expect(dsv4::qwen_gated_delta_sequence_f16(
+               d_state.get(), d_q.get(), d_k.get(), d_v.get(), d_g.get(),
+               d_beta.get(), d_out.get(), rows, heads, key_heads, kKeyDim,
+               kValueDim, q_scale),
+           "gated delta sequence launch");
+    sync_or_throw("gated delta sequence");
+    expect_half_close(d_out.download(), reference.output, 7.0e-3, 2.5e-3,
+                      "gated delta sequence output");
+    expect_float_close(d_state.download(), reference.state, 8.0e-4, 8.0e-6,
+                       "gated delta sequence state");
+
+    // Pre-normalized and shared entry points must implement the same recurrence.
+    std::vector<float> qn32(qn.begin(), qn.end());
+    std::vector<float> kn32(kn.begin(), kn.end());
+    DeviceBuffer<float> d_qn(qn32);
+    DeviceBuffer<float> d_kn(kn32);
+    DeviceBuffer<float> d_norm_state(initial_state);
+    DeviceBuffer<float> d_shared_state(initial_state);
+    DeviceBuffer<uint16_t> d_norm_out(value_count);
+    DeviceBuffer<uint16_t> d_shared_out(value_count);
+    expect(dsv4::qwen_gated_delta_sequence_normalized_f16(
+               d_norm_state.get(), d_qn.get(), d_kn.get(), d_v.get(), d_g.get(),
+               d_beta.get(), d_norm_out.get(), rows, heads, key_heads, kKeyDim,
+               kValueDim, q_scale),
+           "normalized gated delta launch");
+    expect(dsv4::qwen_gated_delta_sequence_normalized_shared_f16(
+               d_shared_state.get(), d_qn.get(), d_kn.get(), d_v.get(), d_g.get(),
+               d_beta.get(), d_shared_out.get(), rows, heads, key_heads, kKeyDim,
+               kValueDim, q_scale),
+           "shared normalized gated delta launch");
+    sync_or_throw("normalized gated delta");
+    const std::vector<uint16_t> norm_out = d_norm_out.download();
+    const std::vector<uint16_t> shared_out = d_shared_out.download();
+    expect(norm_out == shared_out, "normalized and shared outputs are bit-identical");
+    expect(d_norm_state.download() == d_shared_state.download(),
+           "normalized and shared states are bit-identical");
+    expect_half_close(norm_out, reference.output, 7.0e-3, 2.5e-3,
+                      "normalized gated delta output");
+
+    // A one-token sequence and the step entry point start from the same state and
+    // must finish identically. This is the actual decode geometry.
+    const size_t one_key_count = static_cast<size_t>(key_heads) * kKeyDim;
+    const size_t one_value_count = static_cast<size_t>(heads) * kValueDim;
+    std::vector<uint16_t> q1(q.begin(), q.begin() + one_key_count);
+    std::vector<uint16_t> k1(k.begin(), k.begin() + one_key_count);
+    std::vector<uint16_t> v1(v.begin(), v.begin() + one_value_count);
+    std::vector<uint16_t> g1(g.begin(), g.begin() + heads);
+    std::vector<uint16_t> beta1(beta.begin(), beta.begin() + heads);
+    DeviceBuffer<uint16_t> d_q1(q1), d_k1(k1), d_v1(v1), d_g1(g1), d_beta1(beta1);
+    DeviceBuffer<float> d_step_state(initial_state), d_one_state(initial_state);
+    DeviceBuffer<uint16_t> d_step_out(one_value_count), d_one_out(one_value_count);
+    expect(dsv4::qwen_gated_delta_step_f16(
+               d_step_state.get(), d_q1.get(), d_k1.get(), d_v1.get(), d_g1.get(),
+               d_beta1.get(), d_step_out.get(), heads, key_heads, kKeyDim,
+               kValueDim, q_scale),
+           "gated delta step launch");
+    expect(dsv4::qwen_gated_delta_sequence_f16(
+               d_one_state.get(), d_q1.get(), d_k1.get(), d_v1.get(), d_g1.get(),
+               d_beta1.get(), d_one_out.get(), 1, heads, key_heads, kKeyDim,
+               kValueDim, q_scale),
+           "one-row gated delta sequence launch");
+    sync_or_throw("gated delta step parity");
+    expect(d_step_out.download() == d_one_out.download(),
+           "step and one-row sequence outputs are bit-identical");
+    expect(d_step_state.download() == d_one_state.download(),
+           "step and one-row sequence states are bit-identical");
+}
+
+void test_linear_attn_gates(std::mt19937& rng) {
+    const int rows = 9;
+    const int heads = 7;
+    const size_t count = static_cast<size_t>(rows) * heads;
+    std::vector<uint16_t> a = random_halves(count, rng, 4.0f);
+    const std::vector<uint16_t> b = random_halves(count, rng, 7.0f);
+    const std::vector<uint16_t> a_log = random_halves(heads, rng, 1.5f);
+    const std::vector<uint16_t> dt_bias = random_halves(heads, rng, 2.0f);
+    // Exercise the overflow-safe softplus branch explicitly.
+    a[3] = float_to_half(100.0f);
+    a[19] = float_to_half(40.0f);
+    DeviceBuffer<uint16_t> d_a(a), d_b(b), d_a_log(a_log), d_dt(dt_bias);
+    DeviceBuffer<uint16_t> d_g(count), d_beta(count);
+    expect(dsv4::qwen_linear_attn_gates_f16(
+               d_a.get(), d_b.get(), d_a_log.get(), d_dt.get(), d_g.get(),
+               d_beta.get(), rows, heads),
+           "linear attention gates launch");
+    sync_or_throw("linear attention gates");
+
+    std::vector<double> want_g(count), want_beta(count);
+    for (size_t i = 0; i < count; ++i) {
+        const int head = static_cast<int>(i % heads);
+        const double x = static_cast<double>(half_to_float(a[i])) +
+                         half_to_float(dt_bias[head]);
+        const double softplus = x > 0.0 ? x + std::log1p(std::exp(-x))
+                                        : std::log1p(std::exp(x));
+        want_g[i] = -std::exp(static_cast<double>(half_to_float(a_log[head]))) *
+                    softplus;
+        const double bv = half_to_float(b[i]);
+        want_beta[i] = bv >= 0.0 ? 1.0 / (1.0 + std::exp(-bv))
+                                 : std::exp(bv) / (1.0 + std::exp(bv));
+    }
+    expect_half_close(d_g.download(), want_g, 2.5e-3, 2.0e-3,
+                      "linear attention g");
+    // Hardware Reciprocal is intentionally FP16-grade here.
+    expect_half_close(d_beta.download(), want_beta, 4.0e-3, 1.5e-3,
+                      "linear attention beta");
+}
+
+std::vector<double> conv_reference(const std::vector<uint16_t>& x,
+                                   const std::vector<uint16_t>& weight,
+                                   const std::vector<uint16_t>* tail, int seq_len,
+                                   int channels, int kernel) {
+    const int tail_len = kernel - 1;
+    std::vector<double> out(static_cast<size_t>(seq_len) * channels);
+    for (int token = 0; token < seq_len; ++token) {
+        for (int channel = 0; channel < channels; ++channel) {
+            double sum = 0.0;
+            for (int tap = 0; tap < kernel; ++tap) {
+                const int source = token - tail_len + tap;
+                const double value = source >= 0
+                    ? half_to_float(x[static_cast<size_t>(source) * channels + channel])
+                    : tail == nullptr
+                        ? 0.0
+                        : half_to_float((*tail)[static_cast<size_t>(source + tail_len) *
+                                                      channels + channel]);
+                sum += value *
+                       half_to_float(weight[static_cast<size_t>(channel) * kernel + tap]);
+            }
+            out[static_cast<size_t>(token) * channels + channel] =
+                sum / (1.0 + std::exp(-sum));
+        }
+    }
+    return out;
+}
+
+std::vector<uint16_t> expected_tail(const std::vector<uint16_t>& old_tail,
+                                    const std::vector<uint16_t>& x, int seq_len,
+                                    int channels, int kernel) {
+    const int tail_len = kernel - 1;
+    std::vector<uint16_t> history = old_tail;
+    history.insert(history.end(), x.begin(), x.end());
+    std::vector<uint16_t> out(static_cast<size_t>(tail_len) * channels);
+    const int available_rows = tail_len + seq_len;
+    const int first = available_rows - tail_len;
+    std::copy(history.begin() + static_cast<size_t>(first) * channels,
+              history.begin() + static_cast<size_t>(first + tail_len) * channels,
+              out.begin());
+    return out;
+}
+
+void test_causal_conv(std::mt19937& rng) {
+    const int seq_len = 5;
+    const int channels = 517;
+    const int kernel = 4;
+    const int tail_len = kernel - 1;
+    const std::vector<uint16_t> x =
+        random_halves(static_cast<size_t>(seq_len) * channels, rng, 0.5f);
+    const std::vector<uint16_t> weight =
+        random_halves(static_cast<size_t>(channels) * kernel, rng, 0.35f);
+    const std::vector<uint16_t> tail =
+        random_halves(static_cast<size_t>(tail_len) * channels, rng, 0.4f);
+    DeviceBuffer<uint16_t> d_x(x), d_weight(weight), d_tail(tail);
+    DeviceBuffer<uint16_t> d_y(static_cast<size_t>(seq_len) * channels);
+    expect(dsv4::qwen_causal_depthwise_conv_silu_f16(
+               d_x.get(), d_weight.get(), d_tail.get(), d_y.get(), seq_len,
+               channels, kernel, true),
+           "causal conv launch");
+    sync_or_throw("causal conv");
+    expect_half_close(d_y.download(),
+                      conv_reference(x, weight, &tail, seq_len, channels, kernel),
+                      6.0e-3, 2.5e-3, "causal conv output");
+    expect(d_tail.download() ==
+               expected_tail(tail, x, seq_len, channels, kernel),
+           "causal conv updates carried tail");
+
+    // update_tail=false must leave history untouched.
+    DeviceBuffer<uint16_t> d_tail_unchanged(tail);
+    DeviceBuffer<uint16_t> d_y2(static_cast<size_t>(seq_len) * channels);
+    expect(dsv4::qwen_causal_depthwise_conv_silu_f16(
+               d_x.get(), d_weight.get(), d_tail_unchanged.get(), d_y2.get(),
+               seq_len, channels, kernel, false),
+           "causal conv no-tail-update launch");
+    sync_or_throw("causal conv no-tail-update");
+    expect(d_tail_unchanged.download() == tail,
+           "causal conv leaves tail unchanged when requested");
+
+    // Prefill followed by one decode token must equal one fused convolution.
+    const int prefix = seq_len - 1;
+    std::vector<uint16_t> prefix_x(x.begin(), x.begin() +
+                                             static_cast<size_t>(prefix) * channels);
+    std::vector<uint16_t> last_x(x.begin() + static_cast<size_t>(prefix) * channels,
+                                 x.end());
+    DeviceBuffer<uint16_t> d_prefix(prefix_x), d_last(last_x), d_chain_tail(tail);
+    DeviceBuffer<uint16_t> d_prefix_y(static_cast<size_t>(prefix) * channels);
+    DeviceBuffer<uint16_t> d_last_y(channels);
+    expect(dsv4::qwen_causal_depthwise_conv_silu_f16(
+               d_prefix.get(), d_weight.get(), d_chain_tail.get(), d_prefix_y.get(),
+               prefix, channels, kernel, true),
+           "causal conv prefix launch");
+    expect(dsv4::qwen_causal_depthwise_conv_silu_f16(
+               d_last.get(), d_weight.get(), d_chain_tail.get(), d_last_y.get(), 1,
+               channels, kernel, true),
+           "causal conv decode launch");
+    sync_or_throw("causal conv continuity");
+    std::vector<uint16_t> chained = d_prefix_y.download();
+    const std::vector<uint16_t> last = d_last_y.download();
+    chained.insert(chained.end(), last.begin(), last.end());
+    expect(chained == d_y.download(), "causal conv prefill/decode continuity");
+
+    DeviceBuffer<uint16_t> d_zero_y(static_cast<size_t>(seq_len) * channels);
+    expect(dsv4::qwen_causal_depthwise_conv_silu_f16(
+               d_x.get(), d_weight.get(), nullptr, d_zero_y.get(), seq_len,
+               channels, kernel, false),
+           "causal conv null-tail launch");
+    sync_or_throw("causal conv null-tail");
+    expect_half_close(d_zero_y.download(),
+                      conv_reference(x, weight, nullptr, seq_len, channels, kernel),
+                      6.0e-3, 2.5e-3, "causal conv null-tail output");
+}
+
+void rope_reference(std::vector<uint16_t>& values, int rows, int heads,
+                    int head_dim, int rotary_dim, int start_position,
+                    double theta) {
+    const int half = rotary_dim / 2;
+    for (int row = 0; row < rows; ++row) {
+        for (int index = 0; index < half; ++index) {
+            const double frequency =
+                std::pow(theta, -2.0 * static_cast<double>(index) / rotary_dim);
+            const double angle = (start_position + row) * frequency;
+            const double c = std::cos(angle);
+            const double s = std::sin(angle);
+            for (int head = 0; head < heads; ++head) {
+                const size_t base =
+                    (static_cast<size_t>(row) * heads + head) * head_dim;
+                const double a = half_to_float(values[base + index]);
+                const double b = half_to_float(values[base + index + half]);
+                values[base + index] =
+                    float_to_half(static_cast<float>(a * c - b * s));
+                values[base + index + half] =
+                    float_to_half(static_cast<float>(b * c + a * s));
+            }
+        }
+    }
+}
+
+void test_partial_rope(std::mt19937& rng) {
+    const int rows = 3;
+    const int q_heads = 5;
+    const int kv_heads = 2;
+    const int head_dim = 80;
+    const int rotary_dim = 64;
+    const int start_position = 37;
+    const float theta = 1000000.0f;
+    const std::vector<uint16_t> q = random_halves(
+        static_cast<size_t>(rows) * q_heads * head_dim, rng, 0.7f);
+    const std::vector<uint16_t> k = random_halves(
+        static_cast<size_t>(rows) * kv_heads * head_dim, rng, 0.7f);
+    std::vector<uint16_t> want_q = q;
+    std::vector<uint16_t> want_k = k;
+    rope_reference(want_q, rows, q_heads, head_dim, rotary_dim, start_position,
+                   theta);
+    rope_reference(want_k, rows, kv_heads, head_dim, rotary_dim, start_position,
+                   theta);
+    DeviceBuffer<uint16_t> d_q(q), d_k(k);
+    expect(dsv4::qwen_partial_rope_rows_f16(
+               d_q.get(), d_k.get(), start_position, rows, rotary_dim, theta,
+               q_heads, kv_heads, head_dim),
+           "partial rope launch");
+    sync_or_throw("partial rope");
+    const std::vector<uint16_t> got_q = d_q.download();
+    const std::vector<uint16_t> got_k = d_k.download();
+    expect_half_exact(got_q, want_q, "partial rope q matches rounded reference");
+    expect_half_exact(got_k, want_k, "partial rope k matches rounded reference");
+    int untouched_mismatches = 0;
+    for (int row = 0; row < rows; ++row) {
+        for (int head = 0; head < q_heads; ++head) {
+            const size_t base =
+                (static_cast<size_t>(row) * q_heads + head) * head_dim;
+            for (int d = rotary_dim; d < head_dim; ++d) {
+                if (got_q[base + d] != q[base + d]) ++untouched_mismatches;
+            }
+        }
+        for (int head = 0; head < kv_heads; ++head) {
+            const size_t base =
+                (static_cast<size_t>(row) * kv_heads + head) * head_dim;
+            for (int d = rotary_dim; d < head_dim; ++d) {
+                if (got_k[base + d] != k[base + d]) ++untouched_mismatches;
+            }
+        }
+    }
+    expect(untouched_mismatches == 0,
+           "partial rope preserves unrotated dimensions");
+}
+
+void test_append_kv(std::mt19937& rng) {
+    const int seq_len = 3;
+    const int kv_heads = 3;
+    const int head_dim = 17;
+    const int start_pos = 2;
+    const int max_context = 8;
+    const size_t rows_count = static_cast<size_t>(seq_len) * kv_heads * head_dim;
+    const size_t cache_count =
+        static_cast<size_t>(max_context) * kv_heads * head_dim;
+    const std::vector<uint16_t> k_rows = random_halves(rows_count, rng, 0.8f);
+    const std::vector<uint16_t> v_rows = random_halves(rows_count, rng, 0.8f);
+    std::vector<uint16_t> k_cache(cache_count, float_to_half(7.0f));
+    std::vector<uint16_t> v_cache(cache_count, float_to_half(-7.0f));
+    std::vector<uint16_t> want_k = k_cache;
+    std::vector<uint16_t> want_v = v_cache;
+    for (int token = 0; token < seq_len; ++token) {
+        const size_t src = static_cast<size_t>(token) * kv_heads * head_dim;
+        const size_t dst =
+            static_cast<size_t>(start_pos + token) * kv_heads * head_dim;
+        std::copy(k_rows.begin() + src,
+                  k_rows.begin() + src + kv_heads * head_dim,
+                  want_k.begin() + dst);
+        std::copy(v_rows.begin() + src,
+                  v_rows.begin() + src + kv_heads * head_dim,
+                  want_v.begin() + dst);
+    }
+    DeviceBuffer<uint16_t> d_k_rows(k_rows), d_v_rows(v_rows);
+    DeviceBuffer<uint16_t> d_k_cache(k_cache), d_v_cache(v_cache);
+    expect(dsv4::qwen_append_kv_cache_f16(
+               d_k_rows.get(), d_v_rows.get(), d_k_cache.get(), d_v_cache.get(),
+               seq_len, kv_heads, head_dim, start_pos, max_context),
+           "append kv launch");
+    sync_or_throw("append kv");
+    expect_half_exact(d_k_cache.download(), want_k,
+                      "append kv writes K at the offset");
+    expect_half_exact(d_v_cache.download(), want_v,
+                      "append kv writes V at the offset");
+}
+
+std::vector<double> attention_reference(const std::vector<uint16_t>& q,
+                                        const std::vector<uint16_t>& k_cache,
+                                        const std::vector<uint16_t>& v_cache,
+                                        int rows, int q_heads, int kv_heads,
+                                        int head_dim, int position_offset) {
+    std::vector<double> output(static_cast<size_t>(rows) * q_heads * head_dim);
+    const int repeat = q_heads / kv_heads;
+    const double scale = 1.0 / std::sqrt(static_cast<double>(head_dim));
+    std::vector<double> scores;
+    for (int row = 0; row < rows; ++row) {
+        const int context_len = position_offset + row + 1;
+        scores.resize(context_len);
+        for (int head = 0; head < q_heads; ++head) {
+            const int kv_head = head / repeat;
+            const size_t q_base =
+                (static_cast<size_t>(row) * q_heads + head) * head_dim;
+            double maximum = -INFINITY;
+            for (int pos = 0; pos < context_len; ++pos) {
+                const size_t cache_base =
+                    (static_cast<size_t>(pos) * kv_heads + kv_head) * head_dim;
+                double score = 0.0;
+                for (int d = 0; d < head_dim; ++d) {
+                    score += static_cast<double>(half_to_float(q[q_base + d])) *
+                             half_to_float(k_cache[cache_base + d]);
+                }
+                scores[pos] = score * scale;
+                maximum = std::max(maximum, scores[pos]);
+            }
+            double denominator = 0.0;
+            for (double& score : scores) {
+                score = std::exp(score - maximum);
+                denominator += score;
+            }
+            for (int d = 0; d < head_dim; ++d) {
+                double value = 0.0;
+                for (int pos = 0; pos < context_len; ++pos) {
+                    const size_t cache_base =
+                        (static_cast<size_t>(pos) * kv_heads + kv_head) * head_dim;
+                    value += scores[pos] * half_to_float(v_cache[cache_base + d]);
+                }
+                output[q_base + d] = value / denominator;
+            }
+        }
+    }
+    return output;
+}
+
+void test_gqa_decode(std::mt19937& rng) {
+    const int q_heads = 6;
+    const int kv_heads = 2;
+    const int head_dim = 32;
+    const int context_len = 5;
+    const int max_context = 9;
+    const std::vector<uint16_t> q =
+        random_halves(static_cast<size_t>(q_heads) * head_dim, rng, 0.45f);
+    std::vector<uint16_t> k_cache = random_halves(
+        static_cast<size_t>(max_context) * kv_heads * head_dim, rng, 0.5f);
+    std::vector<uint16_t> v_cache = random_halves(
+        static_cast<size_t>(max_context) * kv_heads * head_dim, rng, 0.5f);
+    const size_t poison_start =
+        static_cast<size_t>(context_len) * kv_heads * head_dim;
+    std::fill(k_cache.begin() + poison_start, k_cache.end(), float_to_half(40.0f));
+    std::fill(v_cache.begin() + poison_start, v_cache.end(), float_to_half(-40.0f));
+    DeviceBuffer<uint16_t> d_q(q), d_k(k_cache), d_v(v_cache);
+    DeviceBuffer<uint16_t> d_out(static_cast<size_t>(q_heads) * head_dim);
+    DeviceBuffer<float> d_scores(static_cast<size_t>(q_heads) * context_len);
+    expect(dsv4::qwen_gqa_decode_attention_f16(
+               d_q.get(), d_k.get(), d_v.get(), d_out.get(), d_scores.get(),
+               q_heads, kv_heads, head_dim, context_len, max_context),
+           "GQA decode launch");
+    sync_or_throw("GQA decode");
+    expect_half_close(d_out.download(),
+                      attention_reference(q, k_cache, v_cache, 1, q_heads,
+                                          kv_heads, head_dim, context_len - 1),
+                      5.0e-3, 2.0e-3, "GQA decode output");
+    const std::vector<float> scores = d_scores.download();
+    int bad_probability_rows = 0;
+    for (int head = 0; head < q_heads; ++head) {
+        double sum = 0.0;
+        for (int pos = 0; pos < context_len; ++pos) {
+            const float value = scores[static_cast<size_t>(head) * context_len + pos];
+            if (!(value >= 0.0f)) ++bad_probability_rows;
+            sum += value;
+        }
+        if (std::fabs(sum - 1.0) > 2.0e-4) ++bad_probability_rows;
+    }
+    std::string score_detail;
+    if (bad_probability_rows != 0) {
+        score_detail = " rows=" + std::to_string(bad_probability_rows) + " sums=";
+        for (int head = 0; head < q_heads; ++head) {
+            double sum = 0.0;
+            for (int pos = 0; pos < context_len; ++pos) {
+                sum += scores[static_cast<size_t>(head) * context_len + pos];
+            }
+            score_detail += std::to_string(sum) + (head + 1 == q_heads ? "" : ",");
+        }
+    }
+    expect(bad_probability_rows == 0,
+           "GQA decode score scratch holds probabilities" + score_detail);
+}
+
+void test_argmax(std::mt19937& rng) {
+    (void)rng;
+    const int rows = 5;
+    const int count = 263;
+    const int token_offset = -17;
+    std::vector<float> logits(static_cast<size_t>(rows) * count, -10.0f);
+    logits[7] = 3.0f;
+    logits[2] = 3.0f;
+    logits[static_cast<size_t>(count) + 5] = 4.0f;
+    logits[static_cast<size_t>(count) + 9] = 4.0f;
+    logits[static_cast<size_t>(2) * count + 262] = 9.0f;
+    logits[static_cast<size_t>(2) * count + 3] = 8.0f;
+    logits[static_cast<size_t>(3) * count] = -1.0f;
+    logits[static_cast<size_t>(3) * count + 11] = -1.0f;
+    logits[static_cast<size_t>(4) * count + 129] = 0.5f;
+    logits[static_cast<size_t>(4) * count + 130] = 0.5f;
+
+    DeviceBuffer<float> d_logits(logits);
+    DeviceBuffer<int> d_tokens(rows);
+    DeviceBuffer<float> d_values(rows);
+    expect(dsv4::qwen_argmax_fp32_rows(
+               d_logits.get(), d_tokens.get(), d_values.get(), rows, count,
+               token_offset),
+           "argmax launch");
+    sync_or_throw("argmax");
+
+    const std::vector<int> expected_tokens = {-15, -12, 245, -17, 112};
+    const std::vector<float> expected_values = {3.0f, 4.0f, 9.0f, -1.0f, 0.5f};
+    expect(d_tokens.download() == expected_tokens,
+           "argmax selects lowest global id on ties");
+    expect(d_values.download() == expected_values,
+           "argmax returns winning logits");
+
+    // The decode path calls this with rows == 1 and a vocabulary-wide row, and it
+    // allocates the 4-byte token and logit outputs from one workspace arena, so
+    // they can land in a single 32-byte cache line. Cover that shape explicitly:
+    // the multi-row case above would not catch a single-row store defect.
+    const int wide = 248320;
+    std::vector<float> row(static_cast<size_t>(wide), -3.0f);
+    row[wide - 1] = 11.5f;
+    row[4096] = 11.0f;
+    DeviceBuffer<float> d_row(row);
+    DeviceBuffer<int> d_token(1);
+    DeviceBuffer<float> d_value(1);
+    expect(dsv4::qwen_argmax_fp32_rows(d_row.get(), d_token.get(),
+                                       d_value.get(), 1, wide, 0),
+           "argmax single-row launch");
+    sync_or_throw("argmax single row");
+    expect(d_token.download() == std::vector<int>{wide - 1},
+           "argmax single row selects the last index");
+    expect(d_value.download() == std::vector<float>{11.5f},
+           "argmax single row returns its logit");
+}
+
+void test_gqa_prefill(std::mt19937& rng) {
+    const int rows = 3;
+    const int q_heads = 6;
+    const int kv_heads = 2;
+    const int head_dim = 32;
+    const int position_offset = 2;
+    const int max_context = 9;
+    const std::vector<uint16_t> q = random_halves(
+        static_cast<size_t>(rows) * q_heads * head_dim, rng, 0.45f);
+    std::vector<uint16_t> k_cache = random_halves(
+        static_cast<size_t>(max_context) * kv_heads * head_dim, rng, 0.5f);
+    std::vector<uint16_t> v_cache = random_halves(
+        static_cast<size_t>(max_context) * kv_heads * head_dim, rng, 0.5f);
+    const size_t poison_start = static_cast<size_t>(position_offset + rows) *
+                                kv_heads * head_dim;
+    std::fill(k_cache.begin() + poison_start, k_cache.end(), float_to_half(40.0f));
+    std::fill(v_cache.begin() + poison_start, v_cache.end(), float_to_half(-40.0f));
+    DeviceBuffer<uint16_t> d_q(q), d_k(k_cache), d_v(v_cache);
+    DeviceBuffer<uint16_t> d_out(static_cast<size_t>(rows) * q_heads * head_dim);
+    expect(dsv4::qwen_gqa_prefill_attention_f16(
+               d_q.get(), d_k.get(), d_v.get(), d_out.get(), rows, q_heads,
+               kv_heads, head_dim, position_offset, max_context),
+           "GQA prefill launch");
+    sync_or_throw("GQA prefill");
+    expect_half_close(d_out.download(),
+                      attention_reference(q, k_cache, v_cache, rows, q_heads,
+                                          kv_heads, head_dim, position_offset),
+                      5.0e-3, 2.0e-3, "GQA prefill output");
+}
+
+void test_gqa_verify(std::mt19937& rng) {
+    const int rows = 4;
+    const int q_heads = 6;
+    const int kv_heads = 2;
+    const int head_dim = 32;
+    const int position_offset = 3;
+    const int max_context = 10;
+    const int splits = 5;
+    const std::vector<uint16_t> q = random_halves(
+        static_cast<size_t>(rows) * q_heads * head_dim, rng, 0.45f);
+    std::vector<uint16_t> k_cache = random_halves(
+        static_cast<size_t>(max_context) * kv_heads * head_dim, rng, 0.5f);
+    std::vector<uint16_t> v_cache = random_halves(
+        static_cast<size_t>(max_context) * kv_heads * head_dim, rng, 0.5f);
+    const size_t poison_start = static_cast<size_t>(position_offset + rows) *
+                                kv_heads * head_dim;
+    std::fill(k_cache.begin() + poison_start, k_cache.end(), float_to_half(40.0f));
+    std::fill(v_cache.begin() + poison_start, v_cache.end(), float_to_half(-40.0f));
+    DeviceBuffer<uint16_t> d_q(q), d_k(k_cache), d_v(v_cache);
+    DeviceBuffer<uint16_t> d_out(static_cast<size_t>(rows) * q_heads * head_dim);
+    DeviceBuffer<float> d_partial(static_cast<size_t>(rows) * q_heads * splits *
+                                  (head_dim + 2));
+    expect(dsv4::qwen_gqa_verify_attention_f16(
+               d_q.get(), d_k.get(), d_v.get(), d_out.get(), d_partial.get(),
+               rows, q_heads, kv_heads, head_dim, position_offset, max_context,
+               splits),
+           "GQA verify launch");
+    sync_or_throw("GQA verify");
+    expect_half_close(d_out.download(),
+                      attention_reference(q, k_cache, v_cache, rows, q_heads,
+                                          kv_heads, head_dim, position_offset),
+                      5.0e-3, 2.0e-3, "GQA verify output");
+    const std::vector<float> partial = d_partial.download();
+    int nonfinite = 0;
+    for (size_t group = 0;
+         group < static_cast<size_t>(rows) * q_heads * splits; ++group) {
+        const float maximum = partial[group * (head_dim + 2)];
+        const float denominator = partial[group * (head_dim + 2) + 1];
+        if (!std::isfinite(maximum) && denominator != 0.0f) ++nonfinite;
+        if (!std::isfinite(denominator) || denominator < 0.0f) ++nonfinite;
+    }
+    expect(nonfinite == 0, "GQA verify fills valid split partials");
+}
+
+void test_argument_rejection() {
+    DeviceBuffer<uint16_t> half(1024);
+    DeviceBuffer<float> real(65536);
+    expect(!dsv4::qwen_normalize_gated_delta_qk_f16(
+               nullptr, half.get(), real.get(), real.get(), 1, 1, kKeyDim),
+           "normalize rejects null input");
+    expect(!dsv4::qwen_gated_delta_sequence_f16(
+               real.get(), half.get(), half.get(), half.get(), half.get(),
+               half.get(), half.get(), 1, 3, 2, kKeyDim, kValueDim, 0.1f),
+           "recurrence rejects a bad head ratio");
+    expect(!dsv4::qwen_gated_delta_step_f16(
+               real.get(), half.get(), half.get(), half.get(), half.get(),
+               half.get(), half.get(), 2, 1, 64, kValueDim, 0.1f),
+           "recurrence rejects unsupported key width");
+    expect(!dsv4::qwen_gated_delta_step_f16(
+               real.get(), half.get(), half.get(), half.get(), half.get(),
+               half.get(), half.get(), 2, 1, kKeyDim, kValueDim, 0.0f),
+           "recurrence rejects nonpositive q scale");
+    expect(!dsv4::qwen_linear_attn_gates_f16(
+               half.get(), half.get(), half.get(), half.get(), half.get(),
+               half.get(), 0, 4),
+           "gates reject zero rows");
+    expect(!dsv4::qwen_causal_depthwise_conv_silu_f16(
+               half.get(), half.get(), half.get(), half.get(), 1, 8, 9, true),
+           "convolution rejects a kernel above eight");
+    expect(!dsv4::qwen_partial_rope_rows_f16(
+               half.get(), half.get(), 0, 1, 63, 10000.0f, 2, 1, 64),
+           "rope rejects an odd rotary dimension");
+    expect(!dsv4::qwen_append_kv_cache_f16(
+               half.get(), half.get(), half.get(), half.get(), 2, 1, 16, 3, 4),
+           "KV append rejects cache overflow");
+    expect(!dsv4::qwen_gqa_decode_attention_f16(
+               half.get(), half.get(), half.get(), half.get(), real.get(), 3, 2,
+               16, 2, 4),
+           "GQA decode rejects a bad head ratio");
+    expect(!dsv4::qwen_gqa_prefill_attention_f16(
+               half.get(), half.get(), half.get(), half.get(), 3, 2, 1, 16, 2,
+               4),
+           "GQA prefill rejects context overflow");
+    expect(!dsv4::qwen_gqa_verify_attention_f16(
+               half.get(), half.get(), half.get(), half.get(), real.get(), 2, 2,
+               1, 16, 1, 4, 0),
+           "GQA verify rejects zero splits");
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    int device = 0;
+    std::string only;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--device" && i + 1 < argc) {
+            device = std::stoi(argv[++i]);
+        } else if (arg == "--only" && i + 1 < argc) {
+            only = argv[++i];
+        } else {
+            throw std::runtime_error("unknown or incomplete argument: " + arg);
+        }
+    }
+    if (!dsv4::device_runtime_available()) {
+        std::cout << "[SKIP] no device runtime available\n";
+        return 0;
+    }
+    if (!dsv4::device_set(device)) {
+        std::cout << "[SKIP] device_set failed for device " << device << "\n";
+        return 0;
+    }
+    std::cout << "backend=" << dsv4::device_backend_name() << " device=" << device
+              << "\n";
+
+    std::mt19937 rng(20260830u);
+    const std::vector<std::pair<const char*, void (*)(std::mt19937&)>> suite = {
+        {"normalize_qk", test_normalize_qk},
+        {"gated_delta", test_gated_delta_recurrence},
+        {"linear_attn_gates", test_linear_attn_gates},
+        {"causal_conv", test_causal_conv},
+        {"partial_rope", test_partial_rope},
+        {"append_kv", test_append_kv},
+        {"gqa_decode", test_gqa_decode},
+        {"gqa_prefill", test_gqa_prefill},
+        {"gqa_verify", test_gqa_verify},
+        {"argmax", test_argmax},
+    };
+    for (const auto& entry : suite) {
+        if (!only.empty() &&
+            ("," + only + ",").find("," + std::string(entry.first) + ",") ==
+                std::string::npos) {
+            continue;
+        }
+        std::cout << "[run] " << entry.first << std::endl;
+        try {
+            entry.second(rng);
+        } catch (const std::exception& error) {
+            ++failures;
+            std::cout << "  FAIL " << entry.first << " threw: " << error.what()
+                      << "\n";
+        }
+    }
+    if (only.empty() ||
+        ("," + only + ",").find(",argument_rejection,") != std::string::npos) {
+        std::cout << "[run] argument_rejection" << std::endl;
+        try {
+            test_argument_rejection();
+        } catch (const std::exception& error) {
+            ++failures;
+            std::cout << "  FAIL argument_rejection threw: " << error.what() << "\n";
+        }
+    }
+
+    if (failures != 0) {
+        std::cout << "FAIL " << failures << " of " << checks << " checks\n";
+        return 1;
+    }
+    std::cout << "PASS (" << checks << " checks)\n";
+    return 0;
+}

--- a/scripts/build_ascend.sh
+++ b/scripts/build_ascend.sh
@@ -18,6 +18,12 @@ ASCEND_TOOLKIT_HOME="${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/cann-9.0.0}"
 # shellcheck disable=SC1091
 source "${REPO_ROOT}/scripts/ascend_env.sh"
 
+# The nested AscendC ExternalProject builds select a GCC 12 toolchain while this
+# image provides GCC 11's C++ headers. Environment inheritance is the reliable
+# way to make every nested compiler invocation see the installed headers.
+GCC_CXX_INCLUDE="/usr/include/c++/11:/usr/include/aarch64-linux-gnu/c++/11"
+export CPLUS_INCLUDE_PATH="${GCC_CXX_INCLUDE}${CPLUS_INCLUDE_PATH:+:${CPLUS_INCLUDE_PATH}}"
+
 cmake -S "${ENGINE_DIR}" -B "${BUILD_DIR}" \
     -DPOCKET_BACKEND=ascend \
     -DASCEND_TOOLKIT_HOME="${ASCEND_TOOLKIT_HOME}"
@@ -29,6 +35,7 @@ cmake --build "${BUILD_DIR}" -j"$(nproc)" --target \
     test_qwen_bf16_checkpoint \
     test_qwen_ascend_norm_gamma \
     test_qwen_ascend_ops \
+    test_qwen_ascend_group_b \
     test_tp_comm_smoke
 
 if [ "${1:-test}" = "build" ]; then
@@ -41,7 +48,8 @@ status=0
 # Single-process tests. Binaries land in different directories depending on
 # whether the target sets RUNTIME_OUTPUT_DIRECTORY, so search rather than assume.
 for name in test_device_runtime test_qwen_config test_qwen_bf16_checkpoint \
-            test_qwen_ascend_norm_gamma test_qwen_ascend_ops; do
+            test_qwen_ascend_norm_gamma test_qwen_ascend_ops \
+            test_qwen_ascend_group_b; do
     binary="$(find "${BUILD_DIR}" -name "${name}" -type f -perm -u+x | head -1)"
     if [ -z "${binary}" ]; then
         echo "build_ascend: ${name} not built"


### PR DESCRIPTION
## Summary

Implements baseline AscendC kernel implementations for first-generation Ascend 910 hardware (910A/910B/910Pro with `Short_SoC_version=Ascend910`), establishing token-exact correctness for the Qwen3.8-27B model with 4-way tensor parallelism.

## Implementation

**AscendC Kernels**
- **Full attention** (`qwen_attention_f16.cpp`): GQA decode and prefill kernels with causal masking, online softmax, and explicit KV cache padding handling
- **Gated recurrent delta head** (`qwen_gated_delta_f16.cpp`): UB-resident state with vectorized Mul/Add operations and fold reductions
- **Linear projections** (`qwen_linear_f16.cpp`): Softplus, sigmoid, and SiLU activations using AscendC vector intrinsics
- **Argmax** (`qwen_argmax_f32.cpp`): FP32 tree reduction for token selection

**Multi-rank support**
- HCCL-based AllReduce/AllGather collectives for TP4
- One ACL device context per process (root-info init pattern)
- Stream-ordered execution with proper aclrtSynchronizeStream placement

**Infrastructure**
- Phase profiling with `QWEN_PHASE_PROFILE=1` environment variable
- Shared kernel helpers in `qwen_ascend_kernel_common.hpp`
- Test harness in `cpp_engine/tests/test_qwen_ascend_group_b.cpp`

## Baseline Results

**Hardware:** 8× Ascend 910B (first-gen), 32 GB HBM/card, CANN 9.0.0

**TP4 Qwen3.8-27B resident benchmark** (64-token prefill, 7 decode steps):
- **Prefill:** 0.513 tokens/s (124.7 s for 64 tokens)
- **Decode:** 0.00871 tokens/s (114.79 s/token)
- **Memory:** 15.21 GB/rank
- **Token parity:** Exact match across all 4 ranks ✓

**Phase profile** (4-layer, 64-token prefill):
```
phase=full_attention  30.2s / 31.3s  (96.5%)
phase=STACK.r         30.8s / 61.4s  (50.1%)
```

## Performance Notes

The current attention implementation uses scalar loops for Q·K dot products, making decode effectively O(head_dim² × context). This was intentional for the correctness baseline—the kernel recomputes each dot product once per output dimension to avoid managing intermediate state.

**Next optimization:** Vectorize score computation by loading Q/K vectors to UB, using `AscendC::Mul` + fold reductions for dot products, and accumulating the weighted value with UB-resident scores. This should recover the 30 seconds per attention layer immediately.

## Testing

```bash
# Build
bash scripts/build_ascend.sh

# Single-rank unit test
./cpp_engine/build-ascend-new/tests/test_qwen_ascend_group_b

# TP4 resident benchmark
QWEN_PHASE_PROFILE=1 bash run_tp4.sh
```

## Platform Requirements

- First-generation Ascend 910 (910A/910B/910Pro/910Premium with `Short_SoC_version=Ascend910`)
- CANN 9.0.0 or later
- aarch64 Linux (tested on Ubuntu 22.04)
- Multi-rank: HCCL-capable interconnect (SDMA for intra-server, RDMA with `/etc/hccn.conf` for inter-server)