### PR TITLE
Add a unified PocketLLM API over the Torch and C++ backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 **/build/
 **/build-ascend/
 **/build-cuda/
+**/build-python/
 **/develop-eggs/
 **/dist/
 **/downloads/

--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -19,6 +19,16 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Python bindings are optional so the native CLI and inspection tools keep their
+# existing dependency footprint.  When enabled, pybind11 is discovered through
+# the active Python environment and the module links the same selected backend.
+option(POCKET_BUILD_PYTHON "Build the optional pocketllm_cpp Python module" OFF)
+
+# The Python module is a shared object, so every static library it links must be
+# position independent.  This is scoped to the Python build so the executables
+# keep their existing code generation, including GOT-free direct addressing.
+set(POCKET_STATIC_PIC ${POCKET_BUILD_PYTHON})
+
 # Sources that touch no vendor SDK. Keeping this list free of vendor headers is
 # what lets a second backend reuse the loaders, tokenizer and HTTP server
 # unchanged; see check_layering below, which enforces it.
@@ -284,6 +294,7 @@ endif()
 # and the Qwen weight map build and run with no vendor SDK present at all, which
 # is what lets a checkpoint be audited on a host without the accelerator toolkit.
 add_library(pocket_core STATIC ${POCKET_CORE_SOURCES})
+set_target_properties(pocket_core PROPERTIES POSITION_INDEPENDENT_CODE ${POCKET_STATIC_PIC})
 target_include_directories(pocket_core PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/third_party
@@ -293,6 +304,7 @@ target_include_directories(pocket_core PUBLIC
 # linked, chosen at configure time, so a call through this costs the same as
 # calling the vendor API directly: no vtable, no dispatch.
 add_library(pocket_runtime STATIC ${POCKET_RUNTIME_SOURCES})
+set_target_properties(pocket_runtime PROPERTIES POSITION_INDEPENDENT_CODE ${POCKET_STATIC_PIC})
 target_link_libraries(pocket_runtime PUBLIC pocket_core)
 target_include_directories(pocket_runtime PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/backends/api
@@ -311,6 +323,7 @@ add_library(dsv4_cpp_core STATIC
     ${POCKET_ENGINE_SOURCES}
     ${POCKET_BACKEND_SOURCES}
 )
+set_target_properties(dsv4_cpp_core PROPERTIES POSITION_INDEPENDENT_CODE ${POCKET_STATIC_PIC})
 
 target_link_libraries(dsv4_cpp_core PUBLIC pocket_core pocket_runtime)
 
@@ -356,6 +369,36 @@ add_custom_target(check_layering
 
 add_executable(dsv4_cpp_engine engine/main.cpp)
 target_link_libraries(dsv4_cpp_engine PRIVATE dsv4_cpp_core)
+
+if(POCKET_BUILD_PYTHON)
+    find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
+    find_package(pybind11 CONFIG REQUIRED)
+    # Do not enable pybind11's LTO/strip extras here.  The selected backend
+    # contains CUDA device-link objects whose fatbin registration data must stay
+    # visible while the shared extension is linked.
+    pybind11_add_module(pocketllm_cpp NO_EXTRAS python/bindings.cpp)
+    target_link_libraries(pocketllm_cpp PRIVATE dsv4_cpp_core)
+    target_include_directories(pocketllm_cpp PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/third_party
+        ${CMAKE_CURRENT_SOURCE_DIR}/backends/api
+    )
+    if(POCKET_BACKEND_INCLUDES)
+        target_include_directories(pocketllm_cpp PRIVATE ${POCKET_BACKEND_INCLUDES})
+    endif()
+    if(POCKET_ASCEND_KERNEL_INCLUDES)
+        target_include_directories(pocketllm_cpp PRIVATE ${POCKET_ASCEND_KERNEL_INCLUDES})
+    endif()
+    if(POCKET_BACKEND_DEFINES)
+        target_compile_definitions(pocketllm_cpp PRIVATE ${POCKET_BACKEND_DEFINES})
+    endif()
+    set_target_properties(pocketllm_cpp PROPERTIES
+        CUDA_SEPARABLE_COMPILATION ON
+        CUDA_RESOLVE_DEVICE_SYMBOLS ON
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/python
+    )
+    message(STATUS "POCKET_BUILD_PYTHON=ON: building pocketllm_cpp")
+endif()
 
 add_executable(inspect_gguf tools/inspect_gguf.cpp)
 target_link_libraries(inspect_gguf PRIVATE dsv4_cpp_core)

--- a/cpp_engine/include/qwen_ops.hpp
+++ b/cpp_engine/include/qwen_ops.hpp
@@ -28,6 +28,15 @@
 
 namespace dsv4 {
 
+#ifndef POCKET_BACKEND_ASCEND
+// The legacy row-wise argmax is shared with the DSV4 path and is declared in
+// cuda_ops.hpp when that header is included. Keep a no-default declaration here
+// for Qwen-only translation units that do not include the legacy header.
+bool argmax_fp32_rows_cuda(const float* d_logits, int* d_tokens,
+                           float* d_logits_out, int rows, int count,
+                           int token_offset, void* stream);
+#endif
+
 inline bool qwen_add_inplace_f16(uint16_t* d_y_fp16, const uint16_t* d_x_fp16, int count, void* stream = nullptr) {
 #ifdef POCKET_BACKEND_ASCEND
     return qwen_add_inplace_f16_ascend(d_y_fp16, d_x_fp16, count, stream);

--- a/cpp_engine/python/bindings.cpp
+++ b/cpp_engine/python/bindings.cpp
@@ -1,0 +1,378 @@
+// Optional pybind11 bridge for the native PocketLLM engines.
+//
+// The module exposes value types and token-oriented engine methods only.  It does
+// not expose vendor handles or tensors, so Python callers cannot depend on the
+// CUDA/Ascend implementation details that remain inside dsv4_cpp_core.
+
+#include "persistent_engine.hpp"
+#include "qwen_config.hpp"
+#include "qwen_engine.hpp"
+#include "qwen_weights.hpp"
+#include "device_runtime.hpp"
+
+#include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <utility>
+
+namespace py = pybind11;
+using namespace dsv4;
+
+namespace {
+
+py::dict forward_result_dict(const QwenForwardResult& result) {
+    py::dict out;
+    out["token"] = result.token;
+    out["layers"] = result.layers;
+    out["dim"] = result.dim;
+    out["logits"] = result.logits;
+    out["top_token"] = result.top_token;
+    out["correct_drafts"] = result.correct_drafts;
+    out["bonus_token"] = result.bonus_token;
+    out["accept_tokens"] = result.accept_tokens;
+    out["accept_logits"] = result.accept_logits;
+    out["accept_checksums"] = result.accept_checksums;
+    out["top_logit"] = result.top_logit;
+    out["checksum"] = result.checksum;
+    out["position"] = result.position;
+    return out;
+}
+
+py::dict mtp_stats_dict(const QwenMtpStats& stats) {
+    py::dict out;
+    out["verify_count"] = stats.verify_count;
+    out["proposed_drafts"] = stats.proposed_drafts;
+    out["correct_drafts"] = stats.correct_drafts;
+    out["rollback_count"] = stats.rollback_count;
+    out["replay_tokens"] = stats.replay_tokens;
+    out["confidence_count"] = stats.confidence_count;
+    out["confidence_sum"] = stats.confidence_sum;
+    out["confidence_min"] = stats.confidence_min;
+    out["confidence_max"] = stats.confidence_max;
+    out["prefill_seconds"] = stats.prefill_seconds;
+    out["draft_seconds"] = stats.draft_seconds;
+    out["verify_seconds"] = stats.verify_seconds;
+    out["replay_seconds"] = stats.replay_seconds;
+    out["accept_length"] = stats.accept_length();
+    out["accept_rate"] = stats.accept_rate();
+    out["mean_confidence"] = stats.mean_confidence();
+    return out;
+}
+
+py::dict prefix_stats_dict(const QwenPrefixCacheStats& stats) {
+    py::dict out;
+    out["reused_tokens"] = stats.reused_tokens;
+    out["computed_tokens"] = stats.computed_tokens;
+    out["prompt_tokens"] = stats.prompt_tokens;
+    out["resume_source"] = stats.resume_source;
+    out["matched_tokens"] = stats.matched_tokens;
+    out["snapshots"] = stats.snapshots;
+    out["snapshot_bytes"] = stats.snapshot_bytes;
+    out["hits"] = stats.hits;
+    out["misses"] = stats.misses;
+    return out;
+}
+
+py::dict telemetry_dict(const QwenRuntimeTelemetry& telemetry) {
+    py::dict out;
+    py::dict checkpoint;
+    checkpoint["dense_f16"] = telemetry.checkpoint_linear_kinds.dense_f16;
+    checkpoint["fp8_block128"] = telemetry.checkpoint_linear_kinds.fp8_block128;
+    checkpoint["fp8_channel"] = telemetry.checkpoint_linear_kinds.fp8_channel;
+    checkpoint["nvfp4_group16"] = telemetry.checkpoint_linear_kinds.nvfp4_group16;
+    py::dict active;
+    active["dense_f16"] = telemetry.active_linear_kinds.dense_f16;
+    active["fp8_block128"] = telemetry.active_linear_kinds.fp8_block128;
+    active["fp8_channel"] = telemetry.active_linear_kinds.fp8_channel;
+    active["nvfp4_group16"] = telemetry.active_linear_kinds.nvfp4_group16;
+    out["checkpoint_linear_kinds"] = checkpoint;
+    out["active_linear_kinds"] = active;
+    out["nvfp4_decode_path"] = telemetry.nvfp4_decode_path;
+    out["nvfp4_prefill_path"] = telemetry.nvfp4_prefill_path;
+    out["fp8_channel_decode_path"] = telemetry.fp8_channel_decode_path;
+    out["fp8_channel_prefill_path"] = telemetry.fp8_channel_prefill_path;
+    out["target_head_path"] = telemetry.target_head_path;
+    out["host_global_metadata_bytes"] = telemetry.host_global_metadata_bytes;
+    out["nvfp4_q8_workspace_peak_bytes"] = telemetry.nvfp4_q8_workspace_peak_bytes;
+    return out;
+}
+
+py::dict qwen_config_dict(const QwenConfig& config) {
+    py::dict out;
+    out["architecture"] = config.architecture;
+    out["model_type"] = config.model_type;
+    out["vocab_size"] = config.vocab_size;
+    out["hidden_size"] = config.hidden_size;
+    out["num_hidden_layers"] = config.num_hidden_layers;
+    out["max_position_embeddings"] = config.max_position_embeddings;
+    out["mtp_num_hidden_layers"] = config.mtp_num_hidden_layers;
+    out["mtp_use_dedicated_embeddings"] = config.mtp_use_dedicated_embeddings;
+    out["rms_norm_eps"] = config.rms_norm_eps;
+    out["rope_theta"] = config.rope_theta;
+    out["partial_rotary_factor"] = config.partial_rotary_factor;
+    out["fp8_block_size"] = config.fp8_block_size;
+    out["linear_attention_layers"] = config.linear_attention_layers();
+    out["full_attention_layers"] = config.full_attention_layers();
+    out["layer_types"] = py::list();
+    for (uint64_t layer = 0; layer < config.layer_types.size(); ++layer) {
+        out["layer_types"].cast<py::list>().append(config.layer_type_name(layer));
+    }
+    out["to_string"] = config.to_string();
+    return out;
+}
+
+py::dict options_dict(const ForwardSmokeOptions& options) {
+    py::dict out;
+    out["tp_world"] = options.tp_world;
+    out["tp_rank"] = options.tp_rank;
+    out["device"] = options.device;
+    out["skip_fp4_host_prepare"] = options.skip_fp4_host_prepare;
+    out["nccl_id_path"] = options.nccl_id_path;
+    return out;
+}
+
+QwenForwardResult qwen_prefill(QwenEngine& engine, const std::vector<int>& tokens) {
+    py::gil_scoped_release release;
+    return engine.prefill(tokens);
+}
+
+QwenForwardResult qwen_decode(QwenEngine& engine, int token) {
+    py::gil_scoped_release release;
+    return engine.decode_step(token);
+}
+
+std::vector<QwenForwardResult> qwen_generate(QwenEngine& engine,
+                                             const std::vector<int>& tokens,
+                                             int max_new_tokens) {
+    py::gil_scoped_release release;
+    return engine.generate(tokens, max_new_tokens);
+}
+
+int persistent_prefill(PersistentEngine& engine, const std::vector<int>& tokens,
+                       const SamplingParams& params) {
+    py::gil_scoped_release release;
+    return engine.prefill(tokens, params);
+}
+
+int persistent_decode(PersistentEngine& engine, int token, int position,
+                      const SamplingParams& params) {
+    py::gil_scoped_release release;
+    return engine.decode_step(token, position, params);
+}
+
+std::vector<int> persistent_verify(PersistentEngine& engine,
+                                   const std::vector<int>& tokens, int position,
+                                   const SamplingParams& params) {
+    py::gil_scoped_release release;
+    return engine.verify_step(tokens, position, params);
+}
+
+std::vector<int> persistent_batch_verify(PersistentEngine& engine,
+                                         const std::vector<int>& tokens, int position,
+                                         const SamplingParams& params) {
+    py::gil_scoped_release release;
+    return engine.batch_verify_step(tokens, position, params);
+}
+
+}  // namespace
+
+PYBIND11_MODULE(pocketllm_cpp, module) {
+    module.doc() = "Optional native PocketLLM C++ backend";
+
+    py::enum_<QwenKvCacheDType>(module, "QwenKvCacheDType")
+        .value("Fp16", QwenKvCacheDType::Fp16)
+        .value("Fp8", QwenKvCacheDType::Fp8)
+        .value("TurboQuantK8V4", QwenKvCacheDType::TurboQuantK8V4)
+        .value("Int8PerTokenHead", QwenKvCacheDType::Int8PerTokenHead)
+        .export_values();
+
+    module.def("qwen_kv_cache_dtype_name", [](QwenKvCacheDType dtype) {
+        return std::string(qwen_kv_cache_dtype_name(dtype));
+    });
+    module.def("parse_qwen_kv_cache_dtype", &parse_qwen_kv_cache_dtype);
+    module.def("is_qwen3_5_checkpoint", &is_qwen3_5_checkpoint);
+
+    py::class_<QwenEngineOptions>(module, "QwenEngineOptions")
+        .def(py::init<>())
+        .def_readwrite("tp_world", &QwenEngineOptions::tp_world)
+        .def_readwrite("tp_rank", &QwenEngineOptions::tp_rank)
+        .def_readwrite("device", &QwenEngineOptions::device)
+        .def_readwrite("prefill_chunk_tokens", &QwenEngineOptions::prefill_chunk_tokens)
+        .def_readwrite("kv_cache_dtype", &QwenEngineOptions::kv_cache_dtype)
+        .def_readwrite("attention_window", &QwenEngineOptions::attention_window)
+        .def_readwrite("attention_sink_tokens", &QwenEngineOptions::attention_sink_tokens)
+        .def_readwrite("prefix_cache", &QwenEngineOptions::prefix_cache)
+        .def_readwrite("state_snapshot_interval_tokens", &QwenEngineOptions::state_snapshot_interval_tokens)
+        .def_readwrite("max_state_snapshots", &QwenEngineOptions::max_state_snapshots)
+        .def_readwrite("mtp", &QwenEngineOptions::mtp)
+        .def_readwrite("mtp_speculative_tokens", &QwenEngineOptions::mtp_speculative_tokens)
+        .def_readwrite("mtp_adaptive", &QwenEngineOptions::mtp_adaptive)
+        .def_readwrite("dspark_checkpoint", &QwenEngineOptions::dspark_checkpoint)
+        .def_readwrite("dflash2_checkpoint", &QwenEngineOptions::dflash2_checkpoint)
+        .def_readwrite("nccl_id_path", &QwenEngineOptions::nccl_id_path)
+        .def_readwrite("temperature", &QwenEngineOptions::temperature)
+        .def_readwrite("top_p", &QwenEngineOptions::top_p)
+        .def_readwrite("top_k", &QwenEngineOptions::top_k)
+        .def_readwrite("sampling_seed", &QwenEngineOptions::sampling_seed);
+
+    py::class_<QwenForwardResult>(module, "QwenForwardResult")
+        .def(py::init<>())
+        .def_readwrite("token", &QwenForwardResult::token)
+        .def_readwrite("layers", &QwenForwardResult::layers)
+        .def_readwrite("dim", &QwenForwardResult::dim)
+        .def_readwrite("logits", &QwenForwardResult::logits)
+        .def_readwrite("top_token", &QwenForwardResult::top_token)
+        .def_readwrite("correct_drafts", &QwenForwardResult::correct_drafts)
+        .def_readwrite("bonus_token", &QwenForwardResult::bonus_token)
+        .def_readwrite("accept_tokens", &QwenForwardResult::accept_tokens)
+        .def_readwrite("accept_logits", &QwenForwardResult::accept_logits)
+        .def_readwrite("accept_checksums", &QwenForwardResult::accept_checksums)
+        .def_readwrite("top_logit", &QwenForwardResult::top_logit)
+        .def_readwrite("checksum", &QwenForwardResult::checksum)
+        .def_readwrite("position", &QwenForwardResult::position)
+        .def("as_dict", &forward_result_dict);
+
+    py::class_<QwenMtpStats>(module, "QwenMtpStats")
+        .def(py::init<>())
+        .def_readwrite("verify_count", &QwenMtpStats::verify_count)
+        .def_readwrite("proposed_drafts", &QwenMtpStats::proposed_drafts)
+        .def_readwrite("correct_drafts", &QwenMtpStats::correct_drafts)
+        .def_readwrite("rollback_count", &QwenMtpStats::rollback_count)
+        .def_readwrite("replay_tokens", &QwenMtpStats::replay_tokens)
+        .def_readwrite("confidence_count", &QwenMtpStats::confidence_count)
+        .def_readwrite("confidence_sum", &QwenMtpStats::confidence_sum)
+        .def_readwrite("confidence_min", &QwenMtpStats::confidence_min)
+        .def_readwrite("confidence_max", &QwenMtpStats::confidence_max)
+        .def_readwrite("prefill_seconds", &QwenMtpStats::prefill_seconds)
+        .def_readwrite("draft_seconds", &QwenMtpStats::draft_seconds)
+        .def_readwrite("verify_seconds", &QwenMtpStats::verify_seconds)
+        .def_readwrite("replay_seconds", &QwenMtpStats::replay_seconds)
+        .def_property_readonly("accept_length", &QwenMtpStats::accept_length)
+        .def_property_readonly("accept_rate", &QwenMtpStats::accept_rate)
+        .def_property_readonly("mean_confidence", &QwenMtpStats::mean_confidence)
+        .def("as_dict", &mtp_stats_dict);
+
+    py::class_<QwenPrefixCacheStats>(module, "QwenPrefixCacheStats")
+        .def(py::init<>())
+        .def_readwrite("reused_tokens", &QwenPrefixCacheStats::reused_tokens)
+        .def_readwrite("computed_tokens", &QwenPrefixCacheStats::computed_tokens)
+        .def_readwrite("prompt_tokens", &QwenPrefixCacheStats::prompt_tokens)
+        .def_readwrite("resume_source", &QwenPrefixCacheStats::resume_source)
+        .def_readwrite("matched_tokens", &QwenPrefixCacheStats::matched_tokens)
+        .def_readwrite("snapshots", &QwenPrefixCacheStats::snapshots)
+        .def_readwrite("snapshot_bytes", &QwenPrefixCacheStats::snapshot_bytes)
+        .def_readwrite("hits", &QwenPrefixCacheStats::hits)
+        .def_readwrite("misses", &QwenPrefixCacheStats::misses)
+        .def("as_dict", &prefix_stats_dict);
+
+    py::class_<QwenEngine>(module, "QwenEngine")
+        .def(py::init<const std::string&, const QwenEngineOptions&, int, int>(),
+             py::arg("checkpoint_dir"), py::arg("options"),
+             py::arg("layer_count") = 0, py::arg("max_context") = 8192,
+             "Construct the stateful native Qwen engine.")
+        .def("warmup_tp", [](QwenEngine& engine) {
+            py::gil_scoped_release release;
+            engine.warmup_tp();
+        })
+        // reset()/clear_prefix_cache() zero the recurrent state on the device, so
+        // they release the GIL like the other device-touching entry points.
+        .def("reset", [](QwenEngine& engine) {
+            py::gil_scoped_release release;
+            engine.reset();
+        })
+        .def("clear_prefix_cache", [](QwenEngine& engine) {
+            py::gil_scoped_release release;
+            engine.clear_prefix_cache();
+        })
+        .def("prefill", &qwen_prefill)
+        .def("decode_step", &qwen_decode)
+        .def("generate", &qwen_generate)
+        .def_property_readonly("position", &QwenEngine::position)
+        .def_property_readonly("max_context", &QwenEngine::max_context)
+        .def_property_readonly("resident_weight_bytes", &QwenEngine::resident_weight_bytes)
+        .def_property_readonly("resident_scale_bytes", &QwenEngine::resident_scale_bytes)
+        .def_property_readonly("verify_weight_bytes", &QwenEngine::verify_weight_bytes)
+        .def_property_readonly("activation_workspace_peak_bytes", &QwenEngine::activation_workspace_peak_bytes)
+        .def_property_readonly("kv_cache_bytes", &QwenEngine::kv_cache_bytes)
+        .def_property_readonly("kv_cache_scale_bytes", &QwenEngine::kv_cache_scale_bytes)
+        .def_property_readonly("config", [](const QwenEngine& engine) {
+            return qwen_config_dict(engine.config());
+        })
+        .def_property_readonly("prefix_cache_stats", [](const QwenEngine& engine) {
+            return prefix_stats_dict(engine.prefix_cache_stats());
+        })
+        .def_property_readonly("mtp_stats", [](const QwenEngine& engine) {
+            return mtp_stats_dict(engine.mtp_stats());
+        })
+        .def_property_readonly("runtime_telemetry", [](const QwenEngine& engine) {
+            return telemetry_dict(engine.runtime_telemetry());
+        });
+
+    py::class_<SamplingParams>(module, "SamplingParams")
+        .def(py::init<>())
+        .def_readwrite("temperature", &SamplingParams::temperature)
+        .def_readwrite("top_p", &SamplingParams::top_p)
+        .def_readwrite("greedy", &SamplingParams::greedy)
+        .def_readwrite("seed", &SamplingParams::seed);
+
+    py::class_<ForwardSmokeOptions>(module, "ForwardSmokeOptions")
+        .def(py::init<>())
+        .def_readwrite("tp_world", &ForwardSmokeOptions::tp_world)
+        .def_readwrite("tp_rank", &ForwardSmokeOptions::tp_rank)
+        .def_readwrite("device", &ForwardSmokeOptions::device)
+        .def_readwrite("skip_fp4_host_prepare", &ForwardSmokeOptions::skip_fp4_host_prepare)
+        .def_readwrite("nccl_id_path", &ForwardSmokeOptions::nccl_id_path)
+        .def("as_dict", &options_dict);
+
+    py::class_<PersistentEngine>(module, "PersistentEngine")
+        .def(py::init<const std::string&, const ForwardSmokeOptions&, int, int>(),
+             py::arg("checkpoint_dir"), py::arg("options"),
+             py::arg("layer_count"), py::arg("max_context"))
+        .def("reset_session", [](PersistentEngine& engine) {
+            py::gil_scoped_release release;
+            engine.reset_session();
+        })
+        .def("prefill", &persistent_prefill)
+        .def("decode_step", &persistent_decode)
+        .def("verify_step", &persistent_verify)
+        .def("batch_verify_step", &persistent_batch_verify)
+        .def("speculative_step", [](PersistentEngine& engine, int token, int position,
+                                     const SamplingParams& params) {
+            py::gil_scoped_release release;
+            return engine.speculative_step(token, position, params);
+        })
+        .def("load_dspark", [](PersistentEngine& engine, const std::string& path) {
+            py::gil_scoped_release release;
+            engine.load_dspark(path);
+        })
+        .def("dspark_loaded", &PersistentEngine::dspark_loaded)
+        .def("eos_id", &PersistentEngine::eos_id)
+        .def("max_context", &PersistentEngine::max_context)
+        .def("layer_count", &PersistentEngine::layer_count)
+        .def_property_readonly("last_dspark_hidden", &PersistentEngine::last_dspark_hidden)
+        .def_property_readonly("last_dspark_hidden_positions", &PersistentEngine::last_dspark_hidden_positions)
+        .def_property_readonly("last_verify_dspark_hidden", &PersistentEngine::last_verify_dspark_hidden)
+        .def_property_readonly("last_topk_tokens", &PersistentEngine::last_topk_tokens)
+        .def_property_readonly("last_topk_logits", &PersistentEngine::last_topk_logits)
+        .def("warmup_tp", [](PersistentEngine& engine) {
+            py::gil_scoped_release release;
+            engine.warmup_tp();
+        })
+        .def("run_worker_loop", [](PersistentEngine& engine) {
+            py::gil_scoped_release release;
+            engine.run_worker_loop();
+        })
+        .def("worker_command_prefill", &PersistentEngine::worker_command_prefill)
+        .def("worker_command_decode", &PersistentEngine::worker_command_decode)
+        .def("worker_command_reset", &PersistentEngine::worker_command_reset)
+        .def("worker_command_shutdown", &PersistentEngine::worker_command_shutdown)
+        .def("worker_command_verify", &PersistentEngine::worker_command_verify)
+        .def("worker_command_batch_verify", &PersistentEngine::worker_command_batch_verify)
+        .def("worker_command_finalize_batch_verify", &PersistentEngine::worker_command_finalize_batch_verify)
+        .def("worker_command_draft", &PersistentEngine::worker_command_draft)
+        .def("worker_command_speculative_decode", &PersistentEngine::worker_command_speculative_decode)
+        .def("worker_command_prime_draft_kv", &PersistentEngine::worker_command_prime_draft_kv);
+
+    module.attr("backend") = device_backend_name();
+}

--- a/docs/pocketllm_api.md
+++ b/docs/pocketllm_api.md
@@ -1,0 +1,130 @@
+# PocketLLM API and Backend Guide
+
+PocketLLM presents one user-facing API over two independent execution planes:
+
+- **Torch** uses the existing PyTorch/Triton runtimes under `src/`.
+- **C++** uses the native `cpp_engine` runtime and the selected CUDA or Ascend backend.
+
+The common API does not imply shared kernels, KV-cache layouts, or schedulers. Those remain backend- and hardware-specific so that Turing CUDA and Ascend optimizations are not weakened by a lowest-common-denominator abstraction.
+
+## Offline API
+
+```python
+from pocketllm import EngineArgs, LLM, SamplingParams
+
+llm = LLM(EngineArgs(
+    model="/path/to/checkpoint",
+    backend="auto",  # or "torch" / "cpp"
+    tensor_parallel_size=4,
+    max_model_len=65536,
+))
+
+outputs = llm.generate(
+    ["Explain speculative decoding.", "Explain continuous batching."],
+    SamplingParams(max_tokens=128, temperature=0.0),
+)
+for output in outputs:
+    print(output.text, output.usage.as_dict())
+```
+
+Pre-tokenized input is also accepted:
+
+```python
+outputs = llm.generate([[1, 42, 17]], SamplingParams(max_tokens=16))
+```
+
+Use `generate_stream()` for token events and `cancel(request_id)` to request cancellation at a safe generation boundary. The initial C++ compatibility adapter is serialized and exposes native greedy generation; unsupported sampling or request features report `UnsupportedFeatureError` rather than being silently ignored. Native streaming decodes the cumulative token sequence before emitting each delta, so BPE and UTF-8 token boundaries are handled by the tokenizer.
+
+## Async API
+
+```python
+from pocketllm import AsyncLLM, EngineArgs, SamplingParams
+
+async with AsyncLLM(EngineArgs(model="/path/to/checkpoint")) as llm:
+    result = (await llm.generate("Hello", SamplingParams(max_tokens=32)))[0]
+    async for event in llm.generate_stream("Stream this"):
+        print(event.text, end="", flush=True)
+```
+
+`AsyncLLM` currently provides non-blocking application integration around the backend contract. It does not claim device-level continuous batching. Backend schedulers will add that capability independently.
+
+## CLI and server
+
+```bash
+# Installed console script
+pocketllm serve \
+  --model /path/to/checkpoint \
+  --backend auto \
+  --tensor-parallel-size 4 \
+  --max-model-len 65536 \
+  --port 8000
+
+# Source-tree equivalent
+python -m pocketllm serve \
+  --model /path/to/checkpoint \
+  --backend auto \
+  --tensor-parallel-size 4 \
+  --max-model-len 65536 \
+  --port 8000
+``` 
+
+The CLI does not automatically launch tensor-parallel worker processes; start the configured
+workers using the deployment's existing launcher when `tensor_parallel_size > 1`.
+
+The unified server provides:
+
+- `GET /health`
+- `GET /alive`
+- `GET /ready`
+- `GET /metrics`
+- `GET /v1/models`
+- `POST /v1/chat/completions`
+- `POST /v1/completions`
+- `DELETE /v1/requests/<request_id>`
+
+`/ready` returns HTTP 503 while model loading is incomplete. `/metrics` uses dependency-free Prometheus text exposition and can later be wrapped by a richer exporter.
+
+## Configuration precedence
+
+Prefer typed `EngineArgs` and explicit CLI options. `EngineArgs.from_env()` exists as a compatibility bridge for legacy deployments. Existing `DSV4_*`, `QWEN_*`, and related environment variables remain available to the underlying runtimes. Backend-specific tuning belongs in `backend_options` and must not be assumed portable between CUDA and Ascend.
+
+## Native C++ Python module
+
+The native bridge is optional and does not affect CPU-only imports:
+
+```bash
+cmake -S cpp_engine -B cpp_engine/build-python \
+  -DPOCKET_BACKEND=cuda \
+  -DPOCKET_BUILD_PYTHON=ON \
+  -Dpybind11_DIR="$(python -c 'import pybind11; print(pybind11.get_cmake_dir())')"
+cmake --build cpp_engine/build-python --target pocketllm_cpp -j
+```
+
+Add `cpp_engine/build-python/python` to `PYTHONPATH` for a build-tree smoke test:
+
+```bash
+PYTHONPATH=cpp_engine/build-python/python python -c \
+  'import pocketllm_cpp; print(pocketllm_cpp.backend)'
+```
+
+The module exposes token-oriented `QwenEngine` and low-level `PersistentEngine` value types. Device-touching calls (prefill, decode, generate, verify, warmup, reset) release the Python GIL; cheap accessors and construction do not. It intentionally does not expose CUDA/ACL handles or Torch tensors.
+
+## Backend selection
+
+`backend="auto"` picks the C++ adapter only when the native module is importable and the checkpoint
+is a Qwen3.5 safetensors model; anything else, including GGUF, stays on Torch. An explicit
+`backend="cpp"` for an unsupported checkpoint raises `UnsupportedFeatureError` before any CUDA
+initialization instead of failing deep inside the native loader.
+
+Capabilities reported by the C++ adapter follow the linked device backend. An Ascend build advertises
+only the speculative methods it implements, since the external DSpark and DFlash2 drafters are
+CUDA-only.
+
+## Cancellation semantics
+
+`cancel(request_id)` returns `True` only for a request that is currently active, and cancellation is
+observed at safe boundaries between generation steps. It never interrupts a running device kernel and
+never rolls back a partially executed native step. `DELETE /v1/requests/<request_id>` returns HTTP 404
+for an unknown or already-finished request.
+
+The existing `dsv4_cpp_engine` executable and its CLI remain supported. The shared Python server is a migration path, not a replacement that invalidates existing production commands.

--- a/docs/vllm_sglang_comparison.md
+++ b/docs/vllm_sglang_comparison.md
@@ -1,0 +1,217 @@
+# cpp_engine vs vLLM/SGLang Architecture Comparison
+
+> **Historical baseline:** Sections in this document describe the pre-Phase-1 `cpp_engine` surface
+> where explicitly noted. Phase 1 adds the `pocketllm` control plane without merging the Torch and
+> native C++ data planes.
+
+## Phase 1 status
+
+The new `pocketllm` package provides:
+
+- `EngineArgs`, `SamplingParams`, `LLM`, and `AsyncLLM` public interfaces;
+- explicit `torch` / `cpp` / `auto` backend selection;
+- a native C++ adapter restricted to Qwen3.5 safetensors checkpoints;
+- shared `/health`, `/alive`, `/ready`, `/metrics`, `/v1/chat/completions`, and
+  `/v1/completions` endpoints;
+- request IDs, safe-boundary cancellation, streaming token events, and usage metrics;
+- optional pybind11 bindings for the token-oriented native Qwen engine.
+
+The C++ compatibility adapter is intentionally serialized around one mutable native session. True
+continuous batching, complete OpenAI semantics across both backends, and real-model Torch/C++ parity
+remain follow-up work.
+
+## 1. API entry points
+
+### vLLM and SGLang
+
+Both projects are library-first and expose a Python API in addition to an OpenAI-compatible server.
+For example, vLLM exposes `LLM` and `SamplingParams`, while SGLang provides a native generation DSL
+and server launcher.
+
+### Pre-Phase-1 cpp_engine
+
+The native runtime was primarily CLI-oriented:
+
+```bash
+./dsv4 --serve --port 8000 --model /path/to/checkpoint --tp-world 4
+```
+
+`QwenEngine` and `PersistentEngine` were C++ classes for native callers, not a supported Python
+library surface. The existing executable and its CLI remain supported.
+
+### PocketLLM Phase 1
+
+```python
+from pocketllm import EngineArgs, LLM, SamplingParams
+
+llm = LLM(EngineArgs(model="/path/to/qwen3.5", backend="cpp"))
+outputs = llm.generate(["hello"], SamplingParams(max_tokens=32))
+```
+
+The public facade accepts text or pre-tokenized IDs and returns backend-neutral result/event types.
+The native binding remains token-oriented and does not expose Torch tensors, CUDA handles, ACL
+handles, or a shared physical KV-cache layout.
+
+## 2. Request processing and batching
+
+### vLLM/SGLang
+
+- concurrent request admission;
+- continuous batching during decode;
+- request-aware KV-cache allocation and reclamation;
+- scheduler-level fairness, backpressure, and (depending on configuration) preemption.
+
+### cpp_engine and Phase 1
+
+The legacy native HTTP server serialized requests with an in-flight mutex. The Phase-1 C++ adapter
+preserves this safety property by serializing access to its one mutable Qwen session. Cancellation is
+checked between native decode steps and never interrupts a device kernel.
+
+**Remaining gap:** no true C++ multi-request batching, paged logical KV pool, fair queue, or
+preemption. These require a request-aware scheduler and must not be implemented by sharing the
+current mutable session unsafely. The Torch adapter continues to reuse its existing serving queue.
+
+## 3. Configuration
+
+### vLLM/SGLang
+
+Configuration is primarily validated Python arguments or CLI flags, including model path, tensor
+parallel size, context length, cache dtype, and prefix caching.
+
+### cpp_engine before Phase 1
+
+Configuration was distributed among C++ structs, CLI flags, and more than 50 environment variables.
+This made per-instance configuration and discoverability difficult.
+
+### PocketLLM Phase 1
+
+`EngineArgs` validates common settings such as:
+
+- model and format (`safetensors` or `gguf`);
+- backend and device;
+- tensor-parallel size/rank;
+- maximum context and prefill chunk size;
+- KV-cache dtype and prefix caching;
+- speculative-decoding method and token count.
+
+Backend-specific tuning remains in `backend_options`. `EngineArgs.from_env()` is a compatibility
+bridge; existing `DSV4_*`, `QWEN_*`, and related variables are not removed or globally rewritten.
+Explicit API and CLI values take precedence over this bridge.
+
+**Remaining gap:** not every model-specific tuning switch has a portable typed field, by design.
+Kernel and scheduler tuning remains backend- and hardware-specific.
+
+## 4. Health and observability
+
+Before Phase 1, native serving exposed mostly log output and a basic health response. The shared
+frontend now exposes:
+
+- `/health` for liveness and backend status;
+- `/alive` for a minimal liveness probe;
+- `/ready` with HTTP 503 until the backend is ready;
+- `/metrics` using dependency-free Prometheus text exposition;
+- `/v1/models` for model discovery.
+
+The first metrics surface includes total requests, active-request gauge, request duration,
+prompt/completion token counters, and disconnect cancellation counters. Backend-specific KV usage,
+queue depth, cache-hit, and speculative-decoding metrics remain follow-up work.
+
+## 5. OpenAI compatibility
+
+Phase 1 implements non-streaming and streaming chat completions, text completions, request IDs,
+usage accounting, and safe-boundary cancellation through a shared protocol layer. It deliberately
+does not claim full parity with vLLM or SGLang.
+
+Remaining protocol work includes:
+
+- completion-specific streaming chunk schemas;
+- complete tool-call and reasoning/thinking normalization across both adapters;
+- structured outputs and grammar-constrained decoding;
+- multiple choices (`n`) on the native C++ path;
+- logprobs and stop-string behavior on every backend;
+- embeddings and multimodal request endpoints.
+
+Unsupported native controls raise typed errors rather than being silently ignored.
+
+## 6. Python and native integration
+
+Phase 1 adds:
+
+- `pocketllm.LLM` and `pocketllm.AsyncLLM`;
+- optional `pocketllm_cpp` pybind11 module;
+- lazy imports so `import pocketllm` does not require Torch, CUDA, or the native extension;
+- a stable backend-neutral contract over independent execution implementations.
+
+Native compute wrappers release the Python GIL around expensive prefill, decode, generation, and
+verification calls. Construction and lifecycle operations remain native-boundary operations and are
+not described as universally GIL-free.
+
+## 7. Feature comparison
+
+The native runtime retains strengths that must not be weakened by the common facade:
+
+- MTP, DSpark, and DFlash2 speculative paths where supported;
+- FP4, FP8, GGUF Q2, and other validated quantized kernels;
+- tensor parallel execution and existing TP worker protocol;
+- prefix reuse and recurrent-state snapshots;
+- model-specific reasoning support in the existing Torch/native paths.
+
+Compared with mature vLLM/SGLang deployments, PocketLLM still lacks a common implementation of:
+
+- multimodal inputs;
+- embeddings;
+- LoRA adapter loading and multiplexing;
+- structured/grammar-constrained outputs;
+- complete multi-choice and logprob semantics;
+- a common continuous-batching scheduler.
+
+These are capability-gated follow-up features, not reasons to merge vendor kernels or KV layouts.
+
+## 8. Architecture decision
+
+The intended layering is:
+
+```text
+pocketllm control plane
+  API types, request IDs, lifecycle, cancellation, streaming, OpenAI frontend, metrics, CLI
+       |
+       +-- Torch adapter  --> existing PyTorch/Triton runtime and scheduler
+       |
+       +-- C++ adapter    --> native C++/CUDA or C++/Ascend runtime and scheduler
+```
+
+The following remain backend-specific:
+
+- physical KV-cache layout and memory management;
+- continuous-batching implementation;
+- TP collectives and worker protocol;
+- quantization and attention kernels;
+- CUDA versus Ascend device code;
+- hardware-specific performance switches.
+
+A common API is therefore a product/control-plane unification, not a lowest-common-denominator
+data-plane rewrite.
+
+## 9. Follow-up recommendations
+
+1. Implement a request-aware C++ scheduler with per-request logical state and a backend-specific KV
+   pool; gate it behind capability and latency regression tests.
+2. Finish shared OpenAI semantics for tools, reasoning content, structured outputs, multiple choices,
+   and completion streaming.
+3. Add real-model greedy-token parity fixtures for Torch and C++ with documented tolerances.
+4. Add backend-specific queue, cache, and speculative metrics.
+5. Add embeddings, multimodal, LoRA, and grammar features only when the underlying model/runtime
+   supports them.
+
+## 10. Compatibility guarantees
+
+Phase 1 preserves:
+
+- existing `src.*` imports and environment variables;
+- `dsv4_cpp_engine` executable and legacy CLI/server commands;
+- TP worker-loop behavior;
+- speculative-decoding and quantized kernel implementations;
+- validated single-request latency paths and hardware-specific tuning.
+
+The public API is additive. It does not make a claim of bitwise equality between backend kernels,
+and it does not enable continuous batching by default before parity and performance verification.

--- a/pocketllm/__init__.py
+++ b/pocketllm/__init__.py
@@ -1,0 +1,48 @@
+"""PocketLLM: one user-facing API over independent Torch and C++ backends."""
+
+from .api import (
+    BackendCapabilities,
+    BackendUnavailableError,
+    ConfigurationError,
+    EngineArgs,
+    EngineBackend,
+    GenerationRequest,
+    GenerationResult,
+    HealthStatus,
+    PocketLLMError,
+    RequestCancelledError,
+    SamplingParams,
+    TimingMetrics,
+    TokenEvent,
+    UnsupportedFeatureError,
+    Usage,
+)
+
+# Import lazily to keep `import pocketllm` usable on CPU-only hosts without
+# importing Torch, CUDA extensions, or the optional native module.
+def __getattr__(name: str):
+    if name in {"AsyncLLM", "LLM"}:
+        from .engine import AsyncLLM, LLM
+        return {"LLM": LLM, "AsyncLLM": AsyncLLM}[name]
+    raise AttributeError(name)
+
+
+__all__ = [
+    "AsyncLLM",
+    "BackendCapabilities",
+    "BackendUnavailableError",
+    "ConfigurationError",
+    "EngineArgs",
+    "EngineBackend",
+    "GenerationRequest",
+    "GenerationResult",
+    "HealthStatus",
+    "LLM",
+    "PocketLLMError",
+    "RequestCancelledError",
+    "SamplingParams",
+    "TimingMetrics",
+    "TokenEvent",
+    "UnsupportedFeatureError",
+    "Usage",
+]

--- a/pocketllm/__main__.py
+++ b/pocketllm/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+raise SystemExit(main())

--- a/pocketllm/api/__init__.py
+++ b/pocketllm/api/__init__.py
@@ -1,0 +1,39 @@
+"""Public backend-neutral PocketLLM API types."""
+
+from .backend import EngineBackend
+from .errors import (
+    BackendUnavailableError,
+    ConfigurationError,
+    PocketLLMError,
+    RequestCancelledError,
+    UnsupportedFeatureError,
+)
+from .types import (
+    BackendCapabilities,
+    EngineArgs,
+    GenerationRequest,
+    GenerationResult,
+    HealthStatus,
+    SamplingParams,
+    TimingMetrics,
+    TokenEvent,
+    Usage,
+)
+
+__all__ = [
+    "BackendCapabilities",
+    "BackendUnavailableError",
+    "ConfigurationError",
+    "EngineArgs",
+    "EngineBackend",
+    "GenerationRequest",
+    "GenerationResult",
+    "HealthStatus",
+    "PocketLLMError",
+    "RequestCancelledError",
+    "SamplingParams",
+    "TimingMetrics",
+    "TokenEvent",
+    "UnsupportedFeatureError",
+    "Usage",
+]

--- a/pocketllm/api/backend.py
+++ b/pocketllm/api/backend.py
@@ -1,0 +1,52 @@
+"""Protocol implemented by Torch and native C++ execution adapters."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from typing import Iterator, Protocol, Sequence
+
+from .types import (
+    BackendCapabilities,
+    GenerationRequest,
+    GenerationResult,
+    HealthStatus,
+    TokenEvent,
+)
+
+
+class EngineBackend(Protocol):
+    """Observable engine contract; physical cache and scheduler stay private."""
+
+    @property
+    def capabilities(self) -> BackendCapabilities:
+        ...
+
+    def health(self) -> HealthStatus:
+        ...
+
+    def generate(self, requests: Sequence[GenerationRequest]) -> list[GenerationResult]:
+        ...
+
+    def stream(self, request: GenerationRequest) -> Iterator[TokenEvent]:
+        ...
+
+    def cancel(self, request_id: str) -> bool:
+        ...
+
+    def close(self) -> None:
+        ...
+
+
+class BackendFactory(Protocol):
+    def __call__(self, args):
+        ...
+
+
+class BackendContext(AbstractContextManager):
+    """Typing helper for backend implementations with context-manager support."""
+
+    def __enter__(self) -> EngineBackend:
+        ...
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()

--- a/pocketllm/api/errors.py
+++ b/pocketllm/api/errors.py
@@ -1,0 +1,23 @@
+"""Public exceptions raised by the PocketLLM API."""
+
+from __future__ import annotations
+
+
+class PocketLLMError(RuntimeError):
+    """Base class for errors that are safe to expose to API clients."""
+
+
+class ConfigurationError(PocketLLMError, ValueError):
+    """The engine or request configuration is invalid."""
+
+
+class BackendUnavailableError(PocketLLMError):
+    """A requested backend is not installed or cannot be initialized."""
+
+
+class UnsupportedFeatureError(PocketLLMError, NotImplementedError):
+    """The selected backend does not implement a requested feature."""
+
+
+class RequestCancelledError(PocketLLMError):
+    """Generation was cancelled before it completed."""

--- a/pocketllm/api/types.py
+++ b/pocketllm/api/types.py
@@ -1,0 +1,374 @@
+"""Backend-neutral public types for PocketLLM.
+
+These types describe user intent and observable results only.  They deliberately
+contain no Torch, CUDA, NCCL, ACL, or backend-specific buffer types.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from .errors import ConfigurationError
+
+
+_BACKENDS = {"auto", "torch", "cpp"}
+_FORMATS = {"auto", "safetensors", "gguf"}
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    return default if value is None or value == "" else int(value)
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.getenv(name)
+    return default if value is None or value == "" else float(value)
+
+
+def _coerce_stop(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,) if value else ()
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        result = tuple(item for item in value if isinstance(item, str) and item)
+        if len(result) != len(value):
+            raise ConfigurationError("stop must contain only non-empty strings")
+        return result
+    raise ConfigurationError("stop must be a string, a list of strings, or null")
+
+
+@dataclass(slots=True)
+class EngineArgs:
+    """Validated engine construction options shared by both execution planes."""
+
+    model: str = ""
+    backend: str = "auto"
+    tokenizer_path: str | None = None
+    config_path: str | None = None
+    model_format: str = "auto"
+    tensor_parallel_size: int = 1
+    tensor_parallel_rank: int = 0
+    device: str | int | None = None
+    max_model_len: int | None = None
+    dtype: str | None = None
+    kv_cache_dtype: str = "auto"
+    prefill_chunk_tokens: int = 0
+    enable_prefix_caching: bool = True
+    attention_window: int = 0
+    attention_sink_tokens: int = 0
+    speculative_method: str | None = None
+    speculative_tokens: int = 1
+    max_batch_size: int = 1
+    backend_options: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.backend = str(self.backend).lower()
+        self.model_format = str(self.model_format).lower()
+        self.kv_cache_dtype = str(self.kv_cache_dtype).lower()
+        if self.backend not in _BACKENDS:
+            raise ConfigurationError(f"backend must be one of {sorted(_BACKENDS)}, got {self.backend!r}")
+        if self.model_format not in _FORMATS:
+            raise ConfigurationError(
+                f"model_format must be one of {sorted(_FORMATS)}, got {self.model_format!r}"
+            )
+        if not self.model and not self.backend_options.get("checkpoint_dir"):
+            raise ConfigurationError("model/checkpoint path is required")
+        if self.tensor_parallel_size < 1:
+            raise ConfigurationError("tensor_parallel_size must be >= 1")
+        if not 0 <= self.tensor_parallel_rank < self.tensor_parallel_size:
+            raise ConfigurationError("tensor_parallel_rank must be in [0, tensor_parallel_size)")
+        if self.max_model_len is not None and self.max_model_len < 1:
+            raise ConfigurationError("max_model_len must be positive")
+        if self.prefill_chunk_tokens < 0:
+            raise ConfigurationError("prefill_chunk_tokens must be >= 0")
+        if self.attention_window < 0 or self.attention_sink_tokens < 0:
+            raise ConfigurationError("attention window and sink tokens must not be negative")
+        if self.attention_window == 0 and self.attention_sink_tokens:
+            raise ConfigurationError("attention_sink_tokens requires attention_window")
+        if self.speculative_tokens < 1:
+            raise ConfigurationError("speculative_tokens must be >= 1")
+        if self.max_batch_size < 1:
+            raise ConfigurationError("max_batch_size must be >= 1")
+
+    @property
+    def checkpoint_dir(self) -> str:
+        """Return the checkpoint path under either supported spelling."""
+        return self.model or str(self.backend_options.get("checkpoint_dir", ""))
+
+    @classmethod
+    def from_env(cls, model: str | None = None, **overrides: Any) -> "EngineArgs":
+        """Build common options from legacy environment variables.
+
+        This is a compatibility bridge, not the preferred configuration path.
+        Backend-specific tuning variables remain available to the selected
+        implementation through ``backend_options``.
+        """
+        values: dict[str, Any] = {
+            "model": model or os.getenv("POCKETLLM_MODEL", os.getenv("CKPT_PATH", "")),
+            "backend": os.getenv("POCKETLLM_BACKEND", "auto"),
+            "tokenizer_path": os.getenv("TOKENIZER_PATH") or None,
+            "config_path": os.getenv("CONFIG_PATH") or os.getenv("CONFIG") or None,
+            "model_format": os.getenv("CKPT_FORMAT", "auto"),
+            "tensor_parallel_size": _env_int("TENSOR_PARALLEL_SIZE", _env_int("TP_WORLD", 1)),
+            "tensor_parallel_rank": _env_int("TENSOR_PARALLEL_RANK", _env_int("TP_RANK", 0)),
+            "device": os.getenv("DEVICE") or None,
+            "max_model_len": (
+                _env_int("MAX_MODEL_LEN", _env_int("DEEPSEEK_MAX_MODEL_LEN", 0)) or None
+            ),
+            "dtype": os.getenv("DTYPE") or None,
+            "kv_cache_dtype": os.getenv("DSV4_QWEN_KV_CACHE_DTYPE", os.getenv("KV_CACHE_DTYPE", "auto")),
+            "prefill_chunk_tokens": _env_int(
+                "PREFILL_CHUNK_TOKENS", _env_int("DSV4_CPP_PREFILL_CHUNK", 0)
+            ),
+            "enable_prefix_caching": _env_bool("ENABLE_PREFIX_CACHING", True),
+            "attention_window": _env_int("QWEN_ATTENTION_WINDOW", 0),
+            "attention_sink_tokens": _env_int("QWEN_ATTENTION_SINK_TOKENS", 0),
+            "speculative_method": os.getenv("SPECULATIVE_METHOD") or None,
+            "speculative_tokens": _env_int("SPECULATIVE_TOKENS", 1),
+            "max_batch_size": _env_int(
+                "MAX_BATCH_SIZE", _env_int("DEEPSEEK_SERVING_MAX_RUNNING_REQUESTS", 1)
+            ),
+        }
+        values.update(overrides)
+        return cls(**values)
+
+
+@dataclass(slots=True)
+class SamplingParams:
+    """Per-request sampling and stopping options.
+
+    ``temperature <= 1e-5`` means greedy generation, matching the established
+    behavior of both existing runtimes.
+    """
+
+    max_tokens: int = 256
+    temperature: float = 0.0
+    top_p: float | None = None
+    top_k: int | None = None
+    min_p: float | None = None
+    seed: int | None = None
+    repetition_penalty: float = 1.0
+    frequency_penalty: float = 0.0
+    presence_penalty: float = 0.0
+    stop: tuple[str, ...] = ()
+    n: int = 1
+    logprobs: bool = False
+    top_logprobs: int | None = None
+    response_format: dict[str, Any] | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.stop = _coerce_stop(self.stop)
+        if self.max_tokens < 1:
+            raise ConfigurationError("max_tokens must be >= 1")
+        if self.temperature < 0:
+            raise ConfigurationError("temperature must be >= 0")
+        if self.top_p is not None and not 0 < self.top_p <= 1:
+            raise ConfigurationError("top_p must be in (0, 1]")
+        if self.top_k is not None and self.top_k < 1:
+            raise ConfigurationError("top_k must be >= 1")
+        if self.min_p is not None and not 0 <= self.min_p <= 1:
+            raise ConfigurationError("min_p must be in [0, 1]")
+        if self.repetition_penalty <= 0:
+            raise ConfigurationError("repetition_penalty must be positive")
+        if self.n < 1:
+            raise ConfigurationError("n must be >= 1")
+        if self.top_logprobs is not None and not 0 <= self.top_logprobs <= 20:
+            raise ConfigurationError("top_logprobs must be in [0, 20]")
+        if self.logprobs and self.top_logprobs is None:
+            self.top_logprobs = 0
+
+    @property
+    def greedy(self) -> bool:
+        return self.temperature <= 1.0e-5
+
+    @classmethod
+    def from_openai(cls, body: Mapping[str, Any]) -> "SamplingParams":
+        """Normalize OpenAI-compatible request fields into one typed object."""
+        max_tokens = body.get("max_tokens", body.get("max_completion_tokens", 256))
+        known = {
+            "max_tokens", "max_completion_tokens", "temperature", "top_p", "top_k",
+            "min_p", "seed", "repetition_penalty", "frequency_penalty",
+            "presence_penalty", "stop", "n", "logprobs", "top_logprobs",
+            "response_format",
+        }
+        return cls(
+            max_tokens=int(max_tokens),
+            temperature=float(body.get("temperature", 0.0) or 0.0),
+            top_p=None if body.get("top_p") is None else float(body["top_p"]),
+            top_k=None if body.get("top_k") is None else int(body["top_k"]),
+            min_p=None if body.get("min_p") is None else float(body["min_p"]),
+            seed=None if body.get("seed") is None else int(body["seed"]),
+            repetition_penalty=float(body.get("repetition_penalty", 1.0) or 1.0),
+            frequency_penalty=float(body.get("frequency_penalty", 0.0) or 0.0),
+            presence_penalty=float(body.get("presence_penalty", 0.0) or 0.0),
+            stop=body.get("stop"),
+            n=int(body.get("n", 1) or 1),
+            logprobs=bool(body.get("logprobs", False)),
+            top_logprobs=None if body.get("top_logprobs") is None else int(body["top_logprobs"]),
+            response_format=body.get("response_format"),
+            extra={str(k): v for k, v in body.items() if k not in known},
+        )
+
+    def to_generation_options(self) -> dict[str, Any]:
+        """Return options understood by the current PyTorch generation path."""
+        options = {
+            "top_p": self.top_p,
+            "top_k": self.top_k,
+            "min_p": self.min_p,
+            "frequency_penalty": self.frequency_penalty,
+            "presence_penalty": self.presence_penalty,
+            "repetition_penalty": self.repetition_penalty,
+            "seed": self.seed,
+            "logprobs": self.logprobs,
+            "top_logprobs": self.top_logprobs,
+        }
+        options.update(self.extra)
+        return options
+
+
+@dataclass(slots=True)
+class Usage:
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.total_tokens,
+        }
+
+
+@dataclass(slots=True)
+class TimingMetrics:
+    prefill_seconds: float = 0.0
+    decode_seconds: float = 0.0
+    total_seconds: float = 0.0
+    ttft_seconds: float = 0.0
+    tpot_seconds: float = 0.0
+
+    @classmethod
+    def from_mapping(cls, values: Mapping[str, Any] | None) -> "TimingMetrics":
+        values = values or {}
+        prefill = float(values.get("prefill_time", values.get("prefill_s", 0.0)) or 0.0)
+        decode = float(values.get("decode_time", values.get("decode_s", 0.0)) or 0.0)
+        total = float(values.get("total_time", prefill + decode) or (prefill + decode))
+        ttft = float(values.get("ttft", prefill) or prefill)
+        tpot = float(values.get("tpot", decode) or decode)
+        return cls(prefill, decode, total, ttft, tpot)
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "prefill_seconds": self.prefill_seconds,
+            "decode_seconds": self.decode_seconds,
+            "total_seconds": self.total_seconds,
+            "ttft_seconds": self.ttft_seconds,
+            "tpot_seconds": self.tpot_seconds,
+        }
+
+
+@dataclass(slots=True)
+class GenerationRequest:
+    """A normalized request consumed by a backend."""
+
+    prompt: str | None = None
+    prompt_tokens: list[int] | None = None
+    sampling_params: SamplingParams = field(default_factory=SamplingParams)
+    request_id: str = field(default_factory=lambda: f"req-{uuid.uuid4().hex}")
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.prompt is None and self.prompt_tokens is None:
+            raise ConfigurationError("either prompt or prompt_tokens is required")
+        if self.prompt is not None and not isinstance(self.prompt, str):
+            raise ConfigurationError("prompt must be a string")
+        if self.prompt_tokens is not None:
+            self.prompt_tokens = [int(token) for token in self.prompt_tokens]
+            if not self.prompt_tokens:
+                raise ConfigurationError("prompt_tokens must not be empty")
+        if not self.request_id:
+            raise ConfigurationError("request_id must not be empty")
+
+
+@dataclass(slots=True)
+class GenerationResult:
+    request_id: str
+    token_ids: list[int] = field(default_factory=list)
+    text: str = ""
+    finish_reason: str = "stop"
+    usage: Usage = field(default_factory=Usage)
+    timings: TimingMetrics = field(default_factory=TimingMetrics)
+    logprobs: Any = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class TokenEvent:
+    request_id: str
+    token_id: int | None = None
+    text: str = ""
+    finish_reason: str | None = None
+    usage: Usage | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class BackendCapabilities:
+    """Feature declaration used for deterministic routing and API errors."""
+
+    name: str
+    models: tuple[str, ...] = ()
+    model_formats: tuple[str, ...] = ()
+    devices: tuple[str, ...] = ()
+    supports_batch: bool = False
+    supports_streaming: bool = True
+    supports_cancellation: bool = False
+    supports_embeddings: bool = False
+    supports_logprobs: bool = False
+    supports_structured_outputs: bool = False
+    supports_prefix_caching: bool = False
+    supports_speculative_decoding: tuple[str, ...] = ()
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def supports(self, feature: str) -> bool:
+        value = getattr(self, feature, False)
+        return bool(value)
+
+
+@dataclass(slots=True)
+class HealthStatus:
+    status: str
+    backend: str
+    ready: bool
+    message: str = ""
+    details: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def alive(self) -> bool:
+        return self.status not in {"dead", "stopped"}
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "backend": self.backend,
+            "ready": self.ready,
+            "alive": self.alive,
+            "message": self.message,
+            **self.details,
+        }

--- a/pocketllm/backends/__init__.py
+++ b/pocketllm/backends/__init__.py
@@ -1,0 +1,7 @@
+"""Backend adapters shipped with PocketLLM."""
+
+from .cpp_backend import CppBackend
+from .factory import create_backend, select_backend
+from .torch_backend import TorchBackend
+
+__all__ = ["CppBackend", "TorchBackend", "create_backend", "select_backend"]

--- a/pocketllm/backends/base.py
+++ b/pocketllm/backends/base.py
@@ -1,0 +1,97 @@
+"""Shared helpers for backend adapters."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+from pocketllm.api import (
+    BackendCapabilities,
+    GenerationRequest,
+    GenerationResult,
+    HealthStatus,
+    RequestCancelledError,
+    TokenEvent,
+)
+
+
+class BackendBase:
+    """Small common implementation for lifecycle and cancellation bookkeeping.
+
+    The lock is intentionally at the backend boundary.  Current native engines
+    own one mutable KV-cache transaction, so concurrent calls must serialize
+    until a request-aware cache scheduler is implemented.
+    """
+
+    def __init__(self) -> None:
+        self._closed = False
+        self._ready = False
+        self._state_lock = threading.RLock()
+        self._cancelled: set[str] = set()
+        self._active_requests: set[str] = set()
+
+    @property
+    def capabilities(self) -> BackendCapabilities:
+        raise NotImplementedError
+
+    def health(self) -> HealthStatus:
+        with self._state_lock:
+            closed = self._closed
+            ready = self._ready and not closed
+        return HealthStatus(
+            status="stopped" if closed else "ready" if ready else "loading",
+            backend=self.capabilities.name,
+            ready=ready,
+        )
+
+    def cancel(self, request_id: str) -> bool:
+        with self._state_lock:
+            request_id = str(request_id)
+            if self._closed or request_id not in self._active_requests:
+                return False
+            self._cancelled.add(request_id)
+            return True
+
+    def _begin_request(self, request_id: str) -> None:
+        with self._state_lock:
+            if self._closed:
+                raise RuntimeError("backend is closed")
+            self._active_requests.add(str(request_id))
+
+    def _is_cancelled(self, request_id: str) -> bool:
+        with self._state_lock:
+            return request_id in self._cancelled
+
+    def _clear_request(self, request_id: str) -> None:
+        with self._state_lock:
+            request_id = str(request_id)
+            self._active_requests.discard(request_id)
+            self._cancelled.discard(request_id)
+
+    def active_request_count(self) -> int:
+        with self._state_lock:
+            return len(self._active_requests)
+
+    def _check_cancelled(self, request_id: str) -> None:
+        if self._is_cancelled(request_id):
+            raise RequestCancelledError(f"request {request_id} was cancelled")
+
+    def close(self) -> None:
+        with self._state_lock:
+            self._closed = True
+            self._cancelled.clear()
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("backend is closed")
+
+    def generate(self, requests: Sequence[GenerationRequest]) -> list[GenerationResult]:
+        raise NotImplementedError
+
+    def stream(self, request: GenerationRequest) -> Iterator[TokenEvent]:
+        raise NotImplementedError
+
+    @staticmethod
+    def _metadata_copy(value: Any) -> dict[str, Any]:
+        return dict(value) if isinstance(value, dict) else {}

--- a/pocketllm/backends/cpp_backend.py
+++ b/pocketllm/backends/cpp_backend.py
@@ -1,0 +1,369 @@
+"""Optional native C++ backend adapter.
+
+The native module is deliberately optional.  A CUDA/Ascend build can provide
+``pocketllm_cpp`` without making the public Python package depend on a vendor
+SDK at import time.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+import time
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+from pocketllm.api import (
+    BackendCapabilities,
+    BackendUnavailableError,
+    ConfigurationError,
+    EngineArgs,
+    GenerationRequest,
+    GenerationResult,
+    HealthStatus,
+    SamplingParams,
+    TimingMetrics,
+    TokenEvent,
+    Usage,
+    UnsupportedFeatureError,
+)
+
+from .base import BackendBase
+
+
+_NATIVE_MODULE_NAMES = ("pocketllm_cpp", "_pocketllm_cpp", "cpp_engine")
+
+
+def load_native_module() -> Any:
+    errors: list[str] = []
+    for name in _NATIVE_MODULE_NAMES:
+        try:
+            module = importlib.import_module(name)
+        except ImportError as exc:
+            errors.append(f"{name}: {exc}")
+            continue
+        # The repository's ``cpp_engine`` directory is importable as a Python
+        # namespace package even when no extension was built.  Treat that as
+        # unavailable instead of returning a module that cannot construct an
+        # engine, which would also make ``backend=auto`` select C++ incorrectly.
+        if not hasattr(module, "QwenEngine"):
+            errors.append(f"{name}: QwenEngine binding is missing")
+            continue
+        return module
+    raise BackendUnavailableError(
+        "native C++ backend is unavailable; build cpp_engine with "
+        "-DPOCKET_BUILD_PYTHON=ON (" + "; ".join(errors) + ")"
+    )
+
+
+def _native_kv_cache_dtype(value: str) -> str:
+    """Resolve the public ``auto`` value to the native Qwen default."""
+    normalized = str(value or "auto").lower()
+    return "fp16" if normalized == "auto" else normalized
+
+
+def _native_device_index(value: str | int | None) -> int:
+    """Normalize a public device selector for the native single-rank option."""
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        raise ConfigurationError("C++ backend device must be a non-negative device index")
+    if isinstance(value, int):
+        index = value
+    else:
+        text = str(value).strip().lower()
+        for prefix in ("cuda:", "ascend:", "npu:"):
+            if text.startswith(prefix):
+                text = text[len(prefix):]
+                break
+        try:
+            index = int(text)
+        except ValueError as exc:
+            raise ConfigurationError(
+                "C++ backend device must be an integer or cuda:/ascend:/npu: index"
+            ) from exc
+    if index < 0:
+        raise ConfigurationError("C++ backend device must be a non-negative device index")
+    return index
+
+
+class CppBackend(BackendBase):
+    """Serialized compatibility adapter for the stateful native engines.
+
+    The initial bridge intentionally supports Qwen's token-oriented API.  The
+    native engine still owns its optimized KV layout and TP protocol; this
+    adapter does not turn it into a Torch module or copy its buffers.
+    """
+
+    def __init__(
+        self,
+        args: EngineArgs,
+        *,
+        native_module: Any | None = None,
+        engine: Any | None = None,
+        tokenizer: Any | None = None,
+    ) -> None:
+        super().__init__()
+        self.args = args
+        if native_module is not None:
+            self._native = native_module
+        elif engine is None:
+            self._native = load_native_module()
+        else:
+            self._native = None
+        self._engine = engine if engine is not None else self._construct_engine()
+        # A primitive lock may be released by a different worker thread.  This
+        # matters for AsyncLLM, which advances one generator through an executor
+        # without guaranteeing that every next() call uses the same thread.
+        self._request_lock = threading.Lock()
+        self._tokenizer = tokenizer if tokenizer is not None else self._load_tokenizer()
+        self._ready = True
+
+    @staticmethod
+    def native_available() -> bool:
+        try:
+            load_native_module()
+            return True
+        except BackendUnavailableError:
+            return False
+
+    @property
+    def capabilities(self) -> BackendCapabilities:
+        # The Ascend build rejects the external drafters, so report only what the
+        # linked backend actually implements instead of the CUDA superset.
+        native_backend = str(getattr(self._native, "backend", "") or "").lower()
+        speculative: tuple[str, ...] = ("mtp",) if native_backend == "ascend" else ("mtp", "dspark", "dflash2")
+        return BackendCapabilities(
+            name="cpp",
+            models=("qwen3.5",),
+            model_formats=("safetensors",),
+            devices=(native_backend,) if native_backend else ("cuda", "ascend"),
+            supports_batch=False,
+            supports_streaming=True,
+            supports_cancellation=True,
+            supports_embeddings=False,
+            supports_logprobs=False,
+            supports_structured_outputs=False,
+            supports_prefix_caching=True,
+            supports_speculative_decoding=speculative,
+            details={
+                "execution": "native C++",
+                "scheduler": "serialized compatibility session",
+                "device_backend": native_backend or "unknown",
+                "cancellation": "safe boundary only",
+            },
+        )
+
+    def _load_tokenizer(self) -> Any | None:
+        tokenizer_path = self.args.tokenizer_path or self.args.checkpoint_dir
+        if not tokenizer_path:
+            return None
+        try:
+            from transformers import AutoTokenizer
+
+            return AutoTokenizer.from_pretrained(tokenizer_path)
+        except Exception:
+            return None
+
+    def _construct_engine(self) -> Any:
+        kind = str(self.args.backend_options.get("engine_kind", "qwen")).lower()
+        if kind != "qwen":
+            raise UnsupportedFeatureError(
+                "the initial Python C++ adapter supports QwenEngine; "
+                "PersistentEngine bindings are available for low-level use"
+            )
+        cls = getattr(self._native, "QwenEngine", None)
+        options_cls = getattr(self._native, "QwenEngineOptions", None)
+        if cls is None or options_cls is None:
+            raise BackendUnavailableError("native module does not expose QwenEngine bindings")
+        options = options_cls()
+        mappings = {
+            "tp_world": self.args.tensor_parallel_size,
+            "tp_rank": self.args.tensor_parallel_rank,
+            "device": _native_device_index(self.args.device),
+            "prefill_chunk_tokens": self.args.prefill_chunk_tokens or 8192,
+            "attention_window": self.args.attention_window,
+            "attention_sink_tokens": self.args.attention_sink_tokens,
+            "prefix_cache": self.args.enable_prefix_caching,
+            "state_snapshot_interval_tokens": int(self.args.backend_options.get("state_snapshot_interval_tokens", 4096)),
+            "max_state_snapshots": int(self.args.backend_options.get("max_state_snapshots", 82)),
+            "mtp": self.args.speculative_method == "mtp",
+            "mtp_speculative_tokens": self.args.speculative_tokens,
+            "mtp_adaptive": bool(self.args.backend_options.get("mtp_adaptive", False)),
+            "dspark_checkpoint": str(self.args.backend_options.get("dspark_checkpoint", "")),
+            "dflash2_checkpoint": str(self.args.backend_options.get("dflash2_checkpoint", "")),
+            "nccl_id_path": str(self.args.backend_options.get("nccl_id_path", "")),
+        }
+        for name, value in mappings.items():
+            if hasattr(options, name):
+                setattr(options, name, value)
+        if hasattr(options, "kv_cache_dtype") and hasattr(self._native, "parse_qwen_kv_cache_dtype"):
+            setattr(
+                options,
+                "kv_cache_dtype",
+                self._native.parse_qwen_kv_cache_dtype(_native_kv_cache_dtype(self.args.kv_cache_dtype)),
+            )
+        for name, value in {
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "top_k": 20,
+            "sampling_seed": 0,
+        }.items():
+            if hasattr(options, name):
+                setattr(options, name, value)
+        return cls(self.args.checkpoint_dir, options, 0, self.args.max_model_len or 8192)
+
+    def health(self) -> HealthStatus:
+        status = super().health()
+        details = dict(status.details)
+        details.update({"model": self.args.checkpoint_dir})
+        return HealthStatus(status.status, status.backend, status.ready, status.message, details)
+
+    def _prompt_ids(self, request: GenerationRequest) -> list[int]:
+        if request.prompt_tokens is not None:
+            return list(request.prompt_tokens)
+        if self._tokenizer is None:
+            raise ConfigurationError("C++ backend needs tokenizer_path for text prompts")
+        encoded = self._tokenizer.encode(request.prompt or "")
+        return [int(token) for token in encoded]
+
+    def _check_sampling(self, params: SamplingParams) -> None:
+        if not params.greedy:
+            raise UnsupportedFeatureError("the initial C++ adapter exposes native greedy generation only")
+        if params.top_p is not None or params.top_k is not None or params.min_p is not None:
+            raise UnsupportedFeatureError("C++ sampling controls are not exposed by the initial binding")
+        if params.n != 1 or params.logprobs or params.stop:
+            raise UnsupportedFeatureError("n, logprobs, and stop require the shared scheduler phase")
+
+    @staticmethod
+    def _native_token(item: Any) -> int:
+        if isinstance(item, int):
+            return int(item)
+        return int(getattr(item, "top_token", getattr(item, "token", item)))
+
+    def _decode(self, token_ids: list[int]) -> str:
+        if self._tokenizer is None:
+            return ""
+        decode = getattr(self._tokenizer, "decode", None)
+        if callable(decode):
+            return str(decode(token_ids))
+        decode_tokens = getattr(self._tokenizer, "decode_tokens", None)
+        if callable(decode_tokens):
+            return str(decode_tokens(token_ids))
+        return ""
+
+    def generate(self, requests: Sequence[GenerationRequest]) -> list[GenerationResult]:
+        """Generate requests serially until a request-aware cache scheduler exists."""
+        self._ensure_open()
+        outputs: list[GenerationResult] = []
+        for request in requests:
+            self._begin_request(request.request_id)
+            try:
+                self._check_sampling(request.sampling_params)
+                self._check_cancelled(request.request_id)
+                prompt_ids = self._prompt_ids(request)
+                started = time.perf_counter()
+                with self._request_lock:
+                    self._ensure_open()
+                    self._check_cancelled(request.request_id)
+                    engine = self._engine
+                    if engine is None:
+                        raise RuntimeError("native C++ engine is closed")
+                    raw = engine.generate(
+                        prompt_ids, request.sampling_params.max_tokens
+                    )
+                    self._ensure_open()
+                self._check_cancelled(request.request_id)
+                token_ids = [self._native_token(item) for item in raw]
+                outputs.append(
+                    GenerationResult(
+                        request_id=request.request_id,
+                        token_ids=token_ids,
+                        text=self._decode(token_ids),
+                        finish_reason="length",
+                        usage=Usage(len(prompt_ids), len(token_ids)),
+                        timings=TimingMetrics(
+                            total_seconds=time.perf_counter() - started,
+                            ttft_seconds=0.0,
+                        ),
+                    )
+                )
+            finally:
+                self._clear_request(request.request_id)
+                if self._closed:
+                    self._release_native()
+        return outputs
+
+    def _stream_native(self, request: GenerationRequest) -> Iterator[TokenEvent]:
+        self._check_sampling(request.sampling_params)
+        prompt_ids = self._prompt_ids(request)
+        max_tokens = request.sampling_params.max_tokens
+        engine = self._engine
+        if engine is None:
+            raise RuntimeError("native C++ engine is closed")
+        # Do not reset() here.  QwenEngine::reset() clears the prefix cache, so
+        # calling it per request would disable configured prefix reuse.  prefill()
+        # already matches the common prefix, restores a snapshot, or zeroes the
+        # recurrent state, which is also what native generate() relies on.
+        # QwenEngine.prefill predicts the first token without consuming it. The
+        # following decode steps consume the previous prediction and predict the
+        # next one, matching the native generate() result ordering.
+        result = engine.prefill(prompt_ids)
+        generated: list[int] = []
+        previous_text = ""
+        for index in range(max_tokens):
+            self._ensure_open()
+            self._check_cancelled(request.request_id)
+            token = self._native_token(result)
+            generated.append(token)
+            decoded = self._decode(generated)
+            # Decode the complete sequence so BPE/UTF-8 token boundaries are handled
+            # by the tokenizer. Emit only the newly visible suffix when possible.
+            text = decoded[len(previous_text):] if decoded.startswith(previous_text) else decoded
+            previous_text = decoded
+            event = TokenEvent(request.request_id, token_id=token, text=text)
+            if index + 1 == max_tokens:
+                event.finish_reason = "length"
+                event.usage = Usage(len(prompt_ids), len(generated))
+            yield event
+            if index + 1 < max_tokens:
+                self._ensure_open()
+                self._check_cancelled(request.request_id)
+                result = engine.decode_step(token)
+
+    def stream(self, request: GenerationRequest) -> Iterator[TokenEvent]:
+        # A primitive lock can span generator yields even when AsyncLLM resumes
+        # the generator on a different executor thread. It serializes all access
+        # to the native engine's single mutable KV-cache session.
+        self._begin_request(request.request_id)
+        with self._request_lock:
+            try:
+                self._ensure_open()
+                self._check_cancelled(request.request_id)
+                yield from self._stream_native(request)
+            finally:
+                self._clear_request(request.request_id)
+                if self._closed:
+                    self._release_native()
+
+    def _release_native(self) -> None:
+        engine = self._engine
+        self._engine = None
+        self._tokenizer = None
+        self._native = None
+        self._ready = False
+        close = getattr(engine, "close", None)
+        if callable(close):
+            close()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        super().close()
+        # Never destroy a native engine while a GIL-released kernel is using it.
+        # An active generate/stream call releases it from its own finally block.
+        if self._request_lock.acquire(blocking=False):
+            try:
+                self._release_native()
+            finally:
+                self._request_lock.release()

--- a/pocketllm/backends/factory.py
+++ b/pocketllm/backends/factory.py
@@ -1,0 +1,129 @@
+"""Backend selection and construction."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pocketllm.api import BackendUnavailableError, EngineArgs, UnsupportedFeatureError
+
+from .cpp_backend import CppBackend
+from .torch_backend import TorchBackend
+
+
+_QWEN35_TYPES = {"qwen3_5", "qwen3_5_text"}
+
+
+def _config_path(path: str, explicit: str | None = None) -> Path:
+    candidate = Path(explicit) if explicit else Path(path) / "config.json"
+    if candidate.is_dir():
+        candidate = candidate / "config.json"
+    return candidate
+
+
+def _read_config(path: str, explicit: str | None = None) -> dict[str, Any] | None:
+    try:
+        config = _config_path(path, explicit)
+        if not config.is_file():
+            return None
+        with config.open(encoding="utf-8") as handle:
+            value = json.load(handle)
+        return value if isinstance(value, dict) else None
+    except (OSError, ValueError, TypeError):
+        return None
+
+
+def _is_qwen35_config(config: dict[str, Any]) -> bool:
+    def is_qwen35(value: Any) -> bool:
+        return str(value or "").lower() in _QWEN35_TYPES
+
+    if is_qwen35(config.get("model_type")):
+        return True
+    architectures = config.get("architectures", ())
+    if isinstance(architectures, (list, tuple)):
+        if any("qwen3_5" in str(item).lower() for item in architectures):
+            return True
+    nested = config.get("text_config")
+    return isinstance(nested, dict) and _is_qwen35_config(nested)
+
+
+def _looks_like_qwen35(path: str, config_path: str | None = None) -> bool:
+    config = _read_config(path, config_path)
+    return config is not None and _is_qwen35_config(config)
+
+
+def _checkpoint_has_gguf(path: str) -> bool:
+    """Return whether the requested checkpoint is visibly a GGUF model."""
+    try:
+        candidate = Path(path)
+        if candidate.is_file():
+            return candidate.suffix.lower() == ".gguf"
+        if not candidate.is_dir():
+            return False
+        return any(candidate.glob("*.gguf"))
+    except OSError:
+        return False
+
+
+def _cpp_model_supported(args: EngineArgs) -> bool:
+    if args.model_format == "gguf":
+        return False
+    if args.model_format == "auto" and _checkpoint_has_gguf(args.checkpoint_dir):
+        return False
+    return _looks_like_qwen35(args.checkpoint_dir, args.config_path)
+
+
+def _reject_unsupported_cpp_checkpoint(args: EngineArgs) -> None:
+    """Fail fast for checkpoints the native adapter provably cannot serve.
+
+    A missing or unreadable path is left alone so injected engines and unusual
+    layouts still reach the native loader, which reports the precise error.
+    """
+    if args.model_format == "gguf" or (
+        args.model_format == "auto" and _checkpoint_has_gguf(args.checkpoint_dir)
+    ):
+        raise UnsupportedFeatureError(
+            "the native C++ adapter supports Qwen3.5 safetensors only; "
+            "GGUF checkpoints must use backend='torch'"
+        )
+    config = _read_config(args.checkpoint_dir, args.config_path)
+    if config is not None and not _is_qwen35_config(config):
+        raise UnsupportedFeatureError(
+            "the native C++ adapter supports Qwen3.5 checkpoints only"
+        )
+
+
+def select_backend(args: EngineArgs) -> str:
+    """Select a backend without silently changing an explicit user choice."""
+    if args.backend != "auto":
+        if args.backend == "cpp":
+            _reject_unsupported_cpp_checkpoint(args)
+        return args.backend
+    if CppBackend.native_available() and _cpp_model_supported(args):
+        return "cpp"
+    return "torch"
+
+
+def create_backend(args: EngineArgs, **injected: Any):
+    """Construct the selected adapter.
+
+    ``injected`` is intentionally useful for tests and embedding applications;
+    production callers normally only pass ``EngineArgs``.
+    """
+    selected = select_backend(args)
+    if selected == "torch":
+        return TorchBackend(
+            args,
+            runtime=injected.get("runtime"),
+            serving_engine=injected.get("serving_engine"),
+            runtime_loader=injected.get("runtime_loader"),
+        )
+    if selected == "cpp":
+        return CppBackend(
+            args,
+            native_module=injected.get("native_module"),
+            engine=injected.get("engine"),
+            tokenizer=injected.get("tokenizer"),
+        )
+    raise BackendUnavailableError(f"unsupported backend {selected!r}")

--- a/pocketllm/backends/torch_backend.py
+++ b/pocketllm/backends/torch_backend.py
@@ -1,0 +1,303 @@
+"""Adapter for the existing PyTorch/Triton runtimes.
+
+This module intentionally imports the legacy runtime lazily.  Importing
+``pocketllm`` on a CPU-only host therefore does not import Torch or CUDA
+extensions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import threading
+from collections.abc import Iterator, Sequence
+from typing import Any, Callable, Mapping
+
+from pocketllm.api import (
+    BackendCapabilities,
+    EngineArgs,
+    GenerationRequest,
+    GenerationResult,
+    HealthStatus,
+    SamplingParams,
+    TimingMetrics,
+    TokenEvent,
+    Usage,
+    UnsupportedFeatureError,
+)
+
+from .base import BackendBase
+
+
+class TorchBackend(BackendBase):
+    """Backend adapter over ``src.server`` and model generation functions.
+
+    ``runtime`` and ``serving_engine`` are injectable to keep API tests
+    independent of model checkpoints.  The normal constructor loads the
+    existing DeepSeek serving runtime and leaves all model-specific kernels and
+    performance switches in ``src/``.
+    """
+
+    def __init__(
+        self,
+        args: EngineArgs,
+        *,
+        runtime: Mapping[str, Any] | None = None,
+        serving_engine: Any | None = None,
+        runtime_loader: Callable[[argparse.Namespace], Mapping[str, Any]] | None = None,
+    ) -> None:
+        super().__init__()
+        self.args = args
+        self._runtime: Mapping[str, Any] | None = runtime
+        self._serving_engine = serving_engine
+        self._runtime_loader = runtime_loader
+        self._request_lock = threading.RLock()
+        self._model_id = args.model.rsplit("/", 1)[-1] or "pytorch"
+        if runtime is not None or serving_engine is not None:
+            self._ready = True
+
+    @property
+    def capabilities(self) -> BackendCapabilities:
+        return BackendCapabilities(
+            name="torch",
+            model_formats=("safetensors", "gguf"),
+            devices=("cuda", "cpu"),
+            supports_batch=False,
+            supports_streaming=True,
+            # Cancellation is observed between streamed events and at request
+            # boundaries. It never interrupts a running device kernel.
+            supports_cancellation=True,
+            supports_embeddings=False,
+            supports_logprobs=True,
+            supports_structured_outputs=False,
+            supports_prefix_caching=True,
+            details={
+                "execution": "existing src/ runtime",
+                "scheduler": "legacy serving queue",
+                "cancellation": "safe boundary only",
+            },
+        )
+
+    @property
+    def runtime(self) -> Mapping[str, Any] | None:
+        return self._runtime
+
+    def _load(self) -> None:
+        if self._runtime is not None and self._serving_engine is not None:
+            self._ready = True
+            return
+        if self._runtime is None:
+            if self._runtime_loader is not None:
+                loader = self._runtime_loader
+            else:
+                from src.server.openai import _init_runtime
+
+                loader = _init_runtime
+            ckpt = self.args.checkpoint_dir
+            config = self.args.config_path or ""
+            namespace = argparse.Namespace(
+                ckpt_format=self.args.model_format,
+                partition_policy=str(self.args.backend_options.get("partition_policy", "legacy")),
+                pd_mode=str(self.args.backend_options.get("pd_mode", "scheduler")),
+                routed_experts_device=str(self.args.backend_options.get("routed_experts_device", "gpu")),
+                config=config,
+                ckpt_path=ckpt,
+                tokenizer_path=self.args.tokenizer_path,
+                model=self._model_id,
+                max_model_len=self.args.max_model_len or 0,
+            )
+            self._runtime = loader(namespace)
+        if self._serving_engine is None:
+            from src.server.engine import DeepSeekServingEngine
+            from src.server.openai import _broadcast_payload, _run_payload, _run_payload_stream
+
+            self._serving_engine = DeepSeekServingEngine(
+                self._runtime,
+                _broadcast_payload,
+                _run_payload,
+                _run_payload_stream,
+            )
+        runtime_model_id = self._runtime.get("model_id") if self._runtime else None
+        if runtime_model_id:
+            self._model_id = str(runtime_model_id)
+        self._ready = True
+
+    def _ensure_loaded(self) -> None:
+        self._ensure_open()
+        if not self._ready:
+            with self._request_lock:
+                if not self._ready:
+                    self._load()
+
+    def health(self) -> HealthStatus:
+        status = super().health()
+        if self._runtime is not None and isinstance(self._runtime, Mapping):
+            details = dict(status.details)
+            details.update({"model": self._model_id})
+            return HealthStatus(status.status, status.backend, status.ready, status.message, details)
+        return status
+
+    def _tokenizer(self) -> Any:
+        if self._runtime is None:
+            return None
+        return self._runtime.get("tokenizer")
+
+    def _prompt_ids(self, request: GenerationRequest) -> list[int]:
+        if request.prompt_tokens is not None:
+            return list(request.prompt_tokens)
+        tokenizer = self._tokenizer()
+        if tokenizer is None:
+            raise ValueError("TorchBackend needs a tokenizer for text prompts")
+        encoded = tokenizer.encode(request.prompt or "")
+        if hasattr(encoded, "tolist"):
+            encoded = encoded.tolist()
+        return [int(token) for token in encoded]
+
+    def _payload(self, request: GenerationRequest, *, stream: bool) -> dict[str, Any]:
+        params = request.sampling_params
+        prompt_ids = self._prompt_ids(request)
+        return {
+            "op": "chat_completion",
+            "request_id": request.request_id,
+            "_prompt_ids": prompt_ids,
+            "messages": [{"role": "user", "content": request.prompt or ""}],
+            "thinking_mode": str(request.metadata.get("thinking_mode", "chat")),
+            "reasoning_effort": request.metadata.get("reasoning_effort"),
+            "max_tokens": params.max_tokens,
+            "temperature": params.temperature,
+            "top_p": params.top_p,
+            "top_k": params.top_k,
+            "min_p": params.min_p,
+            "frequency_penalty": params.frequency_penalty,
+            "presence_penalty": params.presence_penalty,
+            "repetition_penalty": params.repetition_penalty,
+            "seed": params.seed,
+            "stop": list(params.stop) if params.stop else None,
+            "logprobs": params.logprobs,
+            "top_logprobs": params.top_logprobs,
+            "n": params.n,
+            "generation_options": params.to_generation_options(),
+            "stream": stream,
+            "stream_options": request.metadata.get("stream_options", {}),
+        }
+
+    @staticmethod
+    def _result_from_mapping(request: GenerationRequest, result: Mapping[str, Any]) -> GenerationResult:
+        token_ids = [int(token) for token in result.get("token_ids", result.get("completion_ids", []))]
+        text = str(result.get("text", result.get("content", "")) or "")
+        usage = Usage(
+            int(result.get("prompt_tokens", 0) or 0),
+            int(result.get("completion_tokens", len(token_ids)) or len(token_ids)),
+        )
+        return GenerationResult(
+            request_id=request.request_id,
+            token_ids=token_ids,
+            text=text,
+            finish_reason=str(result.get("finish_reason", "stop")),
+            usage=usage,
+            timings=TimingMetrics.from_mapping(result.get("timings")),
+            logprobs=result.get("logprobs") or result.get("token_logprobs"),
+            metadata={key: value for key, value in result.items() if key not in {
+                "token_ids", "completion_ids", "text", "content", "finish_reason",
+                "prompt_tokens", "completion_tokens", "timings", "logprobs", "token_logprobs",
+            }},
+        )
+
+    def _generate_injected(self, request: GenerationRequest) -> GenerationResult | Mapping[str, Any]:
+        if self._runtime is None:
+            raise RuntimeError("TorchBackend runtime is not loaded")
+        callback = self._runtime.get("backend_generate")
+        if not callable(callback):
+            raise RuntimeError("injected Torch runtime has no backend_generate callback")
+        return callback(request)
+
+    def generate(self, requests: Sequence[GenerationRequest]) -> list[GenerationResult]:
+        self._ensure_loaded()
+        outputs: list[GenerationResult] = []
+        for request in requests:
+            self._begin_request(request.request_id)
+            try:
+                self._check_cancelled(request.request_id)
+                with self._request_lock:
+                    self._check_cancelled(request.request_id)
+                    if self._runtime and callable(self._runtime.get("backend_generate")):
+                        raw = self._generate_injected(request)
+                    else:
+                        if self._serving_engine is None:
+                            raise RuntimeError("Torch serving engine is unavailable")
+                        raw = self._serving_engine.submit(self._payload(request, stream=False))
+                self._check_cancelled(request.request_id)
+                if isinstance(raw, list):
+                    if not raw:
+                        result = GenerationResult(request.request_id)
+                    else:
+                        result = self._result_from_mapping(request, raw[0])
+                        result.metadata["choices"] = [self._result_from_mapping(request, item) for item in raw]
+                elif isinstance(raw, GenerationResult):
+                    result = raw
+                else:
+                    result = self._result_from_mapping(request, raw)
+                outputs.append(result)
+            finally:
+                self._clear_request(request.request_id)
+        return outputs
+
+    def _stream_injected(self, request: GenerationRequest) -> Iterator[Any]:
+        if self._runtime is None:
+            raise RuntimeError("TorchBackend runtime is not loaded")
+        callback = self._runtime.get("backend_stream")
+        if not callable(callback):
+            raise RuntimeError("injected Torch runtime has no backend_stream callback")
+        yield from callback(request)
+
+    def stream(self, request: GenerationRequest) -> Iterator[TokenEvent]:
+        self._ensure_loaded()
+        self._begin_request(request.request_id)
+        self._check_cancelled(request.request_id)
+        try:
+            with self._request_lock:
+                if self._runtime and callable(self._runtime.get("backend_stream")):
+                    events = self._stream_injected(request)
+                else:
+                    if self._serving_engine is None:
+                        raise RuntimeError("Torch serving engine is unavailable")
+                    events = self._serving_engine.submit_stream(self._payload(request, stream=True))
+                for event in events:
+                    self._check_cancelled(request.request_id)
+                    if isinstance(event, TokenEvent):
+                        yield event
+                        continue
+                    if not isinstance(event, Mapping):
+                        continue
+                    kind = event.get("type")
+                    token_ids = [int(token) for token in event.get("token_ids", [])]
+                    text = str(event.get("text", "") or "")
+                    if not text and token_ids:
+                        tokenizer = self._tokenizer()
+                        if tokenizer is not None:
+                            text = str(tokenizer.decode(token_ids))
+                    usage = None
+                    if event.get("prompt_tokens") is not None:
+                        completion = event.get("completion_tokens") or token_ids
+                        if completion and isinstance(completion[0], list):
+                            completion = completion[0]
+                        usage = Usage(int(event.get("prompt_tokens", 0)), len(completion))
+                    yield TokenEvent(
+                        request_id=request.request_id,
+                        token_id=token_ids[-1] if token_ids else None,
+                        text=text,
+                        finish_reason=event.get("finish_reason") if kind == "done" else None,
+                        usage=usage,
+                        metadata={"type": kind} if kind else {},
+                    )
+        finally:
+            self._clear_request(request.request_id)
+
+    def cancel(self, request_id: str) -> bool:
+        # The flag is checked at safe request boundaries.  The legacy
+        # generation callback is not interruptible inside a device kernel.
+        return super().cancel(request_id)
+
+    def close(self) -> None:
+        if self._serving_engine is not None and hasattr(self._serving_engine, "close"):
+            self._serving_engine.close()
+        super().close()

--- a/pocketllm/cli.py
+++ b/pocketllm/cli.py
@@ -1,0 +1,110 @@
+"""Command-line entry points for the unified PocketLLM API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from .api import EngineArgs
+from .backends.factory import create_backend
+from .server.openai import serve
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="pocketllm", description="PocketLLM unified inference interface")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    serve_parser = subparsers.add_parser("serve", help="start the OpenAI-compatible server")
+    serve_parser.add_argument("--model", required=True, help="checkpoint directory or model path")
+    serve_parser.add_argument("--backend", choices=["auto", "torch", "cpp"], default="auto")
+    serve_parser.add_argument("--tokenizer-path")
+    serve_parser.add_argument("--config-path")
+    serve_parser.add_argument("--model-format", choices=["auto", "safetensors", "gguf"], default="auto")
+    serve_parser.add_argument("--tensor-parallel-size", type=int, default=1)
+    serve_parser.add_argument("--tensor-parallel-rank", type=int, default=0)
+    serve_parser.add_argument("--device")
+    serve_parser.add_argument("--max-model-len", type=int)
+    serve_parser.add_argument("--dtype")
+    serve_parser.add_argument("--kv-cache-dtype", default="auto")
+    serve_parser.add_argument("--prefill-chunk-tokens", type=int, default=0)
+    serve_parser.add_argument("--enable-prefix-caching", action=argparse.BooleanOptionalAction, default=True)
+    serve_parser.add_argument("--max-batch-size", type=int, default=1)
+    serve_parser.add_argument("--host", default="0.0.0.0")
+    serve_parser.add_argument("--port", type=int, default=8000)
+    serve_parser.add_argument("--engine-kind", default="qwen")
+    serve_parser.add_argument("--routed-experts-device", choices=["gpu", "cpu"], default="gpu")
+    serve_parser.add_argument("--pd-mode", choices=["off", "scheduler"], default="scheduler")
+    serve_parser.add_argument("--attention-window", type=int, default=0)
+    serve_parser.add_argument("--attention-sink-tokens", type=int, default=0)
+    serve_parser.add_argument("--speculative-method", choices=["mtp", "dspark", "dflash2"])
+    serve_parser.add_argument("--speculative-tokens", type=int, default=1)
+    serve_parser.add_argument("--served-model-name", help="model id reported by /v1/models")
+    serve_parser.add_argument(
+        "--backend-option",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="backend-specific option; repeatable and parsed as JSON when possible",
+    )
+    return parser
+
+
+def _backend_options(namespace: argparse.Namespace) -> dict[str, object]:
+    options: dict[str, object] = {
+        "engine_kind": namespace.engine_kind,
+        "routed_experts_device": namespace.routed_experts_device,
+        "pd_mode": namespace.pd_mode,
+    }
+    for item in namespace.backend_option or []:
+        key, separator, raw = str(item).partition("=")
+        if not separator or not key.strip():
+            raise SystemExit(f"--backend-option expects KEY=VALUE, got {item!r}")
+        try:
+            # JSON keeps numbers, booleans, and nested values typed; a bare
+            # string stays a string so paths do not need quoting.
+            value = json.loads(raw)
+        except ValueError:
+            value = raw
+        options[key.strip()] = value
+    return options
+
+
+def _args(namespace: argparse.Namespace) -> EngineArgs:
+    return EngineArgs(
+        model=namespace.model,
+        backend=namespace.backend,
+        tokenizer_path=namespace.tokenizer_path,
+        config_path=namespace.config_path,
+        model_format=namespace.model_format,
+        tensor_parallel_size=namespace.tensor_parallel_size,
+        tensor_parallel_rank=namespace.tensor_parallel_rank,
+        device=namespace.device,
+        max_model_len=namespace.max_model_len,
+        dtype=namespace.dtype,
+        kv_cache_dtype=namespace.kv_cache_dtype,
+        prefill_chunk_tokens=namespace.prefill_chunk_tokens,
+        enable_prefix_caching=namespace.enable_prefix_caching,
+        max_batch_size=namespace.max_batch_size,
+        attention_window=namespace.attention_window,
+        attention_sink_tokens=namespace.attention_sink_tokens,
+        speculative_method=namespace.speculative_method,
+        speculative_tokens=namespace.speculative_tokens,
+        backend_options=_backend_options(namespace),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "serve":
+        engine_args = _args(args)
+        backend = create_backend(engine_args)
+        model_name = args.served_model_name or args.model
+        try:
+            serve(backend, host=args.host, port=args.port, model=model_name)
+        except KeyboardInterrupt:
+            backend.close()
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pocketllm/engine.py
+++ b/pocketllm/engine.py
@@ -1,0 +1,178 @@
+"""High-level synchronous and asynchronous PocketLLM facades."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Iterator, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from pocketllm.api import (
+    BackendCapabilities,
+    EngineArgs,
+    GenerationRequest,
+    GenerationResult,
+    HealthStatus,
+    SamplingParams,
+    TokenEvent,
+)
+from pocketllm.backends.factory import create_backend
+
+
+_TOKEN_DONE = object()
+
+
+def _next_event(iterator: Iterator[TokenEvent]) -> TokenEvent | object:
+    try:
+        return next(iterator)
+    except StopIteration:
+        return _TOKEN_DONE
+
+
+
+
+class LLM:
+    """A vLLM-like facade over one selected PocketLLM backend."""
+
+    def __init__(self, args: EngineArgs | None = None, **kwargs: Any) -> None:
+        self.args = args if args is not None else EngineArgs(**kwargs)
+        if kwargs and args is not None:
+            raise TypeError("pass either EngineArgs or keyword options, not both")
+        self._backend = create_backend(self.args)
+        self._closed = False
+
+    @property
+    def backend(self):
+        return self._backend
+
+    @property
+    def backend_name(self) -> str:
+        return self._backend.capabilities.name
+
+    def capabilities(self) -> BackendCapabilities:
+        return self._backend.capabilities
+
+    def health(self) -> HealthStatus:
+        return self._backend.health()
+
+    @staticmethod
+    def _requests(prompts: Sequence[str | Sequence[int]], params: SamplingParams) -> list[GenerationRequest]:
+        requests = []
+        for prompt in prompts:
+            if isinstance(prompt, str):
+                requests.append(GenerationRequest(prompt=prompt, sampling_params=params))
+            else:
+                requests.append(GenerationRequest(prompt_tokens=[int(token) for token in prompt], sampling_params=params))
+        return requests
+
+    def generate(
+        self,
+        prompts: str | Sequence[str | Sequence[int]],
+        sampling_params: SamplingParams | None = None,
+    ) -> list[GenerationResult]:
+        if self._closed:
+            raise RuntimeError("LLM is closed")
+        if isinstance(prompts, str):
+            prompts = [prompts]
+        params = sampling_params or SamplingParams()
+        return self._backend.generate(self._requests(prompts, params))
+
+    def generate_stream(
+        self,
+        prompt: str | Sequence[int],
+        sampling_params: SamplingParams | None = None,
+    ) -> Iterator[TokenEvent]:
+        if self._closed:
+            raise RuntimeError("LLM is closed")
+        params = sampling_params or SamplingParams()
+        request = self._requests([prompt], params)[0]
+        return self._backend.stream(request)
+
+    def cancel(self, request_id: str) -> bool:
+        return self._backend.cancel(request_id)
+
+    def close(self) -> None:
+        if not self._closed:
+            self._backend.close()
+            self._closed = True
+
+    def __enter__(self) -> "LLM":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+class AsyncLLM:
+    """Async facade using a worker executor around the backend contract.
+
+    This provides non-blocking application integration now.  It intentionally
+    does not advertise true multi-request device batching; that remains a
+    backend scheduler feature.
+    """
+
+    def __init__(self, args: EngineArgs | None = None, *, max_workers: int = 1, **kwargs: Any) -> None:
+        self._llm = LLM(args, **kwargs)
+        self._executor = ThreadPoolExecutor(
+            max_workers=max(1, int(max_workers)), thread_name_prefix="pocketllm-async"
+        )
+        self._closed = False
+
+    @property
+    def backend_name(self) -> str:
+        return self._llm.backend_name
+
+    def capabilities(self) -> BackendCapabilities:
+        return self._llm.capabilities()
+
+    def health(self) -> HealthStatus:
+        return self._llm.health()
+
+    async def generate(
+        self,
+        prompts: str | Sequence[str | Sequence[int]],
+        sampling_params: SamplingParams | None = None,
+    ) -> list[GenerationResult]:
+        if self._closed:
+            raise RuntimeError("AsyncLLM is closed")
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._executor, self._llm.generate, prompts, sampling_params)
+
+    async def generate_stream(
+        self,
+        prompt: str | Sequence[int],
+        sampling_params: SamplingParams | None = None,
+    ) -> AsyncIterator[TokenEvent]:
+        if self._closed:
+            raise RuntimeError("AsyncLLM is closed")
+        loop = asyncio.get_running_loop()
+        iterator = await loop.run_in_executor(
+            self._executor,
+            self._llm.generate_stream,
+            prompt,
+            sampling_params,
+        )
+        while True:
+            event = await loop.run_in_executor(self._executor, _next_event, iterator)
+            if event is _TOKEN_DONE:
+                return
+            yield event
+
+    async def cancel(self, request_id: str) -> bool:
+        if self._closed:
+            return False
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._executor, self._llm.cancel, request_id)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._llm.close()
+        self._executor.shutdown(wait=True, cancel_futures=True)
+        self._closed = True
+
+    async def __aenter__(self) -> "AsyncLLM":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()

--- a/pocketllm/server/__init__.py
+++ b/pocketllm/server/__init__.py
@@ -1,0 +1,6 @@
+"""PocketLLM serving components."""
+
+from .metrics import Metrics
+from .openai import OpenAIHandler, PocketLLMHTTPServer, serve
+
+__all__ = ["Metrics", "OpenAIHandler", "PocketLLMHTTPServer", "serve"]

--- a/pocketllm/server/metrics.py
+++ b/pocketllm/server/metrics.py
@@ -1,0 +1,72 @@
+"""Dependency-free Prometheus text metrics for the PocketLLM server."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import defaultdict
+from contextlib import contextmanager
+from typing import Iterator
+
+
+class Metrics:
+    """Small thread-safe counter/gauge/histogram collector.
+
+    The exporter intentionally emits stable names without requiring the
+    prometheus-client package.  Applications may wrap this collector with a
+    richer exporter later without changing backend code.
+    """
+
+    def __init__(self, prefix: str = "pocketllm") -> None:
+        self.prefix = prefix
+        self._lock = threading.Lock()
+        self._counters: defaultdict[str, float] = defaultdict(float)
+        self._gauges: defaultdict[str, float] = defaultdict(float)
+        self._histograms: defaultdict[str, list[float]] = defaultdict(list)
+
+    def inc(self, name: str, value: float = 1.0) -> None:
+        with self._lock:
+            self._counters[name] += float(value)
+
+    def set(self, name: str, value: float) -> None:
+        with self._lock:
+            self._gauges[name] = float(value)
+
+    def add(self, name: str, value: float) -> None:
+        """Add to a gauge while preserving counter monotonicity."""
+        with self._lock:
+            self._gauges[name] += float(value)
+
+    def observe(self, name: str, value: float) -> None:
+        with self._lock:
+            self._histograms[name].append(float(value))
+
+    @contextmanager
+    def time(self, name: str) -> Iterator[None]:
+        started = time.perf_counter()
+        try:
+            yield
+        finally:
+            self.observe(name, time.perf_counter() - started)
+
+    def render(self) -> str:
+        lines: list[str] = []
+        with self._lock:
+            counters = dict(self._counters)
+            gauges = dict(self._gauges)
+            histograms = {key: list(value) for key, value in self._histograms.items()}
+        for name, value in sorted(counters.items()):
+            lines.append(f"{self.prefix}_{name} {value:g}")
+        for name, value in sorted(gauges.items()):
+            lines.append(f"{self.prefix}_{name} {value:g}")
+        for name, values in sorted(histograms.items()):
+            if not values:
+                continue
+            ordered = sorted(values)
+            total = sum(ordered)
+            lines.append(f"{self.prefix}_{name}_count {len(ordered)}")
+            lines.append(f"{self.prefix}_{name}_sum {total:.9g}")
+            for quantile in (0.5, 0.9, 0.99):
+                index = min(len(ordered) - 1, int(quantile * len(ordered)))
+                lines.append(f'{self.prefix}_{name}{{quantile="{quantile}"}} {ordered[index]:.9g}')
+        return "\n".join(lines) + ("\n" if lines else "")

--- a/pocketllm/server/openai.py
+++ b/pocketllm/server/openai.py
@@ -1,0 +1,314 @@
+"""Backend-neutral OpenAI-compatible HTTP server.
+
+The protocol layer accepts any ``EngineBackend``.  Model loading remains the
+responsibility of the chosen adapter, so this module can be tested with a fake
+backend and can serve Torch or native C++ without duplicating JSON handling.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.parse import urlparse
+
+from pocketllm.api import (
+    BackendUnavailableError,
+    ConfigurationError,
+    EngineBackend,
+    GenerationRequest,
+    GenerationResult,
+    RequestCancelledError,
+    SamplingParams,
+    TokenEvent,
+    UnsupportedFeatureError,
+)
+
+from .metrics import Metrics
+
+
+def _json_bytes(obj: Any) -> bytes:
+    return json.dumps(obj, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+
+def _openai_error(message: str, error_type: str = "invalid_request_error") -> dict[str, Any]:
+    return {"error": {"message": message, "type": error_type}}
+
+
+def _messages_text(messages: Any) -> str:
+    if not isinstance(messages, list) or not messages:
+        raise ValueError("messages must be a non-empty list")
+    parts: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            raise ValueError("each message must be an object")
+        role = str(message.get("role", "user"))
+        content = message.get("content", "")
+        if isinstance(content, list):
+            content = "\n".join(
+                str(block.get("text", "")) if isinstance(block, dict) else str(block)
+                for block in content
+            )
+        parts.append(f"{role}: {content}")
+    return "\n".join(parts)
+
+
+def _result_response(result: GenerationResult, model: str, request_id: str) -> dict[str, Any]:
+    choice = {
+        "index": 0,
+        "message": {"role": "assistant", "content": result.text},
+        "finish_reason": result.finish_reason,
+    }
+    if result.logprobs is not None:
+        choice["logprobs"] = result.logprobs
+    return {
+        "id": request_id,
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [choice],
+        "usage": result.usage.as_dict(),
+    }
+
+
+def _completion_response(result: GenerationResult, model: str, request_id: str) -> dict[str, Any]:
+    return {
+        "id": request_id,
+        "object": "text_completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [{
+            "text": result.text,
+            "index": 0,
+            "logprobs": result.logprobs,
+            "finish_reason": result.finish_reason,
+        }],
+        "usage": result.usage.as_dict(),
+    }
+
+
+def _event_json(event: TokenEvent, model: str, *, completion: bool = False) -> dict[str, Any]:
+    if completion:
+        # Text completions use their own chunk schema; a chat delta here would
+        # break OpenAI-compatible clients that read `choices[].text`.
+        item: dict[str, Any] = {
+            "id": event.request_id,
+            "object": "text_completion",
+            "created": int(time.time()),
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "text": event.text,
+                "logprobs": None,
+                "finish_reason": event.finish_reason,
+            }],
+        }
+        if event.usage is not None:
+            item["usage"] = event.usage.as_dict()
+        return item
+    delta: dict[str, Any] = {}
+    if event.text:
+        delta["content"] = event.text
+    if event.metadata.get("role"):
+        delta["role"] = event.metadata["role"]
+    item = {
+        "id": event.request_id,
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": event.finish_reason}],
+    }
+    if event.usage is not None:
+        item["usage"] = event.usage.as_dict()
+    return item
+
+
+def _error_status(exc: BaseException) -> tuple[int, str]:
+    """Map public exception types to HTTP status and OpenAI error type."""
+    if isinstance(exc, RequestCancelledError):
+        return 499, "request_cancelled"
+    if isinstance(exc, UnsupportedFeatureError):
+        return 400, "unsupported_feature"
+    if isinstance(exc, ConfigurationError):
+        return 400, "invalid_request_error"
+    if isinstance(exc, BackendUnavailableError):
+        return 503, "backend_unavailable"
+    if isinstance(exc, (ValueError, TypeError, json.JSONDecodeError)):
+        return 400, "invalid_request_error"
+    return 500, "server_error"
+
+
+class PocketLLMHTTPServer(ThreadingHTTPServer):
+    def __init__(self, address, handler_class, backend: EngineBackend, model: str, metrics: Metrics | None = None):
+        super().__init__(address, handler_class)
+        self.backend = backend
+        self.model = model
+        self.metrics = metrics or Metrics()
+        self.started_at = time.time()
+
+
+class OpenAIHandler(BaseHTTPRequestHandler):
+    server_version = "PocketLLM/0.1"
+
+    @property
+    def pocket_server(self) -> PocketLLMHTTPServer:
+        return self.server  # type: ignore[return-value]
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        return
+
+    def _send_json(self, status: int, obj: Any) -> None:
+        data = _json_bytes(obj)
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _read_body(self) -> dict[str, Any]:
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        raw = self.rfile.read(length) if length else b"{}"
+        value = json.loads(raw.decode("utf-8"))
+        if not isinstance(value, dict):
+            raise ValueError("request body must be a JSON object")
+        return value
+
+    def do_OPTIONS(self) -> None:
+        self.send_response(204)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+        self.end_headers()
+
+    def do_GET(self) -> None:
+        path = urlparse(self.path).path
+        server = self.pocket_server
+        if path in {"/health", "/alive"}:
+            health = server.backend.health()
+            status = 200 if health.alive else 503
+            body = health.as_dict()
+            if path == "/alive":
+                body = {"alive": health.alive, "backend": health.backend}
+            self._send_json(status, body)
+            return
+        if path == "/ready":
+            health = server.backend.health()
+            self._send_json(200 if health.ready else 503, health.as_dict())
+            return
+        if path == "/metrics":
+            data = server.metrics.render().encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+            return
+        if path == "/v1/models":
+            self._send_json(200, {"object": "list", "data": [{"id": server.model, "object": "model", "owned_by": "local"}]})
+            return
+        self._send_json(404, _openai_error("not found"))
+
+    def _request(self, body: dict[str, Any], *, completion: bool = False) -> GenerationRequest:
+        request_id = str(body.get("request_id") or f"chatcmpl-{uuid.uuid4().hex}")
+        params = SamplingParams.from_openai(body)
+        prompt = body.get("prompt") if completion else _messages_text(body.get("messages"))
+        return GenerationRequest(prompt=prompt, sampling_params=params, request_id=request_id, metadata={
+            "stream_options": body.get("stream_options") or {},
+            "response_format": body.get("response_format"),
+        })
+
+    def do_DELETE(self) -> None:
+        path = urlparse(self.path).path
+        if not path.startswith("/v1/requests/"):
+            self._send_json(404, _openai_error("not found"))
+            return
+        request_id = path.rsplit("/", 1)[-1]
+        cancelled = self.pocket_server.backend.cancel(request_id)
+        self._send_json(200 if cancelled else 404, {"id": request_id, "cancelled": cancelled})
+
+    def do_POST(self) -> None:
+        path = urlparse(self.path).path
+        if path not in {"/v1/chat/completions", "/v1/completions"}:
+            self._send_json(404, _openai_error("not found"))
+            return
+        server = self.pocket_server
+        started = time.perf_counter()
+        server.metrics.inc("requests_total")
+        server.metrics.add("requests_active", 1)
+        try:
+            completion = path == "/v1/completions"
+            body = self._read_body()
+            request = self._request(body, completion=completion)
+            if bool(body.get("stream", False)):
+                self._stream(request, completion=completion)
+                return
+            result = server.backend.generate([request])[0]
+            server.metrics.inc("generation_tokens_total", result.usage.completion_tokens)
+            server.metrics.inc("prompt_tokens_total", result.usage.prompt_tokens)
+            response = (_completion_response if completion else _result_response)(
+                result, server.model, request.request_id
+            )
+            self._send_json(200, response)
+        except Exception as exc:
+            status, error_type = _error_status(exc)
+            server.metrics.inc("request_errors_total")
+            self._send_json(status, _openai_error(str(exc), error_type))
+        finally:
+            server.metrics.add("requests_active", -1)
+            server.metrics.observe("request_duration_seconds", time.perf_counter() - started)
+
+    def _stream(self, request: GenerationRequest, *, completion: bool = False) -> None:
+        server = self.pocket_server
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "close")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        if not completion:
+            role = TokenEvent(request.request_id, metadata={"role": "assistant"})
+            self.wfile.write(b"data: " + _json_bytes(_event_json(role, server.model)) + b"\n\n")
+            self.wfile.flush()
+        prompt_counted = False
+        try:
+            for event in server.backend.stream(request):
+                if event.token_id is not None:
+                    server.metrics.inc("generation_tokens_total")
+                if event.usage is not None and not prompt_counted:
+                    server.metrics.inc("prompt_tokens_total", event.usage.prompt_tokens)
+                    prompt_counted = True
+                payload = _event_json(event, server.model, completion=completion)
+                self.wfile.write(b"data: " + _json_bytes(payload) + b"\n\n")
+                self.wfile.flush()
+            self.wfile.write(b"data: [DONE]\n\n")
+            self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            # The client is gone; cancel at the next safe generation boundary.
+            server.metrics.inc("cancellations_total")
+            server.backend.cancel(request.request_id)
+        except Exception as exc:
+            # Headers are already sent, so report backend failures in-band.
+            _, error_type = _error_status(exc)
+            server.metrics.inc("request_errors_total")
+            try:
+                self.wfile.write(b"data: " + _json_bytes(_openai_error(str(exc), error_type)) + b"\n\n")
+                self.wfile.write(b"data: [DONE]\n\n")
+                self.wfile.flush()
+            except OSError:
+                pass
+        finally:
+            self.close_connection = True
+
+
+def serve(backend: EngineBackend, *, host: str = "0.0.0.0", port: int = 8000, model: str = "local", metrics: Metrics | None = None) -> None:
+    """Run the unified HTTP server until interrupted."""
+    server = PocketLLMHTTPServer((host, port), OpenAIHandler, backend, model, metrics)
+    try:
+        server.serve_forever()
+    finally:
+        backend.close()
+        server.server_close()

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,16 @@ setup(
         "src.models.minimax_m2",
         "src.runtime",
         "src.server",
+        "pocketllm",
+        "pocketllm.api",
+        "pocketllm.backends",
+        "pocketllm.server",
     ],
+    entry_points={
+        "console_scripts": [
+            "pocketllm=pocketllm.cli:main",
+        ],
+    },
     ext_modules=[
         CUDAExtension(
             name="cuda_kernel",

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+import threading
+from urllib import error, request
+
+from pocketllm.api import (
+    BackendCapabilities,
+    GenerationResult,
+    TokenEvent,
+    UnsupportedFeatureError,
+    Usage,
+)
+from pocketllm.backends.base import BackendBase
+from pocketllm.server.openai import OpenAIHandler, PocketLLMHTTPServer
+
+
+class ContractBackend(BackendBase):
+    def __init__(self, fail: bool = False):
+        super().__init__()
+        self._ready = True
+        self._fail = fail
+
+    @property
+    def capabilities(self):
+        return BackendCapabilities(name="fake", supports_streaming=True, supports_cancellation=True)
+
+    def generate(self, requests):
+        if self._fail:
+            raise UnsupportedFeatureError("logprobs are not exposed by this backend")
+        return [GenerationResult(
+            request_id=req.request_id,
+            token_ids=[11],
+            text="ok",
+            usage=Usage(2, 1),
+        ) for req in requests]
+
+    def stream(self, req):
+        self._begin_request(req.request_id)
+        try:
+            if self._fail:
+                yield TokenEvent(req.request_id, text="o", token_id=11)
+                raise UnsupportedFeatureError("stop strings are not exposed by this backend")
+            yield TokenEvent(req.request_id, text="o", token_id=11)
+            yield TokenEvent(req.request_id, text="k", token_id=12, finish_reason="stop", usage=Usage(2, 2))
+        finally:
+            self._clear_request(req.request_id)
+
+
+def _server(fail: bool = False):
+    backend = ContractBackend(fail=fail)
+    server = PocketLLMHTTPServer(("127.0.0.1", 0), OpenAIHandler, backend, "fake-model")
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, f"http://127.0.0.1:{server.server_address[1]}"
+
+
+def _post(base, path, body):
+    req = request.Request(
+        base + path,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with request.urlopen(req, timeout=10) as response:
+        return json.loads(response.read().decode())
+
+
+def _post_raw(base, path, body):
+    req = request.Request(
+        base + path,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with request.urlopen(req, timeout=10) as response:
+        return response.read().decode()
+
+
+def _metric_value(text: str, name: str) -> float:
+    for line in text.splitlines():
+        if line.startswith(f"pocketllm_{name} "):
+            return float(line.rsplit(" ", 1)[-1])
+    raise AssertionError(f"metric {name} not exported:\n{text}")
+
+
+def _metrics(base: str) -> str:
+    with request.urlopen(base + "/metrics", timeout=10) as response:
+        return response.read().decode()
+
+
+def test_shared_server_routes_chat_and_completions():
+    server, base = _server()
+    try:
+        chat = _post(base, "/v1/chat/completions", {"messages": [{"role": "user", "content": "hi"}]})
+        assert chat["object"] == "chat.completion"
+        assert chat["choices"][0]["message"]["content"] == "ok"
+        completion = _post(base, "/v1/completions", {"prompt": "hi"})
+        assert completion["object"] == "text_completion"
+        assert completion["choices"][0]["text"] == "ok"
+        with request.urlopen(base + "/ready", timeout=10) as response:
+            assert response.status == 200
+        metrics = _metrics(base)
+        assert "pocketllm_requests_total" in metrics
+        # The active-request gauge must return to zero once requests finish.
+        assert _metric_value(metrics, "requests_active") == 0.0
+        assert _metric_value(metrics, "prompt_tokens_total") == 4.0
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_completion_streaming_uses_text_completion_chunks():
+    server, base = _server()
+    try:
+        raw = _post_raw(base, "/v1/completions", {"prompt": "hi", "stream": True})
+        payloads = [line[len("data: "):] for line in raw.splitlines() if line.startswith("data: ")]
+        assert payloads[-1] == "[DONE]"
+        chunks = [json.loads(item) for item in payloads if item != "[DONE]"]
+        assert all(chunk["object"] == "text_completion" for chunk in chunks)
+        assert "".join(chunk["choices"][0]["text"] for chunk in chunks) == "ok"
+        assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+        assert chunks[-1]["usage"]["completion_tokens"] == 2
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_chat_streaming_keeps_chat_chunk_schema():
+    server, base = _server()
+    try:
+        raw = _post_raw(base, "/v1/chat/completions", {"messages": [{"role": "user", "content": "hi"}], "stream": True})
+        payloads = [line[len("data: "):] for line in raw.splitlines() if line.startswith("data: ")]
+        chunks = [json.loads(item) for item in payloads if item != "[DONE]"]
+        assert chunks[0]["choices"][0]["delta"] == {"role": "assistant"}
+        assert "".join(chunk["choices"][0]["delta"].get("content", "") for chunk in chunks) == "ok"
+        assert chunks[-1]["object"] == "chat.completion.chunk"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_typed_backend_errors_map_to_http_status():
+    server, base = _server(fail=True)
+    try:
+        try:
+            _post(base, "/v1/chat/completions", {"messages": [{"role": "user", "content": "hi"}]})
+            raise AssertionError("expected an HTTP error")
+        except error.HTTPError as exc:
+            assert exc.code == 400
+            body = json.loads(exc.read().decode())
+            assert body["error"]["type"] == "unsupported_feature"
+        metrics = _metrics(base)
+        assert _metric_value(metrics, "request_errors_total") == 1.0
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_stream_backend_failure_is_reported_in_band():
+    server, base = _server(fail=True)
+    try:
+        raw = _post_raw(base, "/v1/chat/completions", {"messages": [{"role": "user", "content": "hi"}], "stream": True})
+        payloads = [line[len("data: "):] for line in raw.splitlines() if line.startswith("data: ")]
+        assert payloads[-1] == "[DONE]"
+        errors = [json.loads(item) for item in payloads if item != "[DONE]" and "error" in item]
+        assert errors and errors[-1]["error"]["type"] == "unsupported_feature"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_cancelling_unknown_request_returns_404():
+    server, base = _server()
+    try:
+        try:
+            req = request.Request(base + "/v1/requests/does-not-exist", method="DELETE")
+            request.urlopen(req, timeout=10)
+            raise AssertionError("expected an HTTP error")
+        except error.HTTPError as exc:
+            assert exc.code == 404
+            assert json.loads(exc.read().decode())["cancelled"] is False
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/test_backend_selection.py
+++ b/tests/test_backend_selection.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pocketllm.api import EngineArgs, UnsupportedFeatureError
+from pocketllm.backends import factory
+
+
+def _write_config(directory, payload) -> None:
+    (directory / "config.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_explicit_backend_is_never_rewritten():
+    assert factory.select_backend(EngineArgs(model="missing", backend="torch")) == "torch"
+    assert factory.select_backend(EngineArgs(model="missing", backend="cpp")) == "cpp"
+
+
+def test_auto_selects_cpp_only_for_qwen35_with_native_module(tmp_path, monkeypatch):
+    _write_config(tmp_path, {"model_type": "qwen3_5", "architectures": ["Qwen3_5ForCausalLM"]})
+    monkeypatch.setattr(factory.CppBackend, "native_available", staticmethod(lambda: True))
+    assert factory.select_backend(EngineArgs(model=str(tmp_path), backend="auto")) == "cpp"
+
+
+def test_auto_falls_back_to_torch_without_native_module(tmp_path, monkeypatch):
+    _write_config(tmp_path, {"model_type": "qwen3_5"})
+    monkeypatch.setattr(factory.CppBackend, "native_available", staticmethod(lambda: False))
+    assert factory.select_backend(EngineArgs(model=str(tmp_path), backend="auto")) == "torch"
+
+
+def test_auto_keeps_torch_for_other_qwen_generations(tmp_path, monkeypatch):
+    # The native public adapter implements Qwen3.5 only, so an older Qwen
+    # checkpoint must not be routed to it just because the name matches.
+    _write_config(tmp_path, {"model_type": "qwen2", "architectures": ["Qwen2ForCausalLM"]})
+    monkeypatch.setattr(factory.CppBackend, "native_available", staticmethod(lambda: True))
+    assert factory.select_backend(EngineArgs(model=str(tmp_path), backend="auto")) == "torch"
+
+
+def test_auto_keeps_torch_for_gguf_checkpoints(tmp_path, monkeypatch):
+    _write_config(tmp_path, {"model_type": "qwen3_5"})
+    (tmp_path / "model.gguf").write_bytes(b"GGUF")
+    monkeypatch.setattr(factory.CppBackend, "native_available", staticmethod(lambda: True))
+    assert factory.select_backend(EngineArgs(model=str(tmp_path), backend="auto")) == "torch"
+
+
+def test_explicit_cpp_rejects_gguf_before_loading_native(tmp_path):
+    _write_config(tmp_path, {"model_type": "qwen3_5"})
+    args = EngineArgs(model=str(tmp_path), backend="cpp", model_format="gguf")
+    with pytest.raises(UnsupportedFeatureError, match="GGUF"):
+        factory.select_backend(args)
+
+
+def test_explicit_cpp_rejects_non_qwen35_checkpoint(tmp_path):
+    _write_config(tmp_path, {"model_type": "deepseek_v4"})
+    args = EngineArgs(model=str(tmp_path), backend="cpp")
+    with pytest.raises(UnsupportedFeatureError, match="Qwen3.5"):
+        factory.select_backend(args)
+
+
+def test_auto_detects_nested_text_config(tmp_path, monkeypatch):
+    _write_config(tmp_path, {"model_type": "qwen3_5_moe_vl", "text_config": {"model_type": "qwen3_5_text"}})
+    monkeypatch.setattr(factory.CppBackend, "native_available", staticmethod(lambda: True))
+    assert factory.select_backend(EngineArgs(model=str(tmp_path), backend="auto")) == "cpp"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from pocketllm.cli import _args, build_parser
+
+
+def _parse(*extra: str):
+    return build_parser().parse_args(["serve", "--model", "checkpoint", *extra])
+
+
+def test_cli_maps_common_engine_fields() -> None:
+    args = _args(_parse(
+        "--backend", "torch",
+        "--tensor-parallel-size", "2",
+        "--max-model-len", "16384",
+        "--kv-cache-dtype", "fp8",
+        "--prefill-chunk-tokens", "4096",
+        "--no-enable-prefix-caching",
+    ))
+
+    assert args.backend == "torch"
+    assert args.tensor_parallel_size == 2
+    assert args.max_model_len == 16384
+    assert args.kv_cache_dtype == "fp8"
+    assert args.prefill_chunk_tokens == 4096
+    assert args.enable_prefix_caching is False
+
+
+def test_cli_exposes_attention_window_and_speculation() -> None:
+    args = _args(_parse(
+        "--attention-window", "4096",
+        "--attention-sink-tokens", "128",
+        "--speculative-method", "mtp",
+        "--speculative-tokens", "3",
+    ))
+
+    assert args.attention_window == 4096
+    assert args.attention_sink_tokens == 128
+    assert args.speculative_method == "mtp"
+    assert args.speculative_tokens == 3
+
+
+def test_backend_option_values_are_json_typed() -> None:
+    args = _args(_parse(
+        "--backend-option", "max_state_snapshots=16",
+        "--backend-option", "mtp_adaptive=true",
+        "--backend-option", "dspark_checkpoint=/models/drafter",
+    ))
+
+    assert args.backend_options["max_state_snapshots"] == 16
+    assert args.backend_options["mtp_adaptive"] is True
+    # A bare path must survive as a string rather than failing JSON parsing.
+    assert args.backend_options["dspark_checkpoint"] == "/models/drafter"
+    # Defaults stay present alongside explicit overrides.
+    assert args.backend_options["engine_kind"] == "qwen"
+
+
+def test_backend_option_requires_key_value_form() -> None:
+    with pytest.raises(SystemExit, match="KEY=VALUE"):
+        _args(_parse("--backend-option", "bare-flag"))
+
+
+def test_served_model_name_defaults_to_model_path() -> None:
+    namespace = _parse()
+    assert namespace.served_model_name is None
+    named = _parse("--served-model-name", "qwen-local")
+    assert named.served_model_name == "qwen-local"

--- a/tests/test_cpp_backend.py
+++ b/tests/test_cpp_backend.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import threading
+import time
+import pytest
+
+from pocketllm.api import (
+    ConfigurationError,
+    EngineArgs,
+    GenerationRequest,
+    RequestCancelledError,
+    SamplingParams,
+    UnsupportedFeatureError,
+)
+from pocketllm.backends.cpp_backend import CppBackend
+from pocketllm.cli import _args, build_parser
+
+
+class FakeTokenizer:
+    def encode(self, text: str) -> list[int]:
+        return [len(text), 7]
+
+    def decode(self, token_ids: list[int]) -> str:
+        return "".join(f"<{token}>" for token in token_ids)
+
+
+class FakeResult:
+    def __init__(self, top_token: int) -> None:
+        self.top_token = top_token
+
+
+class FakeEngine:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, ...]] = []
+        self.closed = 0
+        self.active = 0
+        self.max_active = 0
+        self._active_lock = threading.Lock()
+
+    def generate(self, prompt_ids: list[int], max_tokens: int) -> list[FakeResult]:
+        with self._active_lock:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+        try:
+            self.calls.append(("generate", list(prompt_ids), max_tokens))
+            time.sleep(0.02)
+            return [FakeResult(10 + index) for index in range(max_tokens)]
+        finally:
+            with self._active_lock:
+                self.active -= 1
+
+    def reset(self) -> None:
+        self.calls.append(("reset",))
+
+    def clear_prefix_cache(self) -> None:
+        self.calls.append(("clear_prefix_cache",))
+
+    def prefill(self, prompt_ids: list[int]) -> FakeResult:
+        self.calls.append(("prefill", list(prompt_ids)))
+        return FakeResult(10)
+
+    def decode_step(self, token: int) -> FakeResult:
+        self.calls.append(("decode_step", token))
+        return FakeResult(token + 1)
+
+    def close(self) -> None:
+        self.closed += 1
+
+
+class FakeOptions:
+    def __init__(self) -> None:
+        self.tp_world = 1
+        self.tp_rank = 0
+        self.device = 0
+        self.prefill_chunk_tokens = 0
+        self.kv_cache_dtype = "unset"
+        self.attention_window = 0
+        self.attention_sink_tokens = 0
+        self.prefix_cache = False
+        self.state_snapshot_interval_tokens = 0
+        self.max_state_snapshots = 0
+        self.mtp = False
+        self.mtp_speculative_tokens = 1
+        self.mtp_adaptive = False
+        self.dspark_checkpoint = ""
+        self.dflash2_checkpoint = ""
+        self.nccl_id_path = ""
+        self.temperature = 1.0
+        self.top_p = 0.0
+        self.top_k = 0
+        self.sampling_seed = -1
+
+
+class FakeNativeModule:
+    QwenEngineOptions = FakeOptions
+
+    def __init__(self) -> None:
+        self.constructed: tuple[str, FakeOptions, int, int] | None = None
+
+    @staticmethod
+    def parse_qwen_kv_cache_dtype(value: str) -> str:
+        return f"native:{value}"
+
+    def QwenEngine(
+        self,
+        checkpoint: str,
+        options: FakeOptions,
+        layer_count: int,
+        max_context: int,
+    ) -> FakeEngine:
+        self.constructed = (checkpoint, options, layer_count, max_context)
+        return FakeEngine()
+
+
+def make_backend(engine: FakeEngine | None = None) -> tuple[CppBackend, FakeEngine]:
+    fake_engine = engine or FakeEngine()
+    backend = CppBackend(
+        EngineArgs(model="model", backend="cpp"),
+        engine=fake_engine,
+        tokenizer=FakeTokenizer(),
+    )
+    return backend, fake_engine
+
+
+def test_generate_converts_native_results_and_usage() -> None:
+    backend, engine = make_backend()
+    request = GenerationRequest(
+        prompt="hello",
+        request_id="req-generate",
+        sampling_params=SamplingParams(max_tokens=3),
+    )
+
+    result = backend.generate([request])[0]
+
+    assert engine.calls == [("generate", [5, 7], 3)]
+    assert result.request_id == "req-generate"
+    assert result.token_ids == [10, 11, 12]
+    assert result.text == "<10><11><12>"
+    assert result.finish_reason == "length"
+    assert result.usage.as_dict() == {
+        "prompt_tokens": 2,
+        "completion_tokens": 3,
+        "total_tokens": 5,
+    }
+
+
+def test_stream_matches_native_prefill_decode_order() -> None:
+    backend, engine = make_backend()
+    request = GenerationRequest(
+        prompt_tokens=[4, 5],
+        request_id="req-stream",
+        sampling_params=SamplingParams(max_tokens=3),
+    )
+
+    events = list(backend.stream(request))
+
+    # No reset()/clear_prefix_cache(): native prefill() owns prefix matching, so
+    # resetting per request would disable configured prefix reuse.
+    assert engine.calls == [
+        ("prefill", [4, 5]),
+        ("decode_step", 10),
+        ("decode_step", 11),
+    ]
+    assert [event.token_id for event in events] == [10, 11, 12]
+    assert [event.text for event in events] == ["<10>", "<11>", "<12>"]
+    assert [event.finish_reason for event in events] == [None, None, "length"]
+    assert events[-1].usage is not None
+    assert events[-1].usage.as_dict() == {
+        "prompt_tokens": 2,
+        "completion_tokens": 3,
+        "total_tokens": 5,
+    }
+
+
+def test_stream_cancellation_stops_before_next_decode_step() -> None:
+    backend, engine = make_backend()
+    request = GenerationRequest(
+        prompt_tokens=[4],
+        request_id="req-cancel",
+        sampling_params=SamplingParams(max_tokens=3),
+    )
+    stream = backend.stream(request)
+
+    assert next(stream).token_id == 10
+    assert backend.cancel(request.request_id) is True
+    with pytest.raises(RequestCancelledError):
+        next(stream)
+
+    assert engine.calls == [("prefill", [4])]
+
+
+def test_requests_are_serialized_around_one_native_session() -> None:
+    backend, engine = make_backend()
+    barrier = threading.Barrier(3)
+    errors: list[BaseException] = []
+
+    def generate(index: int) -> None:
+        try:
+            barrier.wait()
+            backend.generate(
+                [
+                    GenerationRequest(
+                        prompt_tokens=[index + 1],
+                        request_id=f"req-{index}",
+                        sampling_params=SamplingParams(max_tokens=1),
+                    )
+                ]
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    workers = [threading.Thread(target=generate, args=(index,)) for index in range(2)]
+    for worker in workers:
+        worker.start()
+    barrier.wait()
+    for worker in workers:
+        worker.join(timeout=2.0)
+
+    assert errors == []
+    assert all(not worker.is_alive() for worker in workers)
+    assert engine.max_active == 1
+
+
+def test_close_releases_native_engine_and_rejects_new_work() -> None:
+    backend, engine = make_backend()
+
+    backend.close()
+    backend.close()
+
+    assert engine.closed == 1
+    assert backend.health().status == "stopped"
+    with pytest.raises(RuntimeError, match="backend is closed"):
+        backend.generate(
+            [GenerationRequest(prompt_tokens=[1], request_id="req-closed")]
+        )
+
+
+def test_close_during_stream_releases_at_safe_boundary() -> None:
+    backend, engine = make_backend()
+    stream = backend.stream(
+        GenerationRequest(
+            prompt_tokens=[1],
+            request_id="req-close-stream",
+            sampling_params=SamplingParams(max_tokens=2),
+        )
+    )
+
+    assert next(stream).token_id == 10
+    backend.close()
+    assert engine.closed == 0
+    with pytest.raises(RuntimeError, match="backend is closed"):
+        next(stream)
+    assert engine.closed == 1
+
+
+def test_native_options_normalize_cli_device_and_auto_kv_dtype() -> None:
+    namespace = build_parser().parse_args(
+        [
+            "serve",
+            "--model",
+            "checkpoint",
+            "--backend",
+            "cpp",
+            "--device",
+            "cuda:2",
+            "--max-model-len",
+            "4096",
+        ]
+    )
+    native = FakeNativeModule()
+
+    backend = CppBackend(_args(namespace), native_module=native, tokenizer=FakeTokenizer())
+
+    assert native.constructed is not None
+    checkpoint, options, layer_count, max_context = native.constructed
+    assert checkpoint == "checkpoint"
+    assert options.device == 2
+    assert options.kv_cache_dtype == "native:fp16"
+    assert options.temperature == 0.0
+    assert (layer_count, max_context) == (0, 4096)
+    backend.close()
+
+
+@pytest.mark.parametrize("device", ["gpu", "cuda:", -1, True])
+def test_invalid_native_device_is_rejected(device: object) -> None:
+    native = FakeNativeModule()
+    with pytest.raises(ConfigurationError, match="device"):
+        CppBackend(
+            EngineArgs(model="checkpoint", backend="cpp", device=device),
+            native_module=native,
+            tokenizer=FakeTokenizer(),
+        )
+
+
+def test_cpp_capabilities_match_phase_one_surface() -> None:
+    backend, _ = make_backend()
+
+    capabilities = backend.capabilities
+    assert capabilities.models == ("qwen3.5",)
+    assert capabilities.model_formats == ("safetensors",)
+    assert capabilities.supports_streaming is True
+    assert capabilities.supports_batch is False
+
+
+def test_cpp_capabilities_follow_the_linked_device_backend() -> None:
+    class AscendModule(FakeNativeModule):
+        backend = "ascend"
+
+    native = AscendModule()
+    backend = CppBackend(
+        EngineArgs(model="checkpoint", backend="cpp"),
+        native_module=native,
+        tokenizer=FakeTokenizer(),
+    )
+
+    capabilities = backend.capabilities
+    # The Ascend build rejects DSpark/DFlash2 drafters, so they must not be
+    # advertised just because the CUDA build supports them.
+    assert capabilities.supports_speculative_decoding == ("mtp",)
+    assert capabilities.devices == ("ascend",)
+    backend.close()
+
+
+def test_cancel_only_accepts_active_request_ids() -> None:
+    backend, _ = make_backend()
+
+    assert backend.cancel("req-never-submitted") is False
+
+    stream = backend.stream(
+        GenerationRequest(
+            prompt_tokens=[1],
+            request_id="req-active",
+            sampling_params=SamplingParams(max_tokens=2),
+        )
+    )
+    assert next(stream).token_id == 10
+    assert backend.cancel("req-active") is True
+    assert backend.cancel("req-other") is False
+    with pytest.raises(RequestCancelledError):
+        next(stream)
+    assert backend.cancel("req-active") is False
+    assert backend.active_request_count() == 0
+
+
+def test_stream_text_deltas_use_cumulative_tokenizer_decode() -> None:
+    class MergingTokenizer:
+        """Emulates a tokenizer whose pieces only render as a full sequence."""
+
+        def encode(self, text: str) -> list[int]:
+            return [1]
+
+        def decode(self, token_ids: list[int]) -> str:
+            return "".join("ab"[index % 2] for index, _ in enumerate(token_ids))
+
+    engine = FakeEngine()
+    backend = CppBackend(
+        EngineArgs(model="model", backend="cpp"),
+        engine=engine,
+        tokenizer=MergingTokenizer(),
+    )
+    request = GenerationRequest(
+        prompt_tokens=[1],
+        request_id="req-delta",
+        sampling_params=SamplingParams(max_tokens=3),
+    )
+
+    events = list(backend.stream(request))
+
+    assert [event.text for event in events] == ["a", "b", "a"]
+    backend.close()
+
+
+def test_cpp_backend_rejects_unexposed_sampling_controls() -> None:
+    backend, _ = make_backend()
+    request = GenerationRequest(
+        prompt_tokens=[1],
+        sampling_params=SamplingParams(max_tokens=1, temperature=0.5),
+    )
+
+    with pytest.raises(UnsupportedFeatureError, match="greedy"):
+        backend.generate([request])

--- a/tests/test_cpp_binding_smoke.py
+++ b/tests/test_cpp_binding_smoke.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def native_module():
+    try:
+        return importlib.import_module("pocketllm_cpp")
+    except ImportError as exc:
+        pytest.skip(f"native pocketllm_cpp module is not built: {exc}")
+
+
+def test_native_value_types_and_enum(native_module):
+    assert native_module.backend in {"cuda", "ascend"}
+    options = native_module.QwenEngineOptions()
+    assert options.tp_world == 1
+    assert options.tp_rank == 0
+    assert native_module.qwen_kv_cache_dtype_name(
+        native_module.QwenKvCacheDType.Fp16
+    ) == "fp16"
+    options.kv_cache_dtype = native_module.QwenKvCacheDType.Fp8
+    assert options.kv_cache_dtype == native_module.QwenKvCacheDType.Fp8
+
+
+def test_native_result_and_sampling_defaults(native_module):
+    result = native_module.QwenForwardResult()
+    assert result.top_token == 0
+    assert result.as_dict()["accept_tokens"] == []
+    sampling = native_module.SamplingParams()
+    assert sampling.greedy is True
+    assert sampling.temperature == 1.0
+    smoke = native_module.ForwardSmokeOptions()
+    assert smoke.as_dict()["skip_fp4_host_prepare"] is False

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pocketllm import (
+    BackendCapabilities,
+    ConfigurationError,
+    EngineArgs,
+    GenerationRequest,
+    GenerationResult,
+    HealthStatus,
+    LLM,
+    SamplingParams,
+    TokenEvent,
+    Usage,
+)
+from pocketllm.backends.base import BackendBase
+from pocketllm.backends.factory import create_backend
+
+
+# The facade uses the factory in production; tests replace it with a small
+# dependency-free backend so API behavior is testable without a checkpoint.
+
+
+_original_create_backend = create_backend
+
+
+
+class FakeBackend(BackendBase):
+    def __init__(self):
+        super().__init__()
+        self._ready = True
+
+    @property
+    def capabilities(self):
+        return BackendCapabilities(
+            name="fake", supports_streaming=True, supports_cancellation=True,
+        )
+
+    def generate(self, requests):
+        result = []
+        for request in requests:
+            self._begin_request(request.request_id)
+            try:
+                self._check_cancelled(request.request_id)
+                result.append(GenerationResult(
+                    request_id=request.request_id,
+                    token_ids=[1, 2],
+                    text=request.prompt or "",
+                    usage=Usage(3, 2),
+                ))
+            finally:
+                self._clear_request(request.request_id)
+        return result
+
+    def stream(self, request):
+        self._begin_request(request.request_id)
+        try:
+            self._check_cancelled(request.request_id)
+            yield TokenEvent(request.request_id, token_id=1, text="a")
+            self._check_cancelled(request.request_id)
+            yield TokenEvent(request.request_id, token_id=2, text="b", finish_reason="stop", usage=Usage(1, 2))
+        finally:
+            self._clear_request(request.request_id)
+
+
+class InjectedLLM(LLM):
+    def __init__(self):
+        self.args = EngineArgs(model="fake", backend="torch")
+        self._backend = FakeBackend()
+        self._closed = False
+
+
+def test_engine_args_and_sampling_aliases():
+    args = EngineArgs(model="model", backend="torch", tensor_parallel_size=2, tensor_parallel_rank=1)
+    assert args.checkpoint_dir == "model"
+    params = SamplingParams.from_openai({"max_completion_tokens": 7, "stop": "END", "n": 2})
+    assert params.max_tokens == 7
+    assert params.stop == ("END",)
+    assert params.n == 2
+
+
+def test_invalid_public_options_fail_early():
+    with pytest.raises(ConfigurationError):
+        EngineArgs(model="x", backend="bad")
+    with pytest.raises(ConfigurationError):
+        SamplingParams(max_tokens=0)
+    with pytest.raises(ConfigurationError):
+        GenerationRequest()
+
+
+def test_fake_backend_sync_and_stream():
+    llm = InjectedLLM()
+    result = llm.generate(["hello"])[0]
+    assert result.text == "hello"
+    assert result.usage.as_dict() == {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
+    events = list(llm.generate_stream("stream"))
+    assert "".join(event.text for event in events) == "ab"
+    assert events[-1].finish_reason == "stop"
+    llm.close()
+    with pytest.raises(RuntimeError):
+        llm.generate("closed")
+
+
+def test_cancel_requires_an_active_request():
+    llm = InjectedLLM()
+    assert llm.cancel("never-submitted") is False
+    stream = llm.generate_stream("stream")
+    first = next(stream)
+    assert llm.cancel(first.request_id) is True
+    llm.close()
+
+
+def test_async_facade_with_fake_backend():
+    from pocketllm.engine import AsyncLLM
+
+    async def run():
+        async_llm = AsyncLLM.__new__(AsyncLLM)
+        async_llm._llm = InjectedLLM()
+        from concurrent.futures import ThreadPoolExecutor
+        async_llm._executor = ThreadPoolExecutor(max_workers=1)
+        async_llm._closed = False
+        result = (await async_llm.generate("hello"))[0]
+        assert result.text == "hello"
+        values = []
+        async for event in async_llm.generate_stream("x"):
+            values.append(event.text)
+        assert values == ["a", "b"]
+        await async_llm.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

Adds a `pocketllm` control plane presenting one user-facing API over the two existing execution planes, without merging their data paths. Kernels, KV-cache layouts, and schedulers stay backend-specific so the Turing CUDA and Ascend optimizations are not weakened by a lowest-common-denominator abstraction.

- `EngineArgs`, `SamplingParams`, `LLM`, `AsyncLLM` public interfaces
- Explicit `torch` / `cpp` / `auto` backend selection
- Shared OpenAI-compatible server: `/health`, `/alive`, `/ready`, `/metrics`, `/v1/models`, `/v1/chat/completions`, `/v1/completions`, `DELETE /v1/requests/<id>`
- `pocketllm serve` console script
- Optional pybind11 bindings for the token-oriented native Qwen engine

The `dsv4_cpp_engine` executable and its CLI remain supported. The shared Python server is a migration path, not a replacement.

## Behavior worth reviewing

- The native adapter is restricted to Qwen3.5 safetensors. An explicit `backend="cpp"` for a GGUF or non-Qwen checkpoint raises `UnsupportedFeatureError` **before** any CUDA initialization, rather than failing deep inside the native loader. Missing or unreadable paths are deliberately left alone so injected engines still reach the native loader.
- Streaming does **not** reset the native session per request. `prefill()` owns prefix matching, so resetting first would silently disable the prefix caching the caller configured.
- Reported capabilities follow the linked device backend, so an Ascend build does not advertise the CUDA-only DSpark and DFlash2 drafters.
- Cancellation is observed at safe boundaries between generation steps and never interrupts a running device kernel or rolls back a partially executed native step. `cancel()` returns `True` only for a currently active request; unknown IDs return HTTP 404.
- `/v1/completions` streams `text_completion` chunks with `choices[].text` rather than chat-style deltas, which would break OpenAI-compatible clients. Backend errors map to typed statuses (cancelled → 499, unsupported/config → 400, unavailable → 503), with in-band SSE reporting once headers are already sent.
- `reset()` and `clear_prefix_cache()` release the GIL like the other device-touching entry points.
- Static-library PIC is scoped to `POCKET_BUILD_PYTHON` via `POCKET_STATIC_PIC`, so the existing executables keep their current code generation.

The C++ adapter is intentionally serialized around one mutable native session. True continuous batching and real-model Torch/C++ parity are out of scope for this phase.

## Testing

- Python suite: **40 passed / 2 skipped** without the native module, **42 passed** with it on `PYTHONPATH` (the 2 skips are the binding smoke tests, which require the module).
- Native CUDA module builds clean and imports, reporting `backend = cuda`.
- Default `dsv4_cpp_engine` executable still configures and links with `POCKET_BUILD_PYTHON=OFF` (the default); `check_layering` reports 52 files clean of vendor SDK includes.
- `import pocketllm` pulls in no torch, so CPU-only imports are unaffected.

Not verified: no real-model end-to-end generation run against a Qwen3.5 checkpoint on this branch. Backend adapters are covered by injected fakes.

Build for the optional module:

```bash
cmake -S cpp_engine -B cpp_engine/build-python \
  -DPOCKET_BACKEND=cuda -DPOCKET_BUILD_PYTHON=ON \
  -Dpybind11_DIR="$(python -c 'import pybind11; print(pybind11.get_cmake_dir())')"
cmake --build cpp_engine/build-python --target pocketllm_cpp -j
```
