### PR TITLE
Share OpenAI request normalization and fix C++ termination

### DIFF
--- a/docs/pocketllm_api.md
+++ b/docs/pocketllm_api.md
@@ -120,6 +120,47 @@ Capabilities reported by the C++ adapter follow the linked device backend. An As
 only the speculative methods it implements, since the external DSpark and DFlash2 drafters are
 CUDA-only.
 
+## Request normalization
+
+`pocketllm.protocol` holds the request normalization shared by the unified server and the legacy
+`src.server.openai` server: OpenAI content-block flattening, tool attachment and `tool_choice`
+instructions, `reasoning`/`reasoning_effort` handling, tool-call shaping, and stop-string truncation.
+There is one implementation, and it imports neither Torch nor the native module.
+
+`/v1/chat/completions` puts the normalized messages, thinking mode, reasoning effort, and tool
+metadata in `GenerationRequest.metadata`, so a backend applies its own chat template. The Torch
+adapter encodes them with the DeepSeek template that the legacy server uses, so both servers build
+the same prompt. `GenerationRequest.prompt` still carries a deterministic `role: content` rendering as
+a fallback for backends that have no template of their own. `/v1/completions` passes `prompt` through
+unchanged and validates that a list prompt contains only strings.
+
+A backend that separates reasoning from content can set `reasoning_content` and `tool_calls` in its
+result or event metadata; those are forwarded to the response and to streamed deltas. A backend that
+does not simply omits them.
+
+## Termination semantics
+
+The C++ adapter decides when generation stops. The first EOS token ends the request, is excluded from
+the returned token ids and text, and yields `finish_reason="stop"`. `finish_reason="length"` means the
+token budget ended first. Usage counts the EOS step the engine executed, so streaming and offline
+usage agree.
+
+`QwenEngine.generate` takes no EOS argument and keeps mutating its session for the whole token budget,
+so when an EOS id is known both the offline and streamed paths drive `prefill`/`decode_step`
+themselves and stop at EOS. Running `generate()` and truncating afterwards would leave the recurrent
+state and prefix cache positioned past text the caller never saw, corrupting reuse for the next
+request. Native `generate()` is still used when no EOS id is available, where the token budget is the
+only stopping rule.
+
+EOS ids are resolved in order: `backend_options["eos_token_id"]`, the native engine's `eos_id`, the
+native config, the checkpoint's `generation_config.json`, the checkpoint's `config.json`, then the
+tokenizer. `generation_config.json` is preferred over the tokenizer because chat checkpoints commonly
+stop on a turn-end token that differs from the tokenizer's EOS. A non-integer override is rejected
+rather than guessed. When no EOS is available, `capabilities.details["eos_source"]` reports `none` and
+only the token budget can end generation. Streaming never issues another `decode_step` after EOS, and
+it never calls `reset()` per request, since `QwenEngine::reset()` would clear the prefix cache that
+`prefill()` relies on.
+
 ## Cancellation semantics
 
 `cancel(request_id)` returns `True` only for a request that is currently active, and cancellation is

--- a/docs/vllm_sglang_comparison.md
+++ b/docs/vllm_sglang_comparison.md
@@ -71,6 +71,11 @@ checked between native decode steps and never interrupts a device kernel.
 preemption. These require a request-aware scheduler and must not be implemented by sharing the
 current mutable session unsafely. The Torch adapter continues to reuse its existing serving queue.
 
+Phase 1.1 hardened protocol and termination behavior only. Chat requests now carry normalized
+messages so each backend applies its own chat template, and the C++ adapter stops at EOS with a
+correct `stop`/`length` finish reason instead of always reporting `length`. Neither change touches
+scheduling: the native path remains one serialized session, and `supports_batch` stays `False`.
+
 ## 3. Configuration
 
 ### vLLM/SGLang

--- a/pocketllm/backends/cpp_backend.py
+++ b/pocketllm/backends/cpp_backend.py
@@ -8,6 +8,8 @@ SDK at import time.
 from __future__ import annotations
 
 import importlib
+import json
+import os
 import threading
 import time
 from collections.abc import Iterator, Sequence
@@ -60,6 +62,43 @@ def _native_kv_cache_dtype(value: str) -> str:
     """Resolve the public ``auto`` value to the native Qwen default."""
     normalized = str(value or "auto").lower()
     return "fp16" if normalized == "auto" else normalized
+
+
+def _coerce_eos_ids(value: Any, *, source: str) -> tuple[int, ...]:
+    """Normalize a configured EOS value into a tuple of token ids."""
+    if value is None:
+        return ()
+    if isinstance(value, bool):
+        raise ConfigurationError(f"{source} eos_token_id must be an integer or list of integers")
+    if isinstance(value, int):
+        return (int(value),)
+    if isinstance(value, (list, tuple)):
+        ids: list[int] = []
+        for item in value:
+            if isinstance(item, bool) or not isinstance(item, int):
+                raise ConfigurationError(f"{source} eos_token_id list must contain integers only")
+            ids.append(int(item))
+        return tuple(dict.fromkeys(ids))
+    raise ConfigurationError(f"{source} eos_token_id must be an integer or list of integers")
+
+
+def _checkpoint_eos_ids(checkpoint_dir: str) -> tuple[tuple[int, ...], str]:
+    """Read the EOS ids a checkpoint declares, preferring generation_config.json."""
+    if not checkpoint_dir:
+        return (), ""
+    for name in ("generation_config.json", "config.json"):
+        path = os.path.join(checkpoint_dir, name)
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        ids = _coerce_eos_ids(data.get("eos_token_id"), source=name)
+        if ids:
+            return ids, name
+    return (), ""
 
 
 def _native_device_index(value: str | int | None) -> int:
@@ -117,7 +156,56 @@ class CppBackend(BackendBase):
         # without guaranteeing that every next() call uses the same thread.
         self._request_lock = threading.Lock()
         self._tokenizer = tokenizer if tokenizer is not None else self._load_tokenizer()
+        self._eos_ids, self._eos_source = self._resolve_eos_ids()
         self._ready = True
+
+    def _resolve_eos_ids(self) -> tuple[frozenset[int], str]:
+        """Resolve the stop tokens without guessing a vocabulary-specific id.
+
+        ``backend_options["eos_token_id"]`` wins so an operator can override a
+        checkpoint.  Otherwise the native engine, the tokenizer, and finally the
+        checkpoint's ``generation_config.json``/``config.json`` are consulted.
+        An empty result means only the token budget can end generation, which the
+        adapter reports as ``finish_reason="length"``.
+        """
+        override = _coerce_eos_ids(self.args.backend_options.get("eos_token_id"), source="backend_options")
+        if override:
+            return frozenset(override), "backend_options"
+        for holder, attribute, source in (
+            (self._engine, "eos_id", "native engine"),
+            (self._engine, "eos_token_id", "native engine"),
+        ):
+            if holder is None:
+                continue
+            value = getattr(holder, attribute, None)
+            if callable(value):
+                try:
+                    value = value()
+                except Exception:
+                    continue
+            ids = _coerce_eos_ids(value, source=source)
+            if ids:
+                return frozenset(ids), source
+        config = getattr(self._engine, "config", None)
+        if isinstance(config, dict):
+            ids = _coerce_eos_ids(config.get("eos_token_id"), source="native config")
+            if ids:
+                return frozenset(ids), "native config"
+        # generation_config.json is consulted before the tokenizer because it is
+        # what the checkpoint declares for generation. Chat checkpoints commonly
+        # stop on a turn-end token that differs from the tokenizer's EOS.
+        ids, name = _checkpoint_eos_ids(self.args.checkpoint_dir)
+        if ids:
+            return frozenset(ids), name
+        value = getattr(self._tokenizer, "eos_token_id", None) if self._tokenizer is not None else None
+        ids = _coerce_eos_ids(value, source="tokenizer")
+        if ids:
+            return frozenset(ids), "tokenizer"
+        return frozenset(), ""
+
+    @property
+    def eos_token_ids(self) -> frozenset[int]:
+        return self._eos_ids
 
     @staticmethod
     def native_available() -> bool:
@@ -151,6 +239,8 @@ class CppBackend(BackendBase):
                 "scheduler": "serialized compatibility session",
                 "device_backend": native_backend or "unknown",
                 "cancellation": "safe boundary only",
+                "eos_token_ids": sorted(self._eos_ids),
+                "eos_source": self._eos_source or "none",
             },
         )
 
@@ -241,6 +331,37 @@ class CppBackend(BackendBase):
             return int(item)
         return int(getattr(item, "top_token", getattr(item, "token", item)))
 
+    def _is_eos(self, token: int) -> bool:
+        return token in self._eos_ids
+
+    def _generate_until_eos(
+        self, request: GenerationRequest, prompt_ids: list[int]
+    ) -> tuple[list[int], bool]:
+        """Step the native session so it never advances past EOS.
+
+        ``QwenEngine.generate`` takes no EOS argument and keeps mutating its
+        session for the whole token budget.  Calling it and truncating the result
+        would leave the recurrent state and prefix cache positioned after text
+        the caller never sees, corrupting reuse for the next request.  Driving
+        prefill/decode here keeps the session and the returned tokens in step,
+        and matches what the streamed path does.
+        """
+        engine = self._engine
+        if engine is None:
+            raise RuntimeError("native C++ engine is closed")
+        result = engine.prefill(prompt_ids)
+        token_ids: list[int] = []
+        for index in range(request.sampling_params.max_tokens):
+            self._ensure_open()
+            self._check_cancelled(request.request_id)
+            token = self._native_token(result)
+            if self._is_eos(token):
+                return token_ids, True
+            token_ids.append(token)
+            if index + 1 < request.sampling_params.max_tokens:
+                result = engine.decode_step(token)
+        return token_ids, False
+
     def _decode(self, token_ids: list[int]) -> str:
         if self._tokenizer is None:
             return ""
@@ -266,22 +387,27 @@ class CppBackend(BackendBase):
                 with self._request_lock:
                     self._ensure_open()
                     self._check_cancelled(request.request_id)
-                    engine = self._engine
-                    if engine is None:
-                        raise RuntimeError("native C++ engine is closed")
-                    raw = engine.generate(
-                        prompt_ids, request.sampling_params.max_tokens
-                    )
+                    if self._eos_ids:
+                        token_ids, hit_eos = self._generate_until_eos(request, prompt_ids)
+                    else:
+                        engine = self._engine
+                        if engine is None:
+                            raise RuntimeError("native C++ engine is closed")
+                        raw = engine.generate(prompt_ids, request.sampling_params.max_tokens)
+                        token_ids = [self._native_token(item) for item in raw]
+                        hit_eos = False
                     self._ensure_open()
                 self._check_cancelled(request.request_id)
-                token_ids = [self._native_token(item) for item in raw]
+                # `completion_tokens` counts the EOS step the engine executed, so
+                # usage stays comparable with the streamed path.
+                completion_tokens = len(token_ids) + (1 if hit_eos else 0)
                 outputs.append(
                     GenerationResult(
                         request_id=request.request_id,
                         token_ids=token_ids,
                         text=self._decode(token_ids),
-                        finish_reason="length",
-                        usage=Usage(len(prompt_ids), len(token_ids)),
+                        finish_reason="stop" if hit_eos else "length",
+                        usage=Usage(len(prompt_ids), completion_tokens),
                         timings=TimingMetrics(
                             total_seconds=time.perf_counter() - started,
                             ttft_seconds=0.0,
@@ -315,6 +441,15 @@ class CppBackend(BackendBase):
             self._ensure_open()
             self._check_cancelled(request.request_id)
             token = self._native_token(result)
+            if self._is_eos(token):
+                # Stop before another decode_step. EOS is counted as a generated
+                # step but is not emitted as visible text.
+                yield TokenEvent(
+                    request.request_id,
+                    finish_reason="stop",
+                    usage=Usage(len(prompt_ids), len(generated) + 1),
+                )
+                return
             generated.append(token)
             decoded = self._decode(generated)
             # Decode the complete sequence so BPE/UTF-8 token boundaries are handled

--- a/pocketllm/backends/torch_backend.py
+++ b/pocketllm/backends/torch_backend.py
@@ -141,13 +141,43 @@ class TorchBackend(BackendBase):
             return None
         return self._runtime.get("tokenizer")
 
+    def _messages(self, request: GenerationRequest) -> list[dict[str, Any]] | None:
+        """Return the normalized chat messages when the request carries them."""
+        messages = request.metadata.get("messages")
+        if isinstance(messages, Sequence) and not isinstance(messages, (str, bytes)):
+            normalized = [dict(message) for message in messages if isinstance(message, Mapping)]
+            if normalized:
+                return normalized
+        return None
+
+    def _prompt_text(self, request: GenerationRequest) -> str:
+        """Render the prompt, preferring the runtime's own chat encoding.
+
+        Chat requests are encoded with the DeepSeek template that the legacy
+        server uses, so the unified API produces the same prompt as
+        ``src.server.openai``.  Raw prompts and non-DeepSeek encodings fall back
+        to the request text unchanged.
+        """
+        messages = self._messages(request)
+        if messages is None:
+            return request.prompt or ""
+        try:
+            from src.encoding.dsv4 import encode_messages
+        except Exception:
+            return request.prompt or ""
+        return encode_messages(
+            messages,
+            thinking_mode=str(request.metadata.get("thinking_mode", "chat")),
+            reasoning_effort=request.metadata.get("reasoning_effort"),
+        )
+
     def _prompt_ids(self, request: GenerationRequest) -> list[int]:
         if request.prompt_tokens is not None:
             return list(request.prompt_tokens)
         tokenizer = self._tokenizer()
         if tokenizer is None:
             raise ValueError("TorchBackend needs a tokenizer for text prompts")
-        encoded = tokenizer.encode(request.prompt or "")
+        encoded = tokenizer.encode(self._prompt_text(request))
         if hasattr(encoded, "tolist"):
             encoded = encoded.tolist()
         return [int(token) for token in encoded]
@@ -159,7 +189,7 @@ class TorchBackend(BackendBase):
             "op": "chat_completion",
             "request_id": request.request_id,
             "_prompt_ids": prompt_ids,
-            "messages": [{"role": "user", "content": request.prompt or ""}],
+            "messages": self._messages(request) or [{"role": "user", "content": request.prompt or ""}],
             "thinking_mode": str(request.metadata.get("thinking_mode", "chat")),
             "reasoning_effort": request.metadata.get("reasoning_effort"),
             "max_tokens": params.max_tokens,

--- a/pocketllm/protocol/__init__.py
+++ b/pocketllm/protocol/__init__.py
@@ -1,0 +1,32 @@
+"""Backend-neutral request/response protocol helpers.
+
+This subpackage holds pure normalization logic shared by the legacy DeepSeek
+server and the unified PocketLLM server.  It imports no Torch, CUDA, or native
+module, so both control planes can depend on it.
+"""
+
+from .chat import (
+    ChatRequest,
+    apply_stop_to_text,
+    normalize_content,
+    normalize_tool_calls,
+    prepare_messages,
+    render_fallback_prompt,
+    stop_strings,
+    thinking_config,
+    tool_choice_instruction,
+    tool_names,
+)
+
+__all__ = [
+    "ChatRequest",
+    "apply_stop_to_text",
+    "normalize_content",
+    "normalize_tool_calls",
+    "prepare_messages",
+    "render_fallback_prompt",
+    "stop_strings",
+    "thinking_config",
+    "tool_choice_instruction",
+    "tool_names",
+]

--- a/pocketllm/protocol/chat.py
+++ b/pocketllm/protocol/chat.py
@@ -1,0 +1,258 @@
+"""Chat/completion request normalization shared by both control planes.
+
+The helpers here are pure functions over JSON-like values.  They hold the
+semantics the legacy DeepSeek server validated over time: multimodal content
+flattening, tool attachment and ``tool_choice`` instructions, reasoning mode
+detection, tool-call normalization, and stop-string truncation.
+
+``src.server.openai`` re-exports these so there is one implementation rather
+than a simplified copy in the unified server.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+_REASONING_EFFORTS = {None, "minimal", "low", "medium", "high", "max"}
+_TOOL_ATTACH_ROLES = {"system", "developer"}
+_INSTRUCTION_ROLES = {"user", "developer", "system"}
+
+
+def normalize_content(content: Any) -> str:
+    """Flatten OpenAI content blocks into the plain text the runtimes accept."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(str(block.get("text", "")))
+            elif isinstance(block, dict):
+                parts.append(f"[Unsupported {block.get('type', 'content')}]")
+            else:
+                parts.append(str(block))
+        return "\n".join(parts)
+    if content is None:
+        return ""
+    return str(content)
+
+
+def tool_names(tools: Any) -> set[str]:
+    names: set[str] = set()
+    if not isinstance(tools, list):
+        return names
+    for tool in tools:
+        if isinstance(tool, dict) and tool.get("type") == "function" and isinstance(tool.get("function"), dict):
+            name = tool["function"].get("name")
+            if isinstance(name, str):
+                names.add(name)
+    return names
+
+
+def tool_choice_instruction(tool_choice: Any, tools: Any) -> tuple[bool, str | None]:
+    """Return whether to attach tools and the instruction implied by the choice."""
+    if tool_choice is None or tool_choice == "auto":
+        return True, None
+    if tool_choice == "none":
+        return False, "Do not call any tools. Answer directly."
+    if tool_choice == "required":
+        return True, "You must call at least one available tool if the user request can be answered with a tool."
+    if isinstance(tool_choice, dict):
+        if tool_choice.get("type") != "function" or not isinstance(tool_choice.get("function"), dict):
+            raise ValueError("tool_choice object must be {type:'function', function:{name:'...'}}")
+        name = tool_choice["function"].get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError("tool_choice.function.name must be a non-empty string")
+        names = tool_names(tools)
+        if names and name not in names:
+            raise ValueError(f"tool_choice references unknown tool: {name}")
+        return True, f"You must call the tool named {name}. Do not call any other tool."
+    raise ValueError("tool_choice must be 'auto', 'none', 'required', or a function choice object")
+
+
+def prepare_messages(body: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Validate and normalize ``messages`` together with tools and response format."""
+    raw_messages = body.get("messages", [])
+    if not isinstance(raw_messages, list) or not raw_messages:
+        raise ValueError("messages must be a non-empty list")
+    messages: list[dict[str, Any]] = []
+    for msg in raw_messages:
+        if not isinstance(msg, dict):
+            raise ValueError("each message must be an object")
+        copied = dict(msg)
+        role = copied.get("role")
+        if "content" in copied and role != "tool":
+            copied["content"] = normalize_content(copied["content"])
+        elif role == "tool" and isinstance(copied.get("content"), list):
+            copied["content"] = normalize_content(copied.get("content"))
+        messages.append(copied)
+    tools = body.get("tools")
+    attach_tools, instruction = tool_choice_instruction(body.get("tool_choice"), tools)
+    tool_attach_idx = None
+    for idx, msg in enumerate(messages):
+        if msg.get("role") in _TOOL_ATTACH_ROLES:
+            tool_attach_idx = idx
+            break
+    if tools is not None and attach_tools and tool_attach_idx is None:
+        messages.insert(0, {"role": "system", "content": ""})
+        tool_attach_idx = 0
+    last_user_idx = None
+    for idx in range(len(messages) - 1, -1, -1):
+        if messages[idx].get("role") in _INSTRUCTION_ROLES:
+            last_user_idx = idx
+            break
+    if tools is not None and attach_tools and tool_attach_idx is not None:
+        messages[tool_attach_idx]["tools"] = tools
+    if last_user_idx is not None:
+        if body.get("response_format") is not None:
+            messages[last_user_idx]["response_format"] = body["response_format"]
+        if instruction:
+            content = messages[last_user_idx].get("content") or ""
+            messages[last_user_idx]["content"] = f"{content}\n\n{instruction}" if content else instruction
+    return messages
+
+
+def thinking_config(body: Mapping[str, Any]) -> tuple[str, str | None]:
+    """Resolve ``reasoning``/``reasoning_effort`` into a thinking mode and effort."""
+    reasoning = body.get("reasoning")
+    effort = body.get("reasoning_effort")
+    if isinstance(reasoning, dict) and reasoning.get("effort") is not None:
+        effort = reasoning.get("effort")
+    if reasoning is None and effort is None:
+        return "chat", None
+    if effort not in _REASONING_EFFORTS:
+        effort = None
+    return "thinking", effort
+
+
+def normalize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
+    """Coerce parsed tool calls into the OpenAI wire shape."""
+    normalized: list[dict[str, Any]] = []
+    if not isinstance(tool_calls, list):
+        return normalized
+    for tool_call in tool_calls:
+        if not isinstance(tool_call, dict):
+            continue
+        function = tool_call.get("function") if isinstance(tool_call.get("function"), dict) else {}
+        name = function.get("name") or tool_call.get("name")
+        arguments = function.get("arguments", tool_call.get("arguments", "{}"))
+        if not isinstance(arguments, str):
+            arguments = json.dumps(arguments, ensure_ascii=False)
+        if not name:
+            continue
+        normalized.append({
+            "id": tool_call.get("id") or f"call_{uuid.uuid4().hex[:24]}",
+            "type": "function",
+            "function": {"name": str(name), "arguments": arguments},
+        })
+    return normalized
+
+
+def stop_strings(stop: Any) -> list[str]:
+    if isinstance(stop, str):
+        return [stop] if stop else []
+    if isinstance(stop, (list, tuple)):
+        return [item for item in stop if isinstance(item, str) and item]
+    return []
+
+
+def apply_stop_to_text(text: str, stop: Any) -> tuple[str, bool]:
+    """Truncate ``text`` at the earliest stop string.
+
+    Returns the possibly truncated text and whether a stop string matched, so
+    callers can set ``finish_reason`` without re-scanning.
+    """
+    earliest: int | None = None
+    for item in stop_strings(stop):
+        position = text.find(item)
+        if position >= 0 and (earliest is None or position < earliest):
+            earliest = position
+    if earliest is None:
+        return text, False
+    return text[:earliest], True
+
+
+def render_fallback_prompt(messages: Any) -> str:
+    """Render messages when no model-specific chat template is available.
+
+    Backends whose tokenizer or runtime owns a real chat template should never
+    reach this.  It exists so fake backends and non-DeepSeek checkpoints still
+    receive a deterministic prompt instead of an error.
+    """
+    if not isinstance(messages, list) or not messages:
+        raise ValueError("messages must be a non-empty list")
+    parts: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            raise ValueError("each message must be an object")
+        role = str(message.get("role", "user"))
+        parts.append(f"{role}: {normalize_content(message.get('content', ''))}")
+    return "\n".join(parts)
+
+
+@dataclass(slots=True)
+class ChatRequest:
+    """Normalized chat/completion body fields with cross-backend meaning."""
+
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    prompt: str | None = None
+    thinking_mode: str = "chat"
+    reasoning_effort: str | None = None
+    tools: Any = None
+    tool_choice: Any = None
+    response_format: Any = None
+    stream_options: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_body(cls, body: Mapping[str, Any], *, completion: bool = False) -> "ChatRequest":
+        stream_options = body.get("stream_options") or {}
+        if not isinstance(stream_options, dict):
+            raise ValueError("stream_options must be an object")
+        if completion:
+            prompt = body.get("prompt")
+            if isinstance(prompt, list):
+                if not prompt or not all(isinstance(item, str) for item in prompt):
+                    raise ValueError("prompt list must contain only strings")
+                prompt = "".join(prompt)
+            if not isinstance(prompt, str) or not prompt:
+                raise ValueError("prompt must be a non-empty string")
+            return cls(
+                prompt=prompt,
+                response_format=body.get("response_format"),
+                stream_options=dict(stream_options),
+            )
+        messages = prepare_messages(body)
+        mode, effort = thinking_config(body)
+        return cls(
+            messages=messages,
+            thinking_mode=mode,
+            reasoning_effort=effort,
+            tools=body.get("tools"),
+            tool_choice=body.get("tool_choice"),
+            response_format=body.get("response_format"),
+            stream_options=dict(stream_options),
+        )
+
+    def metadata(self) -> dict[str, Any]:
+        """Return backend-visible request metadata.
+
+        Only values with a stable meaning across backends are included; no
+        tensors, device handles, or runtime objects.
+        """
+        data: dict[str, Any] = {
+            "thinking_mode": self.thinking_mode,
+            "stream_options": dict(self.stream_options),
+            "response_format": self.response_format,
+        }
+        if self.messages:
+            data["messages"] = [dict(message) for message in self.messages]
+        if self.reasoning_effort is not None:
+            data["reasoning_effort"] = self.reasoning_effort
+        if self.tools is not None:
+            data["tools"] = self.tools
+        if self.tool_choice is not None:
+            data["tool_choice"] = self.tool_choice
+        return data

--- a/pocketllm/server/openai.py
+++ b/pocketllm/server/openai.py
@@ -25,6 +25,7 @@ from pocketllm.api import (
     TokenEvent,
     UnsupportedFeatureError,
 )
+from pocketllm.protocol import ChatRequest, render_fallback_prompt
 
 from .metrics import Metrics
 
@@ -37,28 +38,17 @@ def _openai_error(message: str, error_type: str = "invalid_request_error") -> di
     return {"error": {"message": message, "type": error_type}}
 
 
-def _messages_text(messages: Any) -> str:
-    if not isinstance(messages, list) or not messages:
-        raise ValueError("messages must be a non-empty list")
-    parts: list[str] = []
-    for message in messages:
-        if not isinstance(message, dict):
-            raise ValueError("each message must be an object")
-        role = str(message.get("role", "user"))
-        content = message.get("content", "")
-        if isinstance(content, list):
-            content = "\n".join(
-                str(block.get("text", "")) if isinstance(block, dict) else str(block)
-                for block in content
-            )
-        parts.append(f"{role}: {content}")
-    return "\n".join(parts)
-
-
 def _result_response(result: GenerationResult, model: str, request_id: str) -> dict[str, Any]:
+    message: dict[str, Any] = {"role": "assistant", "content": result.text}
+    reasoning = result.metadata.get("reasoning_content")
+    if reasoning:
+        message["reasoning_content"] = reasoning
+    tool_calls = result.metadata.get("tool_calls")
+    if tool_calls:
+        message["tool_calls"] = tool_calls
     choice = {
         "index": 0,
-        "message": {"role": "assistant", "content": result.text},
+        "message": message,
         "finish_reason": result.finish_reason,
     }
     if result.logprobs is not None:
@@ -113,6 +103,12 @@ def _event_json(event: TokenEvent, model: str, *, completion: bool = False) -> d
         delta["content"] = event.text
     if event.metadata.get("role"):
         delta["role"] = event.metadata["role"]
+    # A backend that separates reasoning from content forwards both; a backend
+    # that does not simply leaves these keys absent.
+    if event.metadata.get("reasoning_content"):
+        delta["reasoning_content"] = event.metadata["reasoning_content"]
+    if event.metadata.get("tool_calls"):
+        delta["tool_calls"] = event.metadata["tool_calls"]
     item = {
         "id": event.request_id,
         "object": "chat.completion.chunk",
@@ -215,11 +211,17 @@ class OpenAIHandler(BaseHTTPRequestHandler):
     def _request(self, body: dict[str, Any], *, completion: bool = False) -> GenerationRequest:
         request_id = str(body.get("request_id") or f"chatcmpl-{uuid.uuid4().hex}")
         params = SamplingParams.from_openai(body)
-        prompt = body.get("prompt") if completion else _messages_text(body.get("messages"))
-        return GenerationRequest(prompt=prompt, sampling_params=params, request_id=request_id, metadata={
-            "stream_options": body.get("stream_options") or {},
-            "response_format": body.get("response_format"),
-        })
+        chat = ChatRequest.from_body(body, completion=completion)
+        # Chat requests carry the normalized messages so a backend can apply its
+        # own chat template.  `prompt` stays populated as a deterministic
+        # fallback for backends that have no template of their own.
+        prompt = chat.prompt if completion else render_fallback_prompt(chat.messages)
+        return GenerationRequest(
+            prompt=prompt,
+            sampling_params=params,
+            request_id=request_id,
+            metadata=chat.metadata(),
+        )
 
     def do_DELETE(self) -> None:
         path = urlparse(self.path).path

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "pocketllm",
         "pocketllm.api",
         "pocketllm.backends",
+        "pocketllm.protocol",
         "pocketllm.server",
     ],
     entry_points={

--- a/src/server/openai.py
+++ b/src/server/openai.py
@@ -71,6 +71,7 @@ from src.runtime.pd_scheduler import PDExecutionFacade, PDScheduler
 from src.server.engine import DeepSeekServingEngine
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
+from pocketllm import protocol  # noqa: E402
 from src.encoding.dsv4 import dsml_token, encode_messages, eos_token, parse_message_from_completion_text  # noqa: E402
 
 
@@ -202,109 +203,13 @@ def _openai_error(message: str, error_type: str = "invalid_request_error", param
     return {"error": {"message": message, "type": error_type, "param": param, "code": code}}
 
 
-def _normalize_content(content: Any) -> str:
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts = []
-        for block in content:
-            if isinstance(block, dict) and block.get("type") == "text":
-                parts.append(str(block.get("text", "")))
-            elif isinstance(block, dict):
-                parts.append(f"[Unsupported {block.get('type', 'content')}]")
-            else:
-                parts.append(str(block))
-        return "\n".join(parts)
-    if content is None:
-        return ""
-    return str(content)
-
-
-def _tool_names(tools: Any) -> set[str]:
-    names: set[str] = set()
-    if not isinstance(tools, list):
-        return names
-    for tool in tools:
-        if isinstance(tool, dict) and tool.get("type") == "function" and isinstance(tool.get("function"), dict):
-            name = tool["function"].get("name")
-            if isinstance(name, str):
-                names.add(name)
-    return names
-
-
-def _tool_choice_instruction(tool_choice: Any, tools: Any) -> tuple[bool, str | None]:
-    if tool_choice is None or tool_choice == "auto":
-        names = _tool_names(tools)
-        return True, None
-    if tool_choice == "none":
-        return False, "Do not call any tools. Answer directly."
-    if tool_choice == "required":
-        return True, "You must call at least one available tool if the user request can be answered with a tool."
-    if isinstance(tool_choice, dict):
-        if tool_choice.get("type") != "function" or not isinstance(tool_choice.get("function"), dict):
-            raise ValueError("tool_choice object must be {type:'function', function:{name:'...'}}")
-        name = tool_choice["function"].get("name")
-        if not isinstance(name, str) or not name:
-            raise ValueError("tool_choice.function.name must be a non-empty string")
-        names = _tool_names(tools)
-        if names and name not in names:
-            raise ValueError(f"tool_choice references unknown tool: {name}")
-        return True, f"You must call the tool named {name}. Do not call any other tool."
-    raise ValueError("tool_choice must be 'auto', 'none', 'required', or a function choice object")
-
-
-def _prepare_messages(body: dict[str, Any]) -> list[dict[str, Any]]:
-    raw_messages = body.get("messages", [])
-    if not isinstance(raw_messages, list) or not raw_messages:
-        raise ValueError("messages must be a non-empty list")
-    messages = []
-    for msg in raw_messages:
-        if not isinstance(msg, dict):
-            raise ValueError("each message must be an object")
-        copied = dict(msg)
-        role = copied.get("role")
-        if "content" in copied and role != "tool":
-            copied["content"] = _normalize_content(copied["content"])
-        elif role == "tool" and isinstance(copied.get("content"), list):
-            copied["content"] = _normalize_content(copied.get("content"))
-        messages.append(copied)
-    tools = body.get("tools")
-    tool_choice = body.get("tool_choice")
-    attach_tools, instruction = _tool_choice_instruction(tool_choice, tools)
-    tool_attach_idx = None
-    for idx, msg in enumerate(messages):
-        if msg.get("role") in {"system", "developer"}:
-            tool_attach_idx = idx
-            break
-    if tools is not None and attach_tools and tool_attach_idx is None:
-        messages.insert(0, {"role": "system", "content": ""})
-        tool_attach_idx = 0
-    last_user_idx = None
-    for idx in range(len(messages) - 1, -1, -1):
-        if messages[idx].get("role") in {"user", "developer", "system"}:
-            last_user_idx = idx
-            break
-    if tools is not None and attach_tools and tool_attach_idx is not None:
-        messages[tool_attach_idx]["tools"] = tools
-    if last_user_idx is not None:
-        if body.get("response_format") is not None:
-            messages[last_user_idx]["response_format"] = body["response_format"]
-        if instruction:
-            content = messages[last_user_idx].get("content") or ""
-            messages[last_user_idx]["content"] = f"{content}\n\n{instruction}" if content else instruction
-    return messages
-
-
-def _thinking_config(body: dict[str, Any]) -> tuple[str, str | None]:
-    reasoning = body.get("reasoning")
-    effort = body.get("reasoning_effort")
-    if isinstance(reasoning, dict) and reasoning.get("effort") is not None:
-        effort = reasoning.get("effort")
-    if reasoning is None and effort is None:
-        return "chat", None
-    if effort not in {None, "minimal", "low", "medium", "high", "max"}:
-        effort = None
-    return "thinking", effort
+# Request normalization lives in the backend-neutral protocol package so the
+# unified PocketLLM server shares one implementation with this legacy server.
+_normalize_content = protocol.normalize_content
+_tool_names = protocol.tool_names
+_tool_choice_instruction = protocol.tool_choice_instruction
+_prepare_messages = protocol.prepare_messages
+_thinking_config = protocol.thinking_config
 
 
 def _strip_special_eos(text: str) -> str:
@@ -332,48 +237,14 @@ def _timing_metrics(prefill_time: float, decode_time: float, prefill_tokens: int
     }
 
 
-def _normalize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
-    normalized = []
-    if not isinstance(tool_calls, list):
-        return normalized
-    for tool_call in tool_calls:
-        if not isinstance(tool_call, dict):
-            continue
-        function = tool_call.get("function") if isinstance(tool_call.get("function"), dict) else {}
-        name = function.get("name") or tool_call.get("name")
-        arguments = function.get("arguments", tool_call.get("arguments", "{}"))
-        if not isinstance(arguments, str):
-            arguments = json.dumps(arguments, ensure_ascii=False)
-        if not name:
-            continue
-        normalized.append({
-            "id": tool_call.get("id") or f"call_{uuid.uuid4().hex[:24]}",
-            "type": "function",
-            "function": {"name": str(name), "arguments": arguments},
-        })
-    return normalized
-
-
-def _stop_strings(stop: Any) -> list[str]:
-    if isinstance(stop, str):
-        return [stop]
-    if isinstance(stop, list):
-        return [s for s in stop if isinstance(s, str) and s]
-    return []
+_normalize_tool_calls = protocol.normalize_tool_calls
+_stop_strings = protocol.stop_strings
 
 
 def _apply_stop_to_result(result: dict[str, Any], stop: Any) -> None:
-    stops = _stop_strings(stop)
-    if not stops:
-        return
-    content = result.get("content") or ""
-    earliest = None
-    for item in stops:
-        pos = content.find(item)
-        if pos >= 0 and (earliest is None or pos < earliest):
-            earliest = pos
-    if earliest is not None:
-        result["content"] = content[:earliest]
+    content, stopped = protocol.apply_stop_to_text(result.get("content") or "", stop)
+    if stopped:
+        result["content"] = content
         result["finish_reason"] = "stop"
 
 

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -20,12 +20,14 @@ class ContractBackend(BackendBase):
         super().__init__()
         self._ready = True
         self._fail = fail
+        self.seen: list = []
 
     @property
     def capabilities(self):
         return BackendCapabilities(name="fake", supports_streaming=True, supports_cancellation=True)
 
     def generate(self, requests):
+        self.seen.extend(requests)
         if self._fail:
             raise UnsupportedFeatureError("logprobs are not exposed by this backend")
         return [GenerationResult(
@@ -47,8 +49,8 @@ class ContractBackend(BackendBase):
             self._clear_request(req.request_id)
 
 
-def _server(fail: bool = False):
-    backend = ContractBackend(fail=fail)
+def _server(fail: bool = False, backend: ContractBackend | None = None):
+    backend = backend or ContractBackend(fail=fail)
     server = PocketLLMHTTPServer(("127.0.0.1", 0), OpenAIHandler, backend, "fake-model")
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -165,6 +167,96 @@ def test_stream_backend_failure_is_reported_in_band():
         assert payloads[-1] == "[DONE]"
         errors = [json.loads(item) for item in payloads if item != "[DONE]" and "error" in item]
         assert errors and errors[-1]["error"]["type"] == "unsupported_feature"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_chat_requests_carry_normalized_messages_to_the_backend():
+    backend = ContractBackend()
+    server, base = _server(backend=backend)
+    try:
+        _post(base, "/v1/chat/completions", {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+            ],
+            "tools": [{"type": "function", "function": {"name": "weather"}}],
+            "tool_choice": "required",
+            "reasoning_effort": "high",
+        })
+        request = backend.seen[-1]
+        # The backend receives the normalized messages so it can apply its own
+        # chat template rather than a flattened "role: content" string.
+        assert request.metadata["messages"][0]["role"] == "system"
+        assert request.metadata["messages"][0]["tools"] == [
+            {"type": "function", "function": {"name": "weather"}}
+        ]
+        assert request.metadata["thinking_mode"] == "thinking"
+        assert request.metadata["reasoning_effort"] == "high"
+        assert "must call at least one available tool" in request.metadata["messages"][-1]["content"]
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_invalid_chat_and_completion_bodies_are_rejected():
+    server, base = _server()
+    try:
+        for path, body in (
+            ("/v1/chat/completions", {"messages": []}),
+            ("/v1/chat/completions", {"messages": ["hi"]}),
+            ("/v1/completions", {"prompt": ""}),
+            ("/v1/completions", {"prompt": [1]}),
+        ):
+            try:
+                _post(base, path, body)
+                raise AssertionError(f"expected an HTTP error for {path} {body}")
+            except error.HTTPError as exc:
+                assert exc.code == 400
+                assert json.loads(exc.read().decode())["error"]["type"] == "invalid_request_error"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_reasoning_and_tool_calls_are_forwarded_in_responses():
+    class ReasoningBackend(ContractBackend):
+        def generate(self, requests):
+            return [GenerationResult(
+                request_id=req.request_id,
+                token_ids=[11],
+                text="answer",
+                usage=Usage(1, 1),
+                metadata={
+                    "reasoning_content": "because",
+                    "tool_calls": [{"id": "call_1", "type": "function",
+                                    "function": {"name": "weather", "arguments": "{}"}}],
+                },
+            ) for req in requests]
+
+        def stream(self, req):
+            self._begin_request(req.request_id)
+            try:
+                yield TokenEvent(req.request_id, text="", metadata={"reasoning_content": "because"})
+                yield TokenEvent(req.request_id, text="answer", token_id=11, finish_reason="stop",
+                                 usage=Usage(1, 1))
+            finally:
+                self._clear_request(req.request_id)
+
+    server, base = _server(backend=ReasoningBackend())
+    try:
+        chat = _post(base, "/v1/chat/completions", {"messages": [{"role": "user", "content": "hi"}]})
+        message = chat["choices"][0]["message"]
+        assert message["reasoning_content"] == "because"
+        assert message["tool_calls"][0]["function"]["name"] == "weather"
+
+        raw = _post_raw(base, "/v1/chat/completions", {
+            "messages": [{"role": "user", "content": "hi"}], "stream": True,
+        })
+        chunks = [json.loads(item) for item in
+                  (line[len("data: "):] for line in raw.splitlines() if line.startswith("data: "))
+                  if item != "[DONE]"]
+        assert any(chunk["choices"][0]["delta"].get("reasoning_content") == "because" for chunk in chunks)
     finally:
         server.shutdown()
         server.server_close()

--- a/tests/test_cpp_backend.py
+++ b/tests/test_cpp_backend.py
@@ -132,6 +132,7 @@ def test_generate_converts_native_results_and_usage() -> None:
 
     result = backend.generate([request])[0]
 
+    # Without a known EOS the adapter delegates to native generate().
     assert engine.calls == [("generate", [5, 7], 3)]
     assert result.request_id == "req-generate"
     assert result.token_ids == [10, 11, 12]
@@ -368,6 +369,157 @@ def test_stream_text_deltas_use_cumulative_tokenizer_decode() -> None:
 
     assert [event.text for event in events] == ["a", "b", "a"]
     backend.close()
+
+
+def test_generate_stops_at_eos_and_reports_stop() -> None:
+    engine = FakeEngine()
+    backend = CppBackend(
+        EngineArgs(model="model", backend="cpp", backend_options={"eos_token_id": 11}),
+        engine=engine,
+        tokenizer=FakeTokenizer(),
+    )
+    request = GenerationRequest(
+        prompt_tokens=[4, 5],
+        request_id="req-eos-generate",
+        sampling_params=SamplingParams(max_tokens=4),
+    )
+
+    result = backend.generate([request])[0]
+
+    # With a known EOS the adapter drives prefill/decode itself so the session is
+    # never advanced past EOS, and EOS stays out of the visible output.
+    assert engine.calls == [("prefill", [4, 5]), ("decode_step", 10)]
+    assert result.token_ids == [10]
+    assert result.text == "<10>"
+    assert result.finish_reason == "stop"
+    assert result.usage.as_dict() == {
+        "prompt_tokens": 2,
+        "completion_tokens": 2,
+        "total_tokens": 4,
+    }
+    backend.close()
+
+
+def test_stream_stops_at_eos_without_another_decode_step() -> None:
+    engine = FakeEngine()
+    backend = CppBackend(
+        EngineArgs(model="model", backend="cpp", backend_options={"eos_token_id": [12]}),
+        engine=engine,
+        tokenizer=FakeTokenizer(),
+    )
+    request = GenerationRequest(
+        prompt_tokens=[4, 5],
+        request_id="req-eos-stream",
+        sampling_params=SamplingParams(max_tokens=8),
+    )
+
+    events = list(backend.stream(request))
+
+    assert engine.calls == [
+        ("prefill", [4, 5]),
+        ("decode_step", 10),
+        ("decode_step", 11),
+    ]
+    assert [event.token_id for event in events] == [10, 11, None]
+    assert [event.text for event in events] == ["<10>", "<11>", ""]
+    assert [event.finish_reason for event in events] == [None, None, "stop"]
+    assert events[-1].usage is not None
+    assert events[-1].usage.as_dict() == {
+        "prompt_tokens": 2,
+        "completion_tokens": 3,
+        "total_tokens": 5,
+    }
+    backend.close()
+
+
+def test_generate_does_not_advance_the_session_past_eos() -> None:
+    engine = FakeEngine()
+    backend = CppBackend(
+        EngineArgs(model="model", backend="cpp", backend_options={"eos_token_id": 11}),
+        engine=engine,
+        tokenizer=FakeTokenizer(),
+    )
+
+    backend.generate([
+        GenerationRequest(
+            prompt_tokens=[4],
+            request_id="req-a",
+            sampling_params=SamplingParams(max_tokens=6),
+        )
+    ])
+    backend.generate([
+        GenerationRequest(
+            prompt_tokens=[5],
+            request_id="req-b",
+            sampling_params=SamplingParams(max_tokens=6),
+        )
+    ])
+
+    # Each request stops at the EOS step, so no decode runs on text the caller
+    # never received and the next request starts from a clean position.
+    assert engine.calls == [
+        ("prefill", [4]),
+        ("decode_step", 10),
+        ("prefill", [5]),
+        ("decode_step", 10),
+    ]
+    backend.close()
+
+
+def test_eos_comes_from_the_native_engine_when_available() -> None:
+    class EosEngine(FakeEngine):
+        def eos_id(self) -> int:
+            return 11
+
+    backend, _ = make_backend(EosEngine())
+
+    assert backend.eos_token_ids == frozenset({11})
+    assert backend.capabilities.details["eos_source"] == "native engine"
+    backend.close()
+
+
+def test_eos_falls_back_to_generation_config(tmp_path) -> None:
+    (tmp_path / "generation_config.json").write_text('{"eos_token_id": [7, 9]}', encoding="utf-8")
+    (tmp_path / "config.json").write_text('{"eos_token_id": 1}', encoding="utf-8")
+
+    backend = CppBackend(
+        EngineArgs(model=str(tmp_path), backend="cpp"),
+        engine=FakeEngine(),
+        tokenizer=FakeTokenizer(),
+    )
+
+    # generation_config.json wins over config.json because it is what the
+    # checkpoint declares for generation.
+    assert backend.eos_token_ids == frozenset({7, 9})
+    assert backend.capabilities.details["eos_source"] == "generation_config.json"
+    backend.close()
+
+
+def test_without_any_eos_generation_ends_on_the_token_budget() -> None:
+    backend, _ = make_backend()
+
+    assert backend.eos_token_ids == frozenset()
+    assert backend.capabilities.details["eos_source"] == "none"
+    result = backend.generate(
+        [
+            GenerationRequest(
+                prompt_tokens=[1],
+                request_id="req-no-eos",
+                sampling_params=SamplingParams(max_tokens=2),
+            )
+        ]
+    )[0]
+    assert result.finish_reason == "length"
+    backend.close()
+
+
+def test_invalid_eos_override_is_rejected() -> None:
+    with pytest.raises(ConfigurationError, match="eos_token_id"):
+        CppBackend(
+            EngineArgs(model="model", backend="cpp", backend_options={"eos_token_id": "11"}),
+            engine=FakeEngine(),
+            tokenizer=FakeTokenizer(),
+        )
 
 
 def test_cpp_backend_rejects_unexposed_sampling_controls() -> None:

--- a/tests/test_protocol_chat.py
+++ b/tests/test_protocol_chat.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import pytest
+
+from pocketllm.protocol import (
+    ChatRequest,
+    apply_stop_to_text,
+    normalize_content,
+    normalize_tool_calls,
+    prepare_messages,
+    render_fallback_prompt,
+    thinking_config,
+)
+
+
+def test_normalize_content_flattens_text_blocks_and_marks_others():
+    assert normalize_content("plain") == "plain"
+    assert normalize_content([{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]) == "a\nb"
+    assert normalize_content([{"type": "image_url"}]) == "[Unsupported image_url]"
+    assert normalize_content(None) == ""
+
+
+def test_prepare_messages_attaches_tools_and_required_instruction():
+    body = {
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+        "tools": [{"type": "function", "function": {"name": "weather", "parameters": {}}}],
+        "tool_choice": "required",
+    }
+
+    messages = prepare_messages(body)
+
+    # A system turn is inserted to carry tools, and the instruction lands on the
+    # last instruction-bearing message.
+    assert messages[0]["role"] == "system"
+    assert messages[0]["tools"] == body["tools"]
+    assert messages[-1]["content"].startswith("hi")
+    assert "must call at least one available tool" in messages[-1]["content"]
+
+
+def test_prepare_messages_rejects_unknown_named_tool():
+    body = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [{"type": "function", "function": {"name": "weather"}}],
+        "tool_choice": {"type": "function", "function": {"name": "missing"}},
+    }
+
+    with pytest.raises(ValueError, match="unknown tool"):
+        prepare_messages(body)
+
+
+def test_prepare_messages_requires_a_non_empty_list():
+    with pytest.raises(ValueError, match="non-empty list"):
+        prepare_messages({"messages": []})
+    with pytest.raises(ValueError, match="each message must be an object"):
+        prepare_messages({"messages": ["hi"]})
+
+
+def test_thinking_config_reads_reasoning_effort_from_either_field():
+    assert thinking_config({}) == ("chat", None)
+    assert thinking_config({"reasoning_effort": "high"}) == ("thinking", "high")
+    assert thinking_config({"reasoning": {"effort": "max"}}) == ("thinking", "max")
+    # An unrecognized effort still selects thinking mode but drops the value.
+    assert thinking_config({"reasoning_effort": "turbo"}) == ("thinking", None)
+
+
+def test_normalize_tool_calls_serializes_arguments_and_assigns_ids():
+    calls = normalize_tool_calls([{"function": {"name": "weather", "arguments": {"city": "sh"}}}])
+
+    assert calls[0]["type"] == "function"
+    assert calls[0]["id"].startswith("call_")
+    assert calls[0]["function"] == {"name": "weather", "arguments": '{"city": "sh"}'}
+    assert normalize_tool_calls([{"function": {}}]) == []
+
+
+def test_apply_stop_to_text_truncates_at_the_earliest_match():
+    assert apply_stop_to_text("abcdef", ["cd", "ef"]) == ("ab", True)
+    assert apply_stop_to_text("abcdef", "zz") == ("abcdef", False)
+    assert apply_stop_to_text("abcdef", None) == ("abcdef", False)
+
+
+def test_chat_request_carries_normalized_messages_as_metadata():
+    request = ChatRequest.from_body({
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+        "reasoning_effort": "low",
+    })
+
+    metadata = request.metadata()
+    assert metadata["thinking_mode"] == "thinking"
+    assert metadata["reasoning_effort"] == "low"
+    assert metadata["messages"] == [{"role": "user", "content": "hi"}]
+
+
+def test_chat_request_validates_completion_prompts():
+    assert ChatRequest.from_body({"prompt": ["a", "b"]}, completion=True).prompt == "ab"
+    with pytest.raises(ValueError, match="prompt must be a non-empty string"):
+        ChatRequest.from_body({"prompt": ""}, completion=True)
+    with pytest.raises(ValueError, match="prompt list must contain only strings"):
+        ChatRequest.from_body({"prompt": [1]}, completion=True)
+    with pytest.raises(ValueError, match="stream_options must be an object"):
+        ChatRequest.from_body({"prompt": "hi", "stream_options": 1}, completion=True)
+
+
+def test_render_fallback_prompt_is_deterministic():
+    text = render_fallback_prompt([
+        {"role": "system", "content": "s"},
+        {"role": "user", "content": [{"type": "text", "text": "u"}]},
+    ])
+
+    assert text == "system: s\nuser: u"

--- a/tests/test_torch_backend_prompt.py
+++ b/tests/test_torch_backend_prompt.py
@@ -1,0 +1,143 @@
+"""Prompt rendering tests for the Torch adapter.
+
+These inject a fake serving engine so no checkpoint, CUDA device, or real
+runtime is required; only the payload the adapter builds is inspected.
+"""
+
+from __future__ import annotations
+
+from pocketllm.api import EngineArgs, GenerationRequest, SamplingParams
+from pocketllm.backends.torch_backend import TorchBackend
+from src.encoding.dsv4 import encode_messages
+
+
+class RecordingTokenizer:
+    eos_token_id = 1
+
+    def __init__(self) -> None:
+        self.encoded: list[str] = []
+
+    def encode(self, text: str) -> list[int]:
+        self.encoded.append(text)
+        return [11, 12]
+
+    def decode(self, token_ids: list[int]) -> str:
+        return "".join(f"<{token}>" for token in token_ids)
+
+
+class RecordingServingEngine:
+    def __init__(self) -> None:
+        self.payloads: list[dict] = []
+
+    def submit(self, payload: dict) -> dict:
+        self.payloads.append(payload)
+        return {"content": "ok", "prompt_tokens": 2, "completion_tokens": 1, "finish_reason": "stop"}
+
+    def submit_stream(self, payload: dict):
+        self.payloads.append(payload)
+        yield {"type": "token", "token_ids": [11]}
+        yield {"type": "done", "prompt_tokens": 2, "completion_tokens": [[11]], "finish_reason": "stop"}
+
+    def close(self) -> None:
+        pass
+
+
+def _backend(tokenizer: RecordingTokenizer) -> tuple[TorchBackend, RecordingServingEngine]:
+    engine = RecordingServingEngine()
+    backend = TorchBackend(
+        EngineArgs(model="model", backend="torch"),
+        runtime={"tokenizer": tokenizer, "model_id": "fake-model"},
+        serving_engine=engine,
+    )
+    return backend, engine
+
+
+def test_chat_metadata_is_rendered_with_the_deepseek_template():
+    tokenizer = RecordingTokenizer()
+    backend, engine = _backend(tokenizer)
+    messages = [{"role": "user", "content": "hi"}]
+    request = GenerationRequest(
+        prompt="user: hi",
+        request_id="req-chat",
+        sampling_params=SamplingParams(max_tokens=1),
+        metadata={"messages": messages, "thinking_mode": "chat"},
+    )
+
+    backend.generate([request])
+
+    # The adapter must reuse the runtime's own chat encoding rather than the
+    # server's plain fallback text.
+    assert tokenizer.encoded == [encode_messages(messages, thinking_mode="chat")]
+    # The normalized messages are forwarded so the runtime can re-encode.
+    assert engine.payloads[-1]["messages"] == messages
+    assert engine.payloads[-1]["thinking_mode"] == "chat"
+    backend.close()
+
+
+def test_thinking_mode_and_effort_reach_the_template():
+    tokenizer = RecordingTokenizer()
+    backend, engine = _backend(tokenizer)
+    messages = [{"role": "user", "content": "hi"}]
+    request = GenerationRequest(
+        prompt="user: hi",
+        request_id="req-thinking",
+        sampling_params=SamplingParams(max_tokens=1),
+        metadata={"messages": messages, "thinking_mode": "thinking", "reasoning_effort": "max"},
+    )
+
+    backend.generate([request])
+
+    assert tokenizer.encoded == [
+        encode_messages(messages, thinking_mode="thinking", reasoning_effort="max")
+    ]
+    assert engine.payloads[-1]["reasoning_effort"] == "max"
+    backend.close()
+
+
+def test_raw_prompts_are_encoded_unchanged():
+    tokenizer = RecordingTokenizer()
+    backend, engine = _backend(tokenizer)
+    request = GenerationRequest(
+        prompt="raw completion prompt",
+        request_id="req-raw",
+        sampling_params=SamplingParams(max_tokens=1),
+    )
+
+    backend.generate([request])
+
+    assert tokenizer.encoded == ["raw completion prompt"]
+    assert engine.payloads[-1]["messages"] == [{"role": "user", "content": "raw completion prompt"}]
+    backend.close()
+
+
+def test_prompt_tokens_bypass_the_tokenizer():
+    tokenizer = RecordingTokenizer()
+    backend, engine = _backend(tokenizer)
+    request = GenerationRequest(
+        prompt_tokens=[7, 8],
+        request_id="req-tokens",
+        sampling_params=SamplingParams(max_tokens=1),
+    )
+
+    backend.generate([request])
+
+    assert tokenizer.encoded == []
+    assert engine.payloads[-1]["_prompt_ids"] == [7, 8]
+    backend.close()
+
+
+def test_streaming_uses_the_same_prompt_rendering():
+    tokenizer = RecordingTokenizer()
+    backend, engine = _backend(tokenizer)
+    messages = [{"role": "user", "content": "hi"}]
+    request = GenerationRequest(
+        prompt="user: hi",
+        request_id="req-stream",
+        sampling_params=SamplingParams(max_tokens=1),
+        metadata={"messages": messages, "thinking_mode": "chat"},
+    )
+
+    list(backend.stream(request))
+
+    assert tokenizer.encoded[0] == encode_messages(messages, thinking_mode="chat")
+    backend.close()


### PR DESCRIPTION
## Summary

Phase 1.1 of the unified API. It closes two correctness gaps and deliberately changes no scheduling behavior.

**Shared request normalization.** OpenAI request handling now lives in `pocketllm/protocol`, used by both the unified server and the legacy `src/server/openai.py`: content-block flattening, tool attachment, `tool_choice` instructions, `reasoning`/`reasoning_effort`, tool-call shaping, and stop-string truncation. The unified server previously flattened chat messages into a `role: content` string and dropped tools and reasoning entirely, so the two servers produced different prompts from the same request.

Chat requests now carry the normalized messages in `GenerationRequest.metadata`, so a backend applies its own chat template. The Torch adapter encodes them with the same DeepSeek template the legacy server uses. `prompt` still holds a deterministic fallback rendering for backends without a template. A backend that separates reasoning from content can return `reasoning_content` and `tool_calls`; both are forwarded to responses and to streamed deltas.

**C++ termination semantics.** The C++ adapter reported `finish_reason="length"` for every request and never stopped at EOS, so a chat response ran to the token budget. EOS ids are now resolved from `backend_options["eos_token_id"]`, the native engine, the native config, `generation_config.json`, `config.json`, then the tokenizer, and the first EOS ends the request with `finish_reason="stop"`. `generation_config.json` is preferred over the tokenizer because chat checkpoints commonly stop on a turn-end token that differs from the tokenizer's EOS. A non-integer override is rejected rather than guessed.

`QwenEngine.generate` takes no EOS argument and keeps mutating its session for the whole budget, so when an EOS id is known both the offline and streamed paths drive `prefill`/`decode_step` themselves and stop at EOS. Calling `generate()` and truncating afterwards would leave the recurrent state and prefix cache positioned past text the caller never saw, corrupting reuse for the next request. Native `generate()` still handles the no-EOS case.

## Not in scope

No scheduling changes. The native path remains one serialized session and `supports_batch` stays `False`. Continuous batching, a paged KV pool, and fair queuing still need a request-aware scheduler.

## Testing

91 CPU-only tests pass:

```
PYTHONPATH=. python -m pytest -q tests/test_public_api.py tests/test_backend_contract.py \
  tests/test_backend_selection.py tests/test_cpp_backend.py tests/test_cli.py \
  tests/test_protocol_chat.py tests/test_torch_backend_prompt.py \
  tests/test_openai_utils.py tests/test_openai_server.py tests/test_encoding_dsv4.py
```

New coverage: protocol normalization and validation, chat metadata reaching the backend over HTTP, `reasoning_content`/`tool_calls` forwarding in both response and stream, prompt rendering through the Torch adapter, EOS resolution precedence, stop semantics in both C++ paths, and that the offline EOS path leaves no session steps past EOS. Verified that importing `pocketllm` still pulls in neither Torch nor the legacy server.

No native rebuild is required: EOS resolution reads the checkpoint from Python.