### PR TITLE
Verify the unified API adapters against real checkpoints

### DIFF
--- a/scripts/_parity_adapter_rank.py
+++ b/scripts/_parity_adapter_rank.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""One TP rank of the C++ adapter, used by verify_cpp_adapter_parity.py.
+
+Runs a single greedy request through ``CppBackend`` and writes the resulting
+tokens, finish reason, usage, and resolved EOS source to a JSON file so the
+parent process can compare them with the reference binary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from pocketllm.api import EngineArgs, GenerationRequest, SamplingParams
+from pocketllm.backends.cpp_backend import CppBackend
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ckpt", required=True)
+    parser.add_argument("--tp-world", type=int, required=True)
+    parser.add_argument("--tp-rank", type=int, required=True)
+    parser.add_argument("--nccl-id-path", required=True)
+    parser.add_argument("--token-ids-file", required=True)
+    parser.add_argument("--max-new-tokens", type=int, required=True)
+    parser.add_argument("--max-context", type=int, required=True)
+    parser.add_argument("--prefill-chunk-tokens", type=int, default=512)
+    parser.add_argument("--kv-cache-dtype", default="fp16")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--stream", action="store_true")
+    args = parser.parse_args()
+
+    prompt_ids = [
+        int(item)
+        for item in Path(args.token_ids_file).read_text().replace(",", " ").split()
+        if item.strip()
+    ]
+
+    engine_args = EngineArgs(
+        model=args.ckpt,
+        backend="cpp",
+        tensor_parallel_size=args.tp_world,
+        tensor_parallel_rank=args.tp_rank,
+        max_model_len=args.max_context,
+        prefill_chunk_tokens=args.prefill_chunk_tokens,
+        kv_cache_dtype=args.kv_cache_dtype,
+        backend_options={"nccl_id_path": args.nccl_id_path},
+    )
+    backend = CppBackend(engine_args)
+    request = GenerationRequest(
+        prompt_tokens=prompt_ids,
+        request_id=f"parity-{args.tp_rank}",
+        sampling_params=SamplingParams(max_tokens=args.max_new_tokens),
+    )
+
+    payload: dict = {
+        "tp_rank": args.tp_rank,
+        "eos_token_ids": sorted(backend.eos_token_ids),
+        "eos_source": backend.capabilities.details.get("eos_source"),
+        "prompt_tokens": len(prompt_ids),
+    }
+    try:
+        if args.stream:
+            token_ids: list[int] = []
+            finish_reason = None
+            usage = None
+            for event in backend.stream(request):
+                if event.token_id is not None:
+                    token_ids.append(int(event.token_id))
+                if event.finish_reason:
+                    finish_reason = event.finish_reason
+                if event.usage is not None:
+                    usage = [event.usage.prompt_tokens, event.usage.completion_tokens]
+            payload.update(
+                mode="stream",
+                token_ids=token_ids,
+                finish_reason=finish_reason,
+                usage=usage,
+            )
+        else:
+            result = backend.generate([request])[0]
+            payload.update(
+                mode="offline",
+                token_ids=[int(token) for token in result.token_ids],
+                text=result.text,
+                finish_reason=result.finish_reason,
+                usage=[result.usage.prompt_tokens, result.usage.completion_tokens],
+            )
+    finally:
+        backend.close()
+
+    Path(args.out).write_text(json.dumps(payload), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/_session_reuse_rank.py
+++ b/scripts/_session_reuse_rank.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""One TP rank of the session-reuse check, used by verify_cpp_session_reuse.py.
+
+Runs several greedy requests back to back through a single ``CppBackend`` and
+records the tokens each one produced.  The point is the request that stops at
+EOS: the native session keeps mutating for the whole token budget, so if the
+adapter let it run past EOS the following request would resume from state the
+caller never saw.  The parent process compares these tokens with the same
+requests run in fresh backends.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from pocketllm.api import EngineArgs, GenerationRequest, SamplingParams
+from pocketllm.backends.cpp_backend import CppBackend
+
+
+def load_cases(path: str) -> list[list[int]]:
+    cases = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        cases.append([int(item) for item in line.replace(",", " ").split()])
+    return cases
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ckpt", required=True)
+    parser.add_argument("--tp-world", type=int, required=True)
+    parser.add_argument("--tp-rank", type=int, required=True)
+    parser.add_argument("--nccl-id-path", required=True)
+    parser.add_argument("--cases-file", required=True)
+    parser.add_argument("--max-new-tokens", type=int, required=True)
+    parser.add_argument("--max-context", type=int, required=True)
+    parser.add_argument("--prefill-chunk-tokens", type=int, default=512)
+    parser.add_argument("--kv-cache-dtype", default="fp16")
+    parser.add_argument("--out", required=True)
+    parser.add_argument(
+        "--isolated",
+        action="store_true",
+        help="build a fresh backend per case instead of reusing one session",
+    )
+    args = parser.parse_args()
+
+    cases = load_cases(args.cases_file)
+
+    def build() -> CppBackend:
+        return CppBackend(
+            EngineArgs(
+                model=args.ckpt,
+                backend="cpp",
+                tensor_parallel_size=args.tp_world,
+                tensor_parallel_rank=args.tp_rank,
+                max_model_len=args.max_context,
+                prefill_chunk_tokens=args.prefill_chunk_tokens,
+                kv_cache_dtype=args.kv_cache_dtype,
+                backend_options={"nccl_id_path": args.nccl_id_path},
+            )
+        )
+
+    records: list[dict] = []
+    eos_ids: list[int] = []
+    eos_source = None
+
+    def run_case(backend: CppBackend, index: int, prompt_ids: list[int]) -> dict:
+        request = GenerationRequest(
+            prompt_tokens=prompt_ids,
+            request_id=f"session-{args.tp_rank}-{index}",
+            sampling_params=SamplingParams(max_tokens=args.max_new_tokens),
+        )
+        result = backend.generate([request])[0]
+        return {
+            "index": index,
+            "prompt_tokens": len(prompt_ids),
+            "token_ids": [int(token) for token in result.token_ids],
+            "finish_reason": result.finish_reason,
+            "usage": [result.usage.prompt_tokens, result.usage.completion_tokens],
+        }
+
+    if args.isolated:
+        for index, prompt_ids in enumerate(cases):
+            backend = build()
+            try:
+                if not eos_ids:
+                    eos_ids = sorted(backend.eos_token_ids)
+                    eos_source = backend.capabilities.details.get("eos_source")
+                records.append(run_case(backend, index, prompt_ids))
+            finally:
+                backend.close()
+    else:
+        backend = build()
+        try:
+            eos_ids = sorted(backend.eos_token_ids)
+            eos_source = backend.capabilities.details.get("eos_source")
+            for index, prompt_ids in enumerate(cases):
+                records.append(run_case(backend, index, prompt_ids))
+        finally:
+            backend.close()
+
+    Path(args.out).write_text(
+        json.dumps(
+            {
+                "tp_rank": args.tp_rank,
+                "mode": "isolated" if args.isolated else "shared",
+                "eos_token_ids": eos_ids,
+                "eos_source": eos_source,
+                "cases": records,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_cpp_adapter_parity.py
+++ b/scripts/verify_cpp_adapter_parity.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Verify the PocketLLM C++ adapter against the reference dsv4_cpp_engine.
+
+Both sides load the same real checkpoint and drive the same native QwenEngine
+with identical greedy settings, so the generated token ids must agree. The
+adapter differs in exactly one documented way: it stops at the first EOS token
+and excludes it, while the reference binary always runs the full
+``--max-new-tokens`` budget. Parity therefore means the adapter's tokens are the
+reference sequence truncated at the first EOS.
+
+One process per TP rank on both sides, sharing an NCCL id file, matching how
+scripts/bench_qwen_long_context.py launches the reference binary.
+
+Usage:
+  PYTHONPATH=. python scripts/verify_cpp_adapter_parity.py \
+    --ckpt /mnt/data2/Qwen3.8-27B-FP8 \
+    --tp-world 2 --devices 0,1 --max-new-tokens 24
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+REFERENCE_STEP = re.compile(r"^generate_step=(\d+) token=(-?\d+)")
+
+DEFAULT_PROMPTS = [
+    "用一句话介绍你自己。",
+    "What is the capital of France? Answer in one word.",
+    "Name three prime numbers.",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt", required=True)
+    parser.add_argument("--binary", default="cpp_engine/build/dsv4_cpp_engine")
+    parser.add_argument("--native-path", default="cpp_engine/build-python/python")
+    parser.add_argument("--tp-world", type=int, default=2)
+    parser.add_argument("--devices", default="0,1")
+    parser.add_argument("--max-new-tokens", type=int, default=24)
+    parser.add_argument("--max-context", type=int, default=4096)
+    parser.add_argument("--prefill-chunk-tokens", type=int, default=512)
+    parser.add_argument("--kv-cache-dtype", default="fp16")
+    parser.add_argument("--work-dir", default="parity_work")
+    parser.add_argument("--prompts", nargs="*", default=None)
+    parser.add_argument("--timeout", type=int, default=3600)
+    parser.add_argument("--json-out", default=None)
+    return parser.parse_args()
+
+
+def launch_ranks(command_for_rank, tp_world, devices, case_dir, timeout, tag):
+    """Run one process per rank and wait for all of them to exit."""
+    case_dir.mkdir(parents=True, exist_ok=True)
+    id_path = case_dir / f"{tag}.nccl.id"
+    if id_path.exists():
+        id_path.unlink()
+    logs: list[Path] = []
+    processes: list[tuple[int, subprocess.Popen]] = []
+    started = time.monotonic()
+    try:
+        for rank in range(tp_world):
+            log_path = case_dir / f"{tag}_rank{rank}.log"
+            logs.append(log_path)
+            env = os.environ.copy()
+            env["CUDA_VISIBLE_DEVICES"] = str(devices[rank])
+            env["PYTHONPATH"] = os.pathsep.join(
+                [str(REPO), str(REPO / "cpp_engine/build-python/python"), env.get("PYTHONPATH", "")]
+            )
+            with log_path.open("wb") as handle:
+                processes.append((
+                    rank,
+                    subprocess.Popen(
+                        command_for_rank(rank, id_path),
+                        stdout=handle,
+                        stderr=subprocess.STDOUT,
+                        env=env,
+                        cwd=str(REPO),
+                    ),
+                ))
+        statuses: dict[int, int] = {}
+        while len(statuses) < len(processes):
+            for rank, process in processes:
+                if rank not in statuses:
+                    code = process.poll()
+                    if code is not None:
+                        statuses[rank] = code
+            if time.monotonic() - started > timeout:
+                raise TimeoutError(f"{tag}: ranks exceeded {timeout}s; see {case_dir}")
+            time.sleep(0.2)
+        failed = {rank: code for rank, code in statuses.items() if code != 0}
+        if failed:
+            tail = logs[0].read_text(errors="replace").splitlines()[-15:]
+            raise RuntimeError(f"{tag}: ranks failed {failed}\n" + "\n".join(tail))
+    finally:
+        for _, process in processes:
+            if process.poll() is None:
+                process.kill()
+    return logs
+
+
+def reference_tokens(args, token_path: Path, case_dir: Path, devices) -> list[int]:
+    def command_for_rank(rank: int, id_path: Path) -> list[str]:
+        return [
+            str((REPO / args.binary).resolve()),
+            "--ckpt", args.ckpt,
+            "--tp-world", str(args.tp_world),
+            "--tp-rank", str(rank),
+            "--device", "0",
+            "--nccl-id-path", str(id_path),
+            "--token-ids-file", str(token_path),
+            "--generate-token", "1",
+            "--max-new-tokens", str(args.max_new_tokens),
+            "--max-context", str(args.max_context),
+            "--prefill-chunk-tokens", str(args.prefill_chunk_tokens),
+            "--kv-cache-dtype", args.kv_cache_dtype,
+            "--qwen-temperature", "0",
+            "--qwen-top-p", "1",
+            "--qwen-top-k", "0",
+            "--qwen-seed", "0",
+            # The adapter builds QwenEngine with layer_count=0 (every layer);
+            # the binary's default is 1, which would compare different models.
+            "--smoke-layers", "0",
+        ]
+
+    logs = launch_ranks(command_for_rank, args.tp_world, devices, case_dir, args.timeout, "reference")
+    steps: dict[int, int] = {}
+    for line in logs[0].read_text(errors="replace").splitlines():
+        match = REFERENCE_STEP.match(line.strip())
+        if match:
+            steps[int(match.group(1))] = int(match.group(2))
+    if not steps:
+        raise RuntimeError(f"reference produced no generate_step lines; see {logs[0]}")
+    return [steps[key] for key in sorted(steps)]
+
+
+def adapter_run(args, token_path: Path, case_dir: Path, devices, mode: str) -> list[dict]:
+    runner = REPO / "scripts/_parity_adapter_rank.py"
+    out_paths = [case_dir / f"adapter_{mode}_rank{rank}.json" for rank in range(args.tp_world)]
+    for path in out_paths:
+        if path.exists():
+            path.unlink()
+
+    def command_for_rank(rank: int, id_path: Path) -> list[str]:
+        command = [
+            sys.executable, str(runner),
+            "--ckpt", args.ckpt,
+            "--tp-world", str(args.tp_world),
+            "--tp-rank", str(rank),
+            "--nccl-id-path", str(id_path),
+            "--token-ids-file", str(token_path),
+            "--max-new-tokens", str(args.max_new_tokens),
+            "--max-context", str(args.max_context),
+            "--prefill-chunk-tokens", str(args.prefill_chunk_tokens),
+            "--kv-cache-dtype", args.kv_cache_dtype,
+            "--out", str(out_paths[rank]),
+        ]
+        if mode == "stream":
+            command.append("--stream")
+        return command
+
+    launch_ranks(command_for_rank, args.tp_world, devices, case_dir, args.timeout, f"adapter_{mode}")
+    payloads = []
+    for path in out_paths:
+        if not path.exists():
+            raise RuntimeError(f"adapter rank produced no output: {path}")
+        payloads.append(json.loads(path.read_text()))
+    return payloads
+
+
+def truncate_at_eos(tokens: list[int], eos_ids: set[int]) -> tuple[list[int], bool]:
+    for index, token in enumerate(tokens):
+        if token in eos_ids:
+            return tokens[:index], True
+    return list(tokens), False
+
+
+def main() -> int:
+    args = parse_args()
+    devices = [int(item) for item in args.devices.split(",")]
+    if len(devices) != args.tp_world:
+        raise SystemExit("--devices count must match --tp-world")
+    prompts = args.prompts if args.prompts else DEFAULT_PROMPTS
+    work_dir = Path(args.work_dir).resolve()
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(args.ckpt)
+
+    cases = []
+    failures = 0
+    for index, prompt in enumerate(prompts):
+        case_dir = work_dir / f"case{index}"
+        case_dir.mkdir(parents=True, exist_ok=True)
+        prompt_ids = [int(token) for token in tokenizer.encode(prompt)]
+        token_path = case_dir / "tokens.txt"
+        # load_token_ids() in main.cpp splits on commas only.
+        token_path.write_text(",".join(str(token) for token in prompt_ids), encoding="utf-8")
+
+        print(f"[case {index}] prompt={prompt!r} prompt_tokens={len(prompt_ids)}", flush=True)
+        reference = reference_tokens(args, token_path, case_dir, devices)
+        offline = adapter_run(args, token_path, case_dir, devices, "offline")
+        streamed = adapter_run(args, token_path, case_dir, devices, "stream")
+
+        eos_ids = set(offline[0]["eos_token_ids"])
+        expected, hit_eos = truncate_at_eos(reference, eos_ids)
+        expected_reason = "stop" if hit_eos else "length"
+
+        rank_offline_agree = all(item["token_ids"] == offline[0]["token_ids"] for item in offline)
+        rank_stream_agree = all(item["token_ids"] == streamed[0]["token_ids"] for item in streamed)
+        offline_ok = offline[0]["token_ids"] == expected
+        stream_ok = streamed[0]["token_ids"] == expected
+        reason_ok = (
+            offline[0]["finish_reason"] == expected_reason
+            and streamed[0]["finish_reason"] == expected_reason
+        )
+        usage_ok = offline[0]["usage"] == streamed[0]["usage"]
+        passed = all([rank_offline_agree, rank_stream_agree, offline_ok, stream_ok, reason_ok, usage_ok])
+        failures += 0 if passed else 1
+
+        case = {
+            "prompt": prompt,
+            "prompt_tokens": len(prompt_ids),
+            "eos_token_ids": sorted(eos_ids),
+            "eos_source": offline[0]["eos_source"],
+            "reference_tokens": reference,
+            "expected_tokens": expected,
+            "reference_hit_eos": hit_eos,
+            "offline_tokens": offline[0]["token_ids"],
+            "stream_tokens": streamed[0]["token_ids"],
+            "offline_finish_reason": offline[0]["finish_reason"],
+            "stream_finish_reason": streamed[0]["finish_reason"],
+            "expected_finish_reason": expected_reason,
+            "offline_usage": offline[0]["usage"],
+            "stream_usage": streamed[0]["usage"],
+            "text": offline[0].get("text"),
+            "checks": {
+                "offline_matches_reference": offline_ok,
+                "stream_matches_reference": stream_ok,
+                "offline_ranks_agree": rank_offline_agree,
+                "stream_ranks_agree": rank_stream_agree,
+                "finish_reason_correct": reason_ok,
+                "usage_consistent": usage_ok,
+            },
+            "pass": passed,
+        }
+        cases.append(case)
+        print(f"  eos={sorted(eos_ids)} source={case['eos_source']}", flush=True)
+        print(f"  reference={reference}", flush=True)
+        print(f"  expected ={expected} reason={expected_reason}", flush=True)
+        print(f"  offline  ={offline[0]['token_ids']} reason={offline[0]['finish_reason']} usage={offline[0]['usage']}", flush=True)
+        print(f"  stream   ={streamed[0]['token_ids']} reason={streamed[0]['finish_reason']} usage={streamed[0]['usage']}", flush=True)
+        print(f"  {'PASS' if passed else 'FAIL'} {case['checks']}", flush=True)
+
+    summary = {
+        "checkpoint": args.ckpt,
+        "tp_world": args.tp_world,
+        "devices": devices,
+        "kv_cache_dtype": args.kv_cache_dtype,
+        "max_new_tokens": args.max_new_tokens,
+        "cases": cases,
+        "failures": failures,
+        "pass": failures == 0,
+    }
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"\n{'ALL PASS' if failures == 0 else f'{failures} CASE(S) FAILED'} ({len(cases)} cases)")
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_cpp_session_reuse.py
+++ b/scripts/verify_cpp_session_reuse.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Check that a request stopping at EOS leaves the C++ adapter session clean.
+
+``QwenEngine.generate`` takes no EOS argument and keeps mutating its session for
+the whole token budget, so an adapter that ran the full budget and truncated the
+result afterwards would leave the recurrent state and prefix cache positioned
+after text the caller never saw.  The next request on that backend would then
+resume from corrupted state.
+
+This runs the same sequence of greedy requests two ways on a real checkpoint:
+
+* ``shared``   - one ``CppBackend``, every request in order (the real serving path)
+* ``isolated`` - a fresh ``CppBackend`` per request (nothing to carry over)
+
+Parity between the two modes is the property under test.  The sequence puts a
+request that hits EOS in the middle, which is exactly the case that used to
+poison its successor.
+
+Usage:
+  python scripts/verify_cpp_session_reuse.py \
+    --ckpt /mnt/data2/Qwen3.8-27B-FP8 --tp-world 2 --devices 0,1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from scripts.verify_cpp_adapter_parity import launch_ranks  # noqa: E402
+
+# The middle prompt terminates in a couple of tokens, so it exercises the EOS
+# stop; the ones around it run to the length limit.
+DEFAULT_PROMPTS = [
+    "Name three prime numbers.",
+    "What is the capital of France? Answer in one word.",
+    "用一句话介绍你自己。",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt", required=True)
+    parser.add_argument("--tp-world", type=int, default=2)
+    parser.add_argument("--devices", default="0,1")
+    parser.add_argument("--max-new-tokens", type=int, default=24)
+    parser.add_argument("--max-context", type=int, default=4096)
+    parser.add_argument("--prefill-chunk-tokens", type=int, default=512)
+    parser.add_argument("--kv-cache-dtype", default="fp16")
+    parser.add_argument("--work-dir", default="session_reuse_work")
+    parser.add_argument("--prompts", nargs="*", default=None)
+    parser.add_argument("--timeout", type=int, default=3600)
+    parser.add_argument("--json-out", default=None)
+    return parser.parse_args()
+
+
+def run_mode(args, cases_path: Path, work_dir: Path, devices, isolated: bool) -> list[dict]:
+    mode = "isolated" if isolated else "shared"
+    mode_dir = work_dir / mode
+    mode_dir.mkdir(parents=True, exist_ok=True)
+    out_paths = [mode_dir / f"rank{rank}.json" for rank in range(args.tp_world)]
+
+    def command_for_rank(rank: int, id_path: Path) -> list[str]:
+        command = [
+            sys.executable,
+            str(REPO / "scripts/_session_reuse_rank.py"),
+            "--ckpt", args.ckpt,
+            "--tp-world", str(args.tp_world),
+            "--tp-rank", str(rank),
+            "--nccl-id-path", str(id_path),
+            "--cases-file", str(cases_path),
+            "--max-new-tokens", str(args.max_new_tokens),
+            "--max-context", str(args.max_context),
+            "--prefill-chunk-tokens", str(args.prefill_chunk_tokens),
+            "--kv-cache-dtype", args.kv_cache_dtype,
+            "--out", str(out_paths[rank]),
+        ]
+        if isolated:
+            command.append("--isolated")
+        return command
+
+    launch_ranks(command_for_rank, args.tp_world, devices, mode_dir, args.timeout, mode)
+    return [json.loads(path.read_text(encoding="utf-8")) for path in out_paths]
+
+
+def main() -> int:
+    args = parse_args()
+    devices = [item.strip() for item in args.devices.split(",") if item.strip()]
+    if len(devices) < args.tp_world:
+        raise SystemExit(f"--devices needs at least {args.tp_world} entries")
+
+    prompts = args.prompts if args.prompts else DEFAULT_PROMPTS
+    work_dir = Path(args.work_dir).resolve()
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    from transformers import AutoTokenizer  # noqa: PLC0415
+
+    tokenizer = AutoTokenizer.from_pretrained(args.ckpt)
+    prompt_ids = [[int(token) for token in tokenizer.encode(prompt)] for prompt in prompts]
+    cases_path = work_dir / "cases.txt"
+    cases_path.write_text(
+        "\n".join(",".join(str(token) for token in ids) for ids in prompt_ids) + "\n",
+        encoding="utf-8",
+    )
+
+    shared = run_mode(args, cases_path, work_dir, devices, isolated=False)
+    isolated = run_mode(args, cases_path, work_dir, devices, isolated=True)
+
+    eos_ids = sorted(shared[0]["eos_token_ids"])
+    print(f"eos={eos_ids} source={shared[0]['eos_source']}", flush=True)
+
+    all_ok = True
+    report: list[dict] = []
+    for index, prompt in enumerate(prompts):
+        shared_case = shared[0]["cases"][index]
+        isolated_case = isolated[0]["cases"][index]
+        tokens_match = shared_case["token_ids"] == isolated_case["token_ids"]
+        reason_match = shared_case["finish_reason"] == isolated_case["finish_reason"]
+        usage_match = shared_case["usage"] == isolated_case["usage"]
+        ranks_agree = all(
+            item["cases"][index]["token_ids"] == shared_case["token_ids"] for item in shared
+        )
+        passed = tokens_match and reason_match and usage_match and ranks_agree
+        all_ok = all_ok and passed
+        checks = {
+            "tokens_match_isolated": tokens_match,
+            "finish_reason_match": reason_match,
+            "usage_match": usage_match,
+            "shared_ranks_agree": ranks_agree,
+        }
+        report.append(
+            {
+                "index": index,
+                "prompt": prompt,
+                "prompt_tokens": shared_case["prompt_tokens"],
+                "shared": shared_case,
+                "isolated": isolated_case,
+                "checks": checks,
+                "pass": passed,
+            }
+        )
+        print(f"[case {index}] prompt={prompt!r} prompt_tokens={shared_case['prompt_tokens']}", flush=True)
+        print(f"  shared   ={shared_case['token_ids']} reason={shared_case['finish_reason']} usage={shared_case['usage']}", flush=True)
+        print(f"  isolated ={isolated_case['token_ids']} reason={isolated_case['finish_reason']} usage={isolated_case['usage']}", flush=True)
+        print(f"  {'PASS' if passed else 'FAIL'} {checks}", flush=True)
+
+    payload = {
+        "ckpt": args.ckpt,
+        "tp_world": args.tp_world,
+        "max_new_tokens": args.max_new_tokens,
+        "eos_token_ids": eos_ids,
+        "eos_source": shared[0]["eos_source"],
+        "cases": report,
+        "pass": all_ok,
+    }
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"wrote {args.json_out}", flush=True)
+
+    failures = sum(1 for case in report if not case["pass"])
+    print("", flush=True)
+    if all_ok:
+        print(f"ALL PASS ({len(report)} cases)", flush=True)
+        return 0
+    print(f"{failures} CASE(S) FAILED ({len(report)} cases)", flush=True)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_torch_prompt_parity.py
+++ b/scripts/verify_torch_prompt_parity.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Check the Torch adapter renders the same prompt ids as the legacy server.
+
+Phase 1.1 moved OpenAI request normalization into ``pocketllm.protocol`` and made
+``TorchBackend`` apply the DeepSeek chat template itself.  The unified server
+previously flattened messages to "role: content", so the prompt it fed the model
+differed from ``src.server.openai``.  This drives real request bodies through
+both paths using the real checkpoint's tokenizer and compares the resulting token
+ids, which is the part of the Torch adapter that can be validated without the
+full 156G model on device.
+
+Usage:
+  python scripts/verify_torch_prompt_parity.py --ckpt /mnt/data3/DeepSeek-V4-Flash-0731
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from pocketllm.api import GenerationRequest, SamplingParams  # noqa: E402
+from pocketllm.protocol import ChatRequest  # noqa: E402
+from src.encoding.dsv4 import encode_messages  # noqa: E402
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Look up the weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+BODIES: list[tuple[str, dict]] = [
+    (
+        "plain chat",
+        {"messages": [{"role": "user", "content": "用一句话介绍你自己。"}]},
+    ),
+    (
+        "system + multi turn",
+        {
+            "messages": [
+                {"role": "system", "content": "You are a terse assistant."},
+                {"role": "user", "content": "What is 2+2?"},
+                {"role": "assistant", "content": "4"},
+                {"role": "user", "content": "And 3+3?"},
+            ]
+        },
+    ),
+    (
+        "content blocks",
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Name three prime numbers."},
+                        {"type": "text", "text": " Answer with digits only."},
+                    ],
+                }
+            ]
+        },
+    ),
+    (
+        "thinking mode",
+        {
+            "messages": [{"role": "user", "content": "Prove that sqrt(2) is irrational."}],
+            "thinking": True,
+            "reasoning_effort": "high",
+        },
+    ),
+    (
+        "tools + tool_choice",
+        {
+            "messages": [{"role": "user", "content": "Weather in Paris?"}],
+            "tools": [WEATHER_TOOL],
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+        },
+    ),
+    (
+        "tool result turn",
+        {
+            "messages": [
+                {"role": "user", "content": "Weather in Paris?"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_0",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_0", "content": "18C, clear"},
+            ],
+            "tools": [WEATHER_TOOL],
+        },
+    ),
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt", required=True)
+    parser.add_argument("--json-out", default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    from transformers import AutoTokenizer  # noqa: PLC0415
+
+    tokenizer = AutoTokenizer.from_pretrained(args.ckpt, trust_remote_code=True)
+
+    # Build a TorchBackend without loading the model: only prompt rendering and
+    # the tokenizer are exercised here, so the runtime loader is stubbed out.
+    from pocketllm.api import EngineArgs  # noqa: PLC0415
+    from pocketllm.backends.torch_backend import TorchBackend  # noqa: PLC0415
+
+    backend = TorchBackend(
+        EngineArgs(model=args.ckpt, backend="torch"),
+        runtime={"tokenizer": tokenizer, "model": None, "executor": None},
+    )
+
+    cases: list[dict] = []
+    all_ok = True
+    for label, body in BODIES:
+        chat = ChatRequest.from_body(body)
+        # Legacy path: src.server.openai encodes the normalized messages with the
+        # DeepSeek template and tokenizes the result.
+        legacy_text = encode_messages(
+            chat.messages,
+            thinking_mode=chat.thinking_mode,
+            reasoning_effort=chat.reasoning_effort,
+        )
+        legacy_ids = [int(token) for token in tokenizer.encode(legacy_text)]
+
+        # Unified path: the adapter renders from request metadata.
+        request = GenerationRequest(
+            prompt=chat.messages[-1].get("content", "") if chat.messages else "",
+            request_id=f"prompt-parity-{len(cases)}",
+            sampling_params=SamplingParams(max_tokens=8),
+            metadata=chat.metadata(),
+        )
+        adapter_ids = backend._prompt_ids(request)
+        adapter_text = backend._prompt_text(request)
+
+        ids_match = adapter_ids == legacy_ids
+        text_match = adapter_text == legacy_text
+        # The old flattening is what this change replaced; if it happened to
+        # agree the test would prove nothing, so record the contrast.
+        flattened = "\n".join(
+            f"{message.get('role', 'user')}: {message.get('content', '')}" for message in chat.messages
+        )
+        differs_from_flattened = adapter_text != flattened
+
+        passed = ids_match and text_match and differs_from_flattened
+        all_ok = all_ok and passed
+        checks = {
+            "ids_match_legacy": ids_match,
+            "text_match_legacy": text_match,
+            "differs_from_old_flattening": differs_from_flattened,
+        }
+        cases.append(
+            {
+                "label": label,
+                "prompt_tokens": len(adapter_ids),
+                "legacy_tokens": len(legacy_ids),
+                "checks": checks,
+                "pass": passed,
+                "prompt_head": adapter_text[:160],
+            }
+        )
+        print(f"[{label}] adapter={len(adapter_ids)} legacy={len(legacy_ids)} tokens", flush=True)
+        print(f"  {'PASS' if passed else 'FAIL'} {checks}", flush=True)
+        if not passed:
+            print(f"  adapter_text={adapter_text!r}", flush=True)
+            print(f"  legacy_text ={legacy_text!r}", flush=True)
+
+    payload = {"ckpt": args.ckpt, "cases": cases, "pass": all_ok}
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"wrote {args.json_out}", flush=True)
+
+    print("", flush=True)
+    if all_ok:
+        print(f"ALL PASS ({len(cases)} cases)", flush=True)
+        return 0
+    failures = sum(1 for case in cases if not case["pass"])
+    print(f"{failures} CASE(S) FAILED ({len(cases)} cases)", flush=True)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Phase 1.1 (#114) was covered only by CPU-only tests with fake native engines. This adds three
scripts that check the same behavior against real checkpoints on device, and reports the results.

- `scripts/verify_cpp_adapter_parity.py` — drives the C++ adapter and the reference
  `dsv4_cpp_engine` binary over the same checkpoint with identical greedy settings and compares
  token ids. The adapter must produce the reference sequence truncated at the first EOS, with
  `finish_reason="stop"` only when EOS was actually hit.
- `scripts/verify_cpp_session_reuse.py` — runs the same requests through one shared backend and
  through a fresh backend per request, with an EOS-terminating request in the middle. This is the
  case the #114 termination fix was about: `QwenEngine.generate` keeps mutating its session for the
  whole token budget, so running the full budget and truncating afterwards would leave the session
  past text the caller never saw and corrupt the next request.
- `scripts/verify_torch_prompt_parity.py` — compares the Torch adapter's rendered prompt ids with
  `src.encoding.dsv4.encode_messages` over the real tokenizer, and asserts the result differs from
  the old `"role: content"` flattening so the comparison cannot pass trivially.

Plus two rank workers (`scripts/_parity_adapter_rank.py`, `scripts/_session_reuse_rank.py`), one
process per TP rank sharing an NCCL id file.

No engine, adapter, or server code changes.

## Results

**C++ adapter vs reference binary** — `/mnt/data2/Qwen3.8-27B-FP8`, TP2 on GPUs 0/1, greedy,
24 new tokens: **3/3 PASS**. Offline and streamed paths agree with the reference token for token on
both ranks. The interesting case is the one that terminates: the reference runs past EOS
(`271, 57590, 248044, 248045, ...`) while the adapter stops before it with `[271, 57590]`,
`finish_reason=stop`, `usage=[12, 3]` (counting the EOS step). EOS resolved to `[248044, 248046]`
from `generation_config.json`, matching the documented precedence.

**Session reuse** — same checkpoint, TP2: **3/3 PASS**. Three requests in order through one backend,
EOS-terminating request in the middle, identical to running each in its own backend.

**Torch prompt rendering** — `/mnt/data3/DeepSeek-V4-Flash-0731` real tokenizer: **6/6 PASS** across
plain chat, system + multi-turn, content blocks, thinking mode, tools with `tool_choice`, and a
tool-result turn (9/29/14/93/296/339 tokens); every case matches the legacy encoding exactly and
differs from the old flattening.

**Unit tests** — 82 passed (`test_backend_contract`, `test_backend_selection`, `test_cpp_backend`,
`test_openai_server`, `test_openai_utils`, `test_protocol_chat`, `test_public_api`,
`test_torch_backend_prompt`).

## Not verified

Cross-backend Torch to C++ token parity **cannot run on this machine**: no checkpoint loads on both
adapters (Torch supports `deepseek_v4` only, the C++ adapter supports Qwen3.5 safetensors only). The
Torch side is therefore verified at the prompt-rendering level; its forward pass was not run on GPU
because the 156G checkpoint does not fit in 4x22GiB.

## Invocation details worth knowing

Getting the reference comparison honest took three fixes, all recorded in comments:

1. `pocketllm_cpp` had been built without NCCL, so every TP>1 adapter run died with
   `Qwen TP requires an NCCL-enabled build`. Rebuilt with `-DDSV4_REQUIRE_NCCL=ON` plus explicit
   `NCCL_INCLUDE_DIR`/`NCCL_LIBRARY`; `ldd` now shows `libnccl.so.2`.
2. `load_token_ids()` in `cpp_engine/engine/main.cpp` splits `--token-ids-file` on commas only, so
   space-separated ids silently collapse to `prompt_tokens=1`.
3. The binary's `--smoke-layers` defaults to 1 while the adapter builds `QwenEngine` with
   `layer_count=0` (all layers). Without `--smoke-layers 0` the run compares a one-layer model
   against the full one; the tell is the reference emitting token 220 at every step.

## Reproduce

```
PYTHONPATH=.:cpp_engine/build-python/python python scripts/verify_cpp_adapter_parity.py \
  --ckpt /mnt/data2/Qwen3.8-27B-FP8 --tp-world 2 --devices 0,1 --max-new-tokens 24 --max-context 2048

PYTHONPATH=.:cpp_engine/build-python/python python scripts/verify_cpp_session_reuse.py \
  --ckpt /mnt/data2/Qwen3.8-27B-FP8 --tp-world 2 --devices 0,1 --max-new-tokens 24 --max-context 2048

PYTHONPATH=. /home/lvyufeng/miniconda3/envs/deepseek/bin/python scripts/verify_torch_prompt_parity.py \
  --ckpt /mnt/data3/DeepSeek-V4-Flash-0731
```

The Torch check needs the `deepseek` env; base-env transformers cannot parse the `deepseek_v4` config.