### PR TITLE
Unify checkpoint-owned chat prompt encoding

### DIFF
--- a/docs/pocketllm_api.md
+++ b/docs/pocketllm_api.md
@@ -128,11 +128,19 @@ instructions, `reasoning`/`reasoning_effort` handling, tool-call shaping, and st
 There is one implementation, and it imports neither Torch nor the native module.
 
 `/v1/chat/completions` puts the normalized messages, thinking mode, reasoning effort, and tool
-metadata in `GenerationRequest.metadata`, so a backend applies its own chat template. The Torch
-adapter encodes them with the DeepSeek template that the legacy server uses, so both servers build
-the same prompt. `GenerationRequest.prompt` still carries a deterministic `role: content` rendering as
-a fallback for backends that have no template of their own. `/v1/completions` passes `prompt` through
+metadata in `GenerationRequest.metadata`. The shared prompt boundary first asks the selected
+checkpoint tokenizer to apply its own `chat_template` with an assistant generation prompt. This is
+the same model-owned-template contract used by vLLM/SGLang and preserves model-specific special
+tokens, reasoning controls, and tool formatting. For DeepSeek checkpoints whose tokenizer has no
+chat template, the validated legacy `src.encoding.dsv4.encode_messages` format is used instead.
+`GenerationRequest.prompt` still carries a deterministic `role: content` rendering only as a last-resort
+fallback for generic tokenizers that provide neither format. `/v1/completions` passes `prompt` through
 unchanged and validates that a list prompt contains only strings.
+
+The template receives normalized tool definitions and a private compatibility copy of prior tool-call
+arguments; public request metadata is never mutated. Template-specific reasoning names are mapped to
+the vocabulary accepted by the checkpoint (for example, `high`/`max` map to Qwen's `xhigh`).
+Unsupported model-specific template features remain the responsibility of the selected backend.
 
 A backend that separates reasoning from content can set `reasoning_content` and `tool_calls` in its
 result or event metadata; those are forwarded to the response and to streamed deltas. A backend that

--- a/docs/vllm_sglang_comparison.md
+++ b/docs/vllm_sglang_comparison.md
@@ -72,9 +72,11 @@ preemption. These require a request-aware scheduler and must not be implemented 
 current mutable session unsafely. The Torch adapter continues to reuse its existing serving queue.
 
 Phase 1.1 hardened protocol and termination behavior only. Chat requests now carry normalized
-messages so each backend applies its own chat template, and the C++ adapter stops at EOS with a
-correct `stop`/`length` finish reason instead of always reporting `length`. Neither change touches
-scheduling: the native path remains one serialized session, and `supports_batch` stays `False`.
+messages through a shared prompt boundary: checkpoint-owned `chat_template` is preferred, the
+validated DeepSeek encoder is used for its no-template checkpoints, and deterministic `role: content`
+is only a generic last resort. The C++ adapter stops at EOS with a correct `stop`/`length` finish reason
+instead of always reporting `length`. Neither change touches scheduling: the native path remains one
+serialized session, and `supports_batch` stays `False`.
 
 ## 3. Configuration
 

--- a/pocketllm/backends/cpp_backend.py
+++ b/pocketllm/backends/cpp_backend.py
@@ -29,6 +29,7 @@ from pocketllm.api import (
     Usage,
     UnsupportedFeatureError,
 )
+from pocketllm.protocol import encode_chat_prompt, render_fallback_prompt
 
 from .base import BackendBase
 
@@ -314,7 +315,21 @@ class CppBackend(BackendBase):
             return list(request.prompt_tokens)
         if self._tokenizer is None:
             raise ConfigurationError("C++ backend needs tokenizer_path for text prompts")
-        encoded = self._tokenizer.encode(request.prompt or "")
+        messages = request.metadata.get("messages")
+        if isinstance(messages, Sequence) and not isinstance(messages, (str, bytes)):
+            encoded = encode_chat_prompt(
+                self._tokenizer,
+                messages,
+                thinking_mode=str(request.metadata.get("thinking_mode", "chat")),
+                reasoning_effort=request.metadata.get("reasoning_effort"),
+                tools=request.metadata.get("tools"),
+            )
+            if encoded is not None:
+                return encoded
+            prompt = request.prompt or render_fallback_prompt(messages)
+        else:
+            prompt = request.prompt or ""
+        encoded = self._tokenizer.encode(prompt)
         return [int(token) for token in encoded]
 
     def _check_sampling(self, params: SamplingParams) -> None:

--- a/pocketllm/backends/torch_backend.py
+++ b/pocketllm/backends/torch_backend.py
@@ -24,6 +24,7 @@ from pocketllm.api import (
     Usage,
     UnsupportedFeatureError,
 )
+from pocketllm.protocol import encode_chat_prompt, render_fallback_prompt
 
 from .base import BackendBase
 
@@ -150,37 +151,37 @@ class TorchBackend(BackendBase):
                 return normalized
         return None
 
-    def _prompt_text(self, request: GenerationRequest) -> str:
-        """Render the prompt, preferring the runtime's own chat encoding.
-
-        Chat requests are encoded with the DeepSeek template that the legacy
-        server uses, so the unified API produces the same prompt as
-        ``src.server.openai``.  Raw prompts and non-DeepSeek encodings fall back
-        to the request text unchanged.
-        """
-        messages = self._messages(request)
-        if messages is None:
-            return request.prompt or ""
-        try:
-            from src.encoding.dsv4 import encode_messages
-        except Exception:
-            return request.prompt or ""
-        return encode_messages(
-            messages,
-            thinking_mode=str(request.metadata.get("thinking_mode", "chat")),
-            reasoning_effort=request.metadata.get("reasoning_effort"),
-        )
-
     def _prompt_ids(self, request: GenerationRequest) -> list[int]:
         if request.prompt_tokens is not None:
             return list(request.prompt_tokens)
         tokenizer = self._tokenizer()
         if tokenizer is None:
             raise ValueError("TorchBackend needs a tokenizer for text prompts")
+        messages = self._messages(request)
+        if messages is not None:
+            encoded = encode_chat_prompt(
+                tokenizer,
+                messages,
+                thinking_mode=str(request.metadata.get("thinking_mode", "chat")),
+                reasoning_effort=request.metadata.get("reasoning_effort"),
+                tools=request.metadata.get("tools"),
+                # The current Torch runtime is the DeepSeek runtime; use its
+                # validated encoder when the checkpoint has no HF template.
+                deepseek_fallback=True,
+            )
+            if encoded is not None:
+                return encoded
         encoded = tokenizer.encode(self._prompt_text(request))
         if hasattr(encoded, "tolist"):
             encoded = encoded.tolist()
         return [int(token) for token in encoded]
+
+    def _prompt_text(self, request: GenerationRequest) -> str:
+        """Return a deterministic text fallback for generic tokenizers."""
+        messages = self._messages(request)
+        if messages is not None:
+            return request.prompt or render_fallback_prompt(messages)
+        return request.prompt or ""
 
     def _payload(self, request: GenerationRequest, *, stream: bool) -> dict[str, Any]:
         params = request.sampling_params

--- a/pocketllm/protocol/__init__.py
+++ b/pocketllm/protocol/__init__.py
@@ -17,10 +17,12 @@ from .chat import (
     tool_choice_instruction,
     tool_names,
 )
+from .prompt import encode_chat_prompt
 
 __all__ = [
     "ChatRequest",
     "apply_stop_to_text",
+    "encode_chat_prompt",
     "normalize_content",
     "normalize_tool_calls",
     "prepare_messages",

--- a/pocketllm/protocol/prompt.py
+++ b/pocketllm/protocol/prompt.py
@@ -1,0 +1,221 @@
+"""Backend-neutral chat prompt encoding helpers.
+
+Tokenization and chat-template application belong to the control plane rather
+than to a device backend.  The helper keeps model-specific template behavior
+behind the tokenizer supplied by the selected runtime, while preserving the
+validated DeepSeek encoder for checkpoints that predate Hugging Face chat
+metadata.
+"""
+
+from __future__ import annotations
+
+import copy
+import inspect
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+_TEMPLATE_REASONING_EFFORTS = {
+    None: "xhigh",
+    "minimal": "low",
+    "low": "low",
+    "medium": "medium",
+    "high": "xhigh",
+    "max": "xhigh",
+}
+
+
+def _template_reasoning_effort(value: Any) -> str:
+    """Map public reasoning names to the names used by Qwen templates."""
+    return _TEMPLATE_REASONING_EFFORTS.get(value, "xhigh")
+
+
+def _template_messages(messages: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Copy messages and make OpenAI tool arguments template-compatible.
+
+    OpenAI carries function arguments as a JSON string.  Qwen's bundled
+    template iterates over ``tool_call.function.arguments`` as an object, so
+    only the private copy passed to the template converts valid JSON objects
+    back to dictionaries.  The normalized request metadata is never mutated.
+    """
+    copied = copy.deepcopy([dict(message) for message in messages])
+    for message in copied:
+        if message.get("role") != "assistant":
+            continue
+        calls = message.get("tool_calls")
+        if not isinstance(calls, list):
+            continue
+        for call in calls:
+            if not isinstance(call, dict):
+                continue
+            function = call.get("function")
+            if not isinstance(function, dict):
+                continue
+            arguments = function.get("arguments")
+            if not isinstance(arguments, str):
+                continue
+            try:
+                decoded = json.loads(arguments)
+            except (TypeError, ValueError):
+                continue
+            if isinstance(decoded, dict):
+                function["arguments"] = decoded
+    return copied
+
+
+def _token_ids(value: Any, tokenizer: Any) -> list[int] | None:
+    """Normalize list/tensor-like tokenizer output to public token ids."""
+    if isinstance(value, str) or value is None:
+        encoder = getattr(tokenizer, "encode", None)
+        if not isinstance(value, str) or not callable(encoder):
+            return None
+        value = encoder(value)
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        value = tolist()
+    if isinstance(value, tuple):
+        value = list(value)
+    if isinstance(value, Mapping):
+        value = value.get("input_ids")
+        tolist = getattr(value, "tolist", None)
+        if callable(tolist):
+            value = tolist()
+    if not isinstance(value, list):
+        return None
+    # A tokenizer may return a single [1, N] batch even when tokenize=True.
+    if len(value) == 1 and isinstance(value[0], (list, tuple)):
+        value = list(value[0])
+    if not all(isinstance(item, (int, bool)) for item in value):
+        return None
+    return [int(item) for item in value]
+
+
+def _encode_with_template(
+    tokenizer: Any,
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    thinking_mode: str,
+    reasoning_effort: Any,
+    tools: Any,
+) -> list[int] | None:
+    # Hugging Face exposes ``apply_chat_template`` on many tokenizers even
+    # when the checkpoint has no actual template.  Check the metadata first so
+    # DeepSeek's legacy fallback is selected instead of raising from the HF
+    # helper.
+    if hasattr(tokenizer, "chat_template") and not getattr(tokenizer, "chat_template", None):
+        return None
+    apply_chat_template = getattr(tokenizer, "apply_chat_template", None)
+    if not callable(apply_chat_template):
+        return None
+
+    kwargs: dict[str, Any] = {
+        "tokenize": True,
+        "add_generation_prompt": True,
+        "enable_thinking": thinking_mode == "thinking",
+        "reasoning_effort": _template_reasoning_effort(reasoning_effort),
+    }
+    if tools is not None:
+        # A custom template is model code from the checkpoint; keep all public
+        # request metadata private from accidental in-place mutations.
+        kwargs["tools"] = copy.deepcopy(tools)
+    template_messages = _template_messages(messages)
+    try:
+        encoded = apply_chat_template(template_messages, **kwargs)
+    except TypeError:
+        # Tokenizers with a valid template but an older or custom method may not
+        # accept optional model-specific controls.  Preserve the core template
+        # contract, dropping only keywords rejected by the callable's signature.
+        try:
+            signature = inspect.signature(apply_chat_template)
+        except (TypeError, ValueError):
+            return None
+        accepts_kwargs = any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD
+            for parameter in signature.parameters.values()
+        )
+        if accepts_kwargs:
+            raise
+        supported = {
+            name for name, parameter in signature.parameters.items()
+            if name != "self"
+            and parameter.kind in {
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            }
+        }
+        if "messages" not in supported:
+            return None
+        # The first positional argument is supplied explicitly; only retain
+        # keyword controls that the callable can actually receive.
+        supported.discard("messages")
+        compatible_kwargs = {name: value for name, value in kwargs.items() if name in supported}
+        try:
+            encoded = apply_chat_template(template_messages, **compatible_kwargs)
+        except TypeError:
+            return None
+    return _token_ids(encoded, tokenizer)
+
+
+def _encode_with_deepseek(
+    tokenizer: Any,
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    thinking_mode: str,
+    reasoning_effort: Any,
+) -> list[int] | None:
+    """Use the legacy DeepSeek encoder only for no-template tokenizers."""
+    try:
+        from src.encoding.dsv4 import encode_messages
+    except Exception:
+        return None
+    text = encode_messages(
+        [dict(message) for message in messages],
+        thinking_mode=thinking_mode,
+        reasoning_effort=reasoning_effort,
+    )
+    encoder = getattr(tokenizer, "encode", None)
+    if not callable(encoder):
+        return None
+    return _token_ids(encoder(text), tokenizer)
+
+
+def encode_chat_prompt(
+    tokenizer: Any,
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    thinking_mode: str = "chat",
+    reasoning_effort: Any = None,
+    tools: Any = None,
+    deepseek_fallback: bool = False,
+) -> list[int] | None:
+    """Encode normalized chat messages using the best available model format.
+
+    A checkpoint-owned ``apply_chat_template`` always wins.  The legacy
+    DeepSeek encoder is used only when ``deepseek_fallback`` is explicitly
+    enabled by the DeepSeek adapter; generic callers otherwise receive
+    ``None`` and may use their own fallback.  ``None`` means the tokenizer
+    cannot encode this chat request.
+    """
+    if not isinstance(messages, Sequence) or isinstance(messages, (str, bytes)):
+        raise ValueError("messages must be a non-empty sequence")
+    normalized = [message for message in messages if isinstance(message, Mapping)]
+    if not normalized:
+        raise ValueError("messages must contain at least one object")
+    encoded = _encode_with_template(
+        tokenizer,
+        normalized,
+        thinking_mode=thinking_mode,
+        reasoning_effort=reasoning_effort,
+        tools=tools,
+    )
+    if encoded is not None:
+        return encoded
+    if not deepseek_fallback:
+        return None
+    return _encode_with_deepseek(
+        tokenizer,
+        normalized,
+        thinking_mode=thinking_mode,
+        reasoning_effort=reasoning_effort,
+    )

--- a/pocketllm/server/openai.py
+++ b/pocketllm/server/openai.py
@@ -212,9 +212,8 @@ class OpenAIHandler(BaseHTTPRequestHandler):
         request_id = str(body.get("request_id") or f"chatcmpl-{uuid.uuid4().hex}")
         params = SamplingParams.from_openai(body)
         chat = ChatRequest.from_body(body, completion=completion)
-        # Chat requests carry the normalized messages so a backend can apply its
-        # own chat template.  `prompt` stays populated as a deterministic
-        # fallback for backends that have no template of their own.
+        # Chat requests carry normalized messages for the shared prompt boundary.
+        # `prompt` remains a deterministic fallback for generic tokenizers.
         prompt = chat.prompt if completion else render_fallback_prompt(chat.messages)
         return GenerationRequest(
             prompt=prompt,

--- a/scripts/verify_torch_prompt_parity.py
+++ b/scripts/verify_torch_prompt_parity.py
@@ -155,22 +155,21 @@ def main() -> int:
             metadata=chat.metadata(),
         )
         adapter_ids = backend._prompt_ids(request)
-        adapter_text = backend._prompt_text(request)
 
         ids_match = adapter_ids == legacy_ids
-        text_match = adapter_text == legacy_text
-        # The old flattening is what this change replaced; if it happened to
-        # agree the test would prove nothing, so record the contrast.
+        # The shared boundary returns ids, while each backend may retain its
+        # own textual rendering for runtime payloads.  Token ids are the
+        # authoritative parity check because those are what the model sees.
         flattened = "\n".join(
             f"{message.get('role', 'user')}: {message.get('content', '')}" for message in chat.messages
         )
-        differs_from_flattened = adapter_text != flattened
+        fallback_ids = [int(token) for token in tokenizer.encode(flattened)]
+        differs_from_flattened = adapter_ids != fallback_ids
 
-        passed = ids_match and text_match and differs_from_flattened
+        passed = ids_match and differs_from_flattened
         all_ok = all_ok and passed
         checks = {
             "ids_match_legacy": ids_match,
-            "text_match_legacy": text_match,
             "differs_from_old_flattening": differs_from_flattened,
         }
         cases.append(
@@ -180,14 +179,14 @@ def main() -> int:
                 "legacy_tokens": len(legacy_ids),
                 "checks": checks,
                 "pass": passed,
-                "prompt_head": adapter_text[:160],
+                "fallback_tokens": len(fallback_ids),
             }
         )
         print(f"[{label}] adapter={len(adapter_ids)} legacy={len(legacy_ids)} tokens", flush=True)
         print(f"  {'PASS' if passed else 'FAIL'} {checks}", flush=True)
         if not passed:
-            print(f"  adapter_text={adapter_text!r}", flush=True)
-            print(f"  legacy_text ={legacy_text!r}", flush=True)
+            print(f"  adapter_ids={adapter_ids[:32]}", flush=True)
+            print(f"  legacy_ids ={legacy_ids[:32]}", flush=True)
 
     payload = {"ckpt": args.ckpt, "cases": cases, "pass": all_ok}
     if args.json_out:

--- a/tests/test_cpp_backend.py
+++ b/tests/test_cpp_backend.py
@@ -24,6 +24,18 @@ class FakeTokenizer:
         return "".join(f"<{token}>" for token in token_ids)
 
 
+class TemplateTokenizer(FakeTokenizer):
+    chat_template = "{{ messages }}"
+
+    def __init__(self) -> None:
+        self.template_calls: list[tuple[list[dict], dict]] = []
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.template_calls.append(([dict(message) for message in messages], dict(kwargs)))
+        return [71, 72]
+
+
+
 class FakeResult:
     def __init__(self, top_token: int) -> None:
         self.top_token = top_token
@@ -120,6 +132,57 @@ def make_backend(engine: FakeEngine | None = None) -> tuple[CppBackend, FakeEngi
         tokenizer=FakeTokenizer(),
     )
     return backend, fake_engine
+
+
+def test_cpp_chat_prompt_uses_tokenizer_owned_template() -> None:
+    tokenizer = TemplateTokenizer()
+    backend, _ = make_backend()
+    backend._tokenizer = tokenizer
+    request = GenerationRequest(
+        prompt="user: hi",
+        request_id="req-template",
+        sampling_params=SamplingParams(max_tokens=1),
+        metadata={
+            "messages": [{"role": "user", "content": "hi"}],
+            "thinking_mode": "chat",
+        },
+    )
+
+    assert backend._prompt_ids(request) == [71, 72]
+    assert tokenizer.template_calls[0][0] == [{"role": "user", "content": "hi"}]
+    assert tokenizer.template_calls[0][1]["add_generation_prompt"] is True
+    backend.close()
+
+
+def test_cpp_pre_tokenized_prompt_bypasses_chat_template() -> None:
+    tokenizer = TemplateTokenizer()
+    backend, _ = make_backend()
+    backend._tokenizer = tokenizer
+    request = GenerationRequest(
+        prompt_tokens=[7, 8],
+        request_id="req-template-tokens",
+        sampling_params=SamplingParams(max_tokens=1),
+        metadata={"messages": [{"role": "user", "content": "ignored"}]},
+    )
+
+    assert backend._prompt_ids(request) == [7, 8]
+    assert tokenizer.template_calls == []
+    backend.close()
+
+
+def test_cpp_raw_prompt_bypasses_chat_template() -> None:
+    tokenizer = TemplateTokenizer()
+    backend, _ = make_backend()
+    backend._tokenizer = tokenizer
+    request = GenerationRequest(
+        prompt="raw completion",
+        request_id="req-template-raw",
+        sampling_params=SamplingParams(max_tokens=1),
+    )
+
+    assert backend._prompt_ids(request) == [len("raw completion"), 7]
+    assert tokenizer.template_calls == []
+    backend.close()
 
 
 def test_generate_converts_native_results_and_usage() -> None:

--- a/tests/test_protocol_prompt.py
+++ b/tests/test_protocol_prompt.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from pocketllm.protocol import encode_chat_prompt
+
+
+class TemplateTokenizer:
+    chat_template = "{{ messages }}"
+
+    def __init__(self, encoded=None) -> None:
+        self.calls: list[tuple[list[dict], dict]] = []
+        self.encoded = encoded if encoded is not None else [31, 32]
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.calls.append(([dict(message) for message in messages], dict(kwargs)))
+        return self.encoded
+
+    def encode(self, text: str) -> list[int]:
+        return [len(text)]
+
+
+class TensorLike:
+    def __init__(self, value):
+        self.value = value
+
+    def tolist(self):
+        return self.value
+
+
+def test_template_encoding_uses_generation_and_reasoning_controls():
+    tokenizer = TemplateTokenizer(TensorLike([[31, 32]]))
+    messages = [{"role": "user", "content": "hi"}]
+
+    result = encode_chat_prompt(
+        tokenizer,
+        messages,
+        thinking_mode="thinking",
+        reasoning_effort="high",
+    )
+
+    assert result == [31, 32]
+    assert tokenizer.calls == [
+        (
+            messages,
+            {
+                "tokenize": True,
+                "add_generation_prompt": True,
+                "enable_thinking": True,
+                "reasoning_effort": "xhigh",
+            },
+        )
+    ]
+
+
+def test_template_encoding_passes_tools_and_does_not_mutate_arguments():
+    tokenizer = TemplateTokenizer()
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_0",
+                    "type": "function",
+                    "function": {"name": "weather", "arguments": '{"city":"Paris"}'},
+                }
+            ],
+        },
+        {"role": "user", "content": "Weather?"},
+    ]
+    tools = [{"type": "function", "function": {"name": "weather", "parameters": {}}}]
+
+    assert encode_chat_prompt(tokenizer, messages, tools=tools) == [31, 32]
+    called_messages, kwargs = tokenizer.calls[0]
+    assert kwargs["tools"] == tools
+    assert kwargs["tools"] is not tools
+    assert called_messages[0]["tool_calls"][0]["function"]["arguments"] == {"city": "Paris"}
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == '{"city":"Paris"}'
+
+
+def test_public_reasoning_aliases_map_to_template_vocabulary():
+    for public, expected in (("minimal", "low"), ("low", "low"), ("medium", "medium"), ("max", "xhigh"), (None, "xhigh")):
+        tokenizer = TemplateTokenizer()
+        encode_chat_prompt(tokenizer, [{"role": "user", "content": "hi"}], reasoning_effort=public)
+        assert tokenizer.calls[0][1]["reasoning_effort"] == expected
+        assert tokenizer.calls[0][1]["enable_thinking"] is False
+
+
+def test_template_with_legacy_signature_drops_unsupported_controls():
+    class LegacyTokenizer:
+        chat_template = "{{ messages }}"
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[list[dict], dict]] = []
+
+        def apply_chat_template(self, messages, *, tokenize, add_generation_prompt):
+            self.calls.append(([dict(message) for message in messages], {
+                "tokenize": tokenize,
+                "add_generation_prompt": add_generation_prompt,
+            }))
+            return [41, 42]
+
+    tokenizer = LegacyTokenizer()
+    assert encode_chat_prompt(
+        tokenizer,
+        [{"role": "user", "content": "hi"}],
+        thinking_mode="thinking",
+        reasoning_effort="high",
+        tools=[],
+    ) == [41, 42]
+    assert tokenizer.calls[0][1] == {"tokenize": True, "add_generation_prompt": True}
+
+
+def test_template_type_error_from_callable_with_kwargs_is_not_hidden():
+    class BrokenTokenizer:
+        chat_template = "{{ messages }}"
+
+        def apply_chat_template(self, messages, **kwargs):
+            raise TypeError("template rendering failed")
+
+    try:
+        encode_chat_prompt(BrokenTokenizer(), [{"role": "user", "content": "hi"}])
+    except TypeError as exc:
+        assert str(exc) == "template rendering failed"
+    else:
+        raise AssertionError("template TypeError should be preserved")
+
+
+def test_no_template_returns_none_without_deepseek_fallback():
+    class GenericTokenizer:
+        def encode(self, text: str) -> list[int]:
+            return [len(text)]
+
+    assert encode_chat_prompt(GenericTokenizer(), [{"role": "user", "content": "hi"}]) is None
+
+
+def test_no_template_uses_deepseek_fallback_when_requested():
+    class DeepSeekTokenizer:
+        def encode(self, text: str) -> list[int]:
+            return [len(text)]
+
+    messages = [{"role": "user", "content": "hi"}]
+    result = encode_chat_prompt(
+        DeepSeekTokenizer(),
+        messages,
+        deepseek_fallback=True,
+    )
+
+    from src.encoding.dsv4 import encode_messages
+
+    assert result == [len(encode_messages(messages, thinking_mode="chat", reasoning_effort=None))]

--- a/tests/test_torch_backend_prompt.py
+++ b/tests/test_torch_backend_prompt.py
@@ -11,20 +11,6 @@ from pocketllm.backends.torch_backend import TorchBackend
 from src.encoding.dsv4 import encode_messages
 
 
-class RecordingTokenizer:
-    eos_token_id = 1
-
-    def __init__(self) -> None:
-        self.encoded: list[str] = []
-
-    def encode(self, text: str) -> list[int]:
-        self.encoded.append(text)
-        return [11, 12]
-
-    def decode(self, token_ids: list[int]) -> str:
-        return "".join(f"<{token}>" for token in token_ids)
-
-
 class RecordingServingEngine:
     def __init__(self) -> None:
         self.payloads: list[dict] = []
@@ -40,6 +26,32 @@ class RecordingServingEngine:
 
     def close(self) -> None:
         pass
+
+
+class RecordingTokenizer:
+    eos_token_id = 1
+
+    def __init__(self) -> None:
+        self.encoded: list[str] = []
+
+    def encode(self, text: str) -> list[int]:
+        self.encoded.append(text)
+        return [11, 12]
+
+    def decode(self, token_ids: list[int]) -> str:
+        return "".join(f"<{token}>" for token in token_ids)
+
+
+class TemplateRecordingTokenizer(RecordingTokenizer):
+    chat_template = "{{ messages }}"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.template_calls: list[tuple[list[dict], dict]] = []
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.template_calls.append(([dict(message) for message in messages], dict(kwargs)))
+        return [91, 92]
 
 
 def _backend(tokenizer: RecordingTokenizer) -> tuple[TorchBackend, RecordingServingEngine]:
@@ -65,10 +77,7 @@ def test_chat_metadata_is_rendered_with_the_deepseek_template():
 
     backend.generate([request])
 
-    # The adapter must reuse the runtime's own chat encoding rather than the
-    # server's plain fallback text.
     assert tokenizer.encoded == [encode_messages(messages, thinking_mode="chat")]
-    # The normalized messages are forwarded so the runtime can re-encode.
     assert engine.payloads[-1]["messages"] == messages
     assert engine.payloads[-1]["thinking_mode"] == "chat"
     backend.close()
@@ -87,10 +96,27 @@ def test_thinking_mode_and_effort_reach_the_template():
 
     backend.generate([request])
 
-    assert tokenizer.encoded == [
-        encode_messages(messages, thinking_mode="thinking", reasoning_effort="max")
-    ]
+    assert tokenizer.encoded == [encode_messages(messages, thinking_mode="thinking", reasoning_effort="max")]
     assert engine.payloads[-1]["reasoning_effort"] == "max"
+    backend.close()
+
+
+def test_tokenizer_owned_template_takes_precedence():
+    tokenizer = TemplateRecordingTokenizer()
+    backend, _ = _backend(tokenizer)
+    messages = [{"role": "user", "content": "hi"}]
+    request = GenerationRequest(
+        prompt="user: hi",
+        request_id="req-owned-template",
+        sampling_params=SamplingParams(max_tokens=1),
+        metadata={"messages": messages, "thinking_mode": "chat"},
+    )
+
+    assert backend._prompt_ids(request) == [91, 92]
+    assert tokenizer.encoded == []
+    assert tokenizer.template_calls[0][0] == messages
+    assert tokenizer.template_calls[0][1]["add_generation_prompt"] is True
+    assert tokenizer.template_calls[0][1]["enable_thinking"] is False
     backend.close()
 
 
@@ -111,17 +137,19 @@ def test_raw_prompts_are_encoded_unchanged():
 
 
 def test_prompt_tokens_bypass_the_tokenizer():
-    tokenizer = RecordingTokenizer()
+    tokenizer = TemplateRecordingTokenizer()
     backend, engine = _backend(tokenizer)
     request = GenerationRequest(
         prompt_tokens=[7, 8],
         request_id="req-tokens",
         sampling_params=SamplingParams(max_tokens=1),
+        metadata={"messages": [{"role": "user", "content": "ignored"}]},
     )
 
     backend.generate([request])
 
     assert tokenizer.encoded == []
+    assert tokenizer.template_calls == []
     assert engine.payloads[-1]["_prompt_ids"] == [7, 8]
     backend.close()
 
@@ -140,4 +168,5 @@ def test_streaming_uses_the_same_prompt_rendering():
     list(backend.stream(request))
 
     assert tokenizer.encoded[0] == encode_messages(messages, thinking_mode="chat")
+    assert engine.payloads[-1]["_prompt_ids"] == [11, 12]
     backend.close()


### PR DESCRIPTION
## Summary
- add a backend-neutral chat prompt boundary for the unified API
- prefer each checkpoint tokenizer's `chat_template`, with DeepSeek and generic fallbacks
- wire Torch and C++ adapters to the same prompt semantics and add regression coverage

## Validation
- `python -m pytest -q tests/test_protocol_prompt.py tests/test_cpp_backend.py tests/test_torch_backend_prompt.py tests/test_protocol_chat.py tests/test_openai_server.py tests/test_backend_contract.py tests/test_backend_selection.py tests/test_public_api.py` — 74 passed
- `python -m py_compile pocketllm/protocol/prompt.py pocketllm/backends/cpp_backend.py pocketllm/backends/torch_backend.py pocketllm/server/openai.py scripts/verify_torch_prompt_parity.py`
- `git diff --check`
- real DeepSeek prompt parity: 6/6 PASS
- real Qwen TP2 adapter/reference parity: 3/3 PASS
- real Qwen session reuse: 3/3 PASS
- real Qwen chat-template E2E: PASS

The full repository test collection remains blocked by the pre-existing experimental `tests/test_gguf_q2_precision.py` import of unavailable `src.gguf.reader`.

🤖 Generated with [Claude Code](https://claude.com/claude-code),description:Push prompt boundary branch and open pull request,timeout:600000,