### PR TITLE
Add library-first offline chat APIs

### DIFF
--- a/docs/pocketllm_api.md
+++ b/docs/pocketllm_api.md
@@ -33,9 +33,39 @@ Pre-tokenized input is also accepted:
 outputs = llm.generate([[1, 42, 17]], SamplingParams(max_tokens=16))
 ```
 
-Use `generate_stream()` for token events and `cancel(request_id)` to request cancellation at a safe generation boundary. The initial C++ compatibility adapter is serialized and exposes native greedy generation; unsupported sampling or request features report `UnsupportedFeatureError` rather than being silently ignored. Native streaming decodes the cumulative token sequence before emitting each delta, so BPE and UTF-8 token boundaries are handled by the tokenizer.
+For chat-shaped inputs, use the library-first chat surface. It accepts the same normalized message
+and optional fields as `/v1/chat/completions`, and returns the same list-shaped result as
+`generate()` (one result for the supplied conversation):
+
+```python
+messages = [
+    {"role": "system", "content": "Answer concisely."},
+    {"role": "user", "content": "What is 2+2?"},
+]
+outputs = llm.chat(
+    messages,
+    SamplingParams(max_tokens=32, temperature=0.0),
+    reasoning_effort="low",
+)
+print(outputs[0].text)
+```
+
+`chat()` also accepts `reasoning`, `tools`, `tool_choice`, `response_format`, and an optional
+`request_id`. The request body is normalized through the same backend-neutral builder used by the
+HTTP endpoint; checkpoint-owned chat templates remain the authority for model-specific prompt
+encoding. Caller-owned message and tool structures are not mutated.
+
+Use `generate_stream()` or `chat_stream()` for token events and `cancel(request_id)` to request
+cancellation at a safe generation boundary. The initial C++ compatibility adapter is serialized and
+exposes native greedy generation; unsupported sampling or request features report
+`UnsupportedFeatureError` rather than being silently ignored. Native streaming decodes the cumulative
+token sequence before emitting each delta, so BPE and UTF-8 token boundaries are handled by the
+tokenizer.
 
 ## Async API
+
+`AsyncLLM` mirrors every offline entry point: `generate`, `generate_stream`, `chat`, and
+`chat_stream`.
 
 ```python
 from pocketllm import AsyncLLM, EngineArgs, SamplingParams
@@ -44,9 +74,19 @@ async with AsyncLLM(EngineArgs(model="/path/to/checkpoint")) as llm:
     result = (await llm.generate("Hello", SamplingParams(max_tokens=32)))[0]
     async for event in llm.generate_stream("Stream this"):
         print(event.text, end="", flush=True)
+
+    chat_result = (await llm.chat(
+        [{"role": "user", "content": "Explain KV caching."}],
+        SamplingParams(max_tokens=32),
+    ))[0]
+    print(chat_result.text)
+    async for event in llm.chat_stream(
+        [{"role": "user", "content": "Stream a short answer."}],
+    ):
+        print(event.text, end="", flush=True)
 ```
 
-`AsyncLLM` currently provides non-blocking application integration around the backend contract. It does not claim device-level continuous batching. Backend schedulers will add that capability independently.
+`AsyncLLM` currently provides non-blocking application integration around the backend contract. It does not claim device-level continuous batching. Backend schedulers will add that capability independently. The async chat methods reuse the same executor-backed lifecycle and `TokenEvent` contract as the sync facade; they do not add a scheduler.
 
 ## CLI and server
 

--- a/docs/vllm_sglang_comparison.md
+++ b/docs/vllm_sglang_comparison.md
@@ -4,7 +4,7 @@
 > where explicitly noted. Phase 1 adds the `pocketllm` control plane without merging the Torch and
 > native C++ data planes.
 
-## Phase 1 status
+## Phase 1 / Phase 2.1 status
 
 The new `pocketllm` package provides:
 
@@ -14,6 +14,8 @@ The new `pocketllm` package provides:
 - shared `/health`, `/alive`, `/ready`, `/metrics`, `/v1/chat/completions`, and
   `/v1/completions` endpoints;
 - request IDs, safe-boundary cancellation, streaming token events, and usage metrics;
+- library-first `LLM.chat()` / `chat_stream()` and matching `AsyncLLM` methods;
+- one shared chat request builder for offline and HTTP entry points;
 - optional pybind11 bindings for the token-oriented native Qwen engine.
 
 The C++ compatibility adapter is intentionally serialized around one mutable native session. True
@@ -39,18 +41,26 @@ The native runtime was primarily CLI-oriented:
 `QwenEngine` and `PersistentEngine` were C++ classes for native callers, not a supported Python
 library surface. The existing executable and its CLI remain supported.
 
-### PocketLLM Phase 1
+### PocketLLM Phase 2.1
 
 ```python
 from pocketllm import EngineArgs, LLM, SamplingParams
 
 llm = LLM(EngineArgs(model="/path/to/qwen3.5", backend="cpp"))
-outputs = llm.generate(["hello"], SamplingParams(max_tokens=32))
+outputs = llm.chat(
+    [{"role": "user", "content": "hello"}],
+    SamplingParams(max_tokens=32),
+)
 ```
 
-The public facade accepts text or pre-tokenized IDs and returns backend-neutral result/event types.
-The native binding remains token-oriented and does not expose Torch tensors, CUDA handles, ACL
-handles, or a shared physical KV-cache layout.
+The public facade accepts raw text, pre-tokenized IDs, and OpenAI-style chat messages. `chat()` and
+`chat_stream()` use the same backend-neutral normalization and prompt-construction path as the
+HTTP chat endpoint; async variants mirror them through the existing executor wrapper. Results and
+stream events remain backend-neutral. The native binding remains token-oriented and does not expose
+Torch tensors, CUDA handles, ACL handles, or a shared physical KV-cache layout.
+
+This is a library-first request surface, not a continuous-batching implementation: the C++ adapter
+still serializes access to one mutable native session and reports `supports_batch=False`.
 
 ## 2. Request processing and batching
 

--- a/pocketllm/engine.py
+++ b/pocketllm/engine.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator, Iterator, Sequence
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from typing import Any
 
 from pocketllm.api import (
@@ -17,6 +18,7 @@ from pocketllm.api import (
     TokenEvent,
 )
 from pocketllm.backends.factory import create_backend
+from pocketllm.protocol import build_chat_request
 
 
 _TOKEN_DONE = object()
@@ -27,8 +29,6 @@ def _next_event(iterator: Iterator[TokenEvent]) -> TokenEvent | object:
         return next(iterator)
     except StopIteration:
         return _TOKEN_DONE
-
-
 
 
 class LLM:
@@ -86,6 +86,109 @@ class LLM:
             raise RuntimeError("LLM is closed")
         params = sampling_params or SamplingParams()
         request = self._requests([prompt], params)[0]
+        return self._backend.stream(request)
+
+    @staticmethod
+    def _chat_body(
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        reasoning: Any = None,
+        reasoning_effort: Any = None,
+        tools: Any = None,
+        tool_choice: Any = None,
+        response_format: Any = None,
+    ) -> dict[str, Any]:
+        """Build an OpenAI-shaped body for the shared chat normalizer."""
+        normalized_messages = [
+            dict(message) if isinstance(message, Mapping) else message
+            for message in messages
+        ]
+        body: dict[str, Any] = {"messages": normalized_messages}
+        for name, value in (
+            ("reasoning", reasoning),
+            ("reasoning_effort", reasoning_effort),
+            ("tools", tools),
+            ("tool_choice", tool_choice),
+            ("response_format", response_format),
+        ):
+            if value is not None:
+                body[name] = value
+        return body
+
+    def _chat_request(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        sampling_params: SamplingParams | None = None,
+        *,
+        reasoning: Any = None,
+        reasoning_effort: Any = None,
+        tools: Any = None,
+        tool_choice: Any = None,
+        response_format: Any = None,
+        request_id: str | None = None,
+    ) -> GenerationRequest:
+        body = self._chat_body(
+            messages,
+            reasoning=reasoning,
+            reasoning_effort=reasoning_effort,
+            tools=tools,
+            tool_choice=tool_choice,
+            response_format=response_format,
+        )
+        return build_chat_request(body, sampling_params, request_id=request_id)
+
+    def chat(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        sampling_params: SamplingParams | None = None,
+        *,
+        reasoning: Any = None,
+        reasoning_effort: Any = None,
+        tools: Any = None,
+        tool_choice: Any = None,
+        response_format: Any = None,
+        request_id: str | None = None,
+    ) -> list[GenerationResult]:
+        """Generate a response for normalized OpenAI-style chat messages."""
+        if self._closed:
+            raise RuntimeError("LLM is closed")
+        request = self._chat_request(
+            messages,
+            sampling_params,
+            reasoning=reasoning,
+            reasoning_effort=reasoning_effort,
+            tools=tools,
+            tool_choice=tool_choice,
+            response_format=response_format,
+            request_id=request_id,
+        )
+        return self._backend.generate([request])
+
+    def chat_stream(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        sampling_params: SamplingParams | None = None,
+        *,
+        reasoning: Any = None,
+        reasoning_effort: Any = None,
+        tools: Any = None,
+        tool_choice: Any = None,
+        response_format: Any = None,
+        request_id: str | None = None,
+    ) -> Iterator[TokenEvent]:
+        """Stream token events for normalized OpenAI-style chat messages."""
+        if self._closed:
+            raise RuntimeError("LLM is closed")
+        request = self._chat_request(
+            messages,
+            sampling_params,
+            reasoning=reasoning,
+            reasoning_effort=reasoning_effort,
+            tools=tools,
+            tool_choice=tool_choice,
+            response_format=response_format,
+            request_id=request_id,
+        )
         return self._backend.stream(request)
 
     def cancel(self, request_id: str) -> bool:
@@ -152,6 +255,67 @@ class AsyncLLM:
             prompt,
             sampling_params,
         )
+        while True:
+            event = await loop.run_in_executor(self._executor, _next_event, iterator)
+            if event is _TOKEN_DONE:
+                return
+            yield event
+
+    async def chat(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        sampling_params: SamplingParams | None = None,
+        *,
+        reasoning: Any = None,
+        reasoning_effort: Any = None,
+        tools: Any = None,
+        tool_choice: Any = None,
+        response_format: Any = None,
+        request_id: str | None = None,
+    ) -> list[GenerationResult]:
+        if self._closed:
+            raise RuntimeError("AsyncLLM is closed")
+        loop = asyncio.get_running_loop()
+        call = partial(
+            self._llm.chat,
+            messages,
+            sampling_params,
+            reasoning=reasoning,
+            reasoning_effort=reasoning_effort,
+            tools=tools,
+            tool_choice=tool_choice,
+            response_format=response_format,
+            request_id=request_id,
+        )
+        return await loop.run_in_executor(self._executor, call)
+
+    async def chat_stream(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        sampling_params: SamplingParams | None = None,
+        *,
+        reasoning: Any = None,
+        reasoning_effort: Any = None,
+        tools: Any = None,
+        tool_choice: Any = None,
+        response_format: Any = None,
+        request_id: str | None = None,
+    ) -> AsyncIterator[TokenEvent]:
+        if self._closed:
+            raise RuntimeError("AsyncLLM is closed")
+        loop = asyncio.get_running_loop()
+        call = partial(
+            self._llm.chat_stream,
+            messages,
+            sampling_params,
+            reasoning=reasoning,
+            reasoning_effort=reasoning_effort,
+            tools=tools,
+            tool_choice=tool_choice,
+            response_format=response_format,
+            request_id=request_id,
+        )
+        iterator = await loop.run_in_executor(self._executor, call)
         while True:
             event = await loop.run_in_executor(self._executor, _next_event, iterator)
             if event is _TOKEN_DONE:

--- a/pocketllm/protocol/__init__.py
+++ b/pocketllm/protocol/__init__.py
@@ -18,9 +18,12 @@ from .chat import (
     tool_names,
 )
 from .prompt import encode_chat_prompt
+from .requests import build_chat_request, build_completion_request
 
 __all__ = [
     "ChatRequest",
+    "build_chat_request",
+    "build_completion_request",
     "apply_stop_to_text",
     "encode_chat_prompt",
     "normalize_content",

--- a/pocketllm/protocol/requests.py
+++ b/pocketllm/protocol/requests.py
@@ -1,0 +1,93 @@
+"""Backend-neutral request construction helpers.
+
+These helpers bridge OpenAI-shaped inputs to the public generation types. They
+are shared by the HTTP server and the library facade so request normalization,
+metadata, and prompt fallbacks do not drift between entry points.
+"""
+
+from __future__ import annotations
+
+import copy
+import uuid
+from collections.abc import Mapping
+from dataclasses import replace
+from typing import Any
+
+from pocketllm.api import GenerationRequest, SamplingParams
+
+from .chat import ChatRequest, render_fallback_prompt
+
+
+_DEFAULT_REQUEST_ID_PREFIX = "req-"
+
+
+def _request_id(value: Any) -> str:
+    return str(value or f"{_DEFAULT_REQUEST_ID_PREFIX}{uuid.uuid4().hex}")
+
+
+def _copy_sampling_params(params: SamplingParams) -> SamplingParams:
+    """Keep request-owned mutable sampling fields independent of callers."""
+    return copy.deepcopy(params)
+
+
+def _copy_body(body: Mapping[str, Any], kind: str) -> dict[str, Any]:
+    if not isinstance(body, Mapping):
+        raise ValueError(f"{kind} body must be an object")
+    return copy.deepcopy(dict(body))
+
+
+def _resolve_sampling_params(
+    body: Mapping[str, Any], sampling_params: SamplingParams | None,
+) -> SamplingParams:
+    """Copy caller params, or normalize OpenAI sampling fields from the body.
+
+    ``response_format`` may arrive either on :class:`SamplingParams` or in the
+    body, so both entry points produce the same request. A body value is the
+    more specific per-call input and wins.
+    """
+    if sampling_params is None:
+        return SamplingParams.from_openai(body)
+    params = _copy_sampling_params(sampling_params)
+    if body.get("response_format") is not None:
+        params = replace(params, response_format=copy.deepcopy(body["response_format"]))
+    return params
+
+
+def build_chat_request(
+    body: Mapping[str, Any],
+    sampling_params: SamplingParams | None = None,
+    *,
+    request_id: str | None = None,
+) -> GenerationRequest:
+    """Build a generation request from an OpenAI chat-completion body.
+
+    If sampling parameters are omitted, OpenAI sampling fields in ``body`` are
+    normalized with :meth:`SamplingParams.from_openai`. The body is deep-copied
+    before normalization so caller-owned messages and tools are not mutated.
+    """
+    copied = _copy_body(body, "chat")
+    chat = ChatRequest.from_body(copied)
+    metadata = copy.deepcopy(chat.metadata())
+    return GenerationRequest(
+        prompt=render_fallback_prompt(metadata["messages"]),
+        sampling_params=_resolve_sampling_params(copied, sampling_params),
+        request_id=_request_id(request_id or copied.get("request_id")),
+        metadata=metadata,
+    )
+
+
+def build_completion_request(
+    body: Mapping[str, Any],
+    sampling_params: SamplingParams | None = None,
+    *,
+    request_id: str | None = None,
+) -> GenerationRequest:
+    """Build a text-completion request without chat normalization."""
+    copied = _copy_body(body, "completion")
+    chat = ChatRequest.from_body(copied, completion=True)
+    return GenerationRequest(
+        prompt=chat.prompt,
+        sampling_params=_resolve_sampling_params(copied, sampling_params),
+        request_id=_request_id(request_id or copied.get("request_id")),
+        metadata=copy.deepcopy(chat.metadata()),
+    )

--- a/pocketllm/server/openai.py
+++ b/pocketllm/server/openai.py
@@ -21,11 +21,10 @@ from pocketllm.api import (
     GenerationRequest,
     GenerationResult,
     RequestCancelledError,
-    SamplingParams,
     TokenEvent,
     UnsupportedFeatureError,
 )
-from pocketllm.protocol import ChatRequest, render_fallback_prompt
+from pocketllm.protocol import build_chat_request, build_completion_request
 
 from .metrics import Metrics
 
@@ -210,17 +209,9 @@ class OpenAIHandler(BaseHTTPRequestHandler):
 
     def _request(self, body: dict[str, Any], *, completion: bool = False) -> GenerationRequest:
         request_id = str(body.get("request_id") or f"chatcmpl-{uuid.uuid4().hex}")
-        params = SamplingParams.from_openai(body)
-        chat = ChatRequest.from_body(body, completion=completion)
-        # Chat requests carry normalized messages for the shared prompt boundary.
-        # `prompt` remains a deterministic fallback for generic tokenizers.
-        prompt = chat.prompt if completion else render_fallback_prompt(chat.messages)
-        return GenerationRequest(
-            prompt=prompt,
-            sampling_params=params,
-            request_id=request_id,
-            metadata=chat.metadata(),
-        )
+        if completion:
+            return build_completion_request(body, request_id=request_id)
+        return build_chat_request(body, request_id=request_id)
 
     def do_DELETE(self) -> None:
         path = urlparse(self.path).path

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -199,6 +199,72 @@ def test_chat_requests_carry_normalized_messages_to_the_backend():
         server.server_close()
 
 
+def test_http_chat_uses_shared_request_builder():
+    backend = ContractBackend()
+    server, base = _server(backend=backend)
+    try:
+        _post(base, "/v1/chat/completions", {
+            "messages": [{"role": "user", "content": "hi"}],
+            "request_id": "http-chat-1",
+            "max_completion_tokens": 9,
+        })
+        request = backend.seen[-1]
+        assert request.request_id == "http-chat-1"
+        assert request.prompt == "user: hi"
+        assert request.sampling_params.max_tokens == 9
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+
+def test_completion_requests_keep_raw_prompt_path():
+    backend = ContractBackend()
+    server, base = _server(backend=backend)
+    try:
+        _post(base, "/v1/completions", {
+            "prompt": "raw completion",
+            "request_id": "completion-1",
+            "max_tokens": 5,
+        })
+        request = backend.seen[-1]
+        assert request.request_id == "completion-1"
+        assert request.prompt == "raw completion"
+        assert "messages" not in request.metadata
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+
+def test_http_and_protocol_builder_construct_equivalent_chat_requests():
+    from pocketllm.api import SamplingParams
+    from pocketllm.protocol import build_chat_request
+
+    body = {
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+        "tools": [{"type": "function", "function": {"name": "weather"}}],
+        "tool_choice": "required",
+        "reasoning_effort": "high",
+        "response_format": {"type": "json_object"},
+        "max_tokens": 9,
+    }
+    expected = build_chat_request(body, SamplingParams.from_openai(body), request_id="parity")
+    backend = ContractBackend()
+    server, base = _server(backend=backend)
+    try:
+        _post(base, "/v1/chat/completions", body)
+        actual = backend.seen[-1]
+        assert actual.prompt == expected.prompt
+        assert actual.metadata == expected.metadata
+        assert actual.sampling_params == expected.sampling_params
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+
+
 def test_invalid_chat_and_completion_bodies_are_rejected():
     server, base = _server()
     try:

--- a/tests/test_protocol_requests.py
+++ b/tests/test_protocol_requests.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from pocketllm.api import SamplingParams
+from pocketllm.protocol import build_chat_request, render_fallback_prompt
+
+
+def test_build_chat_request_accepts_openai_sampling_fields_without_explicit_params():
+    request = build_chat_request(
+        {
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 5,
+            "temperature": 0.4,
+            "stop": "END",
+        }
+    )
+
+    assert request.sampling_params.max_tokens == 5
+    assert request.sampling_params.temperature == 0.4
+    assert request.sampling_params.stop == ("END",)
+
+def test_build_chat_request_preserves_normalized_chat_fields_and_sampling():
+    body = {
+        "messages": [
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": [{"type": "text", "text": "What is 2+2?"}]},
+        ],
+        "reasoning": {"effort": "high"},
+        "tools": [{"type": "function", "function": {"name": "calculator"}}],
+        "tool_choice": "required",
+        "response_format": {"type": "json_object"},
+    }
+
+    request = build_chat_request(body, SamplingParams(max_tokens=7), request_id="chat-7")
+
+    assert request.request_id == "chat-7"
+    assert request.sampling_params.max_tokens == 7
+    assert request.metadata["thinking_mode"] == "thinking"
+    assert request.metadata["reasoning_effort"] == "high"
+    assert request.metadata["response_format"] == {"type": "json_object"}
+    assert request.metadata["tools"] == body["tools"]
+    assert request.metadata["messages"][0]["tools"] == body["tools"]
+    assert "must call at least one available tool" in request.metadata["messages"][-1]["content"]
+    assert request.prompt == render_fallback_prompt(request.metadata["messages"])
+
+
+def test_build_chat_request_does_not_mutate_nested_caller_data():
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "Weather?"}],
+            }
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "weather",
+                    "parameters": {"properties": {"city": {"type": "string"}}},
+                },
+            }
+        ],
+        "tool_choice": {"type": "function", "function": {"name": "weather"}},
+    }
+    original = copy.deepcopy(body)
+
+    request = build_chat_request(body, SamplingParams(max_tokens=2))
+
+    assert body == original
+    request.metadata["messages"][0]["content"] = "changed"
+    request.metadata["tools"][0]["function"]["name"] = "changed"
+    assert body == original
+
+
+def test_build_chat_request_uses_body_id_and_normalizes_sampling_when_omitted():
+    request = build_chat_request({
+        "messages": [{"role": "user", "content": "hi"}],
+        "request_id": "body-id",
+        "max_completion_tokens": 3,
+        "temperature": 0.25,
+    })
+
+    assert request.request_id == "body-id"
+    assert request.sampling_params.max_tokens == 3
+    assert request.sampling_params.temperature == 0.25
+
+
+def test_build_chat_request_generates_id_when_not_supplied():
+    request = build_chat_request(
+        {"messages": [{"role": "user", "content": "hi"}]},
+        SamplingParams(max_tokens=1),
+    )
+
+    assert request.request_id.startswith("req-")
+
+
+def test_build_completion_request_preserves_raw_prompt():
+    from pocketllm.protocol import build_completion_request
+
+    request = build_completion_request({"prompt": "raw", "max_tokens": 2}, request_id="completion-id")
+
+    assert request.prompt == "raw"
+    assert request.request_id == "completion-id"
+    assert request.metadata == {"thinking_mode": "chat", "stream_options": {}, "response_format": None}
+    assert request.sampling_params.max_tokens == 2
+
+
+def test_build_completion_request_does_not_mutate_body():
+    from pocketllm.protocol import build_completion_request
+
+    body = {"prompt": ["a", "b"], "response_format": {"type": "text"}}
+    original = copy.deepcopy(body)
+    build_completion_request(body)
+    assert body == original
+
+
+def test_sampling_params_are_copied_for_request_ownership():
+    params = SamplingParams(max_tokens=2, extra={"nested": {"value": 1}})
+    request = build_chat_request({"messages": [{"role": "user", "content": "hi"}]}, params)
+
+    assert request.sampling_params is not params
+    request.sampling_params.extra["nested"]["value"] = 2
+    assert params.extra["nested"]["value"] == 1
+
+
+@pytest.mark.parametrize(
+    "messages",
+    [[], ["not an object"], "not a message list"],
+)
+def test_build_chat_request_rejects_invalid_messages(messages):
+    with pytest.raises(ValueError):
+        build_chat_request(
+            {"messages": messages},
+            SamplingParams(max_tokens=1),
+        )

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -27,11 +27,11 @@ from pocketllm.backends.factory import create_backend
 _original_create_backend = create_backend
 
 
-
 class FakeBackend(BackendBase):
     def __init__(self):
         super().__init__()
         self._ready = True
+        self.seen: list[GenerationRequest] = []
 
     @property
     def capabilities(self):
@@ -40,6 +40,7 @@ class FakeBackend(BackendBase):
         )
 
     def generate(self, requests):
+        self.seen.extend(requests)
         result = []
         for request in requests:
             self._begin_request(request.request_id)
@@ -56,6 +57,7 @@ class FakeBackend(BackendBase):
         return result
 
     def stream(self, request):
+        self.seen.append(request)
         self._begin_request(request.request_id)
         try:
             self._check_cancelled(request.request_id)
@@ -102,6 +104,88 @@ def test_fake_backend_sync_and_stream():
     llm.close()
     with pytest.raises(RuntimeError):
         llm.generate("closed")
+
+
+def test_chat_normalizes_messages_and_optional_fields():
+    llm = InjectedLLM()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+    tools = [{"type": "function", "function": {"name": "weather"}}]
+    result = llm.chat(
+        messages,
+        SamplingParams(max_tokens=3),
+        reasoning_effort="high",
+        tools=tools,
+        tool_choice="required",
+        response_format={"type": "json_object"},
+        request_id="chat-1",
+    )[0]
+
+    assert result.request_id == "chat-1"
+    assert result.text.startswith("system: ")
+    assert messages == [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+    llm.close()
+
+
+def test_chat_stream_uses_shared_request_path():
+    llm = InjectedLLM()
+    events = list(llm.chat_stream([{"role": "user", "content": "hello"}], request_id="chat-stream"))
+    assert [event.request_id for event in events] == ["chat-stream", "chat-stream"]
+    assert "".join(event.text for event in events) == "ab"
+    request = llm.backend.seen[-1]
+    assert request.prompt == "user: hello"
+    llm.close()
+
+
+def test_chat_and_generate_preserve_sampling_fields():
+    llm = InjectedLLM()
+    params = SamplingParams(max_tokens=4, temperature=0.2)
+    llm.chat(
+        [{"role": "user", "content": "hi"}],
+        params,
+        response_format={"type": "json_object"},
+    )
+    request = llm.backend.seen[-1]
+    assert request.sampling_params is not params
+    assert request.sampling_params.max_tokens == 4
+    assert request.sampling_params.temperature == 0.2
+    assert request.sampling_params.response_format == {"type": "json_object"}
+    assert params.response_format is None
+    llm.close()
+
+
+def test_async_chat_and_chat_stream_use_sync_facade():
+    from pocketllm.engine import AsyncLLM
+
+    async def run():
+        async_llm = AsyncLLM.__new__(AsyncLLM)
+        async_llm._llm = InjectedLLM()
+        from concurrent.futures import ThreadPoolExecutor
+        async_llm._executor = ThreadPoolExecutor(max_workers=1)
+        async_llm._closed = False
+        result = (await async_llm.chat(
+            [{"role": "user", "content": "hello"}],
+            request_id="async-chat",
+        ))[0]
+        assert result.request_id == "async-chat"
+        values = []
+        async for event in async_llm.chat_stream(
+            [{"role": "user", "content": "stream"}],
+            reasoning_effort="high",
+            request_id="async-stream",
+        ):
+            values.append(event.text)
+        assert values == ["a", "b"]
+        assert async_llm._llm.backend.seen[-1].metadata["reasoning_effort"] == "high"
+        await async_llm.close()
+
+    asyncio.run(run())
+
+
+def test_chat_rejects_invalid_messages():
+    llm = InjectedLLM()
+    with pytest.raises(ValueError, match="messages"):
+        llm.chat([])
+    llm.close()
 
 
 def test_cancel_requires_an_active_request():


### PR DESCRIPTION
## Summary

- Add synchronous and asynchronous `chat()` / `chat_stream()` APIs.

- Share OpenAI chat and completion request construction between the library facade and HTTP server.

- Preserve normalized metadata, checkpoint-owned prompt handling, request IDs, cancellation, and raw generation behavior.

- Document the new library-first chat surface and its current non-batching limitations.



## Validation

- `95 passed, 2 skipped` across all PocketLLM tests.

- Real DeepSeek prompt parity: `ALL PASS (6 cases)`.

- `git diff --check` and Python compilation pass.



## Scope

This PR does not add continuous batching, request-local native state, TP process supervision, or new sampling semantics.



🤖 Generated with [Claude Code](https://claude.com/claude-code)