### PR TITLE
Thread slot_id explicitly through the KV cache path (Phase 3.3)

### DIFF
--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -500,8 +500,7 @@ struct QwenEngine::Impl {
     std::unordered_map<uint64_t, int> request_to_slot;
     std::vector<int> free_slots;
 
-    // Current slot_id for kernel calls (Phase 3.2)
-    int current_slot_id = 0;
+    // Phase 3.3: Removed current_slot_id (now passed explicitly as parameter)
 
     // Calculate element offset for a given slot_id in KV cache (Phase 3.2)
     size_t kv_slot_offset_elements(int slot_id, int local_kv_heads, int head_dim) const {
@@ -2147,7 +2146,8 @@ struct QwenEngine::Impl {
     }
 
     void full_attention(DeviceLayer& layer, const uint16_t* hidden,
-                        uint16_t* output, int rows, int position_offset) {
+                        uint16_t* output, int rows, int position_offset,
+                        int slot_id) {
         PhaseScope scope(this, "full_attention");
         const int q_heads = static_cast<int>(
             config.full_attention.num_heads / options.tp_world);
@@ -2246,8 +2246,7 @@ struct QwenEngine::Impl {
         // launchers are compiled. The quantized caches are not merely disabled:
         // naming their kernels here would put a CUDA dependency in this object.
 
-        // Phase 3.2: Calculate slot offset for multi-slot KV cache
-        const int slot_id = current_slot_id;
+        // Phase 3.3: Use slot_id parameter instead of global current_slot_id
         const size_t slot_offset = kv_slot_offset_elements(slot_id, kv_heads, head_dim);
 
         require_launch(qwen_append_kv_cache_f16(
@@ -2306,8 +2305,7 @@ struct QwenEngine::Impl {
         }
         (void)sink_tokens;
 #else
-        // Phase 3.2: Calculate slot offset for multi-slot KV cache
-        const int slot_id = current_slot_id;
+        // Phase 3.3: Use slot_id parameter instead of global current_slot_id
         const size_t slot_offset = kv_slot_offset_elements(slot_id, kv_heads, head_dim);
 
         if (cache_dtype == QwenKvCacheDType::Fp8) {
@@ -2660,7 +2658,7 @@ struct QwenEngine::Impl {
     }
 
     void layer_forward(DeviceLayer& layer, const uint16_t* hidden,
-                       uint16_t* output, int rows, int position_offset) {
+                       uint16_t* output, int rows, int position_offset, int slot_id) {
         const int hidden_size = static_cast<int>(config.hidden_size);
         begin_workspace();
         const size_t hidden_elements = static_cast<size_t>(rows) * hidden_size;
@@ -2728,7 +2726,7 @@ struct QwenEngine::Impl {
                              rows, position_offset);
         } else {
             full_attention(layer, normalized.f16_data(), attention.f16_data(),
-                           rows, position_offset);
+                           rows, position_offset, slot_id);
         }
         // One fused pass replaces the residual copy, the add, and the norm. It is
         // the default: measured on the real 65K TP4 prefill it saves 1.51 s
@@ -3209,7 +3207,7 @@ struct QwenEngine::Impl {
         projection(mtp_fc, mtp_concat.f16_data(), mtp_fused.f16_data(), rows, "mtp.fc");
         allocate_half(mtp_next_hidden, hidden_elements, hidden_shape);
         layer_forward(mtp_layer, mtp_fused.f16_data(),
-                      mtp_next_hidden.f16_data(), rows, position);
+                      mtp_next_hidden.f16_data(), rows, position, 0);  // slot_id=0 for MTP
         allocate_half(mtp_normalized_output, hidden_elements, hidden_shape);
         norm(mtp_norm, mtp_next_hidden.f16_data(),
              mtp_normalized_output.f16_data(), rows, hidden_size);
@@ -3593,7 +3591,8 @@ struct QwenEngine::Impl {
                                 int position_offset, int active_layers,
                                 bool compute_logits,
                                 QwenVerifyBatch* verify_batch = nullptr,
-                                const std::vector<int>* mtp_shifted_tokens = nullptr) {
+                                const std::vector<int>* mtp_shifted_tokens = nullptr,
+                                int slot_id = 0) {
         if (token_ids.empty()) {
             throw std::runtime_error("Qwen forward requires at least one token");
         }
@@ -3648,7 +3647,7 @@ struct QwenEngine::Impl {
             {
                 PhaseScope scope(this, rows == 1 ? "STACK.d" : "STACK.r");
                 layer_forward(layers[static_cast<size_t>(layer_index)], hidden,
-                              output, rows, position_offset);
+                              output, rows, position_offset, slot_id);
             }
             std::swap(hidden, output);
             if (dspark_enabled && dspark_tap_index < dspark_tap_count &&
@@ -4040,9 +4039,8 @@ QwenBatchPrefillResult QwenEngine::batch_prefill(
             throw std::runtime_error("QwenEngine::batch_prefill: invalid request");
         }
 
-        // Single-session prefill path for now
-        // TODO Phase 3.1: Use slot_id to offset KV cache access
-        QwenForwardResult fwd_result = prefill(req->prompt_tokens);
+        // Phase 3.3: Use req->slot_id to isolate KV cache
+        QwenForwardResult fwd_result = prefill(req->prompt_tokens, req->slot_id);
 
         req->seq_len = static_cast<int>(req->prompt_tokens.size());
         req->last_token = fwd_result.top_token;
@@ -4081,8 +4079,8 @@ QwenBatchDecodeResult QwenEngine::batch_decode_step(
             throw std::runtime_error("QwenEngine::batch_decode_step: null request");
         }
 
-        // TODO Phase 3.1: Use slot_id to offset KV cache access
-        QwenForwardResult fwd_result = decode_step(req->last_token);
+        // Phase 3.3: Use req->slot_id to isolate KV cache
+        QwenForwardResult fwd_result = decode_step(req->last_token, req->slot_id);
 
         req->last_token = fwd_result.top_token;
         req->last_result = fwd_result;
@@ -4105,7 +4103,7 @@ QwenBatchDecodeResult QwenEngine::batch_decode_step(
     return result;
 }
 
-QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids) {
+QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids, int slot_id) {
     std::optional<Impl::RangeScope> range;
     if (impl_->range_profile) range.emplace("qwen.prefill");
     if (token_ids.empty()) {
@@ -4245,16 +4243,17 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids) {
             if (shifted.back() < 0) {
                 // The last shifted input is the target token predicted by this
                 // final prompt row, so obtain its logits before priming MTP.
-                result = impl_->run_chunk(chunk, offset, active_layers_, true);
+                result = impl_->run_chunk(chunk, offset, active_layers_, true,
+                                          nullptr, nullptr, slot_id);
                 shifted.back() = result.top_token;
                 (void)impl_->prime_target_mtp(shifted, offset);
             } else {
                 result = impl_->run_chunk(chunk, offset, active_layers_,
-                                          snapshot_result, nullptr, &shifted);
+                                          snapshot_result, nullptr, &shifted, slot_id);
             }
         } else {
             result = impl_->run_chunk(chunk, offset, active_layers_,
-                                      snapshot_result);
+                                      snapshot_result, nullptr, nullptr, slot_id);
         }
         if (periodic_snapshot || end == target_position) {
             impl_->record_snapshot(end, &result, periodic_snapshot);
@@ -4287,14 +4286,14 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids) {
     return result;
 }
 
-QwenForwardResult QwenEngine::decode_step(int token_id) {
+QwenForwardResult QwenEngine::decode_step(int token_id, int slot_id) {
     std::optional<Impl::RangeScope> range;
     if (impl_->range_profile) range.emplace("qwen.decode_step");
     if (position_ >= max_context_) {
         throw std::runtime_error("Qwen context length exceeded");
     }
     QwenForwardResult result = impl_->run_chunk(
-        {token_id}, position_, active_layers_, true);
+        {token_id}, position_, active_layers_, true, nullptr, nullptr, slot_id);
     ++position_;
     if (options_.prefix_cache) {
         impl_->cached_prompt.push_back(token_id);

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -274,8 +274,8 @@ public:
     // Drops every cached prefix so the next prefill recomputes from zero.
     void clear_prefix_cache();
     void warmup_tp();
-    QwenForwardResult prefill(const std::vector<int>& token_ids);
-    QwenForwardResult decode_step(int token_id);
+    QwenForwardResult prefill(const std::vector<int>& token_ids, int slot_id = 0);
+    QwenForwardResult decode_step(int token_id, int slot_id = 0);
     std::vector<QwenForwardResult> generate(const std::vector<int>& prompt_ids,
                                              int max_new_tokens);
 

--- a/docs/phase3_3_completion_summary.md
+++ b/docs/phase3_3_completion_summary.md
@@ -1,0 +1,469 @@
+# Phase 3.3 完成总结 - Slot ID Threading and Batch API Integration
+
+**日期**: 2026-09-02  
+**状态**: ✅ 完成并编译通过
+
+---
+
+## 🎉 主要成就
+
+### 1. ✅ 消除全局状态
+
+成功将 `slot_id` 从全局变量 (`current_slot_id`) 改为显式参数传递，KV cache 寻址不再依赖共享可变状态。
+（引擎其余单 session 状态尚未 slot 化，见文末「已知限制」。）
+
+**Before (Phase 3.2)**:
+```cpp
+struct QwenEngine::Impl {
+    int current_slot_id = 0;  // Global state - not thread-safe!
+};
+
+void full_attention(...) {
+    const int slot_id = current_slot_id;  // Read from global
+    const size_t slot_offset = kv_slot_offset_elements(slot_id, ...);
+}
+```
+
+**After (Phase 3.3)**:
+```cpp
+struct QwenEngine::Impl {
+    // REMOVED: int current_slot_id = 0;
+};
+
+void full_attention(..., int slot_id) {  // Explicit parameter
+    const size_t slot_offset = kv_slot_offset_elements(slot_id, ...);
+}
+```
+
+### 2. ✅ 完整的参数传递链
+
+实现了从顶层 API 到底层 kernel 的完整 `slot_id` 传递链：
+
+```
+batch_prefill/batch_decode_step (req->slot_id)
+    ↓
+prefill/decode_step (slot_id parameter, default 0)
+    ↓
+run_chunk (slot_id parameter, default 0)
+    ↓
+layer_forward (slot_id parameter)
+    ↓
+full_attention (slot_id parameter)
+    ↓
+KV cache kernels (slot_offset = f(slot_id))
+```
+
+### 3. ✅ 向后兼容的默认参数
+
+使用默认参数保持单 session API 的向后兼容性：
+
+```cpp
+// Public API (qwen_engine.hpp)
+QwenForwardResult prefill(const std::vector<int>& tokens, int slot_id = 0);
+QwenForwardResult decode_step(int token, int slot_id = 0);
+
+// Usage: Single-session mode
+engine.prefill(tokens);           // slot_id=0 (implicit)
+engine.decode_step(token);        // slot_id=0 (implicit)
+
+// Usage: Multi-slot mode
+engine.prefill(tokens, req->slot_id);      // explicit slot
+engine.decode_step(token, req->slot_id);   // explicit slot
+```
+
+### 4. ✅ Batch API 集成
+
+成功将 batch API 与 slot 管理机制集成：
+
+```cpp
+QwenBatchPrefillResult QwenEngine::batch_prefill(
+    const std::vector<QwenBatchedRequest*>& requests) {
+    
+    for (QwenBatchedRequest* req : requests) {
+        // Phase 3.3: Use req->slot_id to isolate KV cache
+        QwenForwardResult fwd_result = prefill(req->prompt_tokens, req->slot_id);
+        // ...
+    }
+}
+
+QwenBatchDecodeResult QwenEngine::batch_decode_step(
+    const std::vector<QwenBatchedRequest*>& requests) {
+    
+    for (QwenBatchedRequest* req : requests) {
+        // Phase 3.3: Use req->slot_id to isolate KV cache
+        QwenForwardResult fwd_result = decode_step(req->last_token, req->slot_id);
+        // ...
+    }
+}
+```
+
+---
+
+## 📊 实施统计
+
+### 代码修改
+
+| 文件 | 函数 | 修改类型 |
+|------|------|---------|
+| `qwen_engine.hpp` | `prefill()` | 添加 `slot_id` 参数 (default 0) |
+| `qwen_engine.hpp` | `decode_step()` | 添加 `slot_id` 参数 (default 0) |
+| `qwen_engine.cpp` | `prefill()` | 传递 `slot_id` 到 `run_chunk()` |
+| `qwen_engine.cpp` | `decode_step()` | 传递 `slot_id` 到 `run_chunk()` |
+| `qwen_engine.cpp` | `run_chunk()` | 添加 `slot_id` 参数 (default 0) |
+| `qwen_engine.cpp` | `run_chunk()` | 传递 `slot_id` 到 `layer_forward()` |
+| `qwen_engine.cpp` | `layer_forward()` | 添加 `slot_id` 参数 |
+| `qwen_engine.cpp` | `layer_forward()` | 传递 `slot_id` 到 `full_attention()` |
+| `qwen_engine.cpp` | `full_attention()` | 添加 `slot_id` 参数 |
+| `qwen_engine.cpp` | `full_attention()` | 使用 `slot_id` 计算 offset |
+| `qwen_engine.cpp` | `batch_prefill()` | 使用 `req->slot_id` |
+| `qwen_engine.cpp` | `batch_decode_step()` | 使用 `req->slot_id` |
+| `qwen_engine.cpp` | `Impl` | 移除 `current_slot_id` 全局状态 |
+| `qwen_engine.cpp` | `mtp_forward_rows()` | 传递 `slot_id=0` |
+| **总计** | **14 处修改** | |
+
+### 参数传递链
+
+| 层级 | 函数 | slot_id 来源 |
+|------|------|-------------|
+| 1 | `batch_prefill()` | `req->slot_id` |
+| 1 | `batch_decode_step()` | `req->slot_id` |
+| 2 | `prefill()` | 参数 (default 0) |
+| 2 | `decode_step()` | 参数 (default 0) |
+| 3 | `run_chunk()` | 参数 (default 0) |
+| 4 | `layer_forward()` | 参数 |
+| 5 | `full_attention()` | 参数 |
+| 6 | KV cache kernels | `kv_slot_offset_elements(slot_id, ...)` |
+
+---
+
+## 🔍 设计决策
+
+### 1. 显式参数传递 vs Thread-Local Storage
+
+**选择**: 显式参数传递
+
+**理由**:
+- ✅ 调用链清晰，易于追踪和调试
+- ✅ 线程安全，无隐藏状态
+- ✅ 测试友好，每个调用显式指定 slot
+- ✅ 符合 C++ 最佳实践（显式优于隐式）
+
+**Trade-off**:
+- ⚠️ 需要修改多个函数签名（一次性工作）
+- ⚠️ 参数列表变长（可接受，只增加 1 个参数）
+
+### 2. 默认参数 slot_id=0
+
+**选择**: 在公共 API 使用默认参数 `slot_id=0`
+
+**理由**:
+- ✅ 保持向后兼容性（单 session 代码无需修改）
+- ✅ 简化单 session 用法（不需要显式传递 0）
+- ✅ 清晰的语义（默认使用 slot 0）
+
+**适用范围**:
+- `prefill(tokens, slot_id=0)`
+- `decode_step(token, slot_id=0)`
+- `run_chunk(..., slot_id=0)`
+
+**不适用**:
+- `layer_forward()` - 内部函数，必须显式传递
+- `full_attention()` - 内部函数，必须显式传递
+
+### 3. MTP 使用 slot_id=0
+
+**选择**: MTP (Medusa-style Token Prediction) 始终使用 `slot_id=0`
+
+**理由**:
+- MTP 是单 session 特性（不支持 batch）
+- 简化实现，避免引入不必要的复杂性
+
+```cpp
+// mtp_forward_rows()
+layer_forward(mtp_layer, mtp_fused.f16_data(),
+              mtp_next_hidden.f16_data(), rows, position, 0);  // slot_id=0
+```
+
+---
+
+## 🧪 编译验证
+
+### ✅ 编译成功
+
+```bash
+cd build && make -j8 dsv4_cpp_engine
+[100%] Built target dsv4_cpp_engine
+```
+
+**结果**:
+- ✅ 无编译错误
+- ✅ 无警告
+- ✅ 二进制生成成功
+
+### 关键修复过程
+
+**问题 1**: `full_attention()` 中 `slot_id` 未定义  
+**修复**: 添加 `slot_id` 参数，从 `current_slot_id` 改为参数传递
+
+**问题 2**: `layer_forward()` 调用缺少 `slot_id` 参数  
+**修复**: 添加 `slot_id` 参数到函数签名，并更新所有调用点
+
+**问题 3**: `mtp_forward_rows()` 调用缺少 `slot_id` 参数  
+**修复**: 传递 `slot_id=0`（MTP 不支持 batch）
+
+---
+
+## 🎯 验收标准
+
+### Phase 3.3 最小可行产品 (MVP)
+
+- [x] ✅ **编译通过**: 无错误无警告
+- [x] ✅ **全局状态移除**: `current_slot_id` 已删除
+- [x] ✅ **参数传递链完整**: 从 batch API 到 kernel
+- [x] ✅ **向后兼容**: 单 session API 无需修改
+- [x] ✅ **Batch API 集成**: 使用 `req->slot_id`
+- [ ] ⏳ **功能测试**: 单 session parity（下一步）
+- [ ] ⏳ **Slot 隔离测试**: 不同 slot 互不干扰（下一步）
+
+### Phase 3.3 完整目标
+
+- [x] ✅ **代码完成**: 所有实现完成
+- [x] ✅ **编译验证**: 成功通过
+- [x] ✅ **KV cache 寻址无全局状态**: `slot_id` 全程显式
+- [ ] ⏳ **单 session parity**: 与 Phase 3.2 一致
+- [ ] ⏳ **2-slot 正确性**: 独立生成验证
+- [ ] ⏳ **性能零回归**: ≤1.05× baseline
+
+---
+
+## ⚠️ 已知限制（Phase 3.3 未覆盖）
+
+本阶段只做了 **KV cache 寻址** 的 slot 化，引擎仍有其他单 session 状态没有按 slot 拆分。
+换句话说：**slot_id 让不同请求写到 KV cache 的不同区域，但还不足以让两个请求真正并行推进。**
+
+| 共享状态 | 位置 | 影响 |
+|---------|------|------|
+| `position_` | `QwenEngine` 成员 | 所有 slot 共用一个位置计数器；交替 decode 两个请求会串位 |
+| `cached_prompt` / `cached_result_` | `Impl` / `QwenEngine` | prefix cache 是单份，跨 slot 会互相污染 |
+| `snapshots` | `Impl` | 快照不带 slot 维度 |
+| workspace / `begin_workspace()` | `Impl` | 单份临时缓冲，串行执行下安全，真并发不安全 |
+
+因此当前 `batch_prefill` / `batch_decode_step` **仍必须串行执行**（现有实现正是逐请求 for 循环），
+"线程安全" 只对 `slot_id` 这一路参数成立，不代表整个引擎可并发调用。
+
+Phase 3.4 之后需要把 `position_` 与 prefix cache 状态也做成 per-slot（例如 `std::vector<SlotState>`），
+才能声明多请求并发正确。测试时对每个 slot 独立跑完整序列，不要交替 decode，否则失败来自
+`position_` 而不是 KV cache 寻址。
+
+---
+
+## 📋 下一步工作
+
+### Phase 3.4: 功能测试和验证
+
+#### Test 1: 单 Session Parity
+
+```python
+def test_single_session_parity_phase33():
+    """验证 Phase 3.3 与 Phase 3.2 结果一致"""
+    engine = QwenEngine(config, options)
+    
+    prompt = [1, 2, 3, 4, 5]
+    
+    # 不传 slot_id（使用默认 0）
+    result1 = engine.prefill(prompt)
+    tokens1 = [result1.next_token]
+    for _ in range(10):
+        result1 = engine.decode_step(tokens1[-1])
+        tokens1.append(result1.next_token)
+    
+    # 显式传 slot_id=0
+    engine.reset()
+    result2 = engine.prefill(prompt, 0)
+    tokens2 = [result2.next_token]
+    for _ in range(10):
+        result2 = engine.decode_step(tokens2[-1], 0)
+        tokens2.append(result2.next_token)
+    
+    # 应该完全一致
+    assert tokens1 == tokens2
+```
+
+#### Test 2: Slot 隔离性
+
+```python
+def test_slot_isolation_phase33():
+    """验证不同 slot 互不干扰"""
+    engine = QwenEngine(config, options)
+    engine.allocate_batch_slots(2)
+    
+    prompt_a = [1, 2, 3]
+    prompt_b = [4, 5, 6]
+    
+    # 在 slot 0 中预填充
+    result_a = engine.prefill(prompt_a, slot_id=0)
+    
+    # 在 slot 1 中预填充
+    result_b = engine.prefill(prompt_b, slot_id=1)
+    
+    # 在 slot 0 中解码
+    tokens_a = [result_a.next_token]
+    for _ in range(5):
+        result = engine.decode_step(tokens_a[-1], slot_id=0)
+        tokens_a.append(result.next_token)
+    
+    # 在 slot 1 中解码
+    tokens_b = [result_b.next_token]
+    for _ in range(5):
+        result = engine.decode_step(tokens_b[-1], slot_id=1)
+        tokens_b.append(result.next_token)
+    
+    # slot 0 和 slot 1 应该生成不同的序列
+    assert tokens_a != tokens_b
+    
+    # 验证 slot 0 的状态未被 slot 1 影响
+    # 继续在 slot 0 中解码，应该延续之前的序列
+    result = engine.decode_step(tokens_a[-1], slot_id=0)
+    # ... 进一步验证
+```
+
+#### Test 3: Batch API 正确性
+
+```python
+def test_batch_api_phase33():
+    """验证 batch API 使用正确的 slot_id"""
+    engine = QwenEngine(config, options)
+    engine.allocate_batch_slots(2)
+    
+    req1 = QwenBatchedRequest(
+        request_id=1,
+        prompt_tokens=[1, 2, 3],
+        slot_id=engine.allocate_slot(1),
+        sampling=default_sampling
+    )
+    
+    req2 = QwenBatchedRequest(
+        request_id=2,
+        prompt_tokens=[4, 5, 6],
+        slot_id=engine.allocate_slot(2),
+        sampling=default_sampling
+    )
+    
+    # Batch prefill
+    result = engine.batch_prefill([req1, req2])
+    assert len(result.results) == 2
+    
+    # Batch decode
+    for _ in range(10):
+        result = engine.batch_decode_step([req1, req2])
+        assert len(result.next_tokens) == 2
+    
+    # 验证两个请求生成了不同的序列
+    assert req1.generated_tokens != req2.generated_tokens
+```
+
+#### Test 4: 性能回归测试
+
+```python
+def test_performance_regression():
+    """验证 Phase 3.3 性能无回归"""
+    engine = QwenEngine(config, options)
+    
+    prompt = list(range(100))
+    
+    # Warmup
+    for _ in range(5):
+        engine.reset()
+        engine.prefill(prompt)
+    
+    # Benchmark
+    times = []
+    for _ in range(20):
+        engine.reset()
+        start = time.time()
+        engine.prefill(prompt)
+        times.append(time.time() - start)
+    
+    avg_time = sum(times) / len(times)
+    
+    # 应该 ≤ Phase 3.2 baseline 的 1.05×
+    # (实际应该完全一致，因为默认参数没有运行时开销)
+    assert avg_time <= baseline_time * 1.05
+```
+
+---
+
+## 💡 技术亮点
+
+### 1. 零开销的默认参数
+
+```cpp
+// 编译器优化
+QwenForwardResult prefill(const std::vector<int>& tokens, int slot_id = 0);
+
+// 调用：engine.prefill(tokens)
+// 等价于：engine.prefill(tokens, 0)
+// 编译后：直接传递常量 0，无额外开销
+```
+
+### 2. 清晰的调用链
+
+显式参数传递使调用链一目了然：
+
+```cpp
+// 从 batch API 到 kernel，slot_id 清晰可见
+batch_prefill(req) 
+  → prefill(req->prompt_tokens, req->slot_id)
+    → run_chunk(..., slot_id)
+      → layer_forward(..., slot_id)
+        → full_attention(..., slot_id)
+          → kernel(..., ptr + kv_slot_offset_elements(slot_id, ...))
+```
+
+### 3. slot 寻址不再依赖共享状态
+
+每个调用携带自己的 `slot_id`，KV cache 寻址路径上没有可变共享状态：
+
+```cpp
+// Phase 3.2 (slot 靠全局变量传递)
+impl_->current_slot_id = 0;  // Global write
+full_attention(...);          // Read from global
+
+// Phase 3.3 (slot 显式传参)
+full_attention(..., slot_id);  // Explicit parameter, no shared state
+```
+
+注意这只解决了 `slot_id` 这一路。`position_`、prefix cache 和 workspace 仍是单份共享状态，
+所以引擎整体还不能并发调用（见「已知限制」）。
+
+---
+
+## 🔗 相关文档
+
+- **实施计划**: `docs/phase3_3_implementation_plan.md`
+- **Phase 3.2 总结**: `docs/phase3_2_completion_summary.md`
+- **Phase 3.1 总结**: `docs/phase3_1_completion_summary.md`
+- **总体架构**: `docs/cpp_engine_batching_phase3_1.md`
+
+---
+
+## ✅ 总结
+
+Phase 3.3 成功实现了 **Slot ID Threading and Batch API Integration**：
+
+1. ✅ **消除 slot 全局状态** - `current_slot_id` 已移除，寻址路径无共享可变状态
+2. ✅ **完整参数传递链** - 从 batch API 到 kernel 清晰可追踪
+3. ✅ **向后兼容** - 单 session API 无需修改，默认参数 `slot_id=0`
+4. ✅ **Batch API 集成** - 使用 `req->slot_id` 隔离 KV cache
+5. ✅ **编译成功** - 无错误，可继续迭代
+
+**下一步**: Phase 3.4 实施功能测试，验证正确性和性能。
+
+---
+
+**编译输出**:
+```
+[100%] Built target dsv4_cpp_engine
+```
+
+**代码状态**: 已完成，待测试 ✅

--- a/docs/phase3_3_implementation_plan.md
+++ b/docs/phase3_3_implementation_plan.md
@@ -1,0 +1,355 @@
+# Phase 3.3 Implementation Plan: Slot ID Threading and Batch API Integration
+
+## 目标
+
+将 `slot_id` 从全局状态（`current_slot_id`）改为显式参数传递，实现线程安全的多 slot 管理，并集成到 batch API 中。
+
+## 当前问题
+
+Phase 3.2 使用全局 `current_slot_id`：
+
+```cpp
+struct QwenEngine::Impl {
+    int current_slot_id = 0;  // Global state - not thread-safe!
+};
+
+void full_attention(...) {
+    const int slot_id = current_slot_id;  // Read from global
+    const size_t slot_offset = kv_slot_offset_elements(slot_id, ...);
+    // Use slot_offset in kernel calls
+}
+```
+
+**问题**：
+- ❌ 不是线程安全的
+- ❌ 难以追踪哪个请求使用哪个 slot
+- ❌ 测试和调试困难
+
+## 解决方案：显式参数传递
+
+### 策略
+
+采用自底向上的修改策略：
+1. 从最底层的 `full_attention()` 开始添加 `slot_id` 参数
+2. 逐层向上传递到 `run_chunk()` → `prefill()` / `decode_step()`
+3. 最后在 batch API 中调用时传递 `req->slot_id`
+
+### 实施步骤
+
+## Step 1: 修改 full_attention() 添加 slot_id 参数
+
+```cpp
+// Before
+void full_attention(DeviceLayer& layer, const uint16_t* gate,
+                   uint16_t* merged, int rows, int position_offset);
+
+// After
+void full_attention(DeviceLayer& layer, const uint16_t* gate,
+                   uint16_t* merged, int rows, int position_offset,
+                   int slot_id);  // New parameter
+```
+
+**修改内容**：
+```cpp
+void full_attention(..., int slot_id) {
+    // Remove: const int slot_id = current_slot_id;
+    const size_t slot_offset = kv_slot_offset_elements(slot_id, kv_heads, head_dim);
+    // Rest remains the same
+}
+```
+
+## Step 2: 修改 run_chunk() 添加 slot_id 参数
+
+```cpp
+// Before
+void run_chunk(const int* tokens, int start_row, int row_count,
+               uint16_t* logits_out);
+
+// After
+void run_chunk(const int* tokens, int start_row, int row_count,
+               uint16_t* logits_out, int slot_id);  // New parameter
+```
+
+**调用 full_attention()**：
+```cpp
+void run_chunk(..., int slot_id) {
+    // ... existing code ...
+    
+    if (has_full_attention) {
+        full_attention(layer, gate.data(), merged.data(), 
+                      row_count, position, slot_id);  // Pass slot_id
+    }
+    
+    // ... rest of code ...
+}
+```
+
+## Step 3: 修改 prefill() 和 decode_step() 添加 slot_id 参数
+
+```cpp
+// Before
+QwenForwardResult prefill(const std::vector<int>& tokens);
+QwenForwardResult decode_step(int token);
+
+// After
+QwenForwardResult prefill(const std::vector<int>& tokens, int slot_id = 0);
+QwenForwardResult decode_step(int token, int slot_id = 0);
+```
+
+**使用默认参数保持向后兼容**：
+- 单 session 模式：`prefill(tokens)` → slot_id = 0
+- Multi-slot 模式：`prefill(tokens, req->slot_id)` → 显式传递
+
+**实现**：
+```cpp
+QwenForwardResult QwenEngine::prefill(const std::vector<int>& tokens, int slot_id) {
+    // ... existing validation ...
+    
+    for (size_t chunk_start = 0; chunk_start < tokens.size(); chunk_start += chunk_size) {
+        int chunk_tokens = std::min(chunk_size, 
+                                   static_cast<int>(tokens.size() - chunk_start));
+        impl_->run_chunk(tokens.data() + chunk_start, position_, 
+                        chunk_tokens, logits.data(), slot_id);  // Pass slot_id
+        position_ += chunk_tokens;
+    }
+    
+    // ... rest of code ...
+}
+
+QwenForwardResult QwenEngine::decode_step(int token, int slot_id) {
+    // ... existing code ...
+    impl_->run_chunk(&token, position_, 1, logits.data(), slot_id);  // Pass slot_id
+    position_++;
+    // ... rest of code ...
+}
+```
+
+## Step 4: 更新头文件声明
+
+```cpp
+// qwen_engine.hpp
+class QwenEngine {
+public:
+    // ... existing methods ...
+    
+    // Single-session API (backward compatible)
+    QwenForwardResult prefill(const std::vector<int>& tokens, int slot_id = 0);
+    QwenForwardResult decode_step(int token, int slot_id = 0);
+    
+    // Batch API (Phase 3.1)
+    QwenBatchPrefillResult batch_prefill(const std::vector<QwenBatchedRequest*>& requests);
+    QwenBatchDecodeResult batch_decode_step(const std::vector<QwenBatchedRequest*>& requests);
+};
+```
+
+## Step 5: 修改 batch API 使用 slot_id
+
+```cpp
+QwenBatchPrefillResult QwenEngine::batch_prefill(
+    const std::vector<QwenBatchedRequest*>& requests) {
+    
+    QwenBatchPrefillResult result;
+    
+    for (QwenBatchedRequest* req : requests) {
+        if (req->finished) continue;
+        
+        // Save and restore position for isolation
+        const int saved_position = position_;
+        position_ = req->seq_len;
+        
+        // Use req->slot_id for this request
+        QwenForwardResult fwd_result = prefill(req->prompt_tokens, req->slot_id);
+        
+        req->seq_len = position_;
+        req->last_token = fwd_result.next_token;
+        req->last_result = fwd_result;
+        
+        result.last_tokens.push_back(fwd_result.next_token);
+        result.prompt_lengths.push_back(req->prompt_tokens.size());
+        
+        // Restore position
+        position_ = saved_position;
+    }
+    
+    return result;
+}
+
+QwenBatchDecodeResult QwenEngine::batch_decode_step(
+    const std::vector<QwenBatchedRequest*>& requests) {
+    
+    QwenBatchDecodeResult result;
+    
+    for (QwenBatchedRequest* req : requests) {
+        if (req->finished) {
+            result.next_tokens.push_back(req->last_token);
+            result.finished.push_back(true);
+            continue;
+        }
+        
+        // Save and restore position
+        const int saved_position = position_;
+        position_ = req->seq_len;
+        
+        // Use req->slot_id for this request
+        QwenForwardResult fwd_result = decode_step(req->last_token, req->slot_id);
+        
+        req->seq_len = position_;
+        req->last_token = fwd_result.next_token;
+        req->generated_tokens.push_back(fwd_result.next_token);
+        
+        // Check completion
+        bool is_finished = (req->generated_tokens.size() >= 
+                           static_cast<size_t>(req->sampling.max_new_tokens));
+        req->finished = is_finished;
+        
+        result.next_tokens.push_back(fwd_result.next_token);
+        result.finished.push_back(is_finished);
+        
+        // Restore position
+        position_ = saved_position;
+    }
+    
+    return result;
+}
+```
+
+## Step 6: 移除 current_slot_id
+
+```cpp
+// qwen_engine.cpp Impl
+struct QwenEngine::Impl {
+    // ... existing fields ...
+    
+    // REMOVED: int current_slot_id = 0;  // No longer needed
+    
+    // ... rest of code ...
+};
+```
+
+## 验证清单
+
+### 编译验证
+- [ ] 所有修改的函数签名匹配
+- [ ] 默认参数正确应用
+- [ ] 无编译错误或警告
+
+### 功能验证
+- [ ] 单 session 模式：`prefill(tokens)` 使用 slot_id=0
+- [ ] 单 session parity：与 Phase 3.2 结果一致
+- [ ] Batch API：每个请求使用自己的 slot_id
+
+### 代码质量
+- [ ] 无全局状态（`current_slot_id` 已移除）
+- [ ] 线程安全（每个调用显式传递 slot_id）
+- [ ] 向后兼容（默认参数 `slot_id=0`）
+
+## 测试计划
+
+### Test 1: 单 Session Parity
+
+```python
+def test_single_session_parity():
+    """验证 Phase 3.3 与 Phase 3.2 结果一致"""
+    engine = QwenEngine(config, options)
+    
+    prompt = [1, 2, 3, 4, 5]
+    result1 = engine.prefill(prompt)       # slot_id=0 (default)
+    result2 = engine.prefill(prompt, 0)    # slot_id=0 (explicit)
+    
+    assert result1.next_token == result2.next_token
+```
+
+### Test 2: Slot 隔离性
+
+```python
+def test_slot_isolation():
+    """验证不同 slot 互不干扰"""
+    engine = QwenEngine(config, options)
+    engine.allocate_batch_slots(2)
+    
+    prompt_a = [1, 2, 3]
+    prompt_b = [4, 5, 6]
+    
+    # 在 slot 0 中生成
+    result_a = engine.prefill(prompt_a, slot_id=0)
+    token_a1 = engine.decode_step(result_a.next_token, slot_id=0).next_token
+    
+    # 在 slot 1 中生成
+    result_b = engine.prefill(prompt_b, slot_id=1)
+    token_b1 = engine.decode_step(result_b.next_token, slot_id=1).next_token
+    
+    # 再次在 slot 0 中生成（应该延续之前的状态）
+    token_a2 = engine.decode_step(token_a1, slot_id=0).next_token
+    
+    # slot 0 和 slot 1 应该生成不同的 tokens
+    assert token_a1 != token_b1
+```
+
+### Test 3: Batch API 正确性
+
+```python
+def test_batch_api_with_slots():
+    """验证 batch API 使用正确的 slot_id"""
+    engine = QwenEngine(config, options)
+    engine.allocate_batch_slots(2)
+    
+    req1 = QwenBatchedRequest(
+        request_id=1,
+        prompt_tokens=[1, 2, 3],
+        slot_id=0,
+        sampling=default_sampling
+    )
+    
+    req2 = QwenBatchedRequest(
+        request_id=2,
+        prompt_tokens=[4, 5, 6],
+        slot_id=1,
+        sampling=default_sampling
+    )
+    
+    # Batch prefill
+    result = engine.batch_prefill([req1, req2])
+    assert len(result.last_tokens) == 2
+    
+    # Batch decode
+    for _ in range(10):
+        result = engine.batch_decode_step([req1, req2])
+        assert len(result.next_tokens) == 2
+```
+
+## 向后兼容性
+
+**单 session 代码无需修改**：
+```cpp
+// Phase 3.2 code
+QwenForwardResult result = engine.prefill(tokens);
+int next = engine.decode_step(result.next_token).next_token;
+
+// Phase 3.3 code (same!)
+QwenForwardResult result = engine.prefill(tokens);  // slot_id=0 (default)
+int next = engine.decode_step(result.next_token).next_token;  // slot_id=0 (default)
+```
+
+**Batch API 使用显式 slot_id**：
+```cpp
+// Phase 3.3
+req->slot_id = engine.allocate_slot(req->request_id);
+QwenForwardResult result = engine.prefill(req->prompt_tokens, req->slot_id);
+```
+
+## 实施顺序
+
+1. ✅ Step 1: 修改 `full_attention()` 添加 `slot_id` 参数
+2. ✅ Step 2: 修改 `run_chunk()` 添加 `slot_id` 参数
+3. ✅ Step 3: 修改 `prefill()` 和 `decode_step()` 添加 `slot_id` 参数
+4. ✅ Step 4: 更新头文件声明
+5. ✅ Step 5: 修改 batch API 使用 `req->slot_id`
+6. ✅ Step 6: 移除 `current_slot_id` 全局状态
+7. ⏳ Step 7: 编译测试
+8. ⏳ Step 8: 功能测试
+
+**预计时间**: 2-3 小时
+
+---
+
+**开始实施**: Phase 3.3 Step 1


### PR DESCRIPTION
## What

Phase 3.2 stored the active KV cache slot in a mutable `Impl::current_slot_id` member that `full_attention` read back when computing its offset. Slot selection was an out-of-band side channel — the caller had to remember to set it, and nothing in the signatures revealed that attention depended on it.

`slot_id` is now an explicit parameter along the whole chain:

```
batch_prefill / batch_decode_step  (req->slot_id)
  -> prefill / decode_step         (slot_id = 0)
  -> run_chunk                     (slot_id = 0)
  -> layer_forward                 (slot_id)
  -> full_attention                (slot_id)
  -> kv_slot_offset_elements(slot_id, ...)
```

- Public entry points (`prefill`, `decode_step`, `run_chunk`) default to slot 0, so single-session callers compile and behave unchanged.
- Internal helpers (`layer_forward`, `full_attention`) take it unconditionally, so a new call site cannot silently inherit the wrong slot.
- `mtp_forward_rows` passes 0 explicitly — MTP is single-session only.
- `batch_prefill` / `batch_decode_step` now pass `req->slot_id` instead of routing every request through slot 0.

## Scope and what is *not* fixed

This covers **KV cache addressing only**. The engine still has one-per-engine state that is not slot-partitioned:

| Shared state | Location | Consequence |
|---|---|---|
| `position_` | `QwenEngine` member | one position counter for all slots; interleaving decode across two requests desyncs positions |
| `cached_prompt` / `cached_result_` | `Impl` / `QwenEngine` | prefix cache is single-copy, cross-slot pollution |
| `snapshots` | `Impl` | no slot dimension |
| workspace | `Impl` | single scratch buffer, safe only under serial execution |

So `batch_prefill` / `batch_decode_step` must remain sequential (they are — a per-request `for` loop), and the engine is **not** safe to call concurrently. Phase 3.4 needs to make `position_` and the prefix cache per-slot before multi-request concurrency can be claimed. A test that interleaves decode across slots will fail on `position_`, not on slot addressing.

## Verification

- Clean recompile of `qwen_engine.cpp` and full link, no errors or warnings.
- Functional tests are **not** included: single-session parity, 2-slot isolation, and the zero-overhead performance check are all still pending, tracked in `docs/phase3_3_completion_summary.md`.

## Files

- `cpp_engine/engine/qwen_engine.cpp` — signature threading, removal of `current_slot_id`, batch API wiring
- `cpp_engine/include/qwen_engine.hpp` — `slot_id = 0` on the two public entry points
- `docs/phase3_3_implementation_plan.md`, `docs/phase3_3_completion_summary.md`