### PR TITLE
Isolate per-slot prefix cache state for Qwen batching

### DIFF
--- a/cpp_engine/engine/qwen_batch_scheduler.cpp
+++ b/cpp_engine/engine/qwen_batch_scheduler.cpp
@@ -1,5 +1,6 @@
 #include "qwen_batch_scheduler.hpp"
 #include "qwen_engine.hpp"
+#include "device_runtime.hpp"
 #include <iostream>
 #include <algorithm>
 
@@ -142,6 +143,17 @@ QwenBatchScheduler::Stats QwenBatchScheduler::get_stats() const {
 }
 
 void QwenBatchScheduler::schedule_loop() {
+    // The current device is per-thread, and the engine bound it on the thread
+    // that constructed it.  This loop runs every forward pass from its own
+    // thread, so it has to bind the same device before touching device memory.
+    if (!device_set(engine_->options().device)) {
+        std::cerr << "QwenBatchScheduler: failed to select device "
+                  << engine_->options().device
+                  << "; scheduler thread stopping" << std::endl;
+        running_.store(false);
+        return;
+    }
+
     while (running_.load()) {
         try {
             admit_requests();
@@ -325,17 +337,25 @@ void QwenBatchScheduler::run_decode_batch() {
 
 void QwenBatchScheduler::handle_completions() {
     std::vector<std::unique_ptr<SchedulerRequest>> completed;
+    std::vector<bool> cancelled_completions;
 
     {
         std::lock_guard<std::mutex> lock(queue_mutex_);
 
-        // Find completed or cancelled requests
+        // Find completed or cancelled requests.  Moving the unique_ptr out of the
+        // map leaves the mapped value null, so read every field this loop and the
+        // erase pass need *before* the move rather than through the moved-from
+        // slot.
         std::vector<int> slots_to_remove;
         for (auto& [slot_id, req] : slot_to_request_) {
-            bool is_cancelled = cancelled_requests_.count(req->request_id) > 0;
+            const uint64_t request_id = req->request_id;
+            const bool is_cancelled = cancelled_requests_.count(request_id) > 0;
 
             if (req->finished || is_cancelled) {
                 slots_to_remove.push_back(slot_id);
+                // The cancelled set is erased below and is guarded by this mutex,
+                // so the stats pass outside the lock cannot re-derive this.
+                cancelled_completions.push_back(is_cancelled);
 
                 // Record completion time
                 req->completion_time = std::chrono::steady_clock::now();
@@ -345,23 +365,22 @@ void QwenBatchScheduler::handle_completions() {
 
                 // Clean up cancelled set
                 if (is_cancelled) {
-                    cancelled_requests_.erase(req->request_id);
+                    cancelled_requests_.erase(request_id);
                 }
+
+                request_id_to_slot_.erase(request_id);
             }
         }
 
         // Remove from active maps
         for (int slot_id : slots_to_remove) {
-            auto it = slot_to_request_.find(slot_id);
-            if (it != slot_to_request_.end()) {
-                request_id_to_slot_.erase(it->second->request_id);
-                slot_to_request_.erase(it);
-            }
+            slot_to_request_.erase(slot_id);
         }
     }
 
     // Process completed requests (outside lock to avoid deadlock with callbacks)
-    for (auto& req : completed) {
+    for (size_t i = 0; i < completed.size(); ++i) {
+        auto& req = completed[i];
         // Free slot
         if (req->slot_id >= 0) {
             engine_->free_slot(req->request_id);
@@ -371,8 +390,7 @@ void QwenBatchScheduler::handle_completions() {
         notify_result(req.get());
 
         // Update stats
-        bool was_cancelled = cancelled_requests_.count(req->request_id) > 0;
-        if (was_cancelled) {
+        if (cancelled_completions[i]) {
             total_cancelled_.fetch_add(1);
         } else {
             total_completed_.fetch_add(1);

--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -505,13 +505,56 @@ struct QwenEngine::Impl {
     uint64_t cache_data_bytes = 0;
     uint64_t cache_scale_bytes = 0;
     QwenRuntimeTelemetry telemetry;
-    // Prompt whose KV cache and recurrent state are currently materialized.
-    std::vector<int> cached_prompt;
-    // Ordered by ascending position. Index 0 is always the implicit empty
-    // state, which is not stored.
-    std::vector<QwenRecurrentSnapshot> snapshots;
+
+    // Prefix-reuse bookkeeping for one KV slot.  Every field describes the state
+    // materialized in that slot's rows, so it has to be per-slot: a single shared
+    // copy lets one sequence's tokens be matched as another's prefix, and the
+    // reuse then resumes from recurrent state that belongs to a different
+    // sequence.  Snapshots are per-slot for the same reason, and because
+    // capture/restore address one slot's rows.
+    struct SlotPrefixState {
+        // Prompt whose KV cache and recurrent state are currently materialized.
+        std::vector<int> cached_prompt;
+        // Ordered by ascending position. Index 0 is always the implicit empty
+        // state, which is not stored.
+        std::vector<QwenRecurrentSnapshot> snapshots;
+        QwenForwardResult cached_result;
+        bool has_cached_result = false;
+    };
+    std::vector<SlotPrefixState> slot_prefix;
+    // Hit/miss counters stay engine-wide: they are reported as one aggregate
+    // statistic and carry no per-sequence correctness meaning.
     int prefix_hits = 0;
     int prefix_misses = 0;
+
+    SlotPrefixState& prefix_for(int slot_id) {
+        if (slot_id < 0 || slot_id >= static_cast<int>(slot_prefix.size())) {
+            throw std::runtime_error("Qwen prefix state slot " +
+                                     std::to_string(slot_id) + " is out of range");
+        }
+        return slot_prefix[static_cast<size_t>(slot_id)];
+    }
+
+    // Position of one slot's sequence.  Outside batch mode there is only the
+    // engine-wide position_, which the caller passes in as the fallback so the
+    // single-session path keeps behaving exactly as before.
+    int slot_position(int slot_id, int engine_position) const {
+        if (!batch_mode_enabled || slot_id < 0 ||
+            slot_id >= static_cast<int>(slot_positions.size())) {
+            return engine_position;
+        }
+        return slot_positions[static_cast<size_t>(slot_id)];
+    }
+
+    // Records a slot's new position.  engine_position is updated too because the
+    // non-batch code paths and telemetry still read position_.
+    void set_slot_position(int slot_id, int position, int& engine_position) {
+        engine_position = position;
+        if (batch_mode_enabled && slot_id >= 0 &&
+            slot_id < static_cast<int>(slot_positions.size())) {
+            slot_positions[static_cast<size_t>(slot_id)] = position;
+        }
+    }
 
     // ========== Batch slot management (Phase 3.1) ==========
     int max_batch_size = 1;  // Default single session
@@ -555,6 +598,20 @@ struct QwenEngine::Impl {
         const uint64_t slots = tensor.shape.empty() ? 1 : tensor.shape[0];
         if (slots <= 1) return tensor.nbytes;
         return tensor.nbytes / static_cast<size_t>(slots);
+    }
+
+    // Byte offset of one slot's rows within a recurrent tensor.  Snapshot
+    // capture and restore both need it so they touch only the slot they were
+    // asked about; addressing slot 0 unconditionally would copy another
+    // sequence's state.
+    static size_t recurrent_slot_offset(const QwenDeviceTensor& tensor, int slot_id) {
+        if (tensor.data == nullptr || tensor.nbytes == 0) return 0;
+        const uint64_t slots = tensor.shape.empty() ? 1 : tensor.shape[0];
+        if (slots <= 1) return 0;
+        if (slot_id < 0 || static_cast<uint64_t>(slot_id) >= slots) {
+            throw std::runtime_error("Qwen recurrent slot index out of range");
+        }
+        return static_cast<size_t>(slot_id) * (tensor.nbytes / static_cast<size_t>(slots));
     }
 
     void ensure_nccl_comm_stream() {
@@ -626,6 +683,8 @@ struct QwenEngine::Impl {
         max_batch_size = options_.max_batch_size;
         batch_mode_enabled = (max_batch_size > 1);
         slot_positions.resize(max_batch_size, 0);  // Phase 3.4: per-slot positions
+        // One prefix-reuse record per slot, sized with the KV arena.
+        slot_prefix.resize(static_cast<size_t>(max_batch_size));
         // Phase 3.4: The KV arena is sized here, so the free list must be
         // seeded here as well. Seeding it only from allocate_batch_slots()
         // left the batch API unreachable: that function throws once
@@ -1288,7 +1347,7 @@ struct QwenEngine::Impl {
 
     QwenRecurrentSnapshot capture_recurrent_state(
         int position, const QwenForwardResult* result = nullptr,
-        bool periodic = false) {
+        bool periodic = false, int slot_id = 0) {
         QwenRecurrentSnapshot snapshot;
         snapshot.position = position;
         snapshot.periodic = periodic;
@@ -1296,8 +1355,7 @@ struct QwenEngine::Impl {
             snapshot.result = *result;
             snapshot.has_result = true;
         }
-        // Phase 3.4: One slot's worth per layer. The prefix cache is still
-        // single-session (slot 0), so a snapshot must not size itself over the
+        // One slot's worth per layer: a snapshot must not size itself over the
         // whole multi-slot arena.
         size_t state_bytes = 0;
         size_t tail_bytes = 0;
@@ -1330,16 +1388,19 @@ struct QwenEngine::Impl {
         size_t tail_offset = 0;
         for (const DeviceLayer& layer : layers) {
             if (layer.linear.state.data == nullptr) continue;
-            // Slot 0 only: the prefix cache has no slot dimension yet.
             const size_t layer_state_bytes = recurrent_slot_bytes(layer.linear.state);
             const size_t layer_tail_bytes = recurrent_slot_bytes(layer.linear.conv_tail);
             check_device(memcpy_d2d(static_cast<uint8_t*>(snapshot.state.data) + state_offset,
-                                    layer.linear.state.data, layer_state_bytes),
+                                    static_cast<const uint8_t*>(layer.linear.state.data) +
+                                        recurrent_slot_offset(layer.linear.state, slot_id),
+                                    layer_state_bytes),
                          "Qwen recurrent state snapshot copy");
             state_offset += layer_state_bytes;
             if (layer_tail_bytes != 0) {
                 check_device(memcpy_d2d(static_cast<uint8_t*>(snapshot.conv_tail.data) + tail_offset,
-                                        layer.linear.conv_tail.data, layer_tail_bytes),
+                                        static_cast<const uint8_t*>(layer.linear.conv_tail.data) +
+                                            recurrent_slot_offset(layer.linear.conv_tail, slot_id),
+                                        layer_tail_bytes),
                              "Qwen convolution tail snapshot copy");
                 tail_offset += layer_tail_bytes;
             }
@@ -1348,7 +1409,8 @@ struct QwenEngine::Impl {
     }
 
     void restore_recurrent_state(const QwenRecurrentSnapshot& snapshot,
-                                 bool restore_target_hidden = true) {
+                                 bool restore_target_hidden = true,
+                                 int slot_id = 0) {
         size_t expected_state_bytes = 0;
         size_t expected_tail_bytes = 0;
         for (const DeviceLayer& layer : layers) {
@@ -1402,16 +1464,18 @@ struct QwenEngine::Impl {
         size_t tail_offset = 0;
         for (DeviceLayer& layer : layers) {
             if (layer.linear.state.data == nullptr) continue;
-            // Restores into slot 0 only, matching capture_recurrent_state.
+            // Restores into the requested slot, matching capture_recurrent_state.
             const size_t layer_state_bytes = recurrent_slot_bytes(layer.linear.state);
             const size_t layer_tail_bytes = recurrent_slot_bytes(layer.linear.conv_tail);
-            check_device(memcpy_d2d(layer.linear.state.data,
+            check_device(memcpy_d2d(static_cast<uint8_t*>(layer.linear.state.data) +
+                                        recurrent_slot_offset(layer.linear.state, slot_id),
                                     static_cast<const uint8_t*>(snapshot.state.data) + state_offset,
                                     layer_state_bytes),
                          "Qwen recurrent state snapshot restore");
             state_offset += layer_state_bytes;
             if (layer_tail_bytes != 0) {
-                check_device(memcpy_d2d(layer.linear.conv_tail.data,
+                check_device(memcpy_d2d(static_cast<uint8_t*>(layer.linear.conv_tail.data) +
+                                            recurrent_slot_offset(layer.linear.conv_tail, slot_id),
                                         static_cast<const uint8_t*>(snapshot.conv_tail.data) + tail_offset,
                                         layer_tail_bytes),
                              "Qwen convolution tail snapshot restore");
@@ -1423,14 +1487,15 @@ struct QwenEngine::Impl {
     // Keeps snapshots ordered and bounded. The newest position wins because a
     // monotonically growing prompt resumes from the deepest available point.
     void record_snapshot(int position, const QwenForwardResult* result = nullptr,
-                         bool periodic = false) {
+                         bool periodic = false, int slot_id = 0) {
         if (!options.prefix_cache ||
             options.state_snapshot_interval_tokens <= 0 ||
             options.max_state_snapshots <= 0 || position <= 0) {
             return;
         }
         if (!has_recurrent_state() && !mtp_enabled && !dspark_enabled) return;
-        for (QwenRecurrentSnapshot& entry : snapshots) {
+        std::vector<QwenRecurrentSnapshot>& ring = prefix_for(slot_id).snapshots;
+        for (QwenRecurrentSnapshot& entry : ring) {
             if (entry.position != position) continue;
             entry.periodic = entry.periodic || periodic;
             if (result != nullptr && !entry.has_result) {
@@ -1439,29 +1504,31 @@ struct QwenEngine::Impl {
             }
             return;
         }
-        snapshots.push_back(capture_recurrent_state(position, result, periodic));
-        std::sort(snapshots.begin(), snapshots.end(),
+        ring.push_back(capture_recurrent_state(position, result, periodic, slot_id));
+        std::sort(ring.begin(), ring.end(),
                   [](const QwenRecurrentSnapshot& a,
                      const QwenRecurrentSnapshot& b) {
                       return a.position < b.position;
                   });
         // Preserve periodic coverage. Request-boundary snapshots improve exact
         // repeats but are expendable; evict their oldest entries first.
-        while (static_cast<int>(snapshots.size()) > options.max_state_snapshots) {
+        // The budget is per slot, so a batch cannot let one sequence starve
+        // another's rollback points.
+        while (static_cast<int>(ring.size()) > options.max_state_snapshots) {
             auto evict = std::find_if(
-                snapshots.begin(), snapshots.end(),
+                ring.begin(), ring.end(),
                 [](const QwenRecurrentSnapshot& entry) {
                     return !entry.periodic;
                 });
-            if (evict == snapshots.end()) evict = snapshots.begin();
-            snapshots.erase(evict);
+            if (evict == ring.end()) evict = ring.begin();
+            ring.erase(evict);
         }
     }
 
     // Deepest snapshot at or before limit, or nullptr for the empty state.
-    const QwenRecurrentSnapshot* snapshot_at_or_before(int limit) const {
+    const QwenRecurrentSnapshot* snapshot_at_or_before(int limit, int slot_id = 0) {
         const QwenRecurrentSnapshot* best = nullptr;
-        for (const QwenRecurrentSnapshot& entry : snapshots) {
+        for (const QwenRecurrentSnapshot& entry : prefix_for(slot_id).snapshots) {
             if (entry.position <= limit &&
                 (best == nullptr || entry.position > best->position)) {
                 best = &entry;
@@ -1473,9 +1540,9 @@ struct QwenEngine::Impl {
     // A prompt result needs the hidden/logits for its final token. If the
     // chosen state is already after that token, use an earlier snapshot so the
     // final token is executed again rather than returning stale logits.
-    const QwenRecurrentSnapshot* snapshot_strictly_before(int limit) const {
+    const QwenRecurrentSnapshot* snapshot_strictly_before(int limit, int slot_id = 0) {
         const QwenRecurrentSnapshot* best = nullptr;
-        for (const QwenRecurrentSnapshot& entry : snapshots) {
+        for (const QwenRecurrentSnapshot& entry : prefix_for(slot_id).snapshots) {
             if (entry.position < limit &&
                 (best == nullptr || entry.position > best->position)) {
                 best = &entry;
@@ -1484,12 +1551,19 @@ struct QwenEngine::Impl {
         return best;
     }
 
+    // Totalled across slots: this is reported as engine-wide memory use.
     uint64_t snapshot_bytes() const {
         uint64_t total = 0;
-        for (const QwenRecurrentSnapshot& entry : snapshots) {
-            total += entry.bytes();
+        for (const SlotPrefixState& slot : slot_prefix) {
+            for (const QwenRecurrentSnapshot& entry : slot.snapshots) {
+                total += entry.bytes();
+            }
         }
         return total;
+    }
+
+    int snapshot_count(int slot_id) {
+        return static_cast<int>(prefix_for(slot_id).snapshots.size());
     }
 
     // Snapshots let a later shorter-prefix or branched request resume mid-prompt,
@@ -1546,13 +1620,14 @@ struct QwenEngine::Impl {
         return std::min(next_regular, next_early);
     }
 
-    void drop_snapshots_after(int position) {
-        snapshots.erase(
-            std::remove_if(snapshots.begin(), snapshots.end(),
+    void drop_snapshots_after(int position, int slot_id = 0) {
+        std::vector<QwenRecurrentSnapshot>& ring = prefix_for(slot_id).snapshots;
+        ring.erase(
+            std::remove_if(ring.begin(), ring.end(),
                            [position](const QwenRecurrentSnapshot& entry) {
                                return entry.position > position;
                            }),
-            snapshots.end());
+            ring.end());
     }
 
     // Opt-in prefill phase attribution. Each scope synchronises the device, so it
@@ -4051,14 +4126,21 @@ void QwenEngine::reset() {
 
 void QwenEngine::clear_prefix_cache() {
     position_ = 0;
-    has_cached_result_ = false;
-    cached_result_ = QwenForwardResult{};
     prefix_stats_ = QwenPrefixCacheStats{};
-    impl_->cached_prompt.clear();
-    impl_->snapshots.clear();
+    // Every slot's reuse state, not just slot 0's: a stale entry on any slot
+    // would survive the clear and be matched by the next request there.
+    for (Impl::SlotPrefixState& slot : impl_->slot_prefix) {
+        slot.cached_prompt.clear();
+        slot.snapshots.clear();
+        slot.cached_result = QwenForwardResult{};
+        slot.has_cached_result = false;
+    }
+    std::fill(impl_->slot_positions.begin(), impl_->slot_positions.end(), 0);
     impl_->prefix_hits = 0;
     impl_->prefix_misses = 0;
-    impl_->zero_recurrent_state();
+    for (int slot = 0; slot < impl_->max_batch_size; ++slot) {
+        impl_->zero_recurrent_state(slot);
+    }
     // KV storage is overwritten before it is read. Avoid clearing several GiB
     // on every request; position_ bounds all attention reads.
 }
@@ -4156,6 +4238,11 @@ QwenBatchPrefillResult QwenEngine::batch_prefill(
             throw std::runtime_error("QwenEngine::batch_prefill: invalid request");
         }
 
+        // Under TP the workers sit in run_worker_loop() waiting to be told which
+        // collective to join; rank 0 must announce the op before running it, or
+        // the group deadlocks with rank 0 computing alone.  No-op at world size 1.
+        worker_command_prefill(req->prompt_tokens, req->slot_id);
+
         // Phase 3.3: Use req->slot_id to isolate KV cache
         QwenForwardResult fwd_result = prefill(req->prompt_tokens, req->slot_id);
 
@@ -4195,6 +4282,10 @@ QwenBatchDecodeResult QwenEngine::batch_decode_step(
         if (!req) {
             throw std::runtime_error("QwenEngine::batch_decode_step: null request");
         }
+
+        // Announce before computing, as in batch_prefill: every rank has to enter
+        // the same collective in the same order.
+        worker_command_decode(req->last_token, req->slot_id);
 
         // Phase 3.3: Use req->slot_id to isolate KV cache
         QwenForwardResult fwd_result = decode_step(req->last_token, req->slot_id);
@@ -4239,17 +4330,19 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids, int slo
     prefix_stats_.prompt_tokens = static_cast<int>(token_ids.size());
     impl_->phase_seconds.clear();
     impl_->phase_calls.clear();
-    // Phase 3.4: cached_prompt, position_ and the snapshot ring still describe
-    // slot 0 only, so reuse is confined to it. Other slots always prefill cold;
-    // their recurrent state is isolated by the arena, which is what makes the
-    // result correct rather than merely uncached.
-    const bool can_reuse = options_.prefix_cache && slot_id == 0 &&
-        !impl_->cached_prompt.empty() && position_ ==
-            static_cast<int>(impl_->cached_prompt.size());
+    // Prefix reuse is scoped to this slot.  Each slot keeps its own cached
+    // prompt, snapshot ring and cached result, so a batch can reuse on every
+    // slot independently; sharing one copy would let a prompt match against
+    // another sequence's tokens and resume from its recurrent state.
+    Impl::SlotPrefixState& prefix = impl_->prefix_for(slot_id);
+    const int slot_position = impl_->slot_position(slot_id, position_);
+    const bool can_reuse = options_.prefix_cache &&
+        !prefix.cached_prompt.empty() && slot_position ==
+            static_cast<int>(prefix.cached_prompt.size());
     size_t common = 0;
     if (can_reuse) {
-        const size_t limit = std::min(token_ids.size(), impl_->cached_prompt.size());
-        while (common < limit && token_ids[common] == impl_->cached_prompt[common]) {
+        const size_t limit = std::min(token_ids.size(), prefix.cached_prompt.size());
+        while (common < limit && token_ids[common] == prefix.cached_prompt[common]) {
             ++common;
         }
     }
@@ -4257,20 +4350,20 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids, int slo
 
     // Exact repeat: the cached final logits are already the requested result.
     if (can_reuse && common == token_ids.size() &&
-        token_ids.size() == impl_->cached_prompt.size() && has_cached_result_) {
+        token_ids.size() == prefix.cached_prompt.size() && prefix.has_cached_result) {
         ++impl_->prefix_hits;
         prefix_stats_.hits = impl_->prefix_hits;
         prefix_stats_.misses = impl_->prefix_misses;
         prefix_stats_.reused_tokens = static_cast<int>(token_ids.size());
         prefix_stats_.resume_source = "live";
-        prefix_stats_.snapshots = static_cast<int>(impl_->snapshots.size());
+        prefix_stats_.snapshots = impl_->snapshot_count(slot_id);
         prefix_stats_.snapshot_bytes = impl_->snapshot_bytes();
-        return cached_result_;
+        return prefix.cached_result;
     }
 
     int start_position = 0;
     const QwenRecurrentSnapshot* resume_snapshot = nullptr;
-    if (can_reuse && common == impl_->cached_prompt.size() &&
+    if (can_reuse && common == prefix.cached_prompt.size() &&
         common <= token_ids.size()) {
         // The current recurrent state is exactly the state after the common
         // prefix. This is the hot path for monotonically growing prompts.
@@ -4282,32 +4375,32 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids, int slo
         // A request-boundary snapshot also carries the final-token result, so
         // an exact shorter-prefix request can finish without recomputation.
         resume_snapshot = impl_->snapshot_at_or_before(
-            static_cast<int>(common));
+            static_cast<int>(common), slot_id);
         if (resume_snapshot != nullptr &&
             resume_snapshot->position == static_cast<int>(common) &&
             resume_snapshot->has_result && token_ids.size() == common) {
-            impl_->restore_recurrent_state(*resume_snapshot);
-            position_ = static_cast<int>(common);
-            impl_->cached_prompt = token_ids;
-            cached_result_ = resume_snapshot->result;
-            has_cached_result_ = true;
-            impl_->drop_snapshots_after(position_);
+            impl_->restore_recurrent_state(*resume_snapshot, true, slot_id);
+            impl_->set_slot_position(slot_id, static_cast<int>(common), position_);
+            prefix.cached_prompt = token_ids;
+            prefix.cached_result = resume_snapshot->result;
+            prefix.has_cached_result = true;
+            impl_->drop_snapshots_after(static_cast<int>(common), slot_id);
             prefix_stats_.resume_source = "snapshot";
             prefix_stats_.reused_tokens = static_cast<int>(common);
-            prefix_stats_.snapshots = static_cast<int>(impl_->snapshots.size());
+            prefix_stats_.snapshots = impl_->snapshot_count(slot_id);
             prefix_stats_.snapshot_bytes = impl_->snapshot_bytes();
             ++impl_->prefix_hits;
             prefix_stats_.hits = impl_->prefix_hits;
             prefix_stats_.misses = impl_->prefix_misses;
-            return cached_result_;
+            return prefix.cached_result;
         }
         if (resume_snapshot != nullptr &&
             resume_snapshot->position == static_cast<int>(token_ids.size())) {
             resume_snapshot = impl_->snapshot_strictly_before(
-                static_cast<int>(token_ids.size()));
+                static_cast<int>(token_ids.size()), slot_id);
         }
         if (resume_snapshot != nullptr) {
-            impl_->restore_recurrent_state(*resume_snapshot);
+            impl_->restore_recurrent_state(*resume_snapshot, true, slot_id);
             start_position = resume_snapshot->position;
             prefix_stats_.resume_source = "snapshot";
             ++impl_->prefix_hits;
@@ -4316,14 +4409,14 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids, int slo
             prefix_stats_.resume_source = "empty";
             ++impl_->prefix_misses;
         }
-        if (slot_id == 0) impl_->drop_snapshots_after(start_position);
+        impl_->drop_snapshots_after(start_position, slot_id);
     } else {
         // Clears this slot's rows only; a concurrent request on another slot
         // keeps its state.
         impl_->zero_recurrent_state(slot_id);
         prefix_stats_.resume_source = "empty";
         if (can_reuse) ++impl_->prefix_misses;
-        if (slot_id == 0) impl_->drop_snapshots_after(0);
+        impl_->drop_snapshots_after(0, slot_id);
     }
 
     const int target_position = static_cast<int>(token_ids.size());
@@ -4384,7 +4477,7 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids, int slo
                                       snapshot_result, nullptr, nullptr, slot_id);
         }
         if (periodic_snapshot || end == target_position) {
-            impl_->record_snapshot(end, &result, periodic_snapshot);
+            impl_->record_snapshot(end, &result, periodic_snapshot, slot_id);
         }
 
         offset = end;
@@ -4395,23 +4488,18 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids, int slo
     if (start_position == target_position) {
         throw std::runtime_error("Qwen prefix cache failed to produce logits");
     }
-    position_ = target_position;
-    // Phase 3.4: Track per-slot position independently
-    if (impl_->batch_mode_enabled && slot_id >= 0 &&
-        slot_id < static_cast<int>(impl_->slot_positions.size())) {
-        impl_->slot_positions[static_cast<size_t>(slot_id)] = target_position;
-    }
+    impl_->set_slot_position(slot_id, target_position, position_);
     if (options_.prefix_cache) {
-        impl_->cached_prompt = token_ids;
-        cached_result_ = result;
-        has_cached_result_ = true;
+        prefix.cached_prompt = token_ids;
+        prefix.cached_result = result;
+        prefix.has_cached_result = true;
     } else {
-        impl_->cached_prompt.clear();
-        has_cached_result_ = false;
+        prefix.cached_prompt.clear();
+        prefix.has_cached_result = false;
     }
     prefix_stats_.reused_tokens = start_position;
     prefix_stats_.computed_tokens = target_position - start_position;
-    prefix_stats_.snapshots = static_cast<int>(impl_->snapshots.size());
+    prefix_stats_.snapshots = impl_->snapshot_count(slot_id);
     prefix_stats_.snapshot_bytes = impl_->snapshot_bytes();
     prefix_stats_.hits = impl_->prefix_hits;
     prefix_stats_.misses = impl_->prefix_misses;
@@ -4437,20 +4525,17 @@ QwenForwardResult QwenEngine::decode_step(int token_id, int slot_id) {
         {token_id}, current_position, active_layers_, true, nullptr, nullptr, slot_id);
 
     ++current_position;
-    position_ = current_position;
-
-    // Phase 3.4: Update per-slot position
-    if (impl_->batch_mode_enabled && slot_id >= 0 &&
-        slot_id < static_cast<int>(impl_->slot_positions.size())) {
-        impl_->slot_positions[static_cast<size_t>(slot_id)] = current_position;
-    }
+    impl_->set_slot_position(slot_id, current_position, position_);
 
     if (options_.prefix_cache) {
-        impl_->cached_prompt.push_back(token_id);
-        cached_result_ = result;
-        has_cached_result_ = true;
-        if (impl_->is_periodic_snapshot_position(position_)) {
-            impl_->record_snapshot(position_, &result, true);
+        // Appends to this slot's prompt only.  A shared buffer would splice the
+        // slots' token streams together and corrupt the next prefix match.
+        Impl::SlotPrefixState& prefix = impl_->prefix_for(slot_id);
+        prefix.cached_prompt.push_back(token_id);
+        prefix.cached_result = result;
+        prefix.has_cached_result = true;
+        if (impl_->is_periodic_snapshot_position(current_position)) {
+            impl_->record_snapshot(current_position, &result, true, slot_id);
         }
     }
     return result;
@@ -4551,12 +4636,15 @@ std::vector<QwenForwardResult> QwenEngine::generate(
         const int consumed = 1 + correct;
         position_ += consumed;
         if (options_.prefix_cache) {
-            impl_->cached_prompt.push_back(current_token);
-            impl_->cached_prompt.insert(impl_->cached_prompt.end(),
+            // generate() is the single-session speculative path and has no slot
+            // parameter, so it always drives slot 0.
+            Impl::SlotPrefixState& prefix = impl_->prefix_for(0);
+            prefix.cached_prompt.push_back(current_token);
+            prefix.cached_prompt.insert(prefix.cached_prompt.end(),
                                         next.accept_tokens.begin(),
                                         next.accept_tokens.end());
-            cached_result_ = next;
-            has_cached_result_ = true;
+            prefix.cached_result = next;
+            prefix.has_cached_result = true;
         }
 
         for (size_t index = 0; index < next.accept_tokens.size(); ++index) {
@@ -4607,12 +4695,17 @@ void QwenEngine::run_worker_loop() {
         // A failed collective leaves this rank out of step with rank 0, so the
         // loop must not continue past an error. Propagating exits the process
         // and lets the launcher tear the whole group down.
+        // header[2] carries the KV slot rank 0 is computing into.  A worker that
+        // ignored it would read and write slot 0 while rank 0 used another slot,
+        // so batched decode would silently cross-contaminate sequences.
+        const int slot_id = static_cast<int>(header[2]);
+
         switch (cmd) {
             case WorkerCommand::Prefill:
-                (void)prefill(tokens);
+                (void)prefill(tokens, slot_id);
                 break;
             case WorkerCommand::DecodeStep:
-                (void)decode_step(header[1]);
+                (void)decode_step(header[1], slot_id);
                 break;
             case WorkerCommand::Reset:
                 reset();
@@ -4624,7 +4717,8 @@ void QwenEngine::run_worker_loop() {
     }
 }
 
-void QwenEngine::worker_command_prefill(const std::vector<int>& token_ids) {
+void QwenEngine::worker_command_prefill(const std::vector<int>& token_ids,
+                                        int32_t slot_id) {
     if (options_.tp_world <= 1) return;
     if (options_.tp_rank != 0) {
         throw std::runtime_error("worker_command_prefill: rank 0 only");
@@ -4636,7 +4730,7 @@ void QwenEngine::worker_command_prefill(const std::vector<int>& token_ids) {
     int32_t header[4] = {
         static_cast<int32_t>(WorkerCommand::Prefill),
         0,
-        0,
+        slot_id,
         static_cast<int32_t>(token_ids.size())
     };
     impl_->cmd->send_to_workers(header, 4);
@@ -4647,7 +4741,7 @@ void QwenEngine::worker_command_prefill(const std::vector<int>& token_ids) {
     }
 }
 
-void QwenEngine::worker_command_decode(int32_t last_token) {
+void QwenEngine::worker_command_decode(int32_t last_token, int32_t slot_id) {
     if (options_.tp_world <= 1) return;
     if (options_.tp_rank != 0) {
         throw std::runtime_error("worker_command_decode: rank 0 only");
@@ -4659,7 +4753,7 @@ void QwenEngine::worker_command_decode(int32_t last_token) {
     int32_t header[4] = {
         static_cast<int32_t>(WorkerCommand::DecodeStep),
         last_token,
-        0,
+        slot_id,
         0
     };
     impl_->cmd->send_to_workers(header, 4);

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -320,8 +320,11 @@ public:
         Reset = 2,
         Shutdown = 3,
     };
-    void worker_command_prefill(const std::vector<int>& token_ids);
-    void worker_command_decode(int32_t last_token);
+    // slot_id selects the KV cache slot the workers must use, so it has to match
+    // the slot rank 0 computes into.  It defaults to 0 for the single-session
+    // path, where only slot 0 ever exists.
+    void worker_command_prefill(const std::vector<int>& token_ids, int32_t slot_id = 0);
+    void worker_command_decode(int32_t last_token, int32_t slot_id = 0);
     void worker_command_reset();
     void worker_command_shutdown();
 
@@ -340,8 +343,8 @@ private:
     uint64_t resident_scale_bytes_ = 0;
     QwenPrefixCacheStats prefix_stats_;
     QwenMtpStats mtp_stats_;
-    QwenForwardResult cached_result_;
-    bool has_cached_result_ = false;
+    // The cached prompt/result and snapshot ring live per KV slot inside Impl,
+    // so that a batch cannot match one sequence's prefix against another's.
     Impl* impl_ = nullptr;
 };
 

--- a/cpp_engine/python/bindings.cpp
+++ b/cpp_engine/python/bindings.cpp
@@ -133,14 +133,15 @@ py::dict options_dict(const ForwardSmokeOptions& options) {
     return out;
 }
 
-QwenForwardResult qwen_prefill(QwenEngine& engine, const std::vector<int>& tokens) {
+QwenForwardResult qwen_prefill(QwenEngine& engine, const std::vector<int>& tokens,
+                               int slot_id) {
     py::gil_scoped_release release;
-    return engine.prefill(tokens);
+    return engine.prefill(tokens, slot_id);
 }
 
-QwenForwardResult qwen_decode(QwenEngine& engine, int token) {
+QwenForwardResult qwen_decode(QwenEngine& engine, int token, int slot_id) {
     py::gil_scoped_release release;
-    return engine.decode_step(token);
+    return engine.decode_step(token, slot_id);
 }
 
 std::vector<QwenForwardResult> qwen_generate(QwenEngine& engine,
@@ -199,6 +200,7 @@ PYBIND11_MODULE(pocketllm_cpp, module) {
         .def_readwrite("tp_world", &QwenEngineOptions::tp_world)
         .def_readwrite("tp_rank", &QwenEngineOptions::tp_rank)
         .def_readwrite("device", &QwenEngineOptions::device)
+        .def_readwrite("max_batch_size", &QwenEngineOptions::max_batch_size)
         .def_readwrite("prefill_chunk_tokens", &QwenEngineOptions::prefill_chunk_tokens)
         .def_readwrite("kv_cache_dtype", &QwenEngineOptions::kv_cache_dtype)
         .def_readwrite("attention_window", &QwenEngineOptions::attention_window)
@@ -286,21 +288,23 @@ PYBIND11_MODULE(pocketllm_cpp, module) {
             py::gil_scoped_release release;
             engine.clear_prefix_cache();
         })
-        .def("prefill", &qwen_prefill)
-        .def("decode_step", &qwen_decode)
+        .def("prefill", &qwen_prefill, py::arg("token_ids"), py::arg("slot_id") = 0)
+        .def("decode_step", &qwen_decode, py::arg("token_id"), py::arg("slot_id") = 0)
         .def("generate", &qwen_generate)
         .def("run_worker_loop", [](QwenEngine& engine) {
             py::gil_scoped_release release;
             engine.run_worker_loop();
         }, "TP rank > 0 entry point: blocks on NCCL command channel until shutdown")
-        .def("worker_command_prefill", [](QwenEngine& engine, const std::vector<int>& token_ids) {
+        .def("worker_command_prefill", [](QwenEngine& engine, const std::vector<int>& token_ids,
+                                          int32_t slot_id) {
             py::gil_scoped_release release;
-            engine.worker_command_prefill(token_ids);
-        }, py::arg("token_ids"))
-        .def("worker_command_decode", [](QwenEngine& engine, int32_t last_token) {
+            engine.worker_command_prefill(token_ids, slot_id);
+        }, py::arg("token_ids"), py::arg("slot_id") = 0)
+        .def("worker_command_decode", [](QwenEngine& engine, int32_t last_token,
+                                         int32_t slot_id) {
             py::gil_scoped_release release;
-            engine.worker_command_decode(last_token);
-        }, py::arg("last_token"))
+            engine.worker_command_decode(last_token, slot_id);
+        }, py::arg("last_token"), py::arg("slot_id") = 0)
         .def("worker_command_reset", [](QwenEngine& engine) {
             py::gil_scoped_release release;
             engine.worker_command_reset();

--- a/pocketllm/backends/cpp_backend.py
+++ b/pocketllm/backends/cpp_backend.py
@@ -177,10 +177,15 @@ class CppBackend(BackendBase):
         self._tokenizer = tokenizer if tokenizer is not None else self._load_tokenizer()
         self._eos_ids, self._eos_source = self._resolve_eos_ids()
 
-        # Phase 3.4: Optional batch scheduler
+        # Phase 3.4: Optional batch scheduler.  Only rank 0 drives scheduling:
+        # the scheduler runs a background thread that issues collectives, and on
+        # a worker rank that would race run_worker_loop() and deadlock NCCL.
         self._scheduler = None
         self._batching_enabled = False
-        if self.args.backend_options.get("enable_batching", False):
+        if (
+            self.args.backend_options.get("enable_batching", False)
+            and self.args.tensor_parallel_rank == 0
+        ):
             self._batching_enabled = self._init_batch_scheduler()
 
         self._ready = True
@@ -233,6 +238,21 @@ class CppBackend(BackendBase):
     def eos_token_ids(self) -> frozenset[int]:
         return self._eos_ids
 
+    def _configured_max_batch_size(self) -> int:
+        """Batch width for this backend, shared by the engine and the scheduler.
+
+        The engine sizes its KV cache from this at construction, so the scheduler
+        must not ask for more slots later.  Batching off means a single slot,
+        which keeps the serial path's memory footprint unchanged.
+        """
+        if not self.args.backend_options.get("enable_batching", False):
+            return 1
+        try:
+            requested = int(self.args.backend_options.get("max_batch_size", 8))
+        except (TypeError, ValueError):
+            return 1
+        return requested if requested >= 1 else 1
+
     def _init_batch_scheduler(self) -> bool:
         """Initialize the batch scheduler if available."""
         if not hasattr(self._native, "QwenBatchScheduler"):
@@ -243,8 +263,8 @@ class CppBackend(BackendBase):
             )
             return False
 
-        max_batch_size = self.args.backend_options.get("max_batch_size", 8)
-        if max_batch_size <= 0:
+        max_batch_size = self._configured_max_batch_size()
+        if max_batch_size <= 1:
             return False
 
         try:
@@ -289,7 +309,7 @@ class CppBackend(BackendBase):
                 "cancellation": "safe boundary only",
                 "eos_token_ids": sorted(self._eos_ids),
                 "eos_source": self._eos_source or "none",
-                "max_batch_size": self.args.backend_options.get("max_batch_size", 8) if self._batching_enabled else 1,
+                "max_batch_size": self._configured_max_batch_size() if self._batching_enabled else 1,
             },
         )
 
@@ -362,6 +382,9 @@ class CppBackend(BackendBase):
             "tp_world": self.args.tensor_parallel_size,
             "tp_rank": self.args.tensor_parallel_rank,
             "device": self._native_rank_device(),
+            # The KV cache is sized at construction, so the batch width must be
+            # known here; the scheduler cannot grow it afterwards.
+            "max_batch_size": self._configured_max_batch_size(),
             "prefill_chunk_tokens": self.args.prefill_chunk_tokens or 8192,
             "attention_window": self.args.attention_window,
             "attention_sink_tokens": self.args.attention_sink_tokens,

--- a/pocketllm/backends/factory.py
+++ b/pocketllm/backends/factory.py
@@ -145,12 +145,19 @@ def create_backend(args: EngineArgs, **injected: Any):
 
             # Build environment for worker processes
             # Note: NCCL ID path will be set by supervisor after rendezvous setup
+            # Every field that changes how a rank executes has to be forwarded.
+            # A worker that falls back to an EngineArgs default takes a different
+            # branch from rank 0 and enters a different number of collectives,
+            # which hangs the whole group instead of failing.  enable_prefix_caching
+            # and max_batch_size are the ones that bite: the first decides whether
+            # prefill resumes from a snapshot, the second sizes the KV arena.
             worker_env = {
                 "POCKETLLM_CHECKPOINT": args.checkpoint_dir,
                 "POCKETLLM_TP_SIZE": str(args.tensor_parallel_size),
                 "POCKETLLM_MAX_MODEL_LEN": str(args.max_model_len or 8192),
                 "POCKETLLM_KV_CACHE_DTYPE": str(args.kv_cache_dtype or "auto"),
                 "POCKETLLM_BACKEND_OPTIONS": json.dumps(args.backend_options),
+                "POCKETLLM_WORKER_ARGS": json.dumps(_worker_arg_overrides(args)),
             }
 
             # Create supervisor configuration
@@ -196,6 +203,28 @@ def create_backend(args: EngineArgs, **injected: Any):
     raise BackendUnavailableError(f"unsupported backend {selected!r}")
 
 
+# EngineArgs fields that change control flow or memory layout inside the native
+# engine.  Ranks must agree on all of them; see the comment at the worker_env
+# construction site.  Fields that are per-rank (tensor_parallel_rank, device) or
+# already forwarded explicitly are deliberately absent.
+_WORKER_SHARED_ARGS = (
+    "prefill_chunk_tokens",
+    "enable_prefix_caching",
+    "attention_window",
+    "attention_sink_tokens",
+    "speculative_method",
+    "speculative_tokens",
+    "max_batch_size",
+    "model_format",
+    "dtype",
+)
+
+
+def _worker_arg_overrides(args: EngineArgs) -> dict[str, Any]:
+    """Collect the EngineArgs values a worker rank must match."""
+    return {name: getattr(args, name) for name in _WORKER_SHARED_ARGS}
+
+
 def _worker_script() -> str:
     """Generate Python code for worker processes (ranks 1, 2, 3, ...).
 
@@ -220,6 +249,8 @@ nccl_id_path = os.environ["POCKETLLM_NCCL_ID_PATH"]
 max_model_len = int(os.environ.get("POCKETLLM_MAX_MODEL_LEN", "8192"))
 kv_cache_dtype = os.environ.get("POCKETLLM_KV_CACHE_DTYPE", "auto")
 backend_options = json.loads(os.environ.get("POCKETLLM_BACKEND_OPTIONS", "{}"))
+# Fields rank 0 resolved; a default here would desynchronize the collectives.
+shared_args = json.loads(os.environ.get("POCKETLLM_WORKER_ARGS", "{}"))
 
 # Add NCCL ID to backend options
 backend_options["nccl_id_path"] = nccl_id_path
@@ -233,6 +264,7 @@ args = EngineArgs(
     max_model_len=max_model_len,
     kv_cache_dtype=kv_cache_dtype,
     backend_options=backend_options,
+    **shared_args,
 )
 
 # Create backend and enter worker loop

--- a/pocketllm/supervisor.py
+++ b/pocketllm/supervisor.py
@@ -28,6 +28,58 @@ from .api.errors import ConfigurationError, TensorParallelSupervisorError
 
 _READY_RE = re.compile(r"^POCKETLLM_RANK_READY\s+rank=(?P<rank>[0-9]+)\s*$")
 
+# prctl(2) PR_SET_PDEATHSIG.  Not exposed by the stdlib before 3.13, so the value
+# is inlined; it is part of the kernel ABI and identical on every Linux arch.
+_PR_SET_PDEATHSIG = 1
+
+
+def _resolve_prctl() -> Callable[..., int] | None:
+    """Look up libc's prctl, or None where it is unavailable (non-Linux)."""
+    if not sys.platform.startswith("linux"):
+        return None
+    try:
+        import ctypes
+
+        return ctypes.CDLL("libc.so.6", use_errno=True).prctl
+    except (OSError, AttributeError, ImportError):
+        return None
+
+
+# Resolved at import, deliberately: the hook below runs post-fork in a process
+# that already has output-reader threads, where allocating (as dlopen and ctypes
+# both do) can deadlock on a lock another thread held at fork time.  Doing the
+# lookup here keeps the child down to one bare syscall.
+_PRCTL = _resolve_prctl()
+
+
+def _child_guard(parent_pid: int) -> None:
+    """Make this child die with its parent.  Runs in the child, post-fork.
+
+    ``start_new_session=True`` puts each rank in its own session so the
+    supervisor can ``killpg`` the whole subtree.  The cost is that the child no
+    longer shares the parent's process group, so a signal sent to the parent's
+    group never reaches it.  When the parent dies in a way it cannot handle -- a
+    segfault in a native extension, or SIGKILL from a test harness timeout --
+    none of the Python-level cleanup runs, and the ranks are left spinning on
+    NCCL holding their share of device memory until killed by hand.
+
+    PR_SET_PDEATHSIG is the only mechanism that covers that case: the kernel
+    delivers the signal on parent death, so it needs no cooperation from the
+    parent.  It triggers on the death of the parent *thread*, which is why the
+    supervisor spawns ranks from its main thread.
+    """
+    if _PRCTL is not None:
+        # Losing the guard is not worth failing the launch over, so the return
+        # value is ignored; the supervisor's normal shutdown path still covers
+        # every graceful exit.
+        _PRCTL(_PR_SET_PDEATHSIG, signal.SIGKILL, 0, 0, 0)
+
+    # The parent may have died between fork and prctl, in which case the signal
+    # just armed will never fire.  Re-parenting is the visible symptom, so check
+    # for it rather than linger as an orphan.
+    if os.getppid() != parent_pid:
+        os._exit(1)
+
 
 @dataclass(frozen=True, slots=True)
 class TensorParallelConfig:
@@ -321,6 +373,8 @@ class TensorParallelSupervisor:
     def _spawn(self, rank: int) -> RankProcess:
         env = self._child_env(rank)
         command = self._command_for_rank(rank, env)
+        # Read in the parent: inside preexec_fn, os.getpid() is the child.
+        supervisor_pid = os.getpid()
         try:
             process = subprocess.Popen(
                 command,
@@ -335,6 +389,10 @@ class TensorParallelSupervisor:
                 bufsize=1,
                 close_fds=True,
                 start_new_session=True,
+                # Backstop for supervisor death that skips Python cleanup; see
+                # _child_guard.  Popen runs this after its own setsid, so the
+                # new session is already in place.
+                preexec_fn=lambda: _child_guard(supervisor_pid),
             )
         except OSError as exc:
             raise TensorParallelSupervisorError(


### PR DESCRIPTION
## Summary

Phase 3.2/3.3 slot-ified KV cache addressing, but the prefix cache stayed engine-global. `cached_prompt`, `cached_result_` and the snapshot ring were single copies shared by every slot, so a prefill on one slot overwrote the record another slot depended on.

The visible effect was **not** garbled output but silent loss of reuse: a slot re-sending its own history matched nothing and fell back to a cold prefill. A snapshot resume across slots would have restored a foreign sequence's recurrent state.

## Implementation

**Per-slot prefix state** (`qwen_engine.cpp`, `qwen_engine.hpp`)
- Move `cached_prompt` / `cached_result` / `snapshots` into `Impl::SlotPrefixState`, reached through `prefix_for(slot_id)`.
- Hit/miss counters stay engine-wide: they are an aggregate statistic with no per-sequence correctness meaning.
- Thread `slot_id` through `worker_command_prefill` / `worker_command_decode` and the pybind wrappers, so workers use the same slot rank 0 computes into.

**Worker argument forwarding** (`factory.py`)
- Forward every execution-shaping `EngineArgs` field to worker ranks via `POCKETLLM_WORKER_ARGS`. Workers previously fell back to defaults, which desynchronizes collectives and hangs the group rather than failing cleanly. The worst offenders were `enable_prefix_caching` and `max_batch_size` (default 1 would have sized the worker slot array to a single entry).

**Batch width and scheduler ownership** (`cpp_backend.py`)
- Size the KV cache from `_configured_max_batch_size()` at construction, since the scheduler cannot grow it later; require >1 slot to enable batching.
- Only rank 0 runs the batch scheduler. Its background thread issues collectives and would race `run_worker_loop()` on a worker rank.

**Scheduler thread correctness** (`qwen_batch_scheduler.cpp`)
- Bind the engine's device on the scheduler thread: the current device is per-thread and the engine bound it on its constructing thread.
- Fix a use-after-move in `handle_completions()`, where `request_id` was read through a `unique_ptr` already moved out of the map.

**Rank lifecycle** (`supervisor.py`)
- Arm `PR_SET_PDEATHSIG` in spawned ranks. `start_new_session=True` takes them out of the parent's process group, so a parent SIGKILL or a native segfault previously left ranks spinning on NCCL holding their share of device memory.

## Testing

Verified on `/mnt/data2/Qwen3.8-27B-FP8` under TP4.

Interleaved slot driving (slot 0 prefill+decode → slot 1 prefill+decode → slot 0 re-sends its own prompt):

| | `matched_tokens` | `resume_source` |
|---|---|---|
| With fix | 9 / 9 | `snapshot` |
| Shared record reintroduced | 0 / 9 | `empty` |

- Batched (4 slots, `_batching_enabled` asserted) matches serial token-for-token across two rounds.
- Supervisor unit tests: 28 passed.

**A single round of prefills cannot detect this bug.** Every slot's first prefill starts at position 0 and never attempts reuse, so a batch-vs-serial token comparison passes even with the defect present. Detection requires a second request per slot.

## Known gaps

- `tests/test_cpp_backend_batching.py` is unmodified and still cannot run in this environment: it hardcodes single-GPU and 27B OOMs during weight allocation. This predates the change.
- `position_` on `QwenEngine` and the workspace buffers remain engine-global; they are only used by the non-batch path.

## Checklist

- [x] Per-slot prefix cache isolation
- [x] Worker arg forwarding under TP
- [x] Scheduler thread device binding + use-after-move fix
- [x] Rank death guard
- [x] Real-model TP4 verification with bug-reintroduction control
- [ ] Multi-GPU-aware rewrite of `tests/test_cpp_backend_batching.py` (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)