### PR TITLE
Validate Phase 3.5 batching performance on TP4

### DIFF
--- a/cpp_engine/engine/qwen_batch_scheduler.cpp
+++ b/cpp_engine/engine/qwen_batch_scheduler.cpp
@@ -32,6 +32,13 @@ void QwenBatchScheduler::stop() {
         return;  // Already stopped
     }
 
+    // An idle loop is parked on work_cv_; without this it only notices the
+    // cleared flag after its wait times out.
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+    }
+    work_cv_.notify_all();
+
     // Wait for scheduler thread to exit
     if (schedule_thread_.joinable()) {
         schedule_thread_.join();
@@ -73,6 +80,8 @@ uint64_t QwenBatchScheduler::submit_request(
         std::lock_guard<std::mutex> lock(queue_mutex_);
         waiting_queue_.push(std::move(req));
     }
+    // Wake an idle loop now rather than letting it wait out its tick.
+    work_cv_.notify_one();
 
     return request_id;
 }
@@ -91,6 +100,7 @@ bool QwenBatchScheduler::cancel_request(uint64_t request_id) {
 
     // Mark running request as cancelled
     cancelled_requests_.insert(request_id);
+    work_cv_.notify_one();
     return true;
 }
 
@@ -155,18 +165,33 @@ void QwenBatchScheduler::schedule_loop() {
     }
 
     while (running_.load()) {
+        // Whether this iteration ran a forward pass.  Only an iteration that did
+        // nothing should park the thread: sleeping unconditionally cost a
+        // millisecond per decode step -- one iteration produces one token per
+        // running request -- which showed up as a 1.14x single-request latency
+        // regression against the serial path at 32 tokens.
+        bool progressed = false;
         try {
             admit_requests();
-            run_prefill_batch();
-            run_decode_batch();
+            progressed |= run_prefill_batch();
+            progressed |= run_decode_batch();
             handle_completions();
         } catch (const std::exception& e) {
             std::cerr << "QwenBatchScheduler: exception in schedule loop: "
                      << e.what() << std::endl;
         }
 
-        // Small sleep to avoid busy loop
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        if (progressed) {
+            continue;
+        }
+
+        // Nothing advanced, so park until a submission arrives.  The timeout is
+        // only a backstop for a state change that forgot to notify; both real
+        // triggers (submit_request, cancel_request) signal work_cv_.
+        std::unique_lock<std::mutex> lock(queue_mutex_);
+        work_cv_.wait_for(lock, std::chrono::milliseconds(20), [this] {
+            return !running_.load() || !waiting_queue_.empty();
+        });
     }
 }
 
@@ -200,7 +225,7 @@ void QwenBatchScheduler::admit_requests() {
     }
 }
 
-void QwenBatchScheduler::run_prefill_batch() {
+bool QwenBatchScheduler::run_prefill_batch() {
     std::vector<QwenBatchedRequest*> prefill_batch;
     std::vector<SchedulerRequest*> prefill_requests;
 
@@ -229,7 +254,7 @@ void QwenBatchScheduler::run_prefill_batch() {
     }
 
     if (prefill_batch.empty()) {
-        return;
+        return false;
     }
 
     // Call engine batch_prefill
@@ -259,9 +284,11 @@ void QwenBatchScheduler::run_prefill_batch() {
     for (auto* batch_req : prefill_batch) {
         delete batch_req;
     }
+
+    return true;
 }
 
-void QwenBatchScheduler::run_decode_batch() {
+bool QwenBatchScheduler::run_decode_batch() {
     std::vector<QwenBatchedRequest*> decode_batch;
     std::vector<SchedulerRequest*> decode_requests;
 
@@ -291,7 +318,7 @@ void QwenBatchScheduler::run_decode_batch() {
     }
 
     if (decode_batch.empty()) {
-        return;
+        return false;
     }
 
     // Call engine batch_decode_step
@@ -333,6 +360,8 @@ void QwenBatchScheduler::run_decode_batch() {
     for (auto* batch_req : decode_batch) {
         delete batch_req;
     }
+
+    return true;
 }
 
 void QwenBatchScheduler::handle_completions() {

--- a/cpp_engine/include/qwen_batch_scheduler.hpp
+++ b/cpp_engine/include/qwen_batch_scheduler.hpp
@@ -109,11 +109,11 @@ private:
     // Admit new requests from waiting queue
     void admit_requests();
 
-    // Run prefill batch
-    void run_prefill_batch();
+    // Run prefill batch.  Returns true if a forward pass ran.
+    bool run_prefill_batch();
 
-    // Run decode batch
-    void run_decode_batch();
+    // Run decode batch.  Returns true if a forward pass ran.
+    bool run_decode_batch();
 
     // Handle completed requests
     void handle_completions();
@@ -128,6 +128,9 @@ private:
 
     // Request queues (protected by queue_mutex_)
     mutable std::mutex queue_mutex_;
+    // Signalled when work arrives, so an idle loop wakes on submission instead
+    // of on a fixed timer.
+    std::condition_variable work_cv_;
     std::queue<std::unique_ptr<SchedulerRequest>> waiting_queue_;
     std::unordered_map<int, std::unique_ptr<SchedulerRequest>> slot_to_request_;
     std::unordered_map<uint64_t, int> request_id_to_slot_;

--- a/docs/phase3_5_validation_results.md
+++ b/docs/phase3_5_validation_results.md
@@ -1,0 +1,130 @@
+# Phase 3.5 Validation Results
+
+Measured on commit `c8c3b15`, 4× RTX 2080 Ti (22 GB), TP4, checkpoint
+`/mnt/data2/Qwen3.8-27B-FP8`, 16-token prompts, 32 new tokens, 1 warmup + 5 runs
+per measurement. Driver: `scripts/run_phase35_benchmarks.sh`.
+
+## Verdict
+
+| Target | Result | |
+|---|---|---|
+| Single-request latency ≤1.05× serial | **1.002×** | PASS |
+| 2 concurrent ≥1.7× throughput | **1.00×** | FAIL |
+| 4 concurrent ≥3.0× throughput | **0.99×** | FAIL |
+| 8 concurrent ≥4.5× throughput | **0.99×** | FAIL |
+
+Batching costs nothing for a lone request, and it buys nothing for concurrent
+ones. The concurrency targets cannot be met by tuning the scheduler; they need a
+batched decode kernel that does not exist yet.
+
+## Concurrent throughput detail
+
+| Level | Mode | Wall per round | Avg request latency | Throughput |
+|---|---|---|---|---|
+| 2 | serial | 1.344s | 1.007s | 1.488 req/s |
+| 2 | batch | 1.350s | 1.339s | 1.481 req/s |
+| 4 | serial | 2.703s | 1.689s | 1.480 req/s |
+| 4 | batch | 2.717s | 2.700s | 1.472 req/s |
+| 8 | serial | 5.471s | 3.075s | 1.462 req/s |
+| 8 | batch | 5.517s | 5.494s | 1.450 req/s |
+
+Throughput is flat at ~1.46 req/s regardless of mode or concurrency: wall time
+per round scales linearly with the request count in both modes. Batch mode does
+change the latency *distribution* — every request finishes at about the same time
+(5.494s of 5.517s wall at 8 concurrent) instead of early ones finishing first
+(3.075s average) — which is what fair scheduling looks like, but it moves no
+total work.
+
+The scheduler itself is doing its job. Instrumenting `get_stats()` during an
+8-request run shows peak `running_requests = 8` with 7 waiting, so all slots are
+genuinely occupied concurrently rather than silently serializing.
+
+## Why throughput is flat
+
+`QwenEngine::batch_decode_step` (`cpp_engine/engine/qwen_engine.cpp:4281`) loops
+over the batch and calls the single-sequence `decode_step` once per request, with
+its own comment saying so:
+
+```cpp
+// Phase 3.1: Process decode steps sequentially
+// True batched decode kernel is deferred to Phase 3.2
+for (QwenBatchedRequest* req : requests) {
+    worker_command_decode(req->last_token, req->slot_id);
+    QwenForwardResult fwd_result = decode_step(req->last_token, req->slot_id);
+```
+
+N concurrent requests therefore do N times the sequential work per step, plus a
+TP broadcast each. 1.00× is the structural ceiling of this design, so the ≥1.7×
+/ ≥3.0× / ≥4.5× targets were never reachable at this commit — the batched decode
+kernel deferred from Phase 3.2 is the missing prerequisite. Weight loading is
+what these targets were meant to amortize, and that only happens with a kernel
+that computes several sequences per pass.
+
+## Two measurement bugs found and fixed
+
+**Serial TTFT was hardcoded to `0.0`.** `_generate_serial` filled in a
+placeholder, so the latency benchmark divided by zero comparing TTFT ratios. The
+stepped path now measures it (`pocketllm/backends/cpp_backend.py`), since it
+drives prefill and decode itself and knows when the first token appeared. The
+single-rank fast path still reports `0.0`, because native `generate()` runs its
+own loop and gives no first-token boundary — that is a real absence, not a
+placeholder. Covered by `tests/test_cpp_backend_serial_ttft.py`.
+
+**Building two engines in one process penalizes the second by ~10%, whichever
+mode it is.** This invalidated the original comparison, which always built serial
+first and batch second. Four *serial* engines in a row in one process:
+
+| engine | wall |
+|---|---|
+| #0 | 0.6718s |
+| #1 | 0.7352s |
+| #2 | 0.6746s |
+| #3 | 0.6741s |
+
+Only #1 is slow, and the effect follows build position rather than mode or slot
+count — an 8-slot batch engine measured 1.102× when built second and 1.004× when
+built third with identical configuration. GPU clocks (1860 MHz), power state, and
+host thread/child counts are identical across the slow and fast windows, and a
+20-second sleep between engines does not remove it, so it is neither thermal
+throttling nor teardown overlap. Root cause not identified; a leaked NCCL
+communicator is a candidate, since `cached_comm`
+(`cpp_engine/backends/cuda/collective/tp_comm.cpp:184`) caches per-communicator
+state in a `static` map keyed partly on `id_path` and never destroys entries, but
+I could not isolate it (TP=1 cannot hold this 27B checkpoint, so there is no
+NCCL-free control on this hardware).
+
+Given one config per process the penalty disappears entirely and both modes agree
+to within 0.3%, which is why the driver now spawns a separate process per
+measurement and `scripts/summarize_phase35_benchmarks.py` aggregates the JSON.
+The earlier in-process 1.117× "batching overhead" was this artifact, not a real
+scheduler cost.
+
+## Scheduler fix included
+
+`QwenBatchScheduler::run_prefill_batch` and `run_decode_batch` returned `void`,
+so the scheduler loop could not tell a completed forward pass from an empty one
+and slept 1ms unconditionally between iterations. They now return whether a
+forward pass ran, and the loop only waits when there was no work. This is worth
+~18ms of the 32-step single-request measurement. Idle cost after the change is
+0.2% of one core over a 10-second idle window, so the condition-variable wait
+still parks correctly rather than busy-spinning.
+
+## Reproducing
+
+```bash
+TP=4 bash scripts/run_phase35_benchmarks.sh /mnt/data2/Qwen3.8-27B-FP8 out/
+```
+
+Each mode and concurrency level runs in its own process; the summary applies the
+targets. `scripts/profile_batch_single_request_overhead.py` reproduces the
+build-order artifact by running several engines in one process.
+
+## Test status
+
+`tests/test_cpp_backend_serial_ttft.py` (4 new tests) passes. Of the existing
+suites, `test_cpp_backend.py`, `test_cpp_backend_tp.py`,
+`test_cpp_backend_worker.py`, `test_factory_tp_supervision_reuse.py`, and
+`test_supervisor_orphan_guard.py` pass; 3 failures in
+`test_cpp_backend_batching.py::test_serial_mode`, `::test_batch_mode`, and
+`test_cpp_backend_tp.py::test_tp_requires_nccl_id_path` predate these changes and
+reproduce on a clean tree.

--- a/pocketllm/backends/cpp_backend.py
+++ b/pocketllm/backends/cpp_backend.py
@@ -526,8 +526,8 @@ class CppBackend(BackendBase):
         return token in self._eos_ids
 
     def _generate_until_eos(
-        self, request: GenerationRequest, prompt_ids: list[int]
-    ) -> tuple[list[int], bool]:
+        self, request: GenerationRequest, prompt_ids: list[int], started: float
+    ) -> tuple[list[int], bool, float]:
         """Step the native session so it never advances past EOS.
 
         ``QwenEngine.generate`` takes no EOS argument and keeps mutating its
@@ -536,19 +536,25 @@ class CppBackend(BackendBase):
         the caller never sees, corrupting reuse for the next request.  Driving
         prefill/decode here keeps the session and the returned tokens in step,
         and matches what the streamed path does.
+
+        Returns the tokens, whether EOS stopped generation, and the time to the
+        first token measured from ``started``.  TTFT is observable only here: the
+        loop is what learns when prefill produced a token, so reporting 0.0 as
+        this path used to made every serial timing comparison degenerate.
         """
         result = self._tp_prefill(prompt_ids)
+        ttft = time.perf_counter() - started
         token_ids: list[int] = []
         for index in range(request.sampling_params.max_tokens):
             self._ensure_open()
             self._check_cancelled(request.request_id)
             token = self._native_token(result)
             if self._is_eos(token):
-                return token_ids, True
+                return token_ids, True, ttft
             token_ids.append(token)
             if index + 1 < request.sampling_params.max_tokens:
                 result = self._tp_decode_step(token)
-        return token_ids, False
+        return token_ids, False, ttft
 
     def _decode(self, token_ids: list[int]) -> str:
         if self._tokenizer is None:
@@ -590,13 +596,19 @@ class CppBackend(BackendBase):
                     # workers. Under TP always take the stepped path, which
                     # broadcasts each command.
                     if self._eos_ids or self.args.tensor_parallel_size > 1:
-                        token_ids, hit_eos = self._generate_until_eos(request, prompt_ids)
+                        token_ids, hit_eos, ttft = self._generate_until_eos(
+                            request, prompt_ids, started
+                        )
                     else:
                         raw = self._engine_or_raise().generate(
                             prompt_ids, request.sampling_params.max_tokens
                         )
                         token_ids = [self._native_token(item) for item in raw]
                         hit_eos = False
+                        # Native generate() drives its own loop and reports no
+                        # per-token boundary, so the first token is not separable
+                        # from the whole call here.
+                        ttft = 0.0
                     self._ensure_open()
                 self._check_cancelled(request.request_id)
                 # `completion_tokens` counts the EOS step the engine executed, so
@@ -611,7 +623,7 @@ class CppBackend(BackendBase):
                         usage=Usage(len(prompt_ids), completion_tokens),
                         timings=TimingMetrics(
                             total_seconds=time.perf_counter() - started,
-                            ttft_seconds=0.0,
+                            ttft_seconds=ttft,
                         ),
                     )
                 )

--- a/pocketllm/backends/factory.py
+++ b/pocketllm/backends/factory.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 import tempfile
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -176,17 +177,40 @@ def create_backend(args: EngineArgs, **injected: Any):
             # Get NCCL ID path created by supervisor
             nccl_id_path = str(supervisor.nccl_id_path)
 
-            # Set NCCL ID path for main process (rank 0)
+            # Rank 0 needs the rendezvous path too, but it belongs to this
+            # supervisor only.  Leaking it into os.environ makes the *next*
+            # create_backend() in the same process see a non-empty
+            # POCKETLLM_NCCL_ID_PATH, conclude it is externally supervised, skip
+            # spawning workers, and then block forever in the NCCL rendezvous
+            # waiting for ranks nobody started.  Pass it through backend_options,
+            # which is scoped to this backend, and restore the environment.
+            previous_nccl_id_path = os.environ.get("POCKETLLM_NCCL_ID_PATH")
             os.environ["POCKETLLM_NCCL_ID_PATH"] = nccl_id_path
-            args.backend_options["nccl_id_path"] = nccl_id_path
-
-            # Main process creates rank-0 backend
-            backend = CppBackend(
+            # backend_options is caller-owned; a copy keeps the mutation from
+            # persisting in the EngineArgs a caller may reuse for another engine.
+            args = replace(
                 args,
-                native_module=injected.get("native_module"),
-                engine=injected.get("engine"),
-                tokenizer=injected.get("tokenizer"),
+                backend_options={**args.backend_options, "nccl_id_path": nccl_id_path},
             )
+
+            try:
+                # Main process creates rank-0 backend
+                backend = CppBackend(
+                    args,
+                    native_module=injected.get("native_module"),
+                    engine=injected.get("engine"),
+                    tokenizer=injected.get("tokenizer"),
+                )
+            except BaseException:
+                # The workers are useless without rank 0, and leaving them alive
+                # would hold device memory and block a retry.
+                try:
+                    supervisor.stop()
+                finally:
+                    _restore_env("POCKETLLM_NCCL_ID_PATH", previous_nccl_id_path)
+                raise
+
+            _restore_env("POCKETLLM_NCCL_ID_PATH", previous_nccl_id_path)
 
             # Store supervisor reference so it can be cleaned up
             backend._supervisor = supervisor
@@ -223,6 +247,14 @@ _WORKER_SHARED_ARGS = (
 def _worker_arg_overrides(args: EngineArgs) -> dict[str, Any]:
     """Collect the EngineArgs values a worker rank must match."""
     return {name: getattr(args, name) for name in _WORKER_SHARED_ARGS}
+
+
+def _restore_env(name: str, previous: str | None) -> None:
+    """Put ``name`` back the way it was, distinguishing unset from empty."""
+    if previous is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = previous
 
 
 def _worker_script() -> str:

--- a/scripts/bench_concurrent_throughput.py
+++ b/scripts/bench_concurrent_throughput.py
@@ -10,6 +10,7 @@ with concurrent requests. Target improvements:
 """
 
 import argparse
+import json
 import sys
 import time
 import threading
@@ -93,6 +94,7 @@ def benchmark_concurrent(
     test_runs: int = 3,
     prompt_length: int = 32,
     tensor_parallel_size: int = 1,
+    max_model_len: int = 4096,
 ):
     """Benchmark concurrent request throughput."""
 
@@ -106,9 +108,13 @@ def benchmark_concurrent(
         model=checkpoint,
         backend="cpp",
         tensor_parallel_size=tensor_parallel_size,
+        max_model_len=max_model_len,
         backend_options={
             "enable_batching": enable_batching,
-            "max_batch_size": max(8, num_concurrent) if enable_batching else 1,
+            # Size the arena to this level's concurrency rather than a fixed 8.
+            # max(8, n) made the 2-concurrent run reserve 8 slots' worth of KV
+            # cache, so the low levels paid memory they never used.
+            "max_batch_size": num_concurrent if enable_batching else 1,
         }
     )
 
@@ -120,6 +126,16 @@ def benchmark_concurrent(
     print(f"Scheduler: {caps.details.get('scheduler')}")
     print(f"Supports batch: {caps.supports_batch}")
     print(f"Max batch size: {caps.details.get('max_batch_size', 1)}")
+
+    # A silent fall back to the serial path would be reported as a batch result
+    # and make the comparison meaningless, so fail loudly instead.
+    actually_batching = bool(getattr(llm.backend, "_batching_enabled", False))
+    if actually_batching != enable_batching:
+        llm.close()
+        raise SystemExit(
+            f"requested enable_batching={enable_batching} but backend reports "
+            f"{actually_batching}; refusing to report this as a {mode} measurement"
+        )
 
     # Create test configuration
     prompt_tokens = list(range(1, prompt_length + 1))
@@ -134,27 +150,47 @@ def benchmark_concurrent(
 
     benchmark = ConcurrentBenchmark(llm, prompt_tokens, sampling)
 
-    # Warmup
-    print(f"\nWarmup ({warmup_runs} runs)...")
-    for i in range(warmup_runs):
-        results, total_time = benchmark.run_concurrent(num_concurrent)
-        successful = sum(1 for r in results if r["success"])
-        print(f"  Run {i+1}: {total_time:.3f}s ({successful}/{num_concurrent} successful)")
-
-    # Benchmark
-    print(f"\nBenchmark ({test_runs} runs)...")
     all_total_times = []
     all_request_latencies = []
+    failures = 0
+    try:
+        # Warmup
+        print(f"\nWarmup ({warmup_runs} runs)...")
+        for i in range(warmup_runs):
+            results, total_time = benchmark.run_concurrent(num_concurrent)
+            successful = sum(1 for r in results if r["success"])
+            print(f"  Run {i+1}: {total_time:.3f}s ({successful}/{num_concurrent} successful)")
 
-    for i in range(test_runs):
-        results, total_time = benchmark.run_concurrent(num_concurrent)
-        all_total_times.append(total_time)
+        # Benchmark
+        print(f"\nBenchmark ({test_runs} runs)...")
 
-        successful = sum(1 for r in results if r["success"])
-        avg_latency = sum(r["latency"] for r in results if r["success"]) / max(successful, 1)
-        all_request_latencies.extend([r["latency"] for r in results if r["success"]])
+        for i in range(test_runs):
+            results, total_time = benchmark.run_concurrent(num_concurrent)
+            all_total_times.append(total_time)
 
-        print(f"  Run {i+1}: {total_time:.3f}s total, {avg_latency:.3f}s avg latency ({successful}/{num_concurrent} successful)")
+            successful = sum(1 for r in results if r["success"])
+            failures += num_concurrent - successful
+            avg_latency = sum(r["latency"] for r in results if r["success"]) / max(successful, 1)
+            all_request_latencies.extend([r["latency"] for r in results if r["success"]])
+
+            for failed in (r for r in results if not r["success"]):
+                print(f"    request {failed['request_id']} failed: {failed.get('error')}")
+
+            print(f"  Run {i+1}: {total_time:.3f}s total, {avg_latency:.3f}s avg latency ({successful}/{num_concurrent} successful)")
+    finally:
+        # Each concurrency level builds its own LLM.  Without an explicit close
+        # the engine is only reclaimed at interpreter exit, so rank 0 never sends
+        # the shutdown command and every previous level's TP workers stay alive
+        # holding their share of device memory.  Six levels deep that is six
+        # resident copies of the model.
+        llm.close()
+
+    # A level that dropped requests is not comparable against one that did not.
+    if failures:
+        raise SystemExit(
+            f"{failures} request(s) failed in {mode} mode at {num_concurrent} "
+            "concurrent; results would be misleading"
+        )
 
     # Statistics
     avg_total_time = sum(all_total_times) / len(all_total_times)
@@ -197,6 +233,21 @@ def main():
         "checkpoint",
         help="Path to Qwen3.5 checkpoint directory"
     )
+    # Building a second engine in one process costs the *second* one about 10%,
+    # whichever mode it is -- measured with four serial engines in a row, where
+    # only #1 was slow (0.735s vs 0.672s) at identical clocks.  Comparing modes
+    # inside one process therefore charges that to whichever ran second.  The
+    # driver (run_phase35_benchmarks.sh) gives each measurement its own process
+    # and this flag emits the one result for it to collect.
+    parser.add_argument(
+        "--single",
+        choices=["serial", "batch"],
+        help="Measure only this mode, then write --json-out and exit"
+    )
+    parser.add_argument(
+        "--json-out",
+        help="Write the --single measurement here as JSON"
+    )
     parser.add_argument(
         "--num-concurrent",
         type=int,
@@ -234,6 +285,12 @@ def main():
         default=1,
         help="Tensor parallel size (default: 1)"
     )
+    parser.add_argument(
+        "--max-model-len",
+        type=int,
+        default=4096,
+        help="Max sequence length; bounds per-slot KV cache (default: 4096)"
+    )
 
     args = parser.parse_args()
 
@@ -242,6 +299,24 @@ def main():
     print("="*60)
     print(f"Checkpoint: {args.checkpoint}")
     print(f"Tensor parallel size: {args.tensor_parallel_size}")
+
+    if args.single:
+        if len(args.num_concurrent) != 1:
+            raise SystemExit("--single takes exactly one --num-concurrent level")
+        result = benchmark_concurrent(
+            args.checkpoint,
+            enable_batching=args.single == "batch",
+            num_concurrent=args.num_concurrent[0],
+            max_tokens=args.max_tokens,
+            warmup_runs=args.warmup_runs,
+            test_runs=args.test_runs,
+            prompt_length=args.prompt_length,
+            tensor_parallel_size=args.tensor_parallel_size,
+            max_model_len=args.max_model_len,
+        )
+        if args.json_out:
+            Path(args.json_out).write_text(json.dumps(result, indent=2))
+        return 0
 
     # Expected improvements
     targets = {
@@ -264,6 +339,7 @@ def main():
             test_runs=args.test_runs,
             prompt_length=args.prompt_length,
             tensor_parallel_size=args.tensor_parallel_size,
+            max_model_len=args.max_model_len,
         )
 
         # Batch mode
@@ -276,6 +352,7 @@ def main():
             test_runs=args.test_runs,
             prompt_length=args.prompt_length,
             tensor_parallel_size=args.tensor_parallel_size,
+            max_model_len=args.max_model_len,
         )
 
         all_results[num_concurrent] = {

--- a/scripts/bench_single_request_latency.py
+++ b/scripts/bench_single_request_latency.py
@@ -7,6 +7,7 @@ overhead for single requests. Target: ≤1.05× baseline (serial mode).
 """
 
 import argparse
+import json
 import sys
 import time
 from pathlib import Path
@@ -24,6 +25,8 @@ def benchmark_single_request(
     test_runs: int = 10,
     prompt_length: int = 32,
     tensor_parallel_size: int = 1,
+    max_model_len: int = 4096,
+    max_batch_size: int = 8,
 ):
     """Benchmark single request latency."""
 
@@ -37,9 +40,14 @@ def benchmark_single_request(
         model=checkpoint,
         backend="cpp",
         tensor_parallel_size=tensor_parallel_size,
+        max_model_len=max_model_len,
         backend_options={
             "enable_batching": enable_batching,
-            "max_batch_size": 8 if enable_batching else 1,
+            # Several slots even though this test sends one request at a time: the
+            # point is to measure what a batch-configured engine costs a lone
+            # request.  Sweeping this separates scheduler overhead, which is
+            # slot-count independent, from any per-slot KV layout cost.
+            "max_batch_size": max_batch_size if enable_batching else 1,
         }
     )
 
@@ -51,6 +59,16 @@ def benchmark_single_request(
     print(f"Scheduler: {caps.details.get('scheduler')}")
     print(f"Supports batch: {caps.supports_batch}")
 
+    # A silent fall back to the serial path would be reported as a batch
+    # measurement, which is exactly the comparison this script exists to make.
+    actually_batching = bool(getattr(llm.backend, "_batching_enabled", False))
+    if actually_batching != enable_batching:
+        llm.close()
+        raise SystemExit(
+            f"requested enable_batching={enable_batching} but backend reports "
+            f"{actually_batching}; refusing to report this as a {mode} measurement"
+        )
+
     # Create test prompt (dummy token IDs)
     prompt_tokens = list(range(1, prompt_length + 1))
     sampling = SamplingParams(max_tokens=max_tokens, temperature=0.0)
@@ -60,29 +78,35 @@ def benchmark_single_request(
     print(f"Warmup runs: {warmup_runs}")
     print(f"Test runs: {test_runs}")
 
-    # Warmup
-    print(f"\nWarmup ({warmup_runs} runs)...")
-    for i in range(warmup_runs):
-        result = llm.generate(prompt_tokens=prompt_tokens, sampling_params=sampling)
-        print(f"  Run {i+1}: {result.timings.total_seconds:.3f}s")
-
-    # Benchmark
-    print(f"\nBenchmark ({test_runs} runs)...")
     latencies = []
     ttfts = []
+    try:
+        # Warmup
+        print(f"\nWarmup ({warmup_runs} runs)...")
+        for i in range(warmup_runs):
+            result = llm.generate([prompt_tokens], sampling_params=sampling)[0]
+            print(f"  Run {i+1}: {result.timings.total_seconds:.3f}s")
 
-    for i in range(test_runs):
-        start = time.perf_counter()
-        result = llm.generate(prompt_tokens=prompt_tokens, sampling_params=sampling)
-        end = time.perf_counter()
+        # Benchmark
+        print(f"\nBenchmark ({test_runs} runs)...")
 
-        latency = end - start
-        ttft = result.timings.ttft_seconds
+        for i in range(test_runs):
+            start = time.perf_counter()
+            result = llm.generate([prompt_tokens], sampling_params=sampling)[0]
+            end = time.perf_counter()
 
-        latencies.append(latency)
-        ttfts.append(ttft)
+            latency = end - start
+            ttft = result.timings.ttft_seconds
 
-        print(f"  Run {i+1}: {latency:.3f}s (TTFT: {ttft:.3f}s, generated: {len(result.token_ids)} tokens)")
+            latencies.append(latency)
+            ttfts.append(ttft)
+
+            print(f"  Run {i+1}: {latency:.3f}s (TTFT: {ttft:.3f}s, generated: {len(result.token_ids)} tokens)")
+    finally:
+        # Serial and batch modes each build their own LLM.  Closing releases the
+        # engine, which is what tells rank 0 to send the TP workers a shutdown;
+        # otherwise the serial run's workers stay resident through the batch run.
+        llm.close()
 
     # Statistics
     avg_latency = sum(latencies) / len(latencies)
@@ -126,6 +150,20 @@ def main():
         "checkpoint",
         help="Path to Qwen3.5 checkpoint directory"
     )
+    # Building a second engine in one process costs the *second* one about 10%,
+    # whichever mode it is: four serial engines in a row gave 0.672 / 0.735 /
+    # 0.675 / 0.674s at identical GPU clocks.  Measuring both modes in one
+    # process therefore charges that to whichever ran second, which is why the
+    # driver gives each mode its own process and collects these JSON files.
+    parser.add_argument(
+        "--single",
+        choices=["serial", "batch"],
+        help="Measure only this mode, then write --json-out and exit"
+    )
+    parser.add_argument(
+        "--json-out",
+        help="Write the --single measurement here as JSON"
+    )
     parser.add_argument(
         "--max-tokens",
         type=int,
@@ -151,6 +189,18 @@ def main():
         help="Prompt length in tokens (default: 32)"
     )
     parser.add_argument(
+        "--max-model-len",
+        type=int,
+        default=4096,
+        help="Max sequence length; bounds per-slot KV cache (default: 4096)"
+    )
+    parser.add_argument(
+        "--max-batch-size",
+        type=int,
+        default=8,
+        help="Slots to configure in batch mode (default: 8)"
+    )
+    parser.add_argument(
         "--tensor-parallel-size",
         type=int,
         default=1,
@@ -164,6 +214,24 @@ def main():
     print("="*60)
     print(f"Checkpoint: {args.checkpoint}")
     print(f"Tensor parallel size: {args.tensor_parallel_size}")
+    print(f"Max model len: {args.max_model_len}")
+    print(f"Batch slots: {args.max_batch_size}")
+
+    if args.single:
+        result = benchmark_single_request(
+            args.checkpoint,
+            enable_batching=args.single == "batch",
+            max_tokens=args.max_tokens,
+            warmup_runs=args.warmup_runs,
+            test_runs=args.test_runs,
+            prompt_length=args.prompt_length,
+            tensor_parallel_size=args.tensor_parallel_size,
+            max_model_len=args.max_model_len,
+            max_batch_size=args.max_batch_size,
+        )
+        if args.json_out:
+            Path(args.json_out).write_text(json.dumps(result, indent=2))
+        return 0
 
     # Benchmark serial mode (baseline)
     serial_result = benchmark_single_request(
@@ -174,6 +242,7 @@ def main():
         test_runs=args.test_runs,
         prompt_length=args.prompt_length,
         tensor_parallel_size=args.tensor_parallel_size,
+        max_model_len=args.max_model_len,
     )
 
     # Benchmark batch mode
@@ -185,6 +254,8 @@ def main():
         test_runs=args.test_runs,
         prompt_length=args.prompt_length,
         tensor_parallel_size=args.tensor_parallel_size,
+        max_model_len=args.max_model_len,
+        max_batch_size=args.max_batch_size,
     )
 
     # Compare results
@@ -193,7 +264,6 @@ def main():
     print(f"{'='*60}")
 
     latency_ratio = batch_result["avg_latency"] / serial_result["avg_latency"]
-    ttft_ratio = batch_result["avg_ttft"] / serial_result["avg_ttft"]
 
     print(f"Average Latency:")
     print(f"  Serial: {serial_result['avg_latency']:.3f}s")
@@ -203,7 +273,13 @@ def main():
     print(f"\nAverage TTFT:")
     print(f"  Serial: {serial_result['avg_ttft']:.3f}s")
     print(f"  Batch:  {batch_result['avg_ttft']:.3f}s")
-    print(f"  Ratio:  {ttft_ratio:.3f}× ({'+' if ttft_ratio > 1 else ''}{(ttft_ratio-1)*100:.1f}%)")
+    # A path that cannot separate the first token reports 0.0, and the latency
+    # ratio above is the verdict either way, so say so instead of dividing.
+    if serial_result["avg_ttft"] > 0.0:
+        ttft_ratio = batch_result["avg_ttft"] / serial_result["avg_ttft"]
+        print(f"  Ratio:  {ttft_ratio:.3f}× ({'+' if ttft_ratio > 1 else ''}{(ttft_ratio-1)*100:.1f}%)")
+    else:
+        print("  Ratio:  n/a (serial path does not report TTFT)")
 
     # Verdict
     print(f"\n{'='*60}")

--- a/scripts/profile_batch_single_request_overhead.py
+++ b/scripts/profile_batch_single_request_overhead.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Attribute batch-mode single-request overhead to a specific layer.
+
+The batch path is ~10% slower than the serial path for one request.  Wall time
+alone cannot say whether that sits in the Python submit/poll plumbing or inside
+the scheduler loop, so print both clocks for the same runs:
+
+  * Python wall  - generate() entry to return, everything included.
+  * scheduler    - submit_time to completion_time, measured in C++.
+
+A gap between them is plumbing (thread handoff, poll wakeup, result copy).  A
+scheduler time that already exceeds the serial baseline puts the cost in the
+loop, i.e. in the per-step work around batch_decode_step.
+"""
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from pocketllm import EngineArgs, LLM, SamplingParams
+
+
+def run(checkpoint, *, enable_batching, max_batch_size, tp, max_model_len,
+        prompt_length, max_tokens, warmup, runs):
+    args = EngineArgs(
+        model=checkpoint,
+        backend="cpp",
+        tensor_parallel_size=tp,
+        max_model_len=max_model_len,
+        backend_options={
+            "enable_batching": enable_batching,
+            "max_batch_size": max_batch_size if enable_batching else 1,
+        },
+    )
+    llm = LLM(args)
+    label = "batch" if enable_batching else "serial"
+    actual = bool(getattr(llm.backend, "_batching_enabled", False))
+    if actual != enable_batching:
+        llm.close()
+        raise SystemExit(f"{label}: backend reports _batching_enabled={actual}")
+
+    prompt = list(range(1, prompt_length + 1))
+    sampling = SamplingParams(max_tokens=max_tokens, temperature=0.0)
+
+    walls, engine_times, ttfts = [], [], []
+    try:
+        for _ in range(warmup):
+            llm.generate([prompt], sampling_params=sampling)
+        for _ in range(runs):
+            start = time.perf_counter()
+            result = llm.generate([prompt], sampling_params=sampling)[0]
+            walls.append(time.perf_counter() - start)
+            engine_times.append(result.timings.total_seconds)
+            ttfts.append(result.timings.ttft_seconds)
+            assert len(result.token_ids) == max_tokens, len(result.token_ids)
+    finally:
+        llm.close()
+
+    avg = lambda xs: sum(xs) / len(xs)
+    mode = f"{label}(slots={max_batch_size if enable_batching else 1})"
+    # Per-run values, because the averages moved between sweeps by more than the
+    # effect being measured; a spread this visible has to be reported, not hidden.
+    print(f"  {mode} walls: " + " ".join(f"{w:.4f}" for w in walls), flush=True)
+    return {
+        "mode": mode,
+        "wall": avg(walls),
+        "engine": avg(engine_times),
+        "ttft": avg(ttfts),
+        "min_wall": min(walls),
+        "max_wall": max(walls),
+        "per_step_wall": avg(walls) / max_tokens,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("checkpoint")
+    parser.add_argument("--tensor-parallel-size", type=int, default=4)
+    parser.add_argument("--max-model-len", type=int, default=4096)
+    parser.add_argument("--prompt-length", type=int, default=16)
+    parser.add_argument("--max-tokens", type=int, default=32)
+    parser.add_argument("--warmup-runs", type=int, default=1)
+    parser.add_argument("--test-runs", type=int, default=5)
+    parser.add_argument("--slots", type=int, nargs="+", default=[2, 8])
+    args = parser.parse_args()
+
+    common = dict(
+        tp=args.tensor_parallel_size,
+        max_model_len=args.max_model_len,
+        prompt_length=args.prompt_length,
+        max_tokens=args.max_tokens,
+        warmup=args.warmup_runs,
+        runs=args.test_runs,
+    )
+
+    # Repeat the serial baseline at the end as well.  The first sweep put 8 slots
+    # at 1.005x and the second at 1.117x, so the baseline itself has to be shown
+    # to be stable before any slot-count claim means anything.
+    rows = [run(args.checkpoint, enable_batching=False, max_batch_size=1, **common)]
+    for slots in args.slots:
+        rows.append(run(args.checkpoint, enable_batching=True, max_batch_size=slots, **common))
+    rows.append(run(args.checkpoint, enable_batching=False, max_batch_size=1, **common))
+
+    baseline = rows[0]["wall"]
+    print()
+    print(f"{'mode':<20} {'wall':>9} {'engine':>9} {'min':>9} {'max':>9} {'ms/step':>9} {'vs serial':>10}")
+    for row in rows:
+        print(
+            f"{row['mode']:<20} {row['wall']:>8.4f}s {row['engine']:>8.4f}s "
+            f"{row['min_wall']:>8.4f}s {row['max_wall']:>8.4f}s "
+            f"{row['per_step_wall']*1000:>8.2f} "
+            f"{row['wall']/baseline:>9.3f}x"
+        )
+    print()
+    for row in rows[1:]:
+        gap = row["wall"] - row["engine"]
+        print(
+            f"{row['mode']}: plumbing (wall-engine) {gap*1000:.2f}ms, "
+            f"loop excess over serial {(row['engine']-baseline)*1000:.2f}ms"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_phase35_benchmarks.sh
+++ b/scripts/run_phase35_benchmarks.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Phase 3.5 performance benchmarks wrapper for TP4 execution
+#
+# Every measurement gets its own process.  Building a second engine inside one
+# process costs the second one ~10% regardless of mode -- four serial engines in
+# a row measured 0.672 / 0.735 / 0.675 / 0.674s at identical GPU clocks -- so a
+# script that builds serial and batch back to back charges that penalty to
+# whichever ran second and reports it as a batching effect.  Run per config, then
+# compare the JSON.
+set -euo pipefail
+
+MODEL="${1:-/mnt/data2/Qwen3.8-27B-FP8}"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${2:-$REPO/.scratch/phase3.5_benchmarks}"
+TP="${TP:-4}"
+MAX_TOKENS="${MAX_TOKENS:-32}"
+PROMPT_LEN="${PROMPT_LEN:-16}"
+WARMUP="${WARMUP:-1}"
+RUNS="${RUNS:-5}"
+CONCURRENCY="${CONCURRENCY:-2 4 8}"
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "=== Phase 3.5 Performance Benchmarks ==="
+echo "Model:  $MODEL"
+echo "Output: $OUTPUT_DIR"
+echo "TP:     $TP"
+echo ""
+
+echo "--- Single-request latency (one process per mode) ---"
+for mode in serial batch; do
+    echo "  measuring $mode..."
+    python3 "$REPO/scripts/bench_single_request_latency.py" \
+        "$MODEL" \
+        --single "$mode" \
+        --json-out "$OUTPUT_DIR/single_${mode}.json" \
+        --max-tokens "$MAX_TOKENS" \
+        --warmup-runs "$WARMUP" \
+        --test-runs "$RUNS" \
+        --prompt-length "$PROMPT_LEN" \
+        --tensor-parallel-size "$TP" \
+        > "$OUTPUT_DIR/single_${mode}.log" 2>&1
+done
+
+echo ""
+echo "--- Concurrent throughput (one process per mode per level) ---"
+for n in $CONCURRENCY; do
+    for mode in serial batch; do
+        echo "  measuring $mode at concurrency $n..."
+        python3 "$REPO/scripts/bench_concurrent_throughput.py" \
+            "$MODEL" \
+            --single "$mode" \
+            --json-out "$OUTPUT_DIR/concurrent_${n}_${mode}.json" \
+            --num-concurrent "$n" \
+            --max-tokens "$MAX_TOKENS" \
+            --warmup-runs "$WARMUP" \
+            --test-runs "$RUNS" \
+            --prompt-length "$PROMPT_LEN" \
+            --tensor-parallel-size "$TP" \
+            > "$OUTPUT_DIR/concurrent_${n}_${mode}.log" 2>&1
+    done
+done
+
+echo ""
+python3 "$REPO/scripts/summarize_phase35_benchmarks.py" "$OUTPUT_DIR" \
+    --concurrency $CONCURRENCY | tee "$OUTPUT_DIR/summary.txt"
+
+echo ""
+echo "=== Benchmarks Complete ==="
+echo "Results saved to: $OUTPUT_DIR"

--- a/scripts/summarize_phase35_benchmarks.py
+++ b/scripts/summarize_phase35_benchmarks.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Compare the per-process Phase 3.5 measurements and apply the targets.
+
+run_phase35_benchmarks.sh writes one JSON per (mode, concurrency) because both
+modes cannot share a process without the second engine paying a ~10% penalty.
+This reads those files and does the comparison the bench scripts used to do
+in-process.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+LATENCY_TARGET = 1.05
+THROUGHPUT_TARGETS = {2: 1.7, 4: 3.0, 8: 4.5}
+
+
+def load(path: Path):
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("results_dir", type=Path)
+    parser.add_argument("--concurrency", type=int, nargs="+", default=[2, 4, 8])
+    args = parser.parse_args()
+
+    d = args.results_dir
+    failures = []
+    missing = []
+
+    print("=" * 64)
+    print("Phase 3.5 Summary")
+    print("=" * 64)
+
+    serial = load(d / "single_serial.json")
+    batch = load(d / "single_batch.json")
+    print("\nSingle-request latency (target: batch <= %.2fx serial)" % LATENCY_TARGET)
+    if not serial or not batch:
+        missing.append("single-request latency")
+        print("  missing measurement; cannot compare")
+    else:
+        ratio = batch["avg_latency"] / serial["avg_latency"]
+        print(f"  serial {serial['avg_latency']:.4f}s   batch {batch['avg_latency']:.4f}s"
+              f"   ratio {ratio:.3f}x")
+        if ratio <= LATENCY_TARGET:
+            print("  PASS")
+        else:
+            print(f"  FAIL (over by {(ratio - LATENCY_TARGET) * 100:.1f} points)")
+            failures.append(f"single-request latency {ratio:.3f}x")
+
+    print("\nConcurrent throughput")
+    for n in args.concurrency:
+        s = load(d / f"concurrent_{n}_serial.json")
+        b = load(d / f"concurrent_{n}_batch.json")
+        target = THROUGHPUT_TARGETS.get(n, 1.0)
+        if not s or not b:
+            missing.append(f"concurrency {n}")
+            print(f"  {n:>2} concurrent: missing measurement")
+            continue
+        ratio = b["throughput"] / s["throughput"]
+        verdict = "PASS" if ratio >= target else "FAIL"
+        print(f"  {n:>2} concurrent: serial {s['throughput']:.3f} req/s   "
+              f"batch {b['throughput']:.3f} req/s   {ratio:.2f}x "
+              f"(target >={target}x)  {verdict}")
+        if ratio < target:
+            failures.append(f"concurrency {n} {ratio:.2f}x < {target}x")
+
+    print("\n" + "=" * 64)
+    if missing:
+        print("INCOMPLETE: " + "; ".join(missing))
+    if failures:
+        print("FAIL: " + "; ".join(failures))
+    elif not missing:
+        print("PASS: all Phase 3.5 targets met")
+    return 1 if (failures or missing) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cpp_backend_serial_ttft.py
+++ b/tests/test_cpp_backend_serial_ttft.py
@@ -1,0 +1,94 @@
+"""The serial path must report a real TTFT, not a placeholder.
+
+``_generate_serial`` used to hardcode ``ttft_seconds=0.0``.  Nothing downstream
+notices a zero until something divides by it: the Phase 3.5 latency benchmark
+compares batch TTFT against serial TTFT and died with ZeroDivisionError, and any
+serving metric that averages TTFT silently reports 0 for every serial request.
+
+The stepped path is the one that can measure it -- it drives prefill and decode
+itself, so it knows when the first token appeared.
+"""
+
+from __future__ import annotations
+
+import time
+
+from pocketllm.api import EngineArgs, GenerationRequest, SamplingParams
+from pocketllm.backends.cpp_backend import CppBackend
+
+from test_cpp_backend_tp import SimpleTokenizer, TpFakeNative, make_tp_backend
+
+
+def _request(max_tokens: int = 4) -> GenerationRequest:
+    return GenerationRequest(
+        request_id="ttft",
+        prompt_tokens=[1, 2, 3],
+        sampling_params=SamplingParams(max_tokens=max_tokens, temperature=0.0),
+    )
+
+
+def test_serial_path_reports_nonzero_ttft() -> None:
+    backend, _ = make_tp_backend()
+    try:
+        result = backend.generate([_request()])[0]
+        assert result.timings.ttft_seconds > 0.0, "serial TTFT is still a placeholder"
+    finally:
+        backend.close()
+
+
+def test_serial_ttft_excludes_decode() -> None:
+    """TTFT must cover prefill only, so it stays below the total.
+
+    A TTFT that accidentally measured the whole loop would compare equal to
+    total_seconds and hide any prefill regression.  A slow fake decode makes the
+    two separable.
+    """
+
+    class SlowDecodeNative(TpFakeNative):
+        def QwenEngine(self, checkpoint, options, layer_count, max_context):
+            engine = super().QwenEngine(checkpoint, options, layer_count, max_context)
+            original = engine.decode_step
+
+            def slow_decode_step(token: int):
+                time.sleep(0.01)
+                return original(token)
+
+            engine.decode_step = slow_decode_step
+            return engine
+
+    backend, _ = make_tp_backend(native=SlowDecodeNative())
+    try:
+        result = backend.generate([_request(max_tokens=8)])[0]
+        assert result.timings.ttft_seconds > 0.0
+        # Seven slow decode steps sit between the first token and the last one.
+        assert result.timings.ttft_seconds < result.timings.total_seconds / 2
+    finally:
+        backend.close()
+
+
+def test_ttft_is_measured_from_request_start() -> None:
+    """The clock starts when the request starts, not when prefill is entered."""
+    backend, _ = make_tp_backend()
+    try:
+        start = time.perf_counter()
+        result = backend.generate([_request()])[0]
+        elapsed = time.perf_counter() - start
+        assert 0.0 < result.timings.ttft_seconds <= elapsed
+    finally:
+        backend.close()
+
+
+def test_single_rank_without_eos_reports_no_ttft() -> None:
+    """Native generate() drives its own loop, so the first token is not visible.
+
+    Reporting 0.0 here is honest rather than a placeholder; the alternative would
+    be to attribute the whole call to prefill.
+    """
+    args = EngineArgs(model="model", backend="cpp")
+    backend = CppBackend(args, native_module=TpFakeNative(), tokenizer=SimpleTokenizer())
+    try:
+        result = backend.generate([_request()])[0]
+        assert result.timings.ttft_seconds == 0.0
+        assert result.timings.total_seconds > 0.0
+    finally:
+        backend.close()

--- a/tests/test_factory_tp_supervision_reuse.py
+++ b/tests/test_factory_tp_supervision_reuse.py
@@ -1,0 +1,133 @@
+"""Supervised TP setup must not leak rendezvous state between backends.
+
+``create_backend`` spawns worker ranks and hands rank 0 the NCCL rendezvous path.
+Anything it records process-wide survives the backend, so a second engine built
+in the same process sees leftover state from the first.  These tests build two
+backends in a row, which is what any benchmark comparing two configurations does.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from pocketllm.api import EngineArgs
+from pocketllm.backends import factory
+
+
+class FakeSupervisor:
+    """Stands in for TensorParallelSupervisor; records start/stop only."""
+
+    instances: list["FakeSupervisor"] = []
+
+    def __init__(self, config) -> None:
+        self.config = config
+        self.started = 0
+        self.stopped = 0
+        self.nccl_id_path = f"/tmp/fake-nccl-id-{len(FakeSupervisor.instances)}"
+        FakeSupervisor.instances.append(self)
+
+    def start(self) -> None:
+        self.started += 1
+
+    def stop(self) -> None:
+        self.stopped += 1
+
+
+class FakeBackend:
+    """Captures what create_backend resolved for this rank."""
+
+    def __init__(self, args, **kwargs) -> None:
+        self.args = args
+        self.seen_nccl_id_path = args.backend_options.get("nccl_id_path")
+        self.seen_env = os.environ.get("POCKETLLM_NCCL_ID_PATH")
+
+
+@pytest.fixture
+def supervised(monkeypatch):
+    """Route create_backend at fakes and keep the env var change contained."""
+    FakeSupervisor.instances = []
+
+    import pocketllm.supervisor as supervisor_module
+
+    monkeypatch.setattr(supervisor_module, "TensorParallelSupervisor", FakeSupervisor)
+    monkeypatch.setattr(factory, "CppBackend", FakeBackend)
+    monkeypatch.setattr(factory, "select_backend", lambda args: "cpp")
+    monkeypatch.delenv("POCKETLLM_NCCL_ID_PATH", raising=False)
+    return FakeSupervisor
+
+
+def _args(**overrides) -> EngineArgs:
+    base = dict(
+        model="/nonexistent/checkpoint",
+        backend="cpp",
+        tensor_parallel_size=4,
+    )
+    base.update(overrides)
+    return EngineArgs(**base)
+
+
+def test_second_backend_still_spawns_workers(supervised):
+    """The env var must not make the second backend think it is supervised.
+
+    A leaked POCKETLLM_NCCL_ID_PATH satisfies the ``not os.environ.get(...)``
+    arm of the needs_supervision check, so the second engine skips spawning and
+    then blocks in the NCCL rendezvous waiting for ranks nobody started.
+    """
+    first = factory.create_backend(_args())
+    second = factory.create_backend(_args())
+
+    assert len(supervised.instances) == 2, "second backend did not spawn workers"
+    assert first.seen_nccl_id_path == supervised.instances[0].nccl_id_path
+    assert second.seen_nccl_id_path == supervised.instances[1].nccl_id_path
+    assert first.seen_nccl_id_path != second.seen_nccl_id_path
+
+
+def test_env_restored_after_construction(supervised):
+    """Rank 0 needs the path during construction, not afterwards."""
+    assert "POCKETLLM_NCCL_ID_PATH" not in os.environ
+
+    backend = factory.create_backend(_args())
+
+    # Visible to the backend while it builds ...
+    assert backend.seen_env == supervised.instances[0].nccl_id_path
+    # ... and gone once it is built.
+    assert "POCKETLLM_NCCL_ID_PATH" not in os.environ
+
+
+def test_preexisting_env_value_is_preserved(supervised, monkeypatch):
+    """An externally supervised path belongs to the caller; restore it verbatim."""
+    monkeypatch.setenv("POCKETLLM_NCCL_ID_PATH", "/tmp/external-nccl-id")
+
+    # A non-empty env var means external supervision, so no workers are spawned
+    # and the caller's value must survive untouched.
+    factory.create_backend(_args())
+
+    assert os.environ["POCKETLLM_NCCL_ID_PATH"] == "/tmp/external-nccl-id"
+    assert supervised.instances == []
+
+
+def test_caller_engine_args_not_mutated(supervised):
+    """backend_options is caller-owned and may be reused for another engine."""
+    args = _args()
+    factory.create_backend(args)
+
+    assert "nccl_id_path" not in args.backend_options
+
+
+def test_workers_stopped_when_rank0_fails(supervised, monkeypatch):
+    """Workers are useless without rank 0 and would hold device memory."""
+
+    class Boom(FakeBackend):
+        def __init__(self, args, **kwargs) -> None:
+            raise RuntimeError("rank 0 failed to allocate")
+
+    monkeypatch.setattr(factory, "CppBackend", Boom)
+
+    with pytest.raises(RuntimeError, match="rank 0 failed"):
+        factory.create_backend(_args())
+
+    assert len(supervised.instances) == 1
+    assert supervised.instances[0].stopped == 1
+    assert "POCKETLLM_NCCL_ID_PATH" not in os.environ

--- a/tests/test_supervisor_orphan_guard.py
+++ b/tests/test_supervisor_orphan_guard.py
@@ -1,0 +1,145 @@
+"""Ranks must not survive a supervisor that dies without running cleanup.
+
+SIGKILL and native segfaults bypass the supervisor's signal handlers and
+__exit__, and start_new_session=True means the ranks share no process group with
+it, so nothing else brings them down.  Without the PR_SET_PDEATHSIG guard these
+processes leak, and in the real backend each one holds a share of device memory.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+
+import pytest
+
+from pocketllm.supervisor import TensorParallelConfig, TensorParallelSupervisor
+
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="PR_SET_PDEATHSIG is Linux-specific",
+)
+
+
+# Stands in for a rank: announces readiness, then blocks the way a worker
+# spinning on a collective does.
+_RANK_SCRIPT = textwrap.dedent(
+    """
+    import os, sys, time
+    sys.stdout.write("POCKETLLM_RANK_READY rank=%d\\n" % int(os.environ["TP_RANK"]))
+    sys.stdout.flush()
+    while True:
+        time.sleep(0.05)
+    """
+).strip()
+
+# Parent that starts a supervisor and reports the rank PIDs, so the test can
+# outlive it and check them.  It must not be killed before the ranks are up.
+_PARENT_SCRIPT = textwrap.dedent(
+    """
+    import sys, time
+    from pocketllm.supervisor import TensorParallelConfig, TensorParallelSupervisor
+
+    config = TensorParallelConfig(
+        command=(sys.executable, "-c", {rank_script!r}),
+        world_size=2,
+        startup_timeout=60.0,
+    )
+    supervisor = TensorParallelSupervisor(config)
+    supervisor.start()
+    print("PIDS " + ",".join(str(r.process.pid) for r in supervisor.processes), flush=True)
+    while True:
+        time.sleep(0.05)
+    """
+)
+
+
+def _alive(pid: int) -> bool:
+    """True only for a process still running.
+
+    Reads /proc rather than using ``os.kill(pid, 0)``, which also succeeds for a
+    zombie and would report a dead rank as alive.
+    """
+    try:
+        with open(f"/proc/{pid}/stat", encoding="ascii") as handle:
+            # The comm field can contain spaces and parens, so split after it.
+            state = handle.read().rsplit(")", 1)[1].split()[0]
+    except (FileNotFoundError, ProcessLookupError, IndexError):
+        return False
+    return state != "Z"
+
+
+def _wait_gone(pids: list[int], timeout: float = 15.0) -> list[int]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not any(_alive(pid) for pid in pids):
+            return []
+        time.sleep(0.1)
+    return [pid for pid in pids if _alive(pid)]
+
+
+@pytest.mark.parametrize("kill_signal", [signal.SIGKILL, signal.SIGSEGV])
+def test_ranks_die_when_supervisor_is_killed_uncleanly(kill_signal: signal.Signals) -> None:
+    """An unhandleable signal to the supervisor must still take the ranks down."""
+    source = _PARENT_SCRIPT.format(rank_script=_RANK_SCRIPT)
+    parent = subprocess.Popen(
+        [sys.executable, "-c", source],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    )
+    rank_pids: list[int] = []
+    try:
+        assert parent.stdout is not None
+        deadline = time.monotonic() + 90.0
+        while time.monotonic() < deadline:
+            line = parent.stdout.readline()
+            if not line:
+                break
+            if line.startswith("PIDS "):
+                rank_pids = [int(p) for p in line[5:].strip().split(",")]
+                break
+        assert rank_pids, f"supervisor never reported ranks; stderr={parent.stderr.read()!r}"
+        assert all(_alive(pid) for pid in rank_pids), "ranks not running before kill"
+
+        # The supervisor gets no chance to clean up; only the kernel-level guard
+        # can bring the ranks down from here.
+        parent.send_signal(kill_signal)
+        parent.wait(timeout=30)
+
+        survivors = _wait_gone(rank_pids)
+        assert not survivors, f"ranks leaked after supervisor {kill_signal.name}: {survivors}"
+    finally:
+        if parent.poll() is None:
+            parent.kill()
+            parent.wait(timeout=10)
+        for pid in rank_pids:
+            if _alive(pid):
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+
+def test_graceful_stop_still_reaps_ranks() -> None:
+    """The guard must not disturb the normal shutdown path."""
+    config = TensorParallelConfig(
+        command=(sys.executable, "-c", _RANK_SCRIPT),
+        world_size=2,
+        startup_timeout=60.0,
+    )
+    supervisor = TensorParallelSupervisor(config)
+    supervisor.start()
+    rank_pids = [record.process.pid for record in supervisor.processes]
+    assert all(_alive(pid) for pid in rank_pids)
+
+    supervisor.cleanup()
+
+    survivors = _wait_gone(rank_pids)
+    assert not survivors, f"ranks survived graceful stop: {survivors}"


### PR DESCRIPTION
## Summary

Measures `QwenBatchScheduler` against the Phase 3.5 targets on 4× RTX 2080 Ti with `Qwen3.8-27B-FP8` (TP4, 16-token prompts, 32 new tokens). Full report: `docs/phase3_5_validation_results.md`.

| Target | Result | |
|---|---|---|
| Single-request latency ≤1.05× serial | **1.002×** | PASS |
| 2 concurrent ≥1.7× throughput | **1.00×** | FAIL |
| 4 concurrent ≥3.0× throughput | **0.99×** | FAIL |
| 8 concurrent ≥4.5× throughput | **0.99×** | FAIL |

Batching costs nothing for a lone request and buys nothing for concurrent ones.

## Why throughput is flat

`QwenEngine::batch_decode_step` (`cpp_engine/engine/qwen_engine.cpp:4281`) loops over the batch calling single-sequence `decode_step` once per request. Its own comment says the true batched decode kernel was "deferred to Phase 3.2" — it never landed. N concurrent requests do N× the sequential work plus a TP broadcast each, so 1.00× is the structural ceiling and these targets were never reachable at this commit.

The scheduler is not at fault: instrumenting `get_stats()` during an 8-request run shows peak `running_requests = 8` with 7 waiting, so slots really are occupied concurrently. Batch mode does equalize completion times (5.494s of 5.517s wall at 8 concurrent, vs 3.075s average in serial) — fair scheduling, but no total work moved.

## Two measurement bugs found and fixed

**Serial TTFT was hardcoded `0.0`.** The latency benchmark divided by zero comparing TTFT ratios. The stepped path now measures it, since it drives prefill/decode itself. The single-rank fast path still reports `0.0` — native `generate()` exposes no first-token boundary, so that is a real absence, not a placeholder.

**Building a second engine in one process costs it ~10%, whichever mode it is.** Four *serial* engines in a row:

| engine | wall |
|---|---|
| #0 | 0.6718s |
| #1 | **0.7352s** |
| #2 | 0.6746s |
| #3 | 0.6741s |

The effect follows build *position*, not batching or slot count (an 8-slot batch engine measured 1.102× built second, 1.004× built third). GPU clocks (1860 MHz), power state and host thread/child counts are identical across the slow and fast windows, and a 20s gap does not remove it — neither throttling nor teardown overlap. Root cause not identified; `cached_comm` (`tp_comm.cpp:184`) caching NCCL communicators in a `static` map that is never destroyed is a candidate, but it could not be isolated (TP=1 has no NCCL path but cannot hold this 27B checkpoint).

Since the old scripts always built serial first and batch second, this was being reported as 1.117× "batching overhead". Each measurement now runs in its own process, with `scripts/summarize_phase35_benchmarks.py` aggregating the JSON.

## Scheduler fix

`run_prefill_batch` / `run_decode_batch` returned `void`, so the loop could not distinguish a completed forward pass from an empty one and slept 1ms unconditionally — worth ~18ms of a 32-step request. They now report whether work ran, and the loop only waits when idle. Idle cost measured at 0.2% of one core over a 10s window, so the condition-variable wait still parks correctly.

## Implementation notes

- `factory.py` scopes the NCCL rendezvous path to its own backend instead of leaking it into `os.environ` (which previously hung a second supervised engine in the rendezvous) and stops the workers if rank 0 fails to build.
- Both bench scripts gained `--single {serial,batch}` / `--json-out`; `run_phase35_benchmarks.sh` drives them per-process (it also previously hardcoded TP=1).
- `scripts/profile_batch_single_request_overhead.py` reproduces the build-order artifact.

## Testing

53 pass across the cpp backend, factory and supervisor suites, plus 4 new tests in `tests/test_cpp_backend_serial_ttft.py`.

Pre-existing failures, reproduced identically on a clean tree and **not** addressed here: `test_cpp_backend_tp.py::test_tp_requires_nccl_id_path`, `test_cpp_backend_batching.py::{test_serial_mode,test_batch_mode}`.

## Follow-ups (not in this PR)

- Batched decode kernel — prerequisite for any concurrency throughput work.
- Root-cause the second-engine 10% penalty; it pollutes any cross-engine A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)