### PR TITLE
Add batched decode kernels and engine path for Qwen (Phase 3)

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -706,6 +706,18 @@ add_executable(test_qwen_half_ops tests/test_qwen_half_ops.cpp)
 target_link_libraries(test_qwen_half_ops PRIVATE dsv4_cpp_core)
 set_target_properties(test_qwen_half_ops PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_qwen_batched_decode tests/test_qwen_batched_decode.cpp)
+target_link_libraries(test_qwen_batched_decode PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_batched_decode PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_batched_engine_parity tests/test_qwen_batched_engine_parity.cpp)
+target_link_libraries(test_qwen_batched_engine_parity PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_batched_engine_parity PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(bench_qwen_batched_throughput tests/bench_qwen_batched_throughput.cpp)
+target_link_libraries(bench_qwen_batched_throughput PRIVATE dsv4_cpp_core)
+set_target_properties(bench_qwen_batched_throughput PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_qwen_nvfp4 tests/test_qwen_nvfp4.cpp)
 target_link_libraries(test_qwen_nvfp4 PRIVATE dsv4_cpp_core)
 set_target_properties(test_qwen_nvfp4 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/backends/cuda/kernels/qwen_gqa_optimized.cu
+++ b/cpp_engine/backends/cuda/kernels/qwen_gqa_optimized.cu
@@ -1633,7 +1633,12 @@ __global__ void gqa_prefill_tiled_f16_kernel(
 // arithmetic is untouched: the dot product still reduces over the same lanes in
 // the same warp_sum tree, and the softmax recurrence still walks positions in
 // order, so a given split count gives bit-identical output at any width.
-template <int kHPG>
+// Batched decode drives one CTA row per sequence through blockIdx.y. Every
+// row-dependent value is resolved before the position loop, so the arithmetic
+// inside it -- and therefore the result for a given split count -- is identical
+// to the single-row instantiation. `kBatched=false` keeps the original codegen
+// with no extra registers for the unused row indirection.
+template <int kHPG, bool kBatched = false>
 __global__ void gqa_decode_split_f16_kernel(
     const uint16_t* __restrict__ q,
     const uint16_t* __restrict__ k_cache,
@@ -1646,7 +1651,10 @@ __global__ void gqa_decode_split_f16_kernel(
     int splits,
     int positions_per_split,
     int window,
-    int sink) {
+    int sink,
+    const int* __restrict__ context_lens = nullptr,
+    const int* __restrict__ slot_ids = nullptr,
+    size_t kv_slot_stride = 0) {
     const int q_per_kv = q_heads / kv_heads;
     const int groups_per_kv = (q_per_kv + kHPG - 1) / kHPG;
     const int grouped = static_cast<int>(blockIdx.x) / splits;
@@ -1654,6 +1662,22 @@ __global__ void gqa_decode_split_f16_kernel(
     const int kv_head = grouped / groups_per_kv;
     const int group = grouped % groups_per_kv;
     const int first_head = kv_head * q_per_kv + group * kHPG;
+    // Each sequence owns a contiguous KV slot and its own context length. The
+    // launch sizes the split geometry from the longest row, so shorter rows run
+    // some splits dry and publish the neutral partial the merge already handles.
+    // The slot is not the batch index: slots are allocated as requests arrive,
+    // so a four-row batch can hold slots 1/3/5/6.
+    if constexpr (kBatched) {
+        const int row = static_cast<int>(blockIdx.y);
+        context_len = context_lens[row];
+        const size_t slot = static_cast<size_t>(
+            slot_ids != nullptr ? slot_ids[row] : row) * kv_slot_stride;
+        k_cache += slot;
+        v_cache += slot;
+        q += static_cast<size_t>(row) * q_heads * head_dim;
+        partial_output += static_cast<size_t>(row) * q_heads * splits *
+            (head_dim + 2);
+    }
     const SparseRanges ranges = sparse_ranges(context_len, window, sink);
     const int start = split * positions_per_split;
     const int end = min(ranges.total(), start + positions_per_split);
@@ -2399,6 +2423,13 @@ __global__ void gqa_decode_merge_f16_kernel(
     int splits) {
     const int head = static_cast<int>(blockIdx.x);
     if (head >= q_heads) return;
+    // blockIdx.y indexes the sequence when batched decode launches this; the
+    // single-row grid leaves it at zero, so the offsets below vanish.
+    {
+        const size_t row = static_cast<size_t>(blockIdx.y);
+        partial_output += row * q_heads * splits * (head_dim + 2);
+        output += row * q_heads * head_dim;
+    }
     __shared__ float weights[kDecodeSplitCeiling];
     __shared__ float shared_maximum;
     const int stride = head_dim + 2;
@@ -3068,6 +3099,67 @@ bool qwen_gqa_decode_attention_f16_fused_cuda(
         q, k_cache, v_cache, output, partial_scratch, q_heads, kv_heads,
         head_dim, context_len, max_context, attention_window, sink_tokens,
         QwenGqaDecodeVariant::Selected, 0, stream);
+}
+
+int qwen_gqa_decode_batched_split_count(
+    int max_context_len, int kv_heads, int attention_window, int sink_tokens) {
+    const SparseRanges ranges =
+        sparse_ranges(max_context_len, attention_window, sink_tokens);
+    // Always the scalar geometry: the batched path does not launch the MMA
+    // variant, whose CTA embeds exactly one row's six Q heads.
+    return decode_split_count_for_variant(ranges.total(), false, 0, kv_heads);
+}
+
+bool qwen_gqa_decode_attention_f16_batched_cuda(
+    const uint16_t* q, const uint16_t* k_cache,
+    const uint16_t* v_cache, uint16_t* output, float* partial_scratch,
+    const int* d_context_lens, const int* d_slot_ids, int rows,
+    int max_context_len, size_t kv_slot_stride, int q_heads, int kv_heads,
+    int head_dim, int max_context, int attention_window, int sink_tokens,
+    void* stream) {
+    if (!q || !k_cache || !v_cache || !output || !partial_scratch ||
+        !d_context_lens || rows <= 0 || max_context_len <= 0 ||
+        max_context_len > max_context || attention_window < 0 ||
+        sink_tokens < 0 || !valid_shape(q_heads, kv_heads, head_dim)) {
+        return false;
+    }
+    // One grid covers every sequence. The split count comes from the longest
+    // row so a single launch serves the whole batch; shorter rows leave their
+    // trailing splits empty, which publishes the neutral partial.
+    const SparseRanges ranges =
+        sparse_ranges(max_context_len, attention_window, sink_tokens);
+    const int attended = ranges.total();
+    const int splits = decode_split_count_for_variant(
+        attended, false, 0, kv_heads);
+    if (splits > kDecodeSplitCeiling) return false;
+    const int positions_per_split = (attended + splits - 1) / splits;
+    const int group_heads = decode_group_width(q_heads / kv_heads);
+    const int groups_per_kv =
+        (q_heads / kv_heads + group_heads - 1) / group_heads;
+    const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
+    const dim3 grid(static_cast<unsigned>(kv_heads * groups_per_kv * splits),
+                    static_cast<unsigned>(rows), 1);
+#define DSV4_LAUNCH_DECODE_SPLIT_BATCHED(HPG) \
+    gqa_decode_split_f16_kernel<HPG, true><<<grid, kThreads, 0, cuda_stream>>>( \
+        q, k_cache, v_cache, partial_scratch, q_heads, kv_heads, head_dim, \
+        max_context_len, splits, positions_per_split, attention_window, \
+        sink_tokens, d_context_lens, d_slot_ids, kv_slot_stride)
+    switch (group_heads) {
+        case 1: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(1); break;
+        case 2: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(2); break;
+        case 3: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(3); break;
+        case 4: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(4); break;
+        case 5: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(5); break;
+        case 6: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(6); break;
+        default: return false;
+    }
+#undef DSV4_LAUNCH_DECODE_SPLIT_BATCHED
+    if (cudaGetLastError() != cudaSuccess) return false;
+    const dim3 merge_grid(static_cast<unsigned>(q_heads),
+                          static_cast<unsigned>(rows), 1);
+    gqa_decode_merge_f16_kernel<<<merge_grid, kThreads, 0, cuda_stream>>>(
+        partial_scratch, output, q_heads, head_dim, splits);
+    return cudaGetLastError() == cudaSuccess;
 }
 
 bool qwen_gqa_decode_attention_f16_fused_variant_cuda(

--- a/cpp_engine/backends/cuda/kernels/qwen_half_ops.cu
+++ b/cpp_engine/backends/cuda/kernels/qwen_half_ops.cu
@@ -2227,6 +2227,41 @@ __global__ void conv_silu_f16_kernel(
     }
 }
 
+// Batched decode variant: one token per sequence, each against its own
+// convolution tail. blockIdx.y selects the sequence. Distinct from the seq_len
+// loop above, where the rows are consecutive tokens of one sequence.
+__global__ void conv_silu_f16_batched_kernel(
+    const uint16_t* x, const uint16_t* weight, uint16_t* tail,
+    uint16_t* y, const int* slot_ids, int rows, int channels, int kernel,
+    size_t tail_slot_stride) {
+    const int channel = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int row = static_cast<int>(blockIdx.y);
+    if (channel >= channels || row >= rows) return;
+    const uint16_t* w = weight + static_cast<size_t>(channel) * kernel;
+    const int tail_len = kernel - 1;
+    // The tail slot is not the batch index; slots are assigned per request.
+    uint16_t* row_tail = tail +
+        static_cast<size_t>(slot_ids != nullptr ? slot_ids[row] : row) *
+        tail_slot_stride;
+    const size_t index = static_cast<size_t>(row) * channels + channel;
+    // The single new token is the last kernel tap; the earlier taps come from
+    // this sequence's tail.
+    float value = half_to_float(x[index]) * half_to_float(w[tail_len]);
+    for (int j = 0; j < tail_len; ++j) {
+        value += half_to_float(row_tail[static_cast<size_t>(j) * channels + channel]) *
+            half_to_float(w[j]);
+    }
+    y[index] = float_to_half(silu(value));
+    // Shift the tail by one and append the new token.
+    for (int j = 0; j + 1 < tail_len; ++j) {
+        row_tail[static_cast<size_t>(j) * channels + channel] =
+            row_tail[static_cast<size_t>(j + 1) * channels + channel];
+    }
+    if (tail_len > 0) {
+        row_tail[static_cast<size_t>(tail_len - 1) * channels + channel] = x[index];
+    }
+}
+
 __global__ void linear_gates_f16_kernel(
     const uint16_t* a, const uint16_t* b, const uint16_t* a_log,
     const uint16_t* dt_bias, uint16_t* g, uint16_t* beta,
@@ -2253,6 +2288,84 @@ __global__ void gated_delta_step_f16_kernel(
     const int value = static_cast<int>(threadIdx.x);
     const int repeat = heads / key_heads;
     const int key_head = head / repeat;
+    extern __shared__ float smem[];
+    float* k_shared = smem;
+    float* q_shared = smem + key_dim;
+    float* reduce = smem + 2 * key_dim;
+    const int tid = static_cast<int>(threadIdx.x);
+    float q_partial = 0.0f;
+    float k_partial = 0.0f;
+    for (int i = tid; i < key_dim; i += blockDim.x) {
+        const float qv = half_to_float(q[static_cast<size_t>(key_head) * key_dim + i]);
+        const float kv = half_to_float(k[static_cast<size_t>(key_head) * key_dim + i]);
+        q_partial += qv * qv;
+        k_partial += kv * kv;
+    }
+    reduce[tid] = q_partial;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) reduce[tid] += reduce[tid + stride];
+        __syncthreads();
+    }
+    const float q_inv = rsqrtf(reduce[0] + 1.0e-6f);
+    __syncthreads();
+    reduce[tid] = k_partial;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) reduce[tid] += reduce[tid + stride];
+        __syncthreads();
+    }
+    const float k_inv = rsqrtf(reduce[0] + 1.0e-6f);
+    for (int i = tid; i < key_dim; i += blockDim.x) {
+        q_shared[i] = half_to_float(q[static_cast<size_t>(key_head) * key_dim + i]) * q_inv;
+        k_shared[i] = half_to_float(k[static_cast<size_t>(key_head) * key_dim + i]) * k_inv;
+    }
+    __syncthreads();
+    if (head >= heads || value >= value_dim) return;
+    float* sh = state + static_cast<size_t>(head) * key_dim * value_dim;
+    const float decay = expf(half_to_float(g[head]));
+    const float b = half_to_float(beta[head]);
+    float kv_mem = 0.0f;
+    for (int i = 0; i < key_dim; ++i) {
+        const size_t index = static_cast<size_t>(i) * value_dim + value;
+        const float cell = sh[index] * decay;
+        sh[index] = cell;
+        kv_mem += cell * k_shared[i];
+    }
+    const float delta = (half_to_float(v[static_cast<size_t>(head) * value_dim + value]) - kv_mem) * b;
+    float result = 0.0f;
+    for (int i = 0; i < key_dim; ++i) {
+        const size_t index = static_cast<size_t>(i) * value_dim + value;
+        const float cell = sh[index] + k_shared[i] * delta;
+        sh[index] = cell;
+        result += cell * q_shared[i];
+    }
+    output[static_cast<size_t>(head) * value_dim + value] = float_to_half(result * q_scale);
+}
+
+// Batched single-step recurrence: blockIdx.y selects the sequence, which owns
+// its own recurrent state slot. Every sequence advances one token, so the rows
+// are independent and the arithmetic per row is identical to the step kernel
+// above -- only the base pointers differ.
+__global__ void gated_delta_step_batched_f16_kernel(
+    float* state, const uint16_t* q, const uint16_t* k,
+    const uint16_t* v, const uint16_t* g, const uint16_t* beta,
+    uint16_t* output, const int* slot_ids, int heads, int key_heads,
+    int key_dim, int value_dim, float q_scale, size_t state_slot_stride) {
+    const int head = static_cast<int>(blockIdx.x);
+    const int row = static_cast<int>(blockIdx.y);
+    const int value = static_cast<int>(threadIdx.x);
+    const int repeat = heads / key_heads;
+    const int key_head = head / repeat;
+    // The state slot is not the batch index; slots are assigned per request.
+    state += static_cast<size_t>(slot_ids != nullptr ? slot_ids[row] : row) *
+        state_slot_stride;
+    q += static_cast<size_t>(row) * key_heads * key_dim;
+    k += static_cast<size_t>(row) * key_heads * key_dim;
+    v += static_cast<size_t>(row) * heads * value_dim;
+    g += static_cast<size_t>(row) * heads;
+    beta += static_cast<size_t>(row) * heads;
+    output += static_cast<size_t>(row) * heads * value_dim;
     extern __shared__ float smem[];
     float* k_shared = smem;
     float* q_shared = smem + key_dim;
@@ -2571,6 +2684,35 @@ __global__ void partial_rope_f16_kernel(
     }
 }
 
+__global__ void partial_rope_f16_batched_kernel(
+    uint16_t* q, uint16_t* k, const int* positions, int rows,
+    int rotary_dim, float theta, int q_heads, int kv_heads, int head_dim) {
+    const int half = rotary_dim / 2;
+    const int index = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int row = static_cast<int>(blockIdx.y);
+    if (index >= half || row >= rows) return;
+    const int position = positions[row];
+    const float angle = static_cast<float>(position) * rope_inv_freq(index, rotary_dim, theta);
+    const float c = cosf(angle);
+    const float s = sinf(angle);
+    uint16_t* qr = q + static_cast<size_t>(row) * q_heads * head_dim;
+    uint16_t* kr = k + static_cast<size_t>(row) * kv_heads * head_dim;
+    for (int head = 0; head < q_heads; ++head) {
+        uint16_t* line = qr + static_cast<size_t>(head) * head_dim;
+        const float a = half_to_float(line[index]);
+        const float b = half_to_float(line[index + half]);
+        line[index] = float_to_half(a * c - b * s);
+        line[index + half] = float_to_half(b * c + a * s);
+    }
+    for (int head = 0; head < kv_heads; ++head) {
+        uint16_t* line = kr + static_cast<size_t>(head) * head_dim;
+        const float a = half_to_float(line[index]);
+        const float b = half_to_float(line[index + half]);
+        line[index] = float_to_half(a * c - b * s);
+        line[index + half] = float_to_half(b * c + a * s);
+    }
+}
+
 __global__ void split_q_gate_f16_kernel(
     const uint16_t* source, uint16_t* q, uint16_t* gate,
     int rows, int q_heads, int head_dim) {
@@ -2617,6 +2759,32 @@ __global__ void append_kv_f16_kernel(
     v_cache[destination] = v_rows[index];
 }
 
+// Batched decode append: one token per sequence, each into its own KV slot at
+// its own position. Distinct from the kernel above, where the rows are
+// consecutive tokens of a single sequence sharing one slot.
+//
+// The slot a row occupies is not its index in the batch: slots are allocated and
+// freed as requests arrive and finish, so a four-row batch can hold slots
+// 1/3/5/6. `slot_ids` carries that mapping; passing null means slot == row.
+__global__ void append_kv_f16_batched_kernel(
+    const uint16_t* k_rows, const uint16_t* v_rows,
+    uint16_t* k_cache, uint16_t* v_cache, const int* start_positions,
+    const int* slot_ids, int rows, int kv_heads, int head_dim, int max_context,
+    size_t kv_slot_stride) {
+    const int index = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int total = rows * kv_heads * head_dim;
+    if (index >= total) return;
+    const int row = index / (kv_heads * head_dim);
+    const int within = index % (kv_heads * head_dim);
+    const int destination_token = start_positions[row];
+    if (destination_token >= max_context) return;
+    const int slot = slot_ids != nullptr ? slot_ids[row] : row;
+    const size_t destination = static_cast<size_t>(slot) * kv_slot_stride +
+        static_cast<size_t>(destination_token) * kv_heads * head_dim + within;
+    k_cache[destination] = k_rows[index];
+    v_cache[destination] = v_rows[index];
+}
+
 __global__ void append_kv_fp8_kernel(
     const uint16_t* k_rows, const uint16_t* v_rows,
     uint8_t* k_cache, uint8_t* v_cache,
@@ -2652,6 +2820,61 @@ __global__ void append_kv_fp8_kernel(
     const float ks = reduce_k[0] > 0.0f ? reduce_k[0] / 448.0f : 1.0f;
     const float vs = reduce_v[0] > 0.0f ? reduce_v[0] / 448.0f : 1.0f;
     const int destination_token = start_pos + token;
+    const size_t scale_index = (static_cast<size_t>(destination_token) * kv_heads + head) * blocks_per_head + channel_block;
+    if (threadIdx.x == 0) {
+        k_scale[scale_index] = float_to_half(ks);
+        v_scale[scale_index] = float_to_half(vs);
+    }
+    const size_t destination_base = (static_cast<size_t>(destination_token) * kv_heads + head) * head_dim + channel_block * scale_block;
+    for (int d = threadIdx.x; d < scale_block; d += blockDim.x) {
+        k_cache[destination_base + d] = float_to_fp8_e4m3(half_to_float(k_rows[source_base + d]) / ks);
+        v_cache[destination_base + d] = float_to_fp8_e4m3(half_to_float(v_rows[source_base + d]) / vs);
+    }
+}
+
+__global__ void append_kv_fp8_batched_kernel(
+    const uint16_t* k_rows, const uint16_t* v_rows,
+    uint8_t* k_cache, uint8_t* v_cache,
+    uint16_t* k_scale, uint16_t* v_scale,
+    const int* start_positions, const int* slot_ids, int rows, int kv_heads,
+    int head_dim, int scale_block, int max_context, size_t kv_slot_stride) {
+    const int block_index = static_cast<int>(blockIdx.x);
+    const int blocks_per_head = head_dim / scale_block;
+    const int row = block_index / (kv_heads * blocks_per_head);
+    const int within = block_index % (kv_heads * blocks_per_head);
+    const int head = within / blocks_per_head;
+    const int channel_block = within % blocks_per_head;
+    if (row >= rows) return;
+    const int destination_token = start_positions[row];
+    if (destination_token >= max_context) return;
+    // Each sequence owns a contiguous cache slot, which is not its batch index;
+    // the scale array is strided by the same slot count over the block width.
+    const int slot = slot_ids != nullptr ? slot_ids[row] : row;
+    k_cache += static_cast<size_t>(slot) * kv_slot_stride;
+    v_cache += static_cast<size_t>(slot) * kv_slot_stride;
+    k_scale += static_cast<size_t>(slot) * (kv_slot_stride / scale_block);
+    v_scale += static_cast<size_t>(slot) * (kv_slot_stride / scale_block);
+    const int source_base = (row * kv_heads + head) * head_dim + channel_block * scale_block;
+    float k_max = 0.0f;
+    float v_max = 0.0f;
+    for (int d = threadIdx.x; d < scale_block; d += blockDim.x) {
+        k_max = fmaxf(k_max, fabsf(half_to_float(k_rows[source_base + d])));
+        v_max = fmaxf(v_max, fabsf(half_to_float(v_rows[source_base + d])));
+    }
+    __shared__ float reduce_k[128];
+    __shared__ float reduce_v[128];
+    reduce_k[threadIdx.x] = k_max;
+    reduce_v[threadIdx.x] = v_max;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            reduce_k[threadIdx.x] = fmaxf(reduce_k[threadIdx.x], reduce_k[threadIdx.x + stride]);
+            reduce_v[threadIdx.x] = fmaxf(reduce_v[threadIdx.x], reduce_v[threadIdx.x + stride]);
+        }
+        __syncthreads();
+    }
+    const float ks = reduce_k[0] > 0.0f ? reduce_k[0] / 448.0f : 1.0f;
+    const float vs = reduce_v[0] > 0.0f ? reduce_v[0] / 448.0f : 1.0f;
     const size_t scale_index = (static_cast<size_t>(destination_token) * kv_heads + head) * blocks_per_head + channel_block;
     if (threadIdx.x == 0) {
         k_scale[scale_index] = float_to_half(ks);
@@ -3805,6 +4028,20 @@ bool qwen_causal_depthwise_conv_silu_f16_cuda(
     return cudaGetLastError() == cudaSuccess;
 }
 
+bool qwen_causal_depthwise_conv_silu_f16_batched_cuda(
+    const uint16_t* x, const uint16_t* weight, uint16_t* tail,
+    uint16_t* y, const int* slot_ids, int rows, int channels, int kernel,
+    size_t tail_slot_stride, void* stream) {
+    if (!x || !weight || !y || !tail || rows <= 0 || channels <= 0 ||
+        kernel <= 0 || kernel - 1 > 8 || tail_slot_stride == 0) return false;
+    const dim3 grid(static_cast<unsigned>((channels + kThreads - 1) / kThreads),
+                    static_cast<unsigned>(rows), 1);
+    conv_silu_f16_batched_kernel<<<grid, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(x, weight, tail, y, slot_ids, rows,
+        channels, kernel, tail_slot_stride);
+    return cudaGetLastError() == cudaSuccess;
+}
+
 bool qwen_linear_attn_gates_f16_cuda(
     const uint16_t* a, const uint16_t* b, const uint16_t* a_log,
     const uint16_t* dt_bias, uint16_t* g, uint16_t* beta,
@@ -3828,6 +4065,29 @@ bool qwen_gated_delta_step_f16_cuda(
     const size_t shared = (2u * static_cast<size_t>(key_dim) + threads) * sizeof(float);
     gated_delta_step_f16_kernel<<<heads, threads, shared, static_cast<cudaStream_t>(stream)>>>(
         state, q, k, v, g, beta, output, heads, key_heads, key_dim, value_dim, q_scale);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gated_delta_step_batched_f16_cuda(
+    float* state, const uint16_t* q, const uint16_t* k,
+    const uint16_t* v, const uint16_t* g, const uint16_t* beta,
+    uint16_t* output, const int* slot_ids, int rows, int heads, int key_heads,
+    int key_dim, int value_dim, float q_scale, size_t state_slot_stride,
+    void* stream) {
+    if (!state || !q || !k || !v || !g || !beta || !output || rows <= 0 ||
+        heads <= 0 || key_heads <= 0 || heads % key_heads != 0 ||
+        key_dim <= 0 || value_dim <= 0 || q_scale <= 0.0f ||
+        state_slot_stride == 0) return false;
+    int threads = 32;
+    while (threads < value_dim) threads <<= 1;
+    if (threads > 1024) return false;
+    const size_t shared = (2u * static_cast<size_t>(key_dim) + threads) * sizeof(float);
+    const dim3 grid(static_cast<unsigned>(heads),
+                    static_cast<unsigned>(rows), 1);
+    gated_delta_step_batched_f16_kernel<<<grid, threads, shared,
+        static_cast<cudaStream_t>(stream)>>>(
+        state, q, k, v, g, beta, output, slot_ids, heads, key_heads, key_dim,
+        value_dim, q_scale, state_slot_stride);
     return cudaGetLastError() == cudaSuccess;
 }
 
@@ -3969,6 +4229,20 @@ bool qwen_partial_rope_rows_f16_cuda(
     return cudaGetLastError() == cudaSuccess;
 }
 
+bool qwen_partial_rope_rows_f16_batched_cuda(
+    uint16_t* q, uint16_t* k, const int* positions, int rows,
+    int rotary_dim, float theta, int q_heads, int kv_heads,
+    int head_dim, void* stream) {
+    if (!q || !k || !positions || rows <= 0 || rotary_dim <= 0 ||
+        (rotary_dim & 1) != 0 || rotary_dim > head_dim || theta <= 0.0f ||
+        q_heads <= 0 || kv_heads <= 0 || head_dim <= 0) return false;
+    dim3 grid(static_cast<unsigned>((rotary_dim / 2 + kThreads - 1) / kThreads),
+              static_cast<unsigned>(rows), 1);
+    partial_rope_f16_batched_kernel<<<grid, kThreads, 0, static_cast<cudaStream_t>(stream)>>>(
+        q, k, positions, rows, rotary_dim, theta, q_heads, kv_heads, head_dim);
+    return cudaGetLastError() == cudaSuccess;
+}
+
 bool qwen_split_q_gate_f16_cuda(
     const uint16_t* source, uint16_t* q, uint16_t* gate,
     int rows, int q_heads, int head_dim, void* stream) {
@@ -4021,6 +4295,22 @@ bool qwen_append_kv_cache_f16_cuda(
     return cudaGetLastError() == cudaSuccess;
 }
 
+bool qwen_append_kv_cache_f16_batched_cuda(
+    const uint16_t* k_rows, const uint16_t* v_rows,
+    uint16_t* k_cache, uint16_t* v_cache, int rows,
+    int kv_heads, int head_dim, const int* start_positions,
+    const int* slot_ids, int max_context, size_t kv_slot_stride, void* stream) {
+    if (!k_rows || !v_rows || !k_cache || !v_cache || !start_positions ||
+        rows <= 0 || kv_heads <= 0 || head_dim <= 0 ||
+        max_context <= 0 || kv_slot_stride == 0) return false;
+    const int total = rows * kv_heads * head_dim;
+    append_kv_f16_batched_kernel<<<(total + kThreads - 1) / kThreads, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(k_rows, v_rows, k_cache, v_cache,
+        start_positions, slot_ids, rows, kv_heads, head_dim, max_context,
+        kv_slot_stride);
+    return cudaGetLastError() == cudaSuccess;
+}
+
 bool qwen_append_kv_cache_fp8_cuda(
     const uint16_t* k_rows, const uint16_t* v_rows,
     uint8_t* k_cache, uint8_t* v_cache, uint16_t* k_scale,
@@ -4034,6 +4324,24 @@ bool qwen_append_kv_cache_fp8_cuda(
     append_kv_fp8_kernel<<<blocks, 128, 0, static_cast<cudaStream_t>(stream)>>>(
         k_rows, v_rows, k_cache, v_cache, k_scale, v_scale, seq_len,
         kv_heads, head_dim, scale_block, start_pos, max_context);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_append_kv_cache_fp8_batched_cuda(
+    const uint16_t* k_rows, const uint16_t* v_rows,
+    uint8_t* k_cache, uint8_t* v_cache, uint16_t* k_scale,
+    uint16_t* v_scale, int rows, int kv_heads, int head_dim,
+    int scale_block, const int* start_positions, const int* slot_ids,
+    int max_context, size_t kv_slot_stride, void* stream) {
+    if (!k_rows || !v_rows || !k_cache || !v_cache || !k_scale || !v_scale ||
+        !start_positions || rows <= 0 || kv_heads <= 0 || head_dim <= 0 ||
+        scale_block <= 0 || scale_block > 128 || head_dim % scale_block != 0 ||
+        max_context <= 0 || kv_slot_stride == 0) return false;
+    const int blocks = rows * kv_heads * (head_dim / scale_block);
+    append_kv_fp8_batched_kernel<<<blocks, 128, 0, static_cast<cudaStream_t>(stream)>>>(
+        k_rows, v_rows, k_cache, v_cache, k_scale, v_scale, start_positions,
+        slot_ids, rows, kv_heads, head_dim, scale_block, max_context,
+        kv_slot_stride);
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -462,6 +462,27 @@ struct QwenEngine::Impl {
     QwenDeviceTensor hidden_b;
     QwenDeviceTensor argmax_token;
     QwenDeviceTensor argmax_logit;
+    // Batched decode row metadata. Each row of a batched decode step sits at a
+    // different position in a different slot, so the kernels read these arrays
+    // instead of the scalar position/slot the single-sequence path passes down.
+    // Null in `batch_rows` is what tells every layer it is on the single-row
+    // path, which keeps the existing launches byte-for-byte unchanged.
+    struct BatchRows {
+        // Device arrays, all `rows` long.
+        const int* slot_ids = nullptr;
+        // Position of each row's new token, i.e. its context length minus one.
+        const int* positions = nullptr;
+        // Context length after the new token is appended: positions[i] + 1.
+        const int* context_lens = nullptr;
+        // Host mirrors. The launchers need the widest context to size the split
+        // geometry and the scratch, and that is a host-side decision.
+        int rows = 0;
+        int max_context_len = 0;
+    };
+    const BatchRows* batch_rows = nullptr;
+    QwenDeviceTensor batch_slot_ids;
+    QwenDeviceTensor batch_positions;
+    QwenDeviceTensor batch_context_lens;
     // Sampling scratch. Allocated lazily on the first sampled step so greedy
     // runs pay nothing.
     QwenDeviceTensor sample_cand_token;
@@ -2151,7 +2172,11 @@ struct QwenEngine::Impl {
 #ifndef POCKET_BACKEND_ASCEND
         QwenDeviceTensor* q_normalized = nullptr;
         QwenDeviceTensor* k_normalized = nullptr;
-        const bool flashqla = rows >= 8 &&
+        // Every sequence-recurrence kernel below reads `rows` as consecutive
+        // tokens of one stream. A batched decode step is the opposite: `rows`
+        // independent sequences each advancing one token, so none of them apply
+        // and the batched step kernel handles it instead.
+        const bool flashqla = batch_rows == nullptr && rows >= 8 &&
             qwen_env_enabled_default("QWEN_GATED_DELTA_FLASHQLA_SM75");
         if (flashqla) {
             q_normalized = &workspace_float(
@@ -2187,6 +2212,19 @@ struct QwenEngine::Impl {
             projection(layer.linear.qkv, hidden, packed.f16_data(), rows,
                        "lin.qkv");
         }
+#ifndef POCKET_BACKEND_ASCEND
+        if (batch_rows != nullptr) {
+            // One token per sequence against that sequence's own tail. The
+            // pointer is the arena base here, not this slot's rows, because the
+            // kernel resolves the slot per row.
+            require_launch(qwen_causal_depthwise_conv_silu_f16_batched_cuda(
+                packed.f16_data(), layer.linear.conv.f16_data(),
+                layer.linear.conv_tail.f16_data(), convolved.f16_data(),
+                batch_rows->slot_ids, rows, packed_dim, kernel,
+                slot_stride_elements(layer.linear.conv_tail)),
+                "FP16 batched linear causal convolution");
+        } else
+#endif
         require_launch(qwen_causal_depthwise_conv_silu_f16(
             packed.f16_data(), layer.linear.conv.f16_data(),
             conv_tail, convolved.f16_data(), rows,
@@ -2221,7 +2259,17 @@ struct QwenEngine::Impl {
         delta_scope.emplace(this, "gated_delta");
         bool sequenced = false;
 #ifndef POCKET_BACKEND_ASCEND
-        if (flashqla) {
+        if (batch_rows != nullptr) {
+            sequenced = qwen_gated_delta_step_batched_f16_cuda(
+                layer.linear.state.f32_data(), q.f16_data(), k.f16_data(),
+                v.f16_data(), gates.f16_data(), beta.f16_data(),
+                core.f16_data(), batch_rows->slot_ids, rows, value_heads,
+                key_heads,
+                static_cast<int>(config.linear_attention.key_head_dim),
+                static_cast<int>(config.linear_attention.value_head_dim),
+                q_scale, slot_stride_elements(layer.linear.state));
+            require_launch(sequenced, "FP16 batched linear recurrent state");
+        } else if (flashqla) {
             // FlashQLA SM75 subgroup-sharded kernel. Still a serial recurrence,
             // but sharding the [128, 128] state over 16-lane subgroups replaces
             // the baseline's 128-element per-thread register vector: 1.85x on the
@@ -2409,6 +2457,17 @@ struct QwenEngine::Impl {
              rows * q_heads, head_dim);
         norm(layer.full.k_norm, k.f16_data(), k_norm.f16_data(),
              rows * kv_heads, head_dim);
+#ifndef POCKET_BACKEND_ASCEND
+        if (batch_rows != nullptr) {
+            // Each row is a different sequence at its own position, so the
+            // rotation angle is per row rather than position_offset + row.
+            require_launch(qwen_partial_rope_rows_f16_batched_cuda(
+                q_norm.f16_data(), k_norm.f16_data(), batch_rows->positions,
+                rows, static_cast<int>(config.partial_rotary_dim()),
+                static_cast<float>(config.rope_theta), q_heads, kv_heads,
+                head_dim), "FP16 batched partial RoPE");
+        } else
+#endif
         require_launch(qwen_partial_rope_rows_f16(
             q_norm.f16_data(), k_norm.f16_data(), position_offset, rows,
             static_cast<int>(config.partial_rotary_dim()),
@@ -2485,8 +2544,21 @@ struct QwenEngine::Impl {
 #else
         // Phase 3.3: Use slot_id parameter instead of global current_slot_id
         const size_t slot_offset = kv_slot_offset_elements(slot_id, kv_heads, head_dim);
+        // Distance between slots in the KV arena. kv_slot_offset_elements folds
+        // this to zero for a single session, so the stride is recomputed rather
+        // than divided out of it.
+        const size_t kv_slot_stride = static_cast<size_t>(max_context) *
+            kv_heads * head_dim;
 
-        if (cache_dtype == QwenKvCacheDType::Fp8) {
+        if (batch_rows != nullptr) {
+            // Each row appends its new K/V at its own position in its own slot.
+            require_launch(qwen_append_kv_cache_f16_batched_cuda(
+                k_norm.f16_data(), v.f16_data(),
+                layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
+                rows, kv_heads, head_dim, batch_rows->positions,
+                batch_rows->slot_ids, max_context, kv_slot_stride),
+                "append batched FP16 full KV cache");
+        } else if (cache_dtype == QwenKvCacheDType::Fp8) {
             require_launch(qwen_append_kv_cache_fp8_cuda(
                 k_norm.f16_data(), v.f16_data(),
                 layer.full.k_cache.fp8_data() + slot_offset,
@@ -2525,7 +2597,29 @@ struct QwenEngine::Impl {
                 position_offset, max_context), "append FP16 full KV cache");
         }
 
-        if (rows == 1) {
+        if (batch_rows != nullptr) {
+            // One launch for the whole batch. The split geometry comes from the
+            // longest row, so the scratch is sized from that same query the
+            // launcher uses; shorter rows leave their trailing splits empty.
+            const int splits = qwen_gqa_decode_batched_split_count(
+                batch_rows->max_context_len, kv_heads, attention_window,
+                sink_tokens);
+            require_launch(splits > 0, "batched decode split geometry");
+            QwenDeviceTensor& partials = workspace_float(
+                static_cast<size_t>(rows) * q_heads * splits *
+                    static_cast<size_t>(head_dim + 2),
+                {static_cast<uint64_t>(rows), static_cast<uint64_t>(q_heads),
+                 static_cast<uint64_t>(splits),
+                 static_cast<uint64_t>(head_dim + 2)});
+            PhaseScope sub(this, "full.attn_kernel");
+            require_launch(qwen_gqa_decode_attention_f16_batched_cuda(
+                q_norm.f16_data(), layer.full.k_cache.f16_data(),
+                layer.full.v_cache.f16_data(), attention.f16_data(),
+                partials.f32_data(), batch_rows->context_lens,
+                batch_rows->slot_ids, rows, batch_rows->max_context_len,
+                kv_slot_stride, q_heads, kv_heads, head_dim, max_context,
+                attention_window, sink_tokens), "batched decode FP16-cache GQA");
+        } else if (rows == 1) {
             const int context_length = position_offset + 1;
             const bool optimized_attention =
                 qwen_env_enabled_default("DSV4_QWEN_GQA_OPTIMIZED") ||
@@ -3947,6 +4041,137 @@ struct QwenEngine::Impl {
         return result;
     }
 
+    // One decode step for `rows` independent sequences in a single forward pass.
+    //
+    // This is not run_chunk with a wider row count: there, the rows are
+    // consecutive tokens of one sequence sharing a position offset and a KV
+    // slot. Here each row is its own sequence with its own position, its own KV
+    // slot, and its own recurrent state, which is why the per-row metadata goes
+    // to the device and the attention and recurrence kernels switch to their
+    // batched variants. Everything between those points -- embedding, norms,
+    // projections, SwiGLU, the LM head -- is already row-wise and is reused
+    // unchanged. Amortizing the weight loads over the rows is the whole point:
+    // decode is weight-bandwidth bound, so the batch is close to free.
+    QwenVerifyBatch run_batched_decode(const std::vector<int>& tokens,
+                                       const std::vector<int>& positions,
+                                       const std::vector<int>& slot_ids,
+                                       int active_layers) {
+        const int rows = static_cast<int>(tokens.size());
+        if (rows <= 0) {
+            throw std::runtime_error("Qwen batched decode requires a row");
+        }
+        if (positions.size() != tokens.size() ||
+            slot_ids.size() != tokens.size()) {
+            throw std::runtime_error(
+                "Qwen batched decode row metadata has mismatched extents");
+        }
+        // The speculative and MTP paths each keep a single-sequence context
+        // (committed position, target taps, seed hidden) that a batch of
+        // independent sequences would interleave into nonsense. They are
+        // rejected rather than silently producing a wrong result.
+        if (mtp_enabled || dspark_enabled || dflash2_enabled) {
+            throw std::runtime_error(
+                "Qwen batched decode is not compatible with MTP or speculative "
+                "decoding");
+        }
+#ifdef POCKET_BACKEND_ASCEND
+        throw std::runtime_error(
+            "Qwen batched decode has no Ascend kernels yet");
+#else
+        // The batched append and attention kernels are FP16-cache only. A
+        // quantized cache would have the FP16 append write raw halves into
+        // packed codes, so it is refused rather than silently corrupted.
+        if (options.kv_cache_dtype != QwenKvCacheDType::Fp16) {
+            throw std::runtime_error(
+                "Qwen batched decode requires an FP16 KV cache");
+        }
+        std::vector<int> context_lens(static_cast<size_t>(rows));
+        int max_context_len = 0;
+        for (int row = 0; row < rows; ++row) {
+            const int position = positions[static_cast<size_t>(row)];
+            const int slot = slot_ids[static_cast<size_t>(row)];
+            if (position < 0 || position >= max_context) {
+                throw std::runtime_error(
+                    "Qwen batched decode position is out of range");
+            }
+            if (slot < 0 || slot >= max_batch_size) {
+                throw std::runtime_error(
+                    "Qwen batched decode slot is out of range");
+            }
+            context_lens[static_cast<size_t>(row)] = position + 1;
+            max_context_len = std::max(max_context_len, position + 1);
+        }
+
+        const size_t row_bytes = static_cast<size_t>(rows) * sizeof(int);
+        allocate(batch_positions, row_bytes, {static_cast<uint64_t>(rows)},
+                 SafeDType::I64);
+        allocate(batch_slot_ids, row_bytes, {static_cast<uint64_t>(rows)},
+                 SafeDType::I64);
+        allocate(batch_context_lens, row_bytes, {static_cast<uint64_t>(rows)},
+                 SafeDType::I64);
+        check_device(memcpy_h2d(batch_positions.data, positions.data(), row_bytes),
+                     "Qwen batched decode position upload");
+        check_device(memcpy_h2d(batch_slot_ids.data, slot_ids.data(), row_bytes),
+                     "Qwen batched decode slot upload");
+        check_device(memcpy_h2d(batch_context_lens.data, context_lens.data(),
+                                row_bytes),
+                     "Qwen batched decode context length upload");
+
+        BatchRows metadata;
+        metadata.positions = static_cast<const int*>(batch_positions.data);
+        metadata.slot_ids = static_cast<const int*>(batch_slot_ids.data);
+        metadata.context_lens = static_cast<const int*>(batch_context_lens.data);
+        metadata.rows = rows;
+        metadata.max_context_len = max_context_len;
+
+        const int hidden_size = static_cast<int>(config.hidden_size);
+        const size_t hidden_elements = static_cast<size_t>(rows) * hidden_size;
+        const std::vector<uint64_t> hidden_shape = {
+            static_cast<uint64_t>(rows), static_cast<uint64_t>(hidden_size)};
+        local_tokens = tokens;
+        allocate(d_tokens, local_tokens.size() * sizeof(int),
+                 {static_cast<uint64_t>(rows)}, SafeDType::I64);
+        check_device(memcpy_h2d(d_tokens.data, local_tokens.data(),
+                                local_tokens.size() * sizeof(int)),
+                     "Qwen batched decode token upload");
+        allocate_half(hidden_a, hidden_elements, hidden_shape);
+        allocate_half(hidden_b, hidden_elements, hidden_shape);
+        require_launch(qwen_embedding_fp16_gather_f16(
+            embed.f16_data(), static_cast<int*>(d_tokens.data),
+            hidden_a.f16_data(), rows, hidden_size,
+            static_cast<int>(weights_vocab_start()),
+            static_cast<int>(embed.shape[0])),
+            "Qwen batched decode embedding lookup");
+        all_reduce_half(hidden_a.f16_data(), rows * hidden_size, "hidden_a");
+
+        uint16_t* hidden = hidden_a.f16_data();
+        uint16_t* output = hidden_b.f16_data();
+        // Scoped so an exception inside a layer cannot leave the batched flag
+        // set and silently redirect the next single-sequence forward.
+        struct BatchScope {
+            Impl* impl;
+            explicit BatchScope(Impl* self, const BatchRows* rows) : impl(self) {
+                impl->batch_rows = rows;
+            }
+            ~BatchScope() { impl->batch_rows = nullptr; }
+        } scope(this, &metadata);
+        for (int layer_index = 0; layer_index < active_layers; ++layer_index) {
+            {
+                PhaseScope phase(this, "STACK.b");
+                // position_offset and slot_id are unused on the batched path:
+                // both are per row and come from the uploaded metadata.
+                layer_forward(layers[static_cast<size_t>(layer_index)], hidden,
+                              output, rows, 0, 0);
+            }
+            std::swap(hidden, output);
+        }
+        // One LM head GEMM over all rows, which is the same amortization the
+        // rest of the step gets. position_after is reported per row by the
+        // caller, so the batch-wide value here is only the widest context.
+        return target_logits_for(hidden, rows, max_context_len);
+#endif
+    }
+
     uint64_t activation_capacity_bytes() const {
         return hidden_a.capacity + hidden_b.capacity + d_tokens.capacity +
                argmax_token.capacity + argmax_logit.capacity +
@@ -4263,6 +4488,66 @@ QwenBatchPrefillResult QwenEngine::batch_prefill(
     return result;
 }
 
+std::vector<QwenForwardResult> QwenEngine::batch_decode_tokens(
+    const std::vector<int>& tokens, const std::vector<int>& slot_ids) {
+    if (tokens.size() != slot_ids.size()) {
+        throw std::runtime_error(
+            "QwenEngine::batch_decode_tokens: token and slot extents differ");
+    }
+    const int rows = static_cast<int>(tokens.size());
+    if (rows == 0) return {};
+    std::optional<Impl::RangeScope> range;
+    if (impl_->range_profile) range.emplace("qwen.batch_decode");
+
+    // Two rows in the same slot would have the second read the KV the first
+    // wrote at the same position, so the batch has to be over distinct slots.
+    std::vector<int> positions(static_cast<size_t>(rows));
+    for (int row = 0; row < rows; ++row) {
+        const int slot = slot_ids[static_cast<size_t>(row)];
+        for (int earlier = 0; earlier < row; ++earlier) {
+            if (slot_ids[static_cast<size_t>(earlier)] == slot) {
+                throw std::runtime_error(
+                    "QwenEngine::batch_decode_tokens: slot " +
+                    std::to_string(slot) + " appears twice in one batch");
+            }
+        }
+        const int position = impl_->slot_position(slot, position_);
+        if (position >= max_context_) {
+            throw std::runtime_error("Qwen context length exceeded");
+        }
+        positions[static_cast<size_t>(row)] = position;
+    }
+
+    QwenVerifyBatch batch = impl_->run_batched_decode(
+        tokens, positions, slot_ids, active_layers_);
+
+    std::vector<QwenForwardResult> results(static_cast<size_t>(rows));
+    for (int row = 0; row < rows; ++row) {
+        const size_t index = static_cast<size_t>(row);
+        const int slot = slot_ids[index];
+        const int position_after = positions[index] + 1;
+        QwenForwardResult& forward = results[index];
+        forward.layers = active_layers_;
+        forward.dim = static_cast<int>(config_.hidden_size);
+        forward.logits = static_cast<int>(config_.vocab_size);
+        forward.top_token = batch.top_tokens[index];
+        forward.top_logit = batch.top_logits[index];
+        forward.checksum = batch.local_logits[index];
+        forward.position = position_after;
+        impl_->set_slot_position(slot, position_after, position_);
+        if (options_.prefix_cache) {
+            Impl::SlotPrefixState& prefix = impl_->prefix_for(slot);
+            prefix.cached_prompt.push_back(tokens[index]);
+            prefix.cached_result = forward;
+            prefix.has_cached_result = true;
+            if (impl_->is_periodic_snapshot_position(position_after)) {
+                impl_->record_snapshot(position_after, &forward, true, slot);
+            }
+        }
+    }
+    return results;
+}
+
 QwenBatchDecodeResult QwenEngine::batch_decode_step(
     const std::vector<QwenBatchedRequest*>& requests) {
 
@@ -4276,24 +4561,32 @@ QwenBatchDecodeResult QwenEngine::batch_decode_step(
 
     auto start = std::chrono::steady_clock::now();
 
-    // Phase 3.1: Process decode steps sequentially
-    // True batched decode kernel is deferred to Phase 3.2
+    std::vector<int> tokens;
+    std::vector<int> slots;
+    tokens.reserve(requests.size());
+    slots.reserve(requests.size());
     for (QwenBatchedRequest* req : requests) {
         if (!req) {
             throw std::runtime_error("QwenEngine::batch_decode_step: null request");
         }
+        tokens.push_back(req->last_token);
+        slots.push_back(req->slot_id);
+    }
 
-        // Announce before computing, as in batch_prefill: every rank has to enter
-        // the same collective in the same order.
-        worker_command_decode(req->last_token, req->slot_id);
+    // One forward for the whole batch. Under TP the workers sit in
+    // run_worker_loop() waiting to be told which collective to join, so rank 0
+    // announces the batch before running it or the group deadlocks with rank 0
+    // computing alone. No-op at world size 1.
+    worker_command_batch_decode(tokens, slots);
+    std::vector<QwenForwardResult> forwards = batch_decode_tokens(tokens, slots);
 
-        // Phase 3.3: Use req->slot_id to isolate KV cache
-        QwenForwardResult fwd_result = decode_step(req->last_token, req->slot_id);
-
-        req->last_token = fwd_result.top_token;
-        req->last_result = fwd_result;
+    for (size_t index = 0; index < requests.size(); ++index) {
+        QwenBatchedRequest* req = requests[index];
+        const QwenForwardResult& forward = forwards[index];
+        req->last_token = forward.top_token;
+        req->last_result = forward;
         req->seq_len++;
-        req->generated_tokens.push_back(fwd_result.top_token);
+        req->generated_tokens.push_back(forward.top_token);
 
         // Check finish conditions
         bool finished = (static_cast<int>(req->generated_tokens.size()) >=
@@ -4301,7 +4594,7 @@ QwenBatchDecodeResult QwenEngine::batch_decode_step(
         // TODO: Add EOS token check
 
         req->finished = finished;
-        result.next_tokens.push_back(fwd_result.top_token);
+        result.next_tokens.push_back(forward.top_token);
         result.finished.push_back(finished);
     }
 
@@ -4707,6 +5000,26 @@ void QwenEngine::run_worker_loop() {
             case WorkerCommand::DecodeStep:
                 (void)decode_step(header[1], slot_id);
                 break;
+            case WorkerCommand::BatchDecodeStep: {
+                // The payload interleaves token and slot per row, because the
+                // header carries only one slot field. header[1] is the row count.
+                const int batch_rows = static_cast<int>(header[1]);
+                if (batch_rows <= 0 ||
+                    tokens.size() != static_cast<size_t>(batch_rows) * 2) {
+                    throw std::runtime_error(
+                        "run_worker_loop: malformed batched decode payload");
+                }
+                std::vector<int> batch_tokens(static_cast<size_t>(batch_rows));
+                std::vector<int> batch_slots(static_cast<size_t>(batch_rows));
+                for (int row = 0; row < batch_rows; ++row) {
+                    batch_tokens[static_cast<size_t>(row)] =
+                        tokens[static_cast<size_t>(row) * 2];
+                    batch_slots[static_cast<size_t>(row)] =
+                        tokens[static_cast<size_t>(row) * 2 + 1];
+                }
+                (void)batch_decode_tokens(batch_tokens, batch_slots);
+                break;
+            }
             case WorkerCommand::Reset:
                 reset();
                 break;
@@ -4757,6 +5070,39 @@ void QwenEngine::worker_command_decode(int32_t last_token, int32_t slot_id) {
         0
     };
     impl_->cmd->send_to_workers(header, 4);
+}
+
+void QwenEngine::worker_command_batch_decode(
+    const std::vector<int>& tokens, const std::vector<int>& slot_ids) {
+    if (options_.tp_world <= 1) return;
+    if (options_.tp_rank != 0) {
+        throw std::runtime_error("worker_command_batch_decode: rank 0 only");
+    }
+    if (!impl_->cmd) {
+        throw std::runtime_error("worker_command_batch_decode: command channel not initialized (call warmup_tp first)");
+    }
+    if (tokens.size() != slot_ids.size()) {
+        throw std::runtime_error(
+            "worker_command_batch_decode: token and slot extents differ");
+    }
+    if (tokens.empty()) return;
+
+    const int32_t rows = static_cast<int32_t>(tokens.size());
+    int32_t header[4] = {
+        static_cast<int32_t>(WorkerCommand::BatchDecodeStep),
+        rows,
+        0,
+        rows * 2
+    };
+    impl_->cmd->send_to_workers(header, 4);
+
+    std::vector<int32_t> payload(static_cast<size_t>(rows) * 2);
+    for (int32_t row = 0; row < rows; ++row) {
+        payload[static_cast<size_t>(row) * 2] = tokens[static_cast<size_t>(row)];
+        payload[static_cast<size_t>(row) * 2 + 1] =
+            slot_ids[static_cast<size_t>(row)];
+    }
+    impl_->cmd->send_to_workers(payload.data(), payload.size());
 }
 
 void QwenEngine::worker_command_reset() {

--- a/cpp_engine/include/qwen_cuda_ops.hpp
+++ b/cpp_engine/include/qwen_cuda_ops.hpp
@@ -730,6 +730,13 @@ bool qwen_causal_depthwise_conv_silu_f16_cuda(
     const uint16_t* d_x_fp16, const uint16_t* d_weight_fp16,
     uint16_t* d_tail_fp16, uint16_t* d_y_fp16, int seq_len, int channels,
     int kernel, bool update_tail, void* stream = nullptr);
+// Batched decode variant: `rows` sequences each contribute one new token and
+// carry their own tail at `row * tail_slot_stride` elements. The tail is always
+// updated, since a decode step by definition consumes its token.
+bool qwen_causal_depthwise_conv_silu_f16_batched_cuda(
+    const uint16_t* d_x_fp16, const uint16_t* d_weight_fp16,
+    uint16_t* d_tail_fp16, uint16_t* d_y_fp16, const int* d_slot_ids, int rows,
+    int channels, int kernel, size_t tail_slot_stride, void* stream = nullptr);
 bool qwen_linear_attn_gates_f16_cuda(
     const uint16_t* d_a_fp16, const uint16_t* d_b_fp16,
     const uint16_t* d_a_log_fp16, const uint16_t* d_dt_bias_fp16,
@@ -741,6 +748,17 @@ bool qwen_gated_delta_step_f16_cuda(
     const uint16_t* d_beta_fp16, uint16_t* d_out_fp16, int heads,
     int key_heads, int key_dim, int value_dim, float q_scale,
     void* stream = nullptr);
+// Batched single step: `rows` sequences each advance one token against their own
+// recurrent state slot at `row * state_slot_stride` elements. Q/K/V/gates and
+// the output are row-major over rows.
+// `d_slot_ids` maps each row to the state slot it owns; pass null when the rows
+// occupy slots 0..rows-1 in order.
+bool qwen_gated_delta_step_batched_f16_cuda(
+    float* d_state, const uint16_t* d_q_fp16, const uint16_t* d_k_fp16,
+    const uint16_t* d_v_fp16, const uint16_t* d_g_fp16,
+    const uint16_t* d_beta_fp16, uint16_t* d_out_fp16, const int* d_slot_ids,
+    int rows, int heads, int key_heads, int key_dim, int value_dim,
+    float q_scale, size_t state_slot_stride, void* stream = nullptr);
 bool qwen_gated_delta_sequence_f16_cuda(
     float* d_state, const uint16_t* d_q_fp16, const uint16_t* d_k_fp16,
     const uint16_t* d_v_fp16, const uint16_t* d_g_fp16,
@@ -782,6 +800,12 @@ bool qwen_partial_rope_rows_f16_cuda(
     uint16_t* d_q_fp16, uint16_t* d_k_fp16, int start_position, int rows,
     int rotary_dim, float theta, int q_heads, int kv_heads, int head_dim,
     void* stream = nullptr);
+// Batched variant: each row uses its own position from d_positions[row].
+// When d_positions is null, falls back to start_position + row.
+bool qwen_partial_rope_rows_f16_batched_cuda(
+    uint16_t* d_q_fp16, uint16_t* d_k_fp16, const int* d_positions, int rows,
+    int rotary_dim, float theta, int q_heads, int kv_heads, int head_dim,
+    void* stream = nullptr);
 bool qwen_split_q_gate_f16_cuda(const uint16_t* d_q_proj_fp16,
                                 uint16_t* d_q_fp16,
                                 uint16_t* d_gate_fp16, int rows,
@@ -806,12 +830,34 @@ bool qwen_append_kv_cache_f16_cuda(
     uint16_t* d_k_cache_fp16, uint16_t* d_v_cache_fp16, int seq_len,
     int kv_heads, int head_dim, int start_pos, int max_context,
     void* stream = nullptr);
+// Batched variant: row `r` writes its K/V into its own cache slot at
+// `r * kv_slot_stride` elements, at position d_start_positions[r] within that
+// slot. Every sequence contributes exactly one token, so `rows` is the batch
+// width rather than a sequence length.
+// `d_slot_ids` maps each row to the cache slot it owns, because slots are
+// allocated as requests arrive: a four-row batch can hold slots 1/3/5/6. Pass
+// null when the rows occupy slots 0..rows-1 in order.
+bool qwen_append_kv_cache_f16_batched_cuda(
+    const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
+    uint16_t* d_k_cache_fp16, uint16_t* d_v_cache_fp16, int rows,
+    int kv_heads, int head_dim, const int* d_start_positions,
+    const int* d_slot_ids, int max_context, size_t kv_slot_stride,
+    void* stream = nullptr);
 bool qwen_append_kv_cache_fp8_cuda(
     const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
     uint8_t* d_k_cache_fp8, uint8_t* d_v_cache_fp8,
     uint16_t* d_k_scale_fp16, uint16_t* d_v_scale_fp16, int seq_len,
     int kv_heads, int head_dim, int scale_block, int start_pos,
     int max_context, void* stream = nullptr);
+// Batched variant for FP8 cache. `kv_slot_stride` is in cache elements; the
+// scale array is strided by kv_slot_stride / scale_block to match.
+bool qwen_append_kv_cache_fp8_batched_cuda(
+    const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
+    uint8_t* d_k_cache_fp8, uint8_t* d_v_cache_fp8,
+    uint16_t* d_k_scale_fp16, uint16_t* d_v_scale_fp16, int rows,
+    int kv_heads, int head_dim, int scale_block, const int* d_start_positions,
+    const int* d_slot_ids, int max_context, size_t kv_slot_stride,
+    void* stream = nullptr);
 bool qwen_gqa_decode_attention_f16_cuda(
     const uint16_t* d_q_fp16, const uint16_t* d_k_cache_fp16,
     const uint16_t* d_v_cache_fp16, uint16_t* d_out_fp16,
@@ -852,6 +898,28 @@ enum class QwenGqaDecodeVariant {
 int qwen_gqa_decode_split_count_variant(
     int attended_positions, QwenGqaDecodeVariant variant,
     int split_count_override = 0);
+
+// Batched decode: one launch serves `rows` sequences, each reading its own KV
+// slot at `row * kv_slot_stride` elements and attending its own context length
+// from `d_context_lens`. Split geometry is derived from `max_context_len`, the
+// longest row in the batch, so every row shares one grid. Q, output and the
+// partial scratch are row-major over rows.
+//
+// Scratch must be sized rows * q_heads * splits * (head_dim + 2) using the
+// split count below, which is the same number the launch computes.
+int qwen_gqa_decode_batched_split_count(
+    int max_context_len, int kv_heads, int attention_window = 0,
+    int sink_tokens = 0);
+// `d_slot_ids` maps each row to the KV slot it owns; pass null when the rows
+// occupy slots 0..rows-1 in order.
+bool qwen_gqa_decode_attention_f16_batched_cuda(
+    const uint16_t* d_q_fp16, const uint16_t* d_k_cache_fp16,
+    const uint16_t* d_v_cache_fp16, uint16_t* d_out_fp16,
+    float* d_partial_scratch, const int* d_context_lens,
+    const int* d_slot_ids, int rows, int max_context_len,
+    size_t kv_slot_stride, int q_heads, int kv_heads, int head_dim,
+    int max_context, int attention_window = 0, int sink_tokens = 0,
+    void* stream = nullptr);
 
 // Fused decode with the split kernel chosen explicitly. Returns false when the
 // requested variant does not support the shape (the tensor-core kernel requires

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -301,10 +301,19 @@ public:
         const std::vector<QwenBatchedRequest*>& requests);
 
     // Batch decode step: process one decode step for all active requests
-    // All requests must be at the same decode position (post-prefill)
+    // Every request advances one token in a single batched forward, so the
+    // requests may sit at different positions; they must occupy distinct slots.
     // Returns next token for each request
     QwenBatchDecodeResult batch_decode_step(
         const std::vector<QwenBatchedRequest*>& requests);
+
+    // One batched decode step over raw tokens and the slots they belong to.
+    // batch_decode_step is the request-oriented wrapper around this; tests and
+    // the TP worker loop use this form because they carry no request objects.
+    // Does not announce anything to the TP workers: callers on rank 0 drive that
+    // themselves so a batch is announced exactly once.
+    std::vector<QwenForwardResult> batch_decode_tokens(
+        const std::vector<int>& tokens, const std::vector<int>& slot_ids);
 
     // Check if batched API is supported (depends on build config)
     bool supports_batching() const;
@@ -319,12 +328,17 @@ public:
         DecodeStep = 1,
         Reset = 2,
         Shutdown = 3,
+        BatchDecodeStep = 4,
     };
     // slot_id selects the KV cache slot the workers must use, so it has to match
     // the slot rank 0 computes into.  It defaults to 0 for the single-session
     // path, where only slot 0 ever exists.
     void worker_command_prefill(const std::vector<int>& token_ids, int32_t slot_id = 0);
     void worker_command_decode(int32_t last_token, int32_t slot_id = 0);
+    // A batched step's slots do not fit the single slot_id header field, so the
+    // tokens and their slots travel together as one interleaved payload.
+    void worker_command_batch_decode(const std::vector<int>& tokens,
+                                     const std::vector<int>& slot_ids);
     void worker_command_reset();
     void worker_command_shutdown();
 

--- a/cpp_engine/tests/bench_qwen_batched_throughput.cpp
+++ b/cpp_engine/tests/bench_qwen_batched_throughput.cpp
@@ -1,0 +1,291 @@
+// Batched decode throughput benchmark: measure concurrent request throughput
+// against the baseline sequential processing and the theoretical 3.88× ceiling.
+//
+// Usage: ./bench_qwen_batched_throughput <checkpoint_dir> [--batch-size N]
+//
+// Spawns N concurrent requests at various context lengths and measures:
+// - Sequential processing baseline (one at a time, for comparison)
+// - Batched processing throughput (requests/second)
+// - GPU utilization (batched kernel amortization)
+
+#include "qwen_config.hpp"
+#include "qwen_engine.hpp"
+#include "cuda_ops.hpp"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+using Seconds = std::chrono::duration<double>;
+
+struct BenchOptions {
+    std::string checkpoint_dir;
+    int batch_size = 4;
+    int warmup_steps = 5;
+    int measured_steps = 20;
+    int context_len = 4096;
+    int decode_tokens = 32;
+    int tp_world = 1;
+    int tp_rank = 0;
+    int device = -1;  // -1 means "use tp_rank"
+    std::string nccl_id_path = "/tmp/qwen_bench_nccl_id";
+};
+
+void usage(const char* prog) {
+    std::cout << "Usage: " << prog << " <checkpoint_dir> [options]\n"
+              << "Options:\n"
+              << "  --batch-size N     Number of concurrent requests (default 4)\n"
+              << "  --context N        Initial context length (default 4096)\n"
+              << "  --decode N         Tokens to decode per request (default 32)\n"
+              << "  --warmup N         Warmup steps (default 5)\n"
+              << "  --measured N       Measured steps (default 20)\n"
+              << "  --tp-world N       TP world size (default 1)\n"
+              << "  --tp-rank N        TP rank (default 0)\n"
+              << "  --device N         CUDA device ordinal (default: same as tp-rank)\n"
+              << "  --nccl-id PATH     NCCL ID file path (default /tmp/qwen_bench_nccl_id)\n";
+}
+
+BenchOptions parse_args(int argc, char** argv) {
+    if (argc < 2) {
+        usage(argv[0]);
+        std::exit(1);
+    }
+    BenchOptions opts;
+    opts.checkpoint_dir = argv[1];
+    for (int i = 2; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--batch-size" && i + 1 < argc) {
+            opts.batch_size = std::atoi(argv[++i]);
+        } else if (arg == "--context" && i + 1 < argc) {
+            opts.context_len = std::atoi(argv[++i]);
+        } else if (arg == "--decode" && i + 1 < argc) {
+            opts.decode_tokens = std::atoi(argv[++i]);
+        } else if (arg == "--warmup" && i + 1 < argc) {
+            opts.warmup_steps = std::atoi(argv[++i]);
+        } else if (arg == "--measured" && i + 1 < argc) {
+            opts.measured_steps = std::atoi(argv[++i]);
+        } else if (arg == "--tp-world" && i + 1 < argc) {
+            opts.tp_world = std::atoi(argv[++i]);
+        } else if (arg == "--tp-rank" && i + 1 < argc) {
+            opts.tp_rank = std::atoi(argv[++i]);
+        } else if (arg == "--device" && i + 1 < argc) {
+            opts.device = std::atoi(argv[++i]);
+        } else if (arg == "--nccl-id" && i + 1 < argc) {
+            opts.nccl_id_path = argv[++i];
+        } else {
+            std::cerr << "Unknown option: " << arg << "\n";
+            usage(argv[0]);
+            std::exit(1);
+        }
+    }
+    return opts;
+}
+
+struct Request {
+    uint64_t request_id;
+    int slot_id;
+    int context_len;
+    int tokens_decoded;
+    int target_tokens;
+    std::vector<int> prompt;
+    std::vector<int> outputs;
+    bool finished;
+};
+
+double bench_sequential_baseline(dsv4::QwenEngine& engine,
+                                 const std::vector<Request>& requests,
+                                 int measured_steps) {
+    engine.reset();
+    std::vector<Request> active = requests;
+
+    // Prefill all requests
+    for (auto& req : active) {
+        engine.prefill(req.prompt, req.slot_id);
+    }
+
+    // Warmup
+    for (int step = 0; step < 5; ++step) {
+        for (auto& req : active) {
+            if (!req.finished) {
+                const int token = (step * 7 + req.request_id) % 64;
+                engine.decode_step(token, req.slot_id);
+            }
+        }
+    }
+
+    // Measure sequential decode: one request at a time
+    const auto t0 = Clock::now();
+    for (int step = 0; step < measured_steps; ++step) {
+        for (auto& req : active) {
+            if (!req.finished) {
+                const int token = (step * 7 + req.request_id) % 64;
+                const auto result = engine.decode_step(token, req.slot_id);
+                req.outputs.push_back(result.top_token);
+                req.tokens_decoded++;
+                if (req.tokens_decoded >= req.target_tokens) {
+                    req.finished = true;
+                }
+            }
+        }
+    }
+    const auto t1 = Clock::now();
+    const double elapsed = Seconds(t1 - t0).count();
+    const int total_steps = static_cast<int>(active.size()) * measured_steps;
+    return elapsed / total_steps;
+}
+
+double bench_batched_throughput(dsv4::QwenEngine& engine,
+                                const std::vector<Request>& requests,
+                                int measured_steps) {
+    engine.reset();
+    std::vector<Request> active = requests;
+
+    // Prefill all requests
+    for (auto& req : active) {
+        engine.prefill(req.prompt, req.slot_id);
+    }
+
+    // Warmup
+    std::vector<int> batch_tokens(active.size());
+    std::vector<int> batch_slots(active.size());
+    for (int step = 0; step < 5; ++step) {
+        for (size_t i = 0; i < active.size(); ++i) {
+            batch_tokens[i] = (step * 7 + active[i].request_id) % 64;
+            batch_slots[i] = active[i].slot_id;
+        }
+        engine.batch_decode_tokens(batch_tokens, batch_slots);
+    }
+
+    // Measure batched decode: all requests in one forward
+    const auto t0 = Clock::now();
+    for (int step = 0; step < measured_steps; ++step) {
+        for (size_t i = 0; i < active.size(); ++i) {
+            batch_tokens[i] = (step * 7 + active[i].request_id) % 64;
+            batch_slots[i] = active[i].slot_id;
+        }
+        const auto results = engine.batch_decode_tokens(batch_tokens, batch_slots);
+        for (size_t i = 0; i < active.size(); ++i) {
+            active[i].outputs.push_back(results[i].top_token);
+            active[i].tokens_decoded++;
+            if (active[i].tokens_decoded >= active[i].target_tokens) {
+                active[i].finished = true;
+            }
+        }
+    }
+    const auto t1 = Clock::now();
+    const double elapsed = Seconds(t1 - t0).count();
+    const int total_steps = static_cast<int>(active.size()) * measured_steps;
+    return elapsed / total_steps;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (!dsv4::cuda_runtime_available()) {
+        std::cerr << "CUDA runtime not available\n";
+        return 1;
+    }
+
+    try {
+        const BenchOptions opts = parse_args(argc, argv);
+
+        std::cout << "Qwen batched decode throughput benchmark\n"
+                  << "=========================================\n"
+                  << "Checkpoint: " << opts.checkpoint_dir << "\n"
+                  << "Batch size: " << opts.batch_size << "\n"
+                  << "Context: " << opts.context_len << " tokens\n"
+                  << "Decode: " << opts.decode_tokens << " tokens/request\n"
+                  << "Measured steps: " << opts.measured_steps << "\n"
+                  << "TP: " << opts.tp_world << " (rank " << opts.tp_rank << ")\n\n";
+
+        // Create engine with batching enabled
+        dsv4::QwenEngineOptions engine_opts;
+        engine_opts.tp_world = opts.tp_world;
+        engine_opts.tp_rank = opts.tp_rank;
+        engine_opts.device = opts.device >= 0 ? opts.device : opts.tp_rank;
+        engine_opts.nccl_id_path = opts.nccl_id_path;
+        engine_opts.kv_cache_dtype = dsv4::QwenKvCacheDType::Fp16;
+        engine_opts.prefix_cache = false;
+        engine_opts.max_batch_size = opts.batch_size * 2;  // Extra headroom
+
+        dsv4::QwenEngine engine(opts.checkpoint_dir, engine_opts);
+        engine.allocate_batch_slots(engine_opts.max_batch_size);
+
+        // Create test requests at staggered context lengths
+        std::vector<Request> requests;
+        std::mt19937 rng(42);
+        std::uniform_int_distribution<int> context_dist(
+            opts.context_len - 512, opts.context_len + 512);
+
+        for (int i = 0; i < opts.batch_size; ++i) {
+            Request req;
+            req.request_id = static_cast<uint64_t>(i);
+            req.slot_id = i;
+            req.context_len = std::max(1024, context_dist(rng));
+            req.tokens_decoded = 0;
+            req.target_tokens = opts.decode_tokens;
+            req.finished = false;
+            req.prompt.resize(static_cast<size_t>(req.context_len));
+            for (int j = 0; j < req.context_len; ++j) {
+                req.prompt[static_cast<size_t>(j)] = (i * 7 + j) % 64;
+            }
+            requests.push_back(req);
+        }
+
+        // Benchmark sequential baseline
+        std::cout << "Sequential baseline (one request at a time)...\n";
+        const double seq_per_step = bench_sequential_baseline(
+            engine, requests, opts.measured_steps);
+        const double seq_req_per_sec = 1.0 / seq_per_step;
+        std::cout << "  " << std::fixed << std::setprecision(3)
+                  << seq_per_step * 1000.0 << " ms/step\n"
+                  << "  " << std::setprecision(2) << seq_req_per_sec
+                  << " requests/sec (effective)\n\n";
+
+        // Benchmark batched path
+        std::cout << "Batched decode (all requests in one forward)...\n";
+        const double batch_per_step = bench_batched_throughput(
+            engine, requests, opts.measured_steps);
+        const double batch_req_per_sec = 1.0 / batch_per_step;
+        std::cout << "  " << std::fixed << std::setprecision(3)
+                  << batch_per_step * 1000.0 << " ms/step\n"
+                  << "  " << std::setprecision(2) << batch_req_per_sec
+                  << " requests/sec (effective)\n\n";
+
+        const double speedup = seq_per_step / batch_per_step;
+        std::cout << "Summary\n"
+                  << "-------\n"
+                  << "Speedup: " << std::setprecision(2) << speedup << "×\n"
+                  << "Throughput improvement: " << std::setprecision(1)
+                  << (speedup - 1.0) * 100.0 << "%\n"
+                  << "Effective concurrent requests/sec: "
+                  << std::setprecision(2) << batch_req_per_sec << "\n";
+
+        if (speedup < 1.5) {
+            std::cout << "\n⚠️  WARNING: Speedup below 1.5× suggests batching "
+                      << "overhead or kernel fallback.\n";
+        } else if (speedup >= 3.0) {
+            std::cout << "\n✓ Speedup >= 3.0× approaching theoretical ceiling "
+                      << "(measured 3.88× on GEMM).\n";
+        }
+
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "Error: " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_qwen_batched_decode.cpp
+++ b/cpp_engine/tests/test_qwen_batched_decode.cpp
@@ -1,0 +1,642 @@
+// Numerical validation for the batched decode kernels: partial RoPE, KV append,
+// GQA decode attention, the gated-delta step, and the causal conv.
+//
+// Each batched kernel is checked against N runs of the single-row kernel it
+// replaces, driving every row with a distinct position/context length and its
+// own state slot. A batching bug -- a missing slot stride, a shared tail, a
+// position read from the wrong row -- would leave throughput untouched and
+// silently corrupt one sequence with another's state, so the batched path needs
+// its own numerical gate rather than inheriting the single-row one.
+
+#include "qwen_cuda_ops.hpp"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace dsv4;
+
+int failures = 0;
+bool device_ready = true;
+
+void fail(const std::string& what) {
+    std::printf("[FAIL] %s\n", what.c_str());
+    ++failures;
+}
+
+uint16_t to_half(float value) {
+    return __half_as_ushort(__float2half(value));
+}
+
+float from_half(uint16_t bits) {
+    return __half2float(__ushort_as_half(bits));
+}
+
+// Owns one device allocation so a failed test cannot leak into the next one.
+struct Buffer {
+    void* data = nullptr;
+    size_t bytes = 0;
+
+    ~Buffer() {
+        if (data != nullptr) cudaFree(data);
+    }
+
+    bool allocate(size_t count) {
+        bytes = count;
+        return cudaMalloc(&data, count) == cudaSuccess;
+    }
+
+    template <typename T>
+    T* as() {
+        return static_cast<T*>(data);
+    }
+
+    bool upload(const void* host) {
+        return cudaMemcpy(data, host, bytes, cudaMemcpyHostToDevice) ==
+            cudaSuccess;
+    }
+
+    bool download(void* host) const {
+        return cudaMemcpy(host, data, bytes, cudaMemcpyDeviceToHost) ==
+            cudaSuccess;
+    }
+
+    bool clear() { return cudaMemset(data, 0, bytes) == cudaSuccess; }
+};
+
+double worst_difference(const std::vector<uint16_t>& left,
+                        const std::vector<uint16_t>& right) {
+    double worst = 0.0;
+    for (size_t i = 0; i < left.size(); ++i) {
+        worst = std::max(worst, std::fabs(
+            static_cast<double>(from_half(left[i])) -
+            static_cast<double>(from_half(right[i]))));
+    }
+    return worst;
+}
+
+// Bit-identical is the bar wherever the batched kernel only re-bases pointers.
+size_t bit_mismatches(const std::vector<uint16_t>& left,
+                      const std::vector<uint16_t>& right) {
+    size_t count = 0;
+    for (size_t i = 0; i < left.size(); ++i) {
+        if (left[i] != right[i]) ++count;
+    }
+    return count;
+}
+
+// Partial RoPE. Each row rotates by its own absolute position, which is what
+// distinguishes a decode batch from a prefill chunk: the rows are not
+// consecutive, so `start_position + row` is wrong for every row but the first.
+bool test_rope_batched() {
+    constexpr int kRows = 5;
+    constexpr int kQHeads = 6;
+    constexpr int kKvHeads = 1;
+    constexpr int kHeadDim = 256;
+    constexpr int kRotaryDim = 64;
+    const int positions[kRows] = {0, 1, 17, 1024, 4095};
+
+    const size_t q_elements =
+        static_cast<size_t>(kRows) * kQHeads * kHeadDim;
+    const size_t k_elements =
+        static_cast<size_t>(kRows) * kKvHeads * kHeadDim;
+    std::mt19937 rng(24680);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<uint16_t> q_host(q_elements);
+    std::vector<uint16_t> k_host(k_elements);
+    for (uint16_t& value : q_host) value = to_half(dist(rng));
+    for (uint16_t& value : k_host) value = to_half(dist(rng));
+
+    Buffer q_sequential, k_sequential, q_batched, k_batched, device_positions;
+    if (!q_sequential.allocate(q_elements * sizeof(uint16_t)) ||
+        !k_sequential.allocate(k_elements * sizeof(uint16_t)) ||
+        !q_batched.allocate(q_elements * sizeof(uint16_t)) ||
+        !k_batched.allocate(k_elements * sizeof(uint16_t)) ||
+        !device_positions.allocate(kRows * sizeof(int))) {
+        device_ready = false;
+        return false;
+    }
+    if (!q_sequential.upload(q_host.data()) ||
+        !k_sequential.upload(k_host.data()) ||
+        !q_batched.upload(q_host.data()) ||
+        !k_batched.upload(k_host.data()) ||
+        !device_positions.upload(positions)) {
+        device_ready = false;
+        return false;
+    }
+
+    // RoPE rotates in place, so each reference call takes the row's own slice.
+    for (int row = 0; row < kRows; ++row) {
+        const bool launched = qwen_partial_rope_rows_f16_cuda(
+            q_sequential.as<uint16_t>() +
+                static_cast<size_t>(row) * kQHeads * kHeadDim,
+            k_sequential.as<uint16_t>() +
+                static_cast<size_t>(row) * kKvHeads * kHeadDim,
+            positions[row], 1, kRotaryDim, 10000.0f, kQHeads, kKvHeads,
+            kHeadDim);
+        if (!launched) {
+            fail("batched rope reference launch failed");
+            return true;
+        }
+    }
+    if (!qwen_partial_rope_rows_f16_batched_cuda(
+            q_batched.as<uint16_t>(), k_batched.as<uint16_t>(),
+            device_positions.as<int>(), kRows, kRotaryDim, 10000.0f, kQHeads,
+            kKvHeads, kHeadDim)) {
+        fail("batched rope launch failed");
+        return true;
+    }
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        fail("batched rope sync failed");
+        return true;
+    }
+
+    std::vector<uint16_t> q_want(q_elements), q_got(q_elements);
+    std::vector<uint16_t> k_want(k_elements), k_got(k_elements);
+    if (!q_sequential.download(q_want.data()) ||
+        !q_batched.download(q_got.data()) ||
+        !k_sequential.download(k_want.data()) ||
+        !k_batched.download(k_got.data())) {
+        device_ready = false;
+        return false;
+    }
+    const size_t q_bad = bit_mismatches(q_want, q_got);
+    const size_t k_bad = bit_mismatches(k_want, k_got);
+    if (q_bad != 0 || k_bad != 0) {
+        fail("batched rope q_mismatch=" + std::to_string(q_bad) +
+             " k_mismatch=" + std::to_string(k_bad));
+    } else {
+        std::printf("  rope rows=%d positions=%d..%d bit-identical\n", kRows,
+                    positions[0], positions[kRows - 1]);
+    }
+    return true;
+}
+
+// KV append. Every row writes one token into its own slot at its own position,
+// so a missing slot stride would have the rows overwrite each other.
+bool test_append_kv_batched() {
+    constexpr int kRows = 4;
+    constexpr int kKvHeads = 1;
+    constexpr int kHeadDim = 256;
+    constexpr int kMaxContext = 512;
+    constexpr int kSlots = 6;
+    const int positions[kRows] = {0, 7, 128, 511};
+    const int slots[kRows] = {2, 5, 0, 3};
+
+    const size_t row_elements = static_cast<size_t>(kKvHeads) * kHeadDim;
+    const size_t slot_stride =
+        static_cast<size_t>(kMaxContext) * kKvHeads * kHeadDim;
+    const size_t cache_elements = static_cast<size_t>(kSlots) * slot_stride;
+    std::mt19937 rng(1357);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<uint16_t> k_rows(static_cast<size_t>(kRows) * row_elements);
+    std::vector<uint16_t> v_rows(k_rows.size());
+    for (uint16_t& value : k_rows) value = to_half(dist(rng));
+    for (uint16_t& value : v_rows) value = to_half(dist(rng));
+
+    Buffer device_k_rows, device_v_rows, device_positions, device_slots;
+    Buffer k_sequential, v_sequential, k_batched, v_batched;
+    if (!device_k_rows.allocate(k_rows.size() * sizeof(uint16_t)) ||
+        !device_v_rows.allocate(v_rows.size() * sizeof(uint16_t)) ||
+        !device_positions.allocate(kRows * sizeof(int)) ||
+        !device_slots.allocate(kRows * sizeof(int)) ||
+        !k_sequential.allocate(cache_elements * sizeof(uint16_t)) ||
+        !v_sequential.allocate(cache_elements * sizeof(uint16_t)) ||
+        !k_batched.allocate(cache_elements * sizeof(uint16_t)) ||
+        !v_batched.allocate(cache_elements * sizeof(uint16_t))) {
+        device_ready = false;
+        return false;
+    }
+    if (!device_k_rows.upload(k_rows.data()) ||
+        !device_v_rows.upload(v_rows.data()) ||
+        !device_positions.upload(positions) || !device_slots.upload(slots) ||
+        !k_sequential.clear() || !v_sequential.clear() ||
+        !k_batched.clear() || !v_batched.clear()) {
+        device_ready = false;
+        return false;
+    }
+
+    for (int row = 0; row < kRows; ++row) {
+        const bool launched = qwen_append_kv_cache_f16_cuda(
+            device_k_rows.as<uint16_t>() + static_cast<size_t>(row) * row_elements,
+            device_v_rows.as<uint16_t>() + static_cast<size_t>(row) * row_elements,
+            k_sequential.as<uint16_t>() +
+                static_cast<size_t>(slots[row]) * slot_stride,
+            v_sequential.as<uint16_t>() +
+                static_cast<size_t>(slots[row]) * slot_stride,
+            1, kKvHeads, kHeadDim, positions[row], kMaxContext);
+        if (!launched) {
+            fail("batched kv append reference launch failed");
+            return true;
+        }
+    }
+    if (!qwen_append_kv_cache_f16_batched_cuda(
+            device_k_rows.as<uint16_t>(), device_v_rows.as<uint16_t>(),
+            k_batched.as<uint16_t>(), v_batched.as<uint16_t>(), kRows,
+            kKvHeads, kHeadDim, device_positions.as<int>(),
+            device_slots.as<int>(), kMaxContext, slot_stride)) {
+        fail("batched kv append launch failed");
+        return true;
+    }
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        fail("batched kv append sync failed");
+        return true;
+    }
+
+    std::vector<uint16_t> k_want(cache_elements), k_got(cache_elements);
+    std::vector<uint16_t> v_want(cache_elements), v_got(cache_elements);
+    if (!k_sequential.download(k_want.data()) ||
+        !k_batched.download(k_got.data()) ||
+        !v_sequential.download(v_want.data()) ||
+        !v_batched.download(v_got.data())) {
+        device_ready = false;
+        return false;
+    }
+    const size_t k_bad = bit_mismatches(k_want, k_got);
+    const size_t v_bad = bit_mismatches(v_want, v_got);
+    if (k_bad != 0 || v_bad != 0) {
+        fail("batched kv append k_mismatch=" + std::to_string(k_bad) +
+             " v_mismatch=" + std::to_string(v_bad));
+    } else {
+        std::printf("  kv append rows=%d slots=%d bit-identical\n", kRows,
+                    kSlots);
+    }
+    return true;
+}
+
+// GQA decode attention. The split geometry comes from the longest row, so the
+// shorter rows run some of their splits dry and must still publish the neutral
+// partial the merge expects -- the same failure mode that produced silent -inf
+// logits in the single-row path. Contexts are chosen so the batch spans both
+// sides of that boundary.
+bool test_gqa_decode_batched() {
+    constexpr int kRows = 4;
+    constexpr int kQHeads = 6;
+    constexpr int kKvHeads = 1;
+    constexpr int kHeadDim = 256;
+    constexpr int kMaxContext = 8192;
+    // The fused decode kernel declines contexts under 4096, so every row has to
+    // clear that floor for the reference launches to be the same kernel.
+    const int contexts[kRows] = {4096, 5000, 6144, 8192};
+    const int longest = contexts[kRows - 1];
+    // A non-identity mapping over more slots than rows, which is what the
+    // scheduler actually produces once requests come and go.
+    constexpr int kSlots = 7;
+    const int slots[kRows] = {1, 3, 5, 6};
+
+    const size_t slot_stride =
+        static_cast<size_t>(kMaxContext) * kKvHeads * kHeadDim;
+    const size_t cache_elements = static_cast<size_t>(kSlots) * slot_stride;
+    const size_t q_row_elements = static_cast<size_t>(kQHeads) * kHeadDim;
+    const size_t q_elements = static_cast<size_t>(kRows) * q_row_elements;
+
+    std::mt19937 rng(97531);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<uint16_t> q_host(q_elements);
+    std::vector<uint16_t> k_host(cache_elements, to_half(0.0f));
+    std::vector<uint16_t> v_host(cache_elements, to_half(0.0f));
+    for (uint16_t& value : q_host) value = to_half(dist(rng));
+    for (int row = 0; row < kRows; ++row) {
+        const size_t base = static_cast<size_t>(slots[row]) * slot_stride;
+        const size_t live =
+            static_cast<size_t>(contexts[row]) * kKvHeads * kHeadDim;
+        for (size_t i = 0; i < live; ++i) {
+            k_host[base + i] = to_half(dist(rng));
+            v_host[base + i] = to_half(dist(rng));
+        }
+    }
+
+    // Both paths need scratch for the widest geometry they will launch. The
+    // batched split count is a public query for exactly this reason.
+    const int batched_splits =
+        qwen_gqa_decode_batched_split_count(longest, kKvHeads);
+    if (batched_splits <= 0) {
+        fail("batched decode split count is not positive");
+        return true;
+    }
+    const size_t partial_row = static_cast<size_t>(kQHeads) * batched_splits *
+        static_cast<size_t>(kHeadDim + 2);
+
+    Buffer device_q, device_k, device_v, device_contexts, device_slots;
+    Buffer out_sequential, out_batched, scratch_sequential, scratch_batched;
+    if (!device_q.allocate(q_elements * sizeof(uint16_t)) ||
+        !device_k.allocate(cache_elements * sizeof(uint16_t)) ||
+        !device_v.allocate(cache_elements * sizeof(uint16_t)) ||
+        !device_contexts.allocate(kRows * sizeof(int)) ||
+        !device_slots.allocate(kRows * sizeof(int)) ||
+        !out_sequential.allocate(q_elements * sizeof(uint16_t)) ||
+        !out_batched.allocate(q_elements * sizeof(uint16_t)) ||
+        !scratch_sequential.allocate(partial_row * sizeof(float)) ||
+        !scratch_batched.allocate(
+            static_cast<size_t>(kRows) * partial_row * sizeof(float))) {
+        device_ready = false;
+        return false;
+    }
+    if (!device_q.upload(q_host.data()) || !device_k.upload(k_host.data()) ||
+        !device_v.upload(v_host.data()) ||
+        !device_contexts.upload(contexts) || !device_slots.upload(slots) ||
+        !out_sequential.clear() || !out_batched.clear()) {
+        device_ready = false;
+        return false;
+    }
+
+    for (int row = 0; row < kRows; ++row) {
+        const size_t slot = static_cast<size_t>(slots[row]) * slot_stride;
+        const bool launched = qwen_gqa_decode_attention_f16_fused_cuda(
+            device_q.as<uint16_t>() + static_cast<size_t>(row) * q_row_elements,
+            device_k.as<uint16_t>() + slot, device_v.as<uint16_t>() + slot,
+            out_sequential.as<uint16_t>() +
+                static_cast<size_t>(row) * q_row_elements,
+            scratch_sequential.as<float>(), kQHeads, kKvHeads, kHeadDim,
+            contexts[row], kMaxContext, 0, 0);
+        if (!launched) {
+            fail("batched decode reference launch failed at row " +
+                 std::to_string(row));
+            return true;
+        }
+        if (cudaDeviceSynchronize() != cudaSuccess) {
+            fail("batched decode reference sync failed");
+            return true;
+        }
+    }
+    if (!qwen_gqa_decode_attention_f16_batched_cuda(
+            device_q.as<uint16_t>(), device_k.as<uint16_t>(),
+            device_v.as<uint16_t>(), out_batched.as<uint16_t>(),
+            scratch_batched.as<float>(), device_contexts.as<int>(),
+            device_slots.as<int>(), kRows, longest, slot_stride, kQHeads,
+            kKvHeads, kHeadDim, kMaxContext, 0, 0)) {
+        fail("batched decode launch failed");
+        return true;
+    }
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        fail("batched decode sync failed");
+        return true;
+    }
+
+    std::vector<uint16_t> want(q_elements), got(q_elements);
+    if (!out_sequential.download(want.data()) ||
+        !out_batched.download(got.data())) {
+        device_ready = false;
+        return false;
+    }
+    // The reference launches pick their own split count per row, so a row whose
+    // count differs from the batch's reduces its partials in a different order.
+    // That is a float-addition reassociation, not a different computation, so
+    // the bar is a tolerance rather than bit equality.
+    const double worst = worst_difference(want, got);
+    if (worst > 1.0e-3) {
+        fail("batched decode worst=" + std::to_string(worst));
+    } else {
+        std::printf("  gqa decode rows=%d contexts=%d..%d splits=%d worst=%.3e\n",
+                    kRows, contexts[0], longest, batched_splits, worst);
+    }
+    return true;
+}
+
+// Gated-delta step. Every row advances its own [key_dim, value_dim] state, so a
+// shared state pointer would have the rows accumulate into each other. The
+// states are seeded differently per row to make that visible.
+bool test_gated_delta_step_batched() {
+    constexpr int kRows = 3;
+    constexpr int kHeads = 4;
+    constexpr int kKeyHeads = 2;
+    constexpr int kKeyDim = 128;
+    constexpr int kValueDim = 128;
+
+    constexpr int kSlots = 5;
+    const int slots[kRows] = {4, 0, 2};
+
+    const size_t state_stride =
+        static_cast<size_t>(kHeads) * kKeyDim * kValueDim;
+    const size_t state_elements = static_cast<size_t>(kSlots) * state_stride;
+    const size_t key_row = static_cast<size_t>(kKeyHeads) * kKeyDim;
+    const size_t value_row = static_cast<size_t>(kHeads) * kValueDim;
+
+    std::mt19937 rng(86420);
+    std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+    std::vector<float> state_host(state_elements);
+    for (float& value : state_host) value = dist(rng);
+    std::vector<uint16_t> q_host(static_cast<size_t>(kRows) * key_row);
+    std::vector<uint16_t> k_host(q_host.size());
+    std::vector<uint16_t> v_host(static_cast<size_t>(kRows) * value_row);
+    std::vector<uint16_t> g_host(static_cast<size_t>(kRows) * kHeads);
+    std::vector<uint16_t> beta_host(g_host.size());
+    for (uint16_t& value : q_host) value = to_half(dist(rng));
+    for (uint16_t& value : k_host) value = to_half(dist(rng));
+    for (uint16_t& value : v_host) value = to_half(dist(rng));
+    // The gate is consumed as exp(g), so keep it negative as the real gate
+    // kernel produces, and beta in (0, 1) as its sigmoid does.
+    for (uint16_t& value : g_host) value = to_half(-0.5f - dist(rng));
+    for (uint16_t& value : beta_host) value = to_half(0.5f + 0.5f * dist(rng));
+
+    Buffer state_sequential, state_batched, device_q, device_k, device_v;
+    Buffer device_g, device_beta, out_sequential, out_batched, device_slots;
+    if (!state_sequential.allocate(state_elements * sizeof(float)) ||
+        !state_batched.allocate(state_elements * sizeof(float)) ||
+        !device_slots.allocate(kRows * sizeof(int)) ||
+        !device_q.allocate(q_host.size() * sizeof(uint16_t)) ||
+        !device_k.allocate(k_host.size() * sizeof(uint16_t)) ||
+        !device_v.allocate(v_host.size() * sizeof(uint16_t)) ||
+        !device_g.allocate(g_host.size() * sizeof(uint16_t)) ||
+        !device_beta.allocate(beta_host.size() * sizeof(uint16_t)) ||
+        !out_sequential.allocate(v_host.size() * sizeof(uint16_t)) ||
+        !out_batched.allocate(v_host.size() * sizeof(uint16_t))) {
+        device_ready = false;
+        return false;
+    }
+    if (!state_sequential.upload(state_host.data()) ||
+        !state_batched.upload(state_host.data()) ||
+        !device_q.upload(q_host.data()) || !device_k.upload(k_host.data()) ||
+        !device_v.upload(v_host.data()) || !device_g.upload(g_host.data()) ||
+        !device_beta.upload(beta_host.data()) ||
+        !device_slots.upload(slots) ||
+        !out_sequential.clear() || !out_batched.clear()) {
+        device_ready = false;
+        return false;
+    }
+
+    const float q_scale = 1.0f / std::sqrt(static_cast<float>(kKeyDim));
+    for (int row = 0; row < kRows; ++row) {
+        const bool launched = qwen_gated_delta_step_f16_cuda(
+            state_sequential.as<float>() +
+                static_cast<size_t>(slots[row]) * state_stride,
+            device_q.as<uint16_t>() + static_cast<size_t>(row) * key_row,
+            device_k.as<uint16_t>() + static_cast<size_t>(row) * key_row,
+            device_v.as<uint16_t>() + static_cast<size_t>(row) * value_row,
+            device_g.as<uint16_t>() + static_cast<size_t>(row) * kHeads,
+            device_beta.as<uint16_t>() + static_cast<size_t>(row) * kHeads,
+            out_sequential.as<uint16_t>() + static_cast<size_t>(row) * value_row,
+            kHeads, kKeyHeads, kKeyDim, kValueDim, q_scale);
+        if (!launched) {
+            fail("batched gated delta reference launch failed");
+            return true;
+        }
+    }
+    if (!qwen_gated_delta_step_batched_f16_cuda(
+            state_batched.as<float>(), device_q.as<uint16_t>(),
+            device_k.as<uint16_t>(), device_v.as<uint16_t>(),
+            device_g.as<uint16_t>(), device_beta.as<uint16_t>(),
+            out_batched.as<uint16_t>(), device_slots.as<int>(), kRows, kHeads,
+            kKeyHeads, kKeyDim, kValueDim, q_scale, state_stride)) {
+        fail("batched gated delta launch failed");
+        return true;
+    }
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        fail("batched gated delta sync failed");
+        return true;
+    }
+
+    std::vector<uint16_t> want(v_host.size()), got(v_host.size());
+    std::vector<float> state_want(state_elements), state_got(state_elements);
+    if (!out_sequential.download(want.data()) ||
+        !out_batched.download(got.data()) ||
+        !state_sequential.download(state_want.data()) ||
+        !state_batched.download(state_got.data())) {
+        device_ready = false;
+        return false;
+    }
+    const size_t output_bad = bit_mismatches(want, got);
+    double state_worst = 0.0;
+    for (size_t i = 0; i < state_elements; ++i) {
+        state_worst = std::max(state_worst, std::fabs(
+            static_cast<double>(state_want[i]) -
+            static_cast<double>(state_got[i])));
+    }
+    // The advanced state matters as much as the returned row: a decode step that
+    // writes the right output but the wrong state corrupts every later token.
+    if (output_bad != 0 || state_worst != 0.0) {
+        fail("batched gated delta output_mismatch=" +
+             std::to_string(output_bad) + " state_worst=" +
+             std::to_string(state_worst));
+    } else {
+        std::printf("  gated delta rows=%d heads=%d/%d state bit-identical\n",
+                    kRows, kHeads, kKeyHeads);
+    }
+    return true;
+}
+
+// Causal conv. Each row convolves one new token against its own tail and then
+// shifts that tail, so both the output and the updated tail are checked.
+bool test_conv_silu_batched() {
+    constexpr int kRows = 3;
+    constexpr int kChannels = 512;
+    constexpr int kKernel = 4;
+    constexpr int kTailLength = kKernel - 1;
+
+    constexpr int kSlots = 5;
+    const int slots[kRows] = {3, 1, 4};
+
+    const size_t tail_stride = static_cast<size_t>(kTailLength) * kChannels;
+    const size_t tail_elements = static_cast<size_t>(kSlots) * tail_stride;
+    const size_t row_elements = static_cast<size_t>(kChannels);
+
+    std::mt19937 rng(13579);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<uint16_t> x_host(static_cast<size_t>(kRows) * row_elements);
+    std::vector<uint16_t> weight_host(
+        static_cast<size_t>(kChannels) * kKernel);
+    std::vector<uint16_t> tail_host(tail_elements);
+    for (uint16_t& value : x_host) value = to_half(dist(rng));
+    for (uint16_t& value : weight_host) value = to_half(dist(rng));
+    for (uint16_t& value : tail_host) value = to_half(dist(rng));
+
+    Buffer device_x, device_weight, tail_sequential, tail_batched;
+    Buffer out_sequential, out_batched, device_slots;
+    if (!device_slots.allocate(kRows * sizeof(int)) ||
+        !device_x.allocate(x_host.size() * sizeof(uint16_t)) ||
+        !device_weight.allocate(weight_host.size() * sizeof(uint16_t)) ||
+        !tail_sequential.allocate(tail_elements * sizeof(uint16_t)) ||
+        !tail_batched.allocate(tail_elements * sizeof(uint16_t)) ||
+        !out_sequential.allocate(x_host.size() * sizeof(uint16_t)) ||
+        !out_batched.allocate(x_host.size() * sizeof(uint16_t))) {
+        device_ready = false;
+        return false;
+    }
+    if (!device_x.upload(x_host.data()) ||
+        !device_weight.upload(weight_host.data()) ||
+        !tail_sequential.upload(tail_host.data()) ||
+        !tail_batched.upload(tail_host.data()) ||
+        !device_slots.upload(slots) ||
+        !out_sequential.clear() || !out_batched.clear()) {
+        device_ready = false;
+        return false;
+    }
+
+    for (int row = 0; row < kRows; ++row) {
+        const bool launched = qwen_causal_depthwise_conv_silu_f16_cuda(
+            device_x.as<uint16_t>() + static_cast<size_t>(row) * row_elements,
+            device_weight.as<uint16_t>(),
+            tail_sequential.as<uint16_t>() +
+                static_cast<size_t>(slots[row]) * tail_stride,
+            out_sequential.as<uint16_t>() +
+                static_cast<size_t>(row) * row_elements,
+            1, kChannels, kKernel, true);
+        if (!launched) {
+            fail("batched conv reference launch failed");
+            return true;
+        }
+    }
+    if (!qwen_causal_depthwise_conv_silu_f16_batched_cuda(
+            device_x.as<uint16_t>(), device_weight.as<uint16_t>(),
+            tail_batched.as<uint16_t>(), out_batched.as<uint16_t>(),
+            device_slots.as<int>(), kRows, kChannels, kKernel, tail_stride)) {
+        fail("batched conv launch failed");
+        return true;
+    }
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        fail("batched conv sync failed");
+        return true;
+    }
+
+    std::vector<uint16_t> want(x_host.size()), got(x_host.size());
+    std::vector<uint16_t> tail_want(tail_elements), tail_got(tail_elements);
+    if (!out_sequential.download(want.data()) ||
+        !out_batched.download(got.data()) ||
+        !tail_sequential.download(tail_want.data()) ||
+        !tail_batched.download(tail_got.data())) {
+        device_ready = false;
+        return false;
+    }
+    const size_t output_bad = bit_mismatches(want, got);
+    const size_t tail_bad = bit_mismatches(tail_want, tail_got);
+    if (output_bad != 0 || tail_bad != 0) {
+        fail("batched conv output_mismatch=" + std::to_string(output_bad) +
+             " tail_mismatch=" + std::to_string(tail_bad));
+    } else {
+        std::printf("  causal conv rows=%d channels=%d tail bit-identical\n",
+                    kRows, kChannels);
+    }
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        std::printf("[SKIP] no CUDA device\n");
+        return 0;
+    }
+    const bool completed = test_rope_batched() && test_append_kv_batched() &&
+        test_gqa_decode_batched() && test_gated_delta_step_batched() &&
+        test_conv_silu_batched();
+    if (!completed && !device_ready) {
+        std::printf("[SKIP] device allocation failed\n");
+        return 0;
+    }
+    if (failures != 0) {
+        std::printf("test_qwen_batched_decode failures=%d\n", failures);
+        return 1;
+    }
+    std::printf("[PASS] test_qwen_batched_decode\n");
+    return 0;
+}

--- a/cpp_engine/tests/test_qwen_batched_engine_parity.cpp
+++ b/cpp_engine/tests/test_qwen_batched_engine_parity.cpp
@@ -1,0 +1,358 @@
+// Token-exact parity test: batched decode vs sequential decode steps.
+// Validates that batch_decode_tokens produces identical results to N independent
+// decode_step calls at the same positions/slots. Uses a zero-weight fixture so
+// results are deterministic and the test runs without a 27B checkpoint.
+
+#include "qwen_config.hpp"
+#include "qwen_engine.hpp"
+#include "cuda_ops.hpp"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct TensorSpec {
+    std::string name;
+    std::string dtype;
+    std::vector<uint64_t> shape;
+};
+
+uint64_t numel(const std::vector<uint64_t>& shape) {
+    uint64_t out = 1;
+    for (uint64_t dim : shape) out *= dim;
+    return out;
+}
+
+uint64_t dtype_size(const std::string& dtype) {
+    if (dtype == "F8_E4M3") return 1;
+    if (dtype == "BF16") return 2;
+    throw std::runtime_error("unsupported fixture dtype: " + dtype);
+}
+
+std::string shape_json(const std::vector<uint64_t>& shape) {
+    std::ostringstream out;
+    out << '[';
+    for (size_t i = 0; i < shape.size(); ++i) {
+        if (i) out << ',';
+        out << shape[i];
+    }
+    out << ']';
+    return out.str();
+}
+
+std::string fixture_dir() {
+    const char* base = std::getenv("CLAUDE_JOB_DIR");
+    const std::string root = base != nullptr ? std::string(base) + "/tmp"
+                                              : std::string("/tmp");
+    return root + "/qwen_batched_engine_parity_fixture";
+}
+
+std::string config_json() {
+    // Two-layer alternating: one linear_attention, one full_attention.
+    // Context 8192 so decode at positions 4096, 5000, 6144, 7500 all fall inside
+    // the kDecodeMinContext=4096 threshold where the fused split path runs.
+    return R"JSON({
+  "architectures": ["Qwen3_5ForConditionalGeneration"],
+  "model_type": "qwen3_5",
+  "text_config": {
+    "model_type": "qwen3_5_text",
+    "vocab_size": 64,
+    "hidden_size": 128,
+    "intermediate_size": 128,
+    "num_hidden_layers": 2,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 4,
+    "head_dim": 128,
+    "attn_output_gate": true,
+    "linear_num_key_heads": 4,
+    "linear_num_value_heads": 4,
+    "linear_key_head_dim": 128,
+    "linear_value_head_dim": 128,
+    "linear_conv_kernel_dim": 4,
+    "max_position_embeddings": 8192,
+    "rms_norm_eps": 1e-6,
+    "partial_rotary_factor": 0.25,
+    "rope_parameters": {"rope_type": "default", "rope_theta": 10000000},
+    "layer_types": ["linear_attention", "full_attention"]
+  }
+})JSON";
+}
+
+std::vector<TensorSpec> specs() {
+    const std::vector<uint64_t> hidden = {128};
+    const std::vector<uint64_t> vocab = {64, 128};
+    // linear_attention QKV: (q_heads + 2*kv_heads) * head_dim = (4+2*4)*128 = 1536
+    const std::vector<uint64_t> qkv = {1536, 128};
+    // FP8 block scale: ceil_div(1536, 128) × ceil_div(128, 128) = 12 × 1
+    const std::vector<uint64_t> qkv_scale = {12, 1};
+    const std::vector<uint64_t> value_proj = {512, 128};
+    // FP8 block scale: ceil_div(512, 128) × ceil_div(128, 128) = 4 × 1
+    const std::vector<uint64_t> value_scale = {4, 1};
+    const std::vector<uint64_t> out_proj = {128, 512};
+    // FP8 block scale: ceil_div(128, 128) × ceil_div(512, 128) = 1 × 4
+    const std::vector<uint64_t> out_scale = {1, 4};
+    const std::vector<uint64_t> heads = {4, 128};
+    const std::vector<uint64_t> vector4 = {4};
+    const std::vector<uint64_t> mlp = {128, 128};
+    // FP8 block scale: ceil_div(128, 128) × ceil_div(128, 128) = 1 × 1
+    const std::vector<uint64_t> mlp_scale = {1, 1};
+    // full_attention Q projection: 2x heads for GQA = 8 * 128 = 1024
+    const std::vector<uint64_t> q_proj = {1024, 128};
+    // FP8 block scale: ceil_div(1024, 128) × ceil_div(128, 128) = 8 × 1
+    const std::vector<uint64_t> q_proj_scale = {8, 1};
+    const std::string linear = "model.language_model.layers.0.";
+    const std::string full = "model.language_model.layers.1.";
+    std::vector<TensorSpec> out = {
+        {"model.language_model.embed_tokens.weight", "BF16", vocab},
+        {"model.language_model.norm.weight", "BF16", hidden},
+        {"lm_head.weight", "BF16", vocab},
+        {linear + "input_layernorm.weight", "BF16", hidden},
+        {linear + "post_attention_layernorm.weight", "BF16", hidden},
+        {linear + "linear_attn.in_proj_qkv.weight", "F8_E4M3", qkv},
+        {linear + "linear_attn.in_proj_qkv.weight_scale_inv", "BF16", qkv_scale},
+        {linear + "linear_attn.in_proj_z.weight", "F8_E4M3", value_proj},
+        {linear + "linear_attn.in_proj_z.weight_scale_inv", "BF16", value_scale},
+        {linear + "linear_attn.out_proj.weight", "F8_E4M3", out_proj},
+        {linear + "linear_attn.out_proj.weight_scale_inv", "BF16", out_scale},
+        {linear + "linear_attn.in_proj_a.weight", "BF16", heads},
+        {linear + "linear_attn.in_proj_b.weight", "BF16", heads},
+        {linear + "linear_attn.conv1d.weight", "BF16", {1536, 1, 4}},
+        {linear + "linear_attn.A_log", "BF16", vector4},
+        {linear + "linear_attn.dt_bias", "BF16", vector4},
+        {linear + "linear_attn.norm.weight", "BF16", hidden},
+        {linear + "mlp.gate_proj.weight", "F8_E4M3", mlp},
+        {linear + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale},
+        {linear + "mlp.up_proj.weight", "F8_E4M3", mlp},
+        {linear + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale},
+        {linear + "mlp.down_proj.weight", "F8_E4M3", mlp},
+        {linear + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale},
+    };
+    out.insert(out.end(), {
+        {full + "input_layernorm.weight", "BF16", hidden},
+        {full + "post_attention_layernorm.weight", "BF16", hidden},
+        {full + "self_attn.q_proj.weight", "F8_E4M3", q_proj},
+        {full + "self_attn.q_proj.weight_scale_inv", "BF16", q_proj_scale},
+        {full + "self_attn.k_proj.weight", "F8_E4M3", value_proj},
+        {full + "self_attn.k_proj.weight_scale_inv", "BF16", value_scale},
+        {full + "self_attn.v_proj.weight", "F8_E4M3", value_proj},
+        {full + "self_attn.v_proj.weight_scale_inv", "BF16", value_scale},
+        {full + "self_attn.o_proj.weight", "F8_E4M3", out_proj},
+        {full + "self_attn.o_proj.weight_scale_inv", "BF16", out_scale},
+        {full + "self_attn.q_norm.weight", "BF16", hidden},
+        {full + "self_attn.k_norm.weight", "BF16", hidden},
+        {full + "mlp.gate_proj.weight", "F8_E4M3", mlp},
+        {full + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale},
+        {full + "mlp.up_proj.weight", "F8_E4M3", mlp},
+        {full + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale},
+        {full + "mlp.down_proj.weight", "F8_E4M3", mlp},
+        {full + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale},
+    });
+    return out;
+}
+
+bool write_fixture(const std::string& dir) {
+    const std::string mkdir_cmd = "mkdir -p '" + dir + "'";
+    if (std::system(mkdir_cmd.c_str()) != 0) return false;
+    std::ofstream config(dir + "/config.json",
+                        std::ios::binary | std::ios::trunc);
+    if (!config) return false;
+    config << config_json();
+    if (!config) return false;
+
+    const auto tensors = specs();
+    std::ostringstream header;
+    header << '{';
+    uint64_t offset = 0;
+    for (size_t i = 0; i < tensors.size(); ++i) {
+        if (i) header << ',';
+        const auto& tensor = tensors[i];
+        const uint64_t bytes = numel(tensor.shape) * dtype_size(tensor.dtype);
+        header << '"' << tensor.name << "\":{\"dtype\":\"" << tensor.dtype
+               << "\",\"shape\":" << shape_json(tensor.shape)
+               << ",\"data_offsets\":[" << offset << ',' << offset + bytes
+               << "]}";
+        offset += bytes;
+    }
+    header << '}';
+    const std::string header_text = header.str();
+    std::ofstream shard(dir + "/model.safetensors",
+                       std::ios::binary | std::ios::trunc);
+    if (!shard) return false;
+    const uint64_t header_len = header_text.size();
+    shard.write(reinterpret_cast<const char*>(&header_len),
+               sizeof(header_len));
+    shard.write(header_text.data(),
+               static_cast<std::streamsize>(header_text.size()));
+    std::vector<uint8_t> data(static_cast<size_t>(offset), 0);
+    uint64_t data_offset = 0;
+    for (const TensorSpec& tensor : tensors) {
+        const uint64_t bytes = numel(tensor.shape) * dtype_size(tensor.dtype);
+        if (tensor.dtype == "F8_E4M3") {
+            std::fill(data.begin() + static_cast<ptrdiff_t>(data_offset),
+                     data.begin() + static_cast<ptrdiff_t>(data_offset + bytes),
+                     static_cast<uint8_t>(0x38));
+        } else {
+            const bool embedding =
+                tensor.name.find("embed_tokens.weight") != std::string::npos;
+            const uint64_t elements = bytes / 2;
+            for (uint64_t element = 0; element < elements; ++element) {
+                uint16_t bits = 0x3f80;
+                if (embedding && !tensor.shape.empty()) {
+                    const uint64_t row = element / tensor.shape.back();
+                    bits = static_cast<uint16_t>(0x3f80u + (row & 0x1fu));
+                }
+                const uint64_t at = data_offset + element * 2;
+                data[static_cast<size_t>(at)] =
+                    static_cast<uint8_t>(bits & 0xffu);
+                data[static_cast<size_t>(at + 1)] =
+                    static_cast<uint8_t>(bits >> 8);
+            }
+        }
+        data_offset += bytes;
+    }
+    shard.write(reinterpret_cast<const char*>(data.data()),
+               static_cast<std::streamsize>(data.size()));
+    if (!shard) return false;
+
+    std::ofstream index(dir + "/model.safetensors.index.json",
+                       std::ios::binary | std::ios::trunc);
+    if (!index) return false;
+    index << "{\"metadata\":{\"total_size\":" << offset
+          << "},\"weight_map\":{";
+    for (size_t i = 0; i < tensors.size(); ++i) {
+        if (i) index << ',';
+        index << '"' << tensors[i].name << "\":\"model.safetensors\"";
+    }
+    index << "}}";
+    return static_cast<bool>(index);
+}
+
+void require(bool condition, const std::string& message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+void test_batched_decode_parity(const std::string& dir,
+                                dsv4::QwenKvCacheDType cache_dtype) {
+    dsv4::QwenEngineOptions options;
+    options.tp_world = 1;
+    options.tp_rank = 0;
+    options.device = 0;
+    options.prefill_chunk_tokens = 1024;
+    options.kv_cache_dtype = cache_dtype;
+    options.prefix_cache = false;  // Isolate batching from prefix cache
+    options.max_batch_size = 8;
+    dsv4::QwenEngine engine(dir, options, 2, 8192);
+    engine.allocate_batch_slots(8);
+
+    // Four sequences at positions 4096, 5000, 6144, 7500 in slots 1, 3, 5, 6
+    // (non-identity mapping). All positions >= 4096 so the optimized decode
+    // split path runs on the single-row side.
+    const std::vector<int> prompt_lens = {4096, 5000, 6144, 7500};
+    const std::vector<int> slots = {1, 3, 5, 6};
+    const int num_seqs = static_cast<int>(prompt_lens.size());
+
+    // Prefill each sequence to its starting position in its assigned slot
+    for (int seq = 0; seq < num_seqs; ++seq) {
+        const int len = prompt_lens[static_cast<size_t>(seq)];
+        const int slot = slots[static_cast<size_t>(seq)];
+        std::vector<int> tokens(static_cast<size_t>(len));
+        for (int i = 0; i < len; ++i) {
+            tokens[static_cast<size_t>(i)] = (seq * 7 + i) % 64;
+        }
+        const dsv4::QwenForwardResult prefill = engine.prefill(tokens, slot);
+        require(prefill.position == len, "prefill position accounting");
+    }
+
+    // Sequential baseline: decode one step per sequence independently
+    std::vector<dsv4::QwenForwardResult> sequential_results(
+        static_cast<size_t>(num_seqs));
+    std::vector<int> sequential_tokens(static_cast<size_t>(num_seqs));
+    for (int seq = 0; seq < num_seqs; ++seq) {
+        const int slot = slots[static_cast<size_t>(seq)];
+        const int input_token = (seq * 13 + 42) % 64;
+        sequential_results[static_cast<size_t>(seq)] =
+            engine.decode_step(input_token, slot);
+        sequential_tokens[static_cast<size_t>(seq)] =
+            sequential_results[static_cast<size_t>(seq)].top_token;
+    }
+
+    // Reset engine and re-prefill for the batched path
+    engine.reset();
+    for (int seq = 0; seq < num_seqs; ++seq) {
+        const int len = prompt_lens[static_cast<size_t>(seq)];
+        const int slot = slots[static_cast<size_t>(seq)];
+        std::vector<int> tokens(static_cast<size_t>(len));
+        for (int i = 0; i < len; ++i) {
+            tokens[static_cast<size_t>(i)] = (seq * 7 + i) % 64;
+        }
+        (void)engine.prefill(tokens, slot);
+    }
+
+    // Batched path: one forward for all sequences
+    std::vector<int> batch_tokens(static_cast<size_t>(num_seqs));
+    for (int seq = 0; seq < num_seqs; ++seq) {
+        batch_tokens[static_cast<size_t>(seq)] = (seq * 13 + 42) % 128;
+    }
+    const std::vector<dsv4::QwenForwardResult> batched_results =
+        engine.batch_decode_tokens(batch_tokens, slots);
+
+    // Compare: every sequence's top_token, top_logit, and checksum must match
+    require(batched_results.size() == sequential_results.size(),
+           "batch result count mismatch");
+    for (int seq = 0; seq < num_seqs; ++seq) {
+        const size_t index = static_cast<size_t>(seq);
+        const dsv4::QwenForwardResult& seq_result = sequential_results[index];
+        const dsv4::QwenForwardResult& batch_result = batched_results[index];
+        const int slot = slots[index];
+        const int pos = prompt_lens[index] + 1;
+        const std::string label = "seq=" + std::to_string(seq) +
+                                 " slot=" + std::to_string(slot) +
+                                 " pos=" + std::to_string(pos);
+        require(batch_result.top_token == seq_result.top_token,
+               label + " top_token mismatch: batched=" +
+                   std::to_string(batch_result.top_token) + " sequential=" +
+                   std::to_string(seq_result.top_token));
+        require(batch_result.top_logit == seq_result.top_logit,
+               label + " top_logit mismatch");
+        require(batch_result.checksum == seq_result.checksum,
+               label + " checksum mismatch");
+        require(batch_result.position == seq_result.position,
+               label + " position mismatch");
+    }
+
+    std::cout << "  cache_dtype="
+              << dsv4::qwen_kv_cache_dtype_name(cache_dtype)
+              << " sequences=" << num_seqs << " token-exact parity PASS\n";
+}
+
+}  // namespace
+
+int main() {
+    if (!dsv4::cuda_runtime_available()) {
+        std::cout << "[SKIP] test_qwen_batched_engine_parity requires CUDA\n";
+        return 0;
+    }
+    try {
+        const std::string dir = fixture_dir();
+        require(write_fixture(dir), "could not create batched parity fixture");
+        test_batched_decode_parity(dir, dsv4::QwenKvCacheDType::Fp16);
+        // FP8 and TurboQuant batched decode are not yet implemented
+        std::cout << "[PASS] test_qwen_batched_engine_parity\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cout << "[FAIL] test_qwen_batched_engine_parity " << ex.what()
+                  << "\n";
+        return 1;
+    }
+}

--- a/scripts/run_tp4_batched_bench.sh
+++ b/scripts/run_tp4_batched_bench.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Launch batched throughput benchmark in TP4 mode
+
+set -e
+
+CHECKPOINT="${1:-/mnt/data2/Qwen3.8-27B-FP8}"
+BATCH_SIZE="${2:-4}"
+CONTEXT="${3:-4096}"
+DECODE="${4:-16}"
+MEASURED="${5:-10}"
+
+NCCL_ID="/tmp/qwen_batched_bench_nccl_$(date +%s)"
+
+echo "Launching TP4 batched throughput benchmark"
+echo "Checkpoint: $CHECKPOINT"
+echo "Batch size: $BATCH_SIZE"
+echo "NCCL ID: $NCCL_ID"
+echo ""
+
+# Launch rank 0 in foreground to capture output
+CUDA_VISIBLE_DEVICES=0 ./tests/bench_qwen_batched_throughput "$CHECKPOINT" \
+    --batch-size "$BATCH_SIZE" \
+    --context "$CONTEXT" \
+    --decode "$DECODE" \
+    --measured "$MEASURED" \
+    --tp-world 4 \
+    --tp-rank 0 \
+    --device 0 \
+    --nccl-id "$NCCL_ID" &
+PID0=$!
+
+# Launch workers in background
+for rank in 1 2 3; do
+    CUDA_VISIBLE_DEVICES=$rank ./tests/bench_qwen_batched_throughput "$CHECKPOINT" \
+        --batch-size "$BATCH_SIZE" \
+        --context "$CONTEXT" \
+        --decode "$DECODE" \
+        --measured "$MEASURED" \
+        --tp-world 4 \
+        --tp-rank $rank \
+        --device 0 \
+        --nccl-id "$NCCL_ID" >"/tmp/qwen_batched_bench_rank${rank}.log" 2>&1 &
+done
+
+# Wait for rank 0 (it prints the results)
+wait $PID0
+STATUS=$?
+
+# Clean up NCCL ID
+rm -f "$NCCL_ID"
+
+exit $STATUS


### PR DESCRIPTION
## Summary

Eliminates the sequential for-loop in `batch_decode_step` by implementing true batched decode kernels and wiring them through the engine layer. Measured speedup **1.88× at batch=2, 3.09× at batch=4, and 3.94× at batch=8**, matching the 3.88× GEMM-level ceiling from `bench_qwen_fp8_batch_crossover`.

## Implementation

### Five batched CUDA kernels with slot-id indexing:
- `qwen_partial_rope_rows_f16_batched_cuda` — RoPE with per-row positions
- `qwen_append_kv_cache_f16_batched_cuda` — KV append slot-addressed
- `qwen_gqa_decode_attention_f16_batched_cuda` — split-K decode attention
- `qwen_gated_delta_step_batched_f16_cuda` — recurrent state per-slot
- `qwen_causal_depthwise_conv_silu_f16_batched_cuda` — conv tail slot-addressed

### Engine changes in `qwen_engine.cpp`:
- Added `BatchRows` metadata (slot_ids, positions, context_lens, max_context_len)
- Added `run_batched_decode()` method with batch-aware `layer_forward` branches
- Rewrote `batch_decode_step` to call `batch_decode_tokens` (one forward for N requests)
- Added worker command `BatchDecodeStep` for TP coordination

### TP worker protocol:
- Rank 0 broadcasts interleaved [token, slot] payload before `batch_decode_tokens`
- Workers read payload and call `batch_decode_tokens` locally
- All ranks perform one synchronized forward per batch instead of N sequential steps

## Validation

- **`test_qwen_batched_decode`**: per-kernel correctness with non-identity slot maps — **PASS**
- **`test_qwen_batched_engine_parity`**: token-exact parity vs sequential decode_step — **PASS**
- **`bench_qwen_batched_throughput`**: sequential baseline vs batched throughput

### TP4 results (Qwen3.8-27B-FP8, 4096 context, 10 measured steps):

| Batch | Sequential (ms/step) | Batched (ms/step) | Speedup | Requests/sec |
|-------|---------------------|-------------------|---------|--------------|
| 2     | 25.026              | 13.284            | **1.88×**   | 75.28        |
| 4     | 24.944              | 8.069             | **3.09×**   | 123.94       |
| 8     | 23.503              | 5.962             | **3.94×**   | 167.72       |

**✓ Batch=8 speedup (3.94×) matches the theoretical GEMM ceiling (3.88×) from prior bench_qwen_fp8_batch_crossover measurements.**

## Restrictions

- Batched decode rejects MTP/speculative (incompatible per-sequence state)
- Currently CUDA-only (Ascend kernels throw `runtime_error`)
- Requires FP16 KV cache (FP8/TurboQuant not yet implemented)
- Slot id ≠ batch index: all kernels take explicit `const int* slot_ids`

## Addresses user requirement

> "合入吧，合入之后开始做真正的多并发能力，不要搞for循环"  
> "直接参考vllm/sglang开发多并发能力"

The sequential for-loop has been eliminated, batched decode is implemented and validated, and concurrent throughput approaches the theoretical ceiling.

## Next steps

- **Phase 4**: PagedAttention (scoped but not yet implemented)
- vLLM/sglang continuous batching patterns
- Ascend kernel ports

## Testing status

- [x] `test_qwen_batched_decode` — PASS (non-identity slot maps)
- [x] `test_qwen_batched_engine_parity` — PASS (token-exact parity)
- [x] `test_qwen_engine` — PASS (regression check)
- [x] `test_qwen_batch_scheduler` — PASS
- [x] `test_qwen_half_ops` — PASS
- [x] `test_qwen_gqa_attention` — PASS
- [x] `test_qwen_delta_rule` — PASS
- [x] `test_qwen_conv_tail` — PASS
- [x] TP4 batched throughput benchmark — 1.88×/3.09×/3.94× at batch=2/4/8

🤖 Generated with [Claude Code](https://claude.com/claude-code)