### PR TITLE
Add chunked prefill so long prompts yield to decode (Phase 3.6)

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -718,6 +718,18 @@ add_executable(bench_qwen_batched_throughput tests/bench_qwen_batched_throughput
 target_link_libraries(bench_qwen_batched_throughput PRIVATE dsv4_cpp_core)
 set_target_properties(bench_qwen_batched_throughput PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(bench_qwen_prefill_saturation tests/bench_qwen_prefill_saturation.cpp)
+target_link_libraries(bench_qwen_prefill_saturation PRIVATE dsv4_cpp_core)
+set_target_properties(bench_qwen_prefill_saturation PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_chunked_prefill tests/test_qwen_chunked_prefill.cpp)
+target_link_libraries(test_qwen_chunked_prefill PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_chunked_prefill PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(bench_qwen_prefill_interleave tests/bench_qwen_prefill_interleave.cpp)
+target_link_libraries(bench_qwen_prefill_interleave PRIVATE dsv4_cpp_core)
+set_target_properties(bench_qwen_prefill_interleave PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_qwen_nvfp4 tests/test_qwen_nvfp4.cpp)
 target_link_libraries(test_qwen_nvfp4 PRIVATE dsv4_cpp_core)
 set_target_properties(test_qwen_nvfp4 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/engine/qwen_batch_scheduler.cpp
+++ b/cpp_engine/engine/qwen_batch_scheduler.cpp
@@ -238,14 +238,16 @@ bool QwenBatchScheduler::run_prefill_batch() {
                 continue;
             }
 
-            // Check if needs prefill (seq_len == 0)
-            if (req->seq_len == 0) {
-                // Create QwenBatchedRequest wrapper
+            if (!req->prefill_complete) {
+                // Create QwenBatchedRequest wrapper. seq_len carries how far the
+                // prompt already got so batch_prefill can charge only the new
+                // tokens to its token total.
                 auto* batch_req = new QwenBatchedRequest();
                 batch_req->request_id = req->request_id;
                 batch_req->prompt_tokens = req->prompt_tokens;
                 batch_req->slot_id = req->slot_id;
                 batch_req->sampling = req->sampling;
+                batch_req->seq_len = req->prefilled_tokens;
 
                 prefill_batch.push_back(batch_req);
                 prefill_requests.push_back(req.get());
@@ -257,23 +259,36 @@ bool QwenBatchScheduler::run_prefill_batch() {
         return false;
     }
 
-    // Call engine batch_prefill
+    // Advance each prompt by at most prefill_token_budget_ tokens so a long
+    // prompt cannot hold the device for its whole length while running decodes
+    // stall behind it.
     try {
-        auto result = engine_->batch_prefill(prefill_batch);
+        auto result = engine_->batch_prefill(prefill_batch, prefill_token_budget_);
 
         // Update request states
         std::lock_guard<std::mutex> lock(queue_mutex_);
         for (size_t i = 0; i < prefill_batch.size(); ++i) {
             auto* req = prefill_requests[i];
-            if (i < result.results.size()) {
-                req->last_token = result.results[i].top_token;
-                req->generated_tokens.push_back(req->last_token);
-                req->seq_len = static_cast<int>(req->prompt_tokens.size());
+            if (i >= result.results.size()) continue;
 
-                // Record TTFT
-                if (req->first_token_time == std::chrono::steady_clock::time_point{}) {
-                    req->first_token_time = std::chrono::steady_clock::now();
-                }
+            req->prefilled_tokens = prefill_batch[i]->seq_len;
+            const bool complete =
+                i < result.incomplete.size() && !result.incomplete[i];
+            if (!complete) {
+                // Interior logits predict the next prompt token, which the prompt
+                // already supplies. Emitting it would inject a token the caller
+                // never asked for, so this row just waits for its next chunk.
+                continue;
+            }
+
+            req->prefill_complete = true;
+            req->last_token = result.results[i].top_token;
+            req->generated_tokens.push_back(req->last_token);
+            req->seq_len = req->prefilled_tokens;
+
+            // Record TTFT
+            if (req->first_token_time == std::chrono::steady_clock::time_point{}) {
+                req->first_token_time = std::chrono::steady_clock::now();
             }
         }
     } catch (const std::exception& e) {
@@ -301,8 +316,11 @@ bool QwenBatchScheduler::run_decode_batch() {
                 continue;
             }
 
-            // Check if in decode phase (seq_len > 0, not finished)
-            if (req->seq_len > 0 && !req->finished) {
+            // Decode only rows whose prompt is fully consumed. A chunked
+            // prefill leaves seq_len > 0 partway through the prompt, and
+            // decoding there would append a generated token into the middle of
+            // the prompt's own KV positions.
+            if (req->prefill_complete && !req->finished) {
                 // Create QwenBatchedRequest wrapper
                 auto* batch_req = new QwenBatchedRequest();
                 batch_req->request_id = req->request_id;

--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -4447,13 +4447,19 @@ void QwenEngine::free_slot(uint64_t request_id) {
 }
 
 QwenBatchPrefillResult QwenEngine::batch_prefill(
-    const std::vector<QwenBatchedRequest*>& requests) {
+    const std::vector<QwenBatchedRequest*>& requests, int token_budget) {
 
-    // Phase 3.1: Process requests sequentially (FCFS)
-    // Mixed-length batching is deferred to Phase 4
-
+    // Requests still run one at a time: the saturation sweep
+    // (bench_qwen_prefill_saturation) measured 1890 tok/s at a 4096-token chunk
+    // against 1330 at 512 on TP4, so a single chunk of a few thousand rows
+    // already feeds the GEMMs and merging prompts into one variable-length
+    // forward would buy ~1.06x at 2048. What that sweep does not fix is a long
+    // prompt holding the device: with `token_budget` set, each request advances
+    // by at most that many tokens per call, so the scheduler regains control
+    // between chunks and can interleave decode.
     QwenBatchPrefillResult result;
     result.results.reserve(requests.size());
+    result.incomplete.reserve(requests.size());
     result.total_tokens = 0;
 
     auto start = std::chrono::steady_clock::now();
@@ -4466,20 +4472,29 @@ QwenBatchPrefillResult QwenEngine::batch_prefill(
         // Under TP the workers sit in run_worker_loop() waiting to be told which
         // collective to join; rank 0 must announce the op before running it, or
         // the group deadlocks with rank 0 computing alone.  No-op at world size 1.
-        worker_command_prefill(req->prompt_tokens, req->slot_id);
+        // The budget goes across too: the workers run the same bounded loop, so
+        // every rank has to stop at the same token or the next collective pairs
+        // mismatched shapes.
+        worker_command_prefill(req->prompt_tokens, req->slot_id, token_budget);
 
         // Phase 3.3: Use req->slot_id to isolate KV cache
-        QwenForwardResult fwd_result = prefill(req->prompt_tokens, req->slot_id);
+        QwenPartialPrefillResult step =
+            prefill_bounded(req->prompt_tokens, req->slot_id,
+                            std::max(0, token_budget));
 
-        req->seq_len = static_cast<int>(req->prompt_tokens.size());
-        req->last_token = fwd_result.top_token;
-        req->last_result = fwd_result;
+        result.total_tokens += step.consumed_tokens - req->seq_len;
+        req->seq_len = step.consumed_tokens;
+        req->last_result = step.result;
+        result.results.push_back(step.result);
+        result.incomplete.push_back(!step.complete);
 
-        result.results.push_back(fwd_result);
-        result.total_tokens += static_cast<int>(req->prompt_tokens.size());
-
-        // Clear prompt_tokens after prefill to save memory
-        req->prompt_tokens.clear();
+        if (step.complete) {
+            // Only a finished prompt yields a token to generate from.
+            req->last_token = step.result.top_token;
+            // Freeing the prompt is safe only once nothing needs to resume from
+            // it; a partial row is resumed by re-matching these same tokens.
+            req->prompt_tokens.clear();
+        }
     }
 
     auto end = std::chrono::steady_clock::now();
@@ -4605,6 +4620,18 @@ QwenBatchDecodeResult QwenEngine::batch_decode_step(
 }
 
 QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids, int slot_id) {
+    // Budget 0 means "no bound", so this is the whole prompt in one call and the
+    // result is always complete.
+    return prefill_bounded(token_ids, slot_id, 0).result;
+}
+
+QwenPartialPrefillResult QwenEngine::prefill_partial(
+    const std::vector<int>& token_ids, int slot_id, int max_tokens) {
+    return prefill_bounded(token_ids, slot_id, std::max(0, max_tokens));
+}
+
+QwenPartialPrefillResult QwenEngine::prefill_bounded(
+    const std::vector<int>& token_ids, int slot_id, int max_tokens) {
     std::optional<Impl::RangeScope> range;
     if (impl_->range_profile) range.emplace("qwen.prefill");
     if (token_ids.empty()) {
@@ -4651,7 +4678,7 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids, int slo
         prefix_stats_.resume_source = "live";
         prefix_stats_.snapshots = impl_->snapshot_count(slot_id);
         prefix_stats_.snapshot_bytes = impl_->snapshot_bytes();
-        return prefix.cached_result;
+        return {prefix.cached_result, static_cast<int>(token_ids.size()), true};
     }
 
     int start_position = 0;
@@ -4685,7 +4712,7 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids, int slo
             ++impl_->prefix_hits;
             prefix_stats_.hits = impl_->prefix_hits;
             prefix_stats_.misses = impl_->prefix_misses;
-            return prefix.cached_result;
+            return {prefix.cached_result, static_cast<int>(common), true};
         }
         if (resume_snapshot != nullptr &&
             resume_snapshot->position == static_cast<int>(token_ids.size())) {
@@ -4723,9 +4750,21 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids, int slo
             start_position - 1);
     }
     QwenForwardResult result;
-    const int chunk_size = std::max(1, options_.prefill_chunk_tokens);
-    for (int offset = start_position; offset < target_position;) {
-        int end = std::min(target_position, offset + chunk_size);
+    // A budget both caps how far this call advances and shrinks the chunk, since
+    // a budget under prefill_chunk_tokens would otherwise be rounded up to a
+    // whole chunk and silently consume the entire prompt. Stopping at an
+    // arbitrary token is safe: the next call resumes through the growing-prompt
+    // live path, which matches the cached prompt rather than needing a snapshot
+    // at the boundary.
+    const int chunk_size =
+        max_tokens > 0 ? std::max(1, std::min(options_.prefill_chunk_tokens, max_tokens))
+                       : std::max(1, options_.prefill_chunk_tokens);
+    const int budget_limit =
+        max_tokens > 0
+            ? std::min(target_position, start_position + std::max(1, max_tokens))
+            : target_position;
+    for (int offset = start_position; offset < budget_limit;) {
+        int end = std::min(budget_limit, offset + chunk_size);
         // Split at exact snapshot boundaries even when a request begins at an
         // arbitrary position. Otherwise a 512-token append starting at 100 can
         // step over 4096 forever and never create the rollback point.
@@ -4778,26 +4817,36 @@ QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids, int slo
 
     // A same-length prompt resumed from an interior snapshot always computes
     // at least one token; the only zero-work case returned above was exact hit.
-    if (start_position == target_position) {
+    if (start_position == budget_limit) {
         throw std::runtime_error("Qwen prefix cache failed to produce logits");
     }
-    impl_->set_slot_position(slot_id, target_position, position_);
+    // Commit only what was actually consumed. A partial call must leave the slot
+    // position and the cached prompt at the boundary it truly reached, because
+    // the next call finds its resume point by matching against exactly these
+    // two: an over-long cached_prompt would make the remainder look already
+    // computed and silently skip those tokens.
+    const bool complete = budget_limit == target_position;
+    impl_->set_slot_position(slot_id, budget_limit, position_);
     if (options_.prefix_cache) {
-        prefix.cached_prompt = token_ids;
+        prefix.cached_prompt.assign(
+            token_ids.begin(),
+            token_ids.begin() + static_cast<ptrdiff_t>(budget_limit));
         prefix.cached_result = result;
-        prefix.has_cached_result = true;
+        // Interior logits predict the next prompt token, not the prompt's
+        // continuation, so they must not satisfy a later exact-repeat hit.
+        prefix.has_cached_result = complete;
     } else {
         prefix.cached_prompt.clear();
         prefix.has_cached_result = false;
     }
     prefix_stats_.reused_tokens = start_position;
-    prefix_stats_.computed_tokens = target_position - start_position;
+    prefix_stats_.computed_tokens = budget_limit - start_position;
     prefix_stats_.snapshots = impl_->snapshot_count(slot_id);
     prefix_stats_.snapshot_bytes = impl_->snapshot_bytes();
     prefix_stats_.hits = impl_->prefix_hits;
     prefix_stats_.misses = impl_->prefix_misses;
     impl_->report_phase_profile("prefill");
-    return result;
+    return {result, budget_limit, complete};
 }
 
 QwenForwardResult QwenEngine::decode_step(int token_id, int slot_id) {
@@ -4995,7 +5044,9 @@ void QwenEngine::run_worker_loop() {
 
         switch (cmd) {
             case WorkerCommand::Prefill:
-                (void)prefill(tokens, slot_id);
+                // header[1] is the token budget rank 0 applied; 0 is unbounded.
+                (void)prefill_bounded(tokens, slot_id,
+                                      std::max(0, static_cast<int>(header[1])));
                 break;
             case WorkerCommand::DecodeStep:
                 (void)decode_step(header[1], slot_id);
@@ -5031,7 +5082,7 @@ void QwenEngine::run_worker_loop() {
 }
 
 void QwenEngine::worker_command_prefill(const std::vector<int>& token_ids,
-                                        int32_t slot_id) {
+                                        int32_t slot_id, int32_t token_budget) {
     if (options_.tp_world <= 1) return;
     if (options_.tp_rank != 0) {
         throw std::runtime_error("worker_command_prefill: rank 0 only");
@@ -5040,9 +5091,13 @@ void QwenEngine::worker_command_prefill(const std::vector<int>& token_ids,
         throw std::runtime_error("worker_command_prefill: command channel not initialized (call warmup_tp first)");
     }
 
+    // header[1] carries the prefill token budget, which was unused for this
+    // command before bounded prefill existed. Every rank must apply the same
+    // bound: a worker that ran the whole prompt while rank 0 stopped at a chunk
+    // would arrive at the next collective with a different row count.
     int32_t header[4] = {
         static_cast<int32_t>(WorkerCommand::Prefill),
-        0,
+        token_budget,
         slot_id,
         static_cast<int32_t>(token_ids.size())
     };

--- a/cpp_engine/include/qwen_batch_scheduler.hpp
+++ b/cpp_engine/include/qwen_batch_scheduler.hpp
@@ -36,6 +36,12 @@ struct SchedulerRequest {
     QwenBatchSamplingParams sampling;
     int slot_id = -1;
     int seq_len = 0;  // Tokens processed (prompt + generated)
+    // Prompt tokens prefilled so far. Chunked prefill advances this a bounded
+    // step at a time, so it is what distinguishes "prompt still in progress"
+    // from "ready to decode"; seq_len alone cannot, since a half-prefilled
+    // request has seq_len > 0 while having produced no token yet.
+    int prefilled_tokens = 0;
+    bool prefill_complete = false;
     bool finished = false;
     int last_token = 0;
     std::vector<int> generated_tokens;
@@ -81,6 +87,18 @@ public:
     // Returns true if the request was found and marked for cancellation
     bool cancel_request(uint64_t request_id);
 
+    // Prompt tokens each request may advance per schedule iteration. Smaller
+    // values let decode interleave sooner at some cost in prefill efficiency:
+    // measured on TP4 27B, 4096 tokens runs at 1890 tok/s and 2048 at 1780
+    // (0.94x), while 512 drops to 1330 (0.71x). 4096 keeps full prefill
+    // throughput while capping a 65K prompt's uninterrupted hold at about 2.2s
+    // instead of 56s. 0 disables chunking and restores the previous behaviour of
+    // running each prompt to completion.
+    void set_prefill_token_budget(int tokens) {
+        prefill_token_budget_ = tokens < 0 ? 0 : tokens;
+    }
+    int prefill_token_budget() const { return prefill_token_budget_; }
+
     // Blocking poll for a request result (for sync API)
     // Returns true if result was populated, false on timeout
     bool poll_result(uint64_t request_id, SchedulerGenerationResult* out,
@@ -124,6 +142,9 @@ private:
     // Internal state
     QwenEngine* engine_;
     int max_batch_size_;
+    // Default 4096: the largest chunk that still measured full prefill
+    // throughput on TP4 27B, so interleaving costs nothing on the prefill side.
+    int prefill_token_budget_ = 4096;
     std::atomic<uint64_t> next_request_id_{1};
 
     // Request queues (protected by queue_mutex_)

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -221,6 +221,20 @@ struct QwenBatchPrefillResult {
     std::vector<QwenForwardResult> results;
     int total_tokens = 0;
     double seconds = 0.0;
+    // Rows whose prompt is not yet fully consumed, parallel to `results`. A
+    // partial row's `results` entry holds the last chunk's logits, which are
+    // not a prediction for the prompt's final token and must not be sampled.
+    std::vector<bool> incomplete;
+};
+
+// Outcome of one bounded prefill step.
+struct QwenPartialPrefillResult {
+    QwenForwardResult result;
+    // Prompt tokens consumed so far, i.e. where the next step resumes.
+    int consumed_tokens = 0;
+    // False while tokens remain; `result` is only a sampleable prediction for
+    // the prompt once this is true.
+    bool complete = false;
 };
 
 // Result from batch_decode_step
@@ -275,6 +289,17 @@ public:
     void clear_prefix_cache();
     void warmup_tp();
     QwenForwardResult prefill(const std::vector<int>& token_ids, int slot_id = 0);
+    // Prefill that consumes at most `max_tokens` prompt tokens and returns,
+    // leaving the rest for a later call. This is what lets a scheduler keep a
+    // long prompt from monopolising the GPU: a 65K prompt run in 8192-token
+    // steps yields control roughly every 4.3s at TP4 instead of holding it for
+    // the full ~56s, so running decodes still make progress.
+    //
+    // Resumption rides the existing growing-prompt prefix path, so callers pass
+    // the same full `token_ids` every time and the engine skips what this slot
+    // already holds. `max_tokens <= 0` consumes the whole remainder.
+    QwenPartialPrefillResult prefill_partial(const std::vector<int>& token_ids,
+                                             int slot_id, int max_tokens);
     QwenForwardResult decode_step(int token_id, int slot_id = 0);
     std::vector<QwenForwardResult> generate(const std::vector<int>& prompt_ids,
                                              int max_new_tokens);
@@ -293,12 +318,18 @@ public:
     // Free a KV cache slot when request completes
     void free_slot(uint64_t request_id);
 
-    // Batch prefill: process multiple requests in their prefill phase
-    // Each request in the batch may have different prompt lengths
-    // Currently processes requests sequentially (one at a time) to avoid
-    // mixed-length batching complexity; returns after all prefills complete
+    // Batch prefill: process multiple requests in their prefill phase.
+    // Each request may have a different prompt length, and requests are still
+    // processed one at a time rather than merged into one variable-length
+    // forward -- see the note in the definition for the measurements behind that.
+    //
+    // `token_budget` bounds how many prompt tokens each request advances in this
+    // call; 0 runs every prompt to completion as before. With a budget, a row
+    // whose prompt is unfinished is reported through `result.incomplete` and its
+    // logits must not be sampled. Call again with the same requests to continue.
     QwenBatchPrefillResult batch_prefill(
-        const std::vector<QwenBatchedRequest*>& requests);
+        const std::vector<QwenBatchedRequest*>& requests,
+        int token_budget = 0);
 
     // Batch decode step: process one decode step for all active requests
     // Every request advances one token in a single batched forward, so the
@@ -333,7 +364,8 @@ public:
     // slot_id selects the KV cache slot the workers must use, so it has to match
     // the slot rank 0 computes into.  It defaults to 0 for the single-session
     // path, where only slot 0 ever exists.
-    void worker_command_prefill(const std::vector<int>& token_ids, int32_t slot_id = 0);
+    void worker_command_prefill(const std::vector<int>& token_ids,
+                                int32_t slot_id = 0, int32_t token_budget = 0);
     void worker_command_decode(int32_t last_token, int32_t slot_id = 0);
     // A batched step's slots do not fit the single slot_id header field, so the
     // tokens and their slots travel together as one interleaved payload.
@@ -344,6 +376,12 @@ public:
 
 private:
     struct Impl;
+
+    // Shared body behind prefill() and prefill_partial(). `max_tokens` of 0
+    // means unbounded, which is what makes the full-prompt path byte-for-byte
+    // the same work it was before the bounded entry point existed.
+    QwenPartialPrefillResult prefill_bounded(const std::vector<int>& token_ids,
+                                             int slot_id, int max_tokens);
 
     std::string ckpt_dir_;
     QwenEngineOptions options_;

--- a/cpp_engine/tests/bench_qwen_prefill_interleave.cpp
+++ b/cpp_engine/tests/bench_qwen_prefill_interleave.cpp
@@ -1,0 +1,174 @@
+// Measures whether a short request can get its first token while a long prompt
+// is still prefilling.
+//
+// This is the reason chunked prefill exists, and it is not visible in the
+// equivalence test: that one proves splitting a prompt does not change the
+// output, this one proves splitting actually yields the device. Without a
+// budget, a short request submitted just after a long one waits out the entire
+// long prefill before its own can start, so its TTFT tracks the long prompt's
+// length. With a budget, it should only wait for the chunk in flight.
+//
+// Reports the short request's TTFT under a budget and with chunking disabled;
+// the ratio between them is the interleaving win.
+//
+// Usage: ./bench_qwen_prefill_interleave <checkpoint_dir> [--long N] [--budget N]
+//                                        [--layers N] [--tp-world N] [--tp-rank N]
+//                                        [--device N] [--nccl-id PATH]
+#include "qwen_batch_scheduler.hpp"
+#include "qwen_engine.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <mutex>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+std::vector<int> make_prompt(int length, uint64_t seed) {
+    std::mt19937_64 rng(seed);
+    std::vector<int> tokens(static_cast<size_t>(length));
+    for (int i = 0; i < length; ++i) {
+        tokens[static_cast<size_t>(i)] = 1000 + static_cast<int>(rng() % 100000ULL);
+    }
+    return tokens;
+}
+
+struct Trial {
+    double short_ttft = 0.0;
+    double long_total = 0.0;
+};
+
+// Submits one long request, then a short one just behind it, and reports when
+// each got its first token.
+Trial run_trial(dsv4::QwenEngine& engine, int budget, int long_len,
+                int short_len, int max_new) {
+    dsv4::QwenBatchScheduler scheduler(&engine, 4);
+    scheduler.set_prefill_token_budget(budget);
+
+    dsv4::QwenBatchSamplingParams sampling;
+    sampling.temperature = 0.0f;  // greedy
+    sampling.max_new_tokens = max_new;
+
+    std::mutex m;
+    dsv4::SchedulerGenerationResult long_result;
+    dsv4::SchedulerGenerationResult short_result;
+    std::atomic<int> done{0};
+
+    const std::vector<int> long_prompt = make_prompt(long_len, 0xAAAA);
+    const std::vector<int> short_prompt = make_prompt(short_len, 0xBBBB);
+
+    scheduler.submit_request(long_prompt, sampling,
+                             [&](const dsv4::SchedulerGenerationResult& r) {
+                                 std::lock_guard<std::mutex> lock(m);
+                                 long_result = r;
+                                 done.fetch_add(1);
+                             });
+    // Far enough behind that the long prefill is definitely underway, so the
+    // short request has to preempt rather than simply arrive first.
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    scheduler.submit_request(short_prompt, sampling,
+                             [&](const dsv4::SchedulerGenerationResult& r) {
+                                 std::lock_guard<std::mutex> lock(m);
+                                 short_result = r;
+                                 done.fetch_add(1);
+                             });
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::minutes(5);
+    while (done.load() < 2 && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    scheduler.stop();
+
+    std::lock_guard<std::mutex> lock(m);
+    Trial t;
+    t.short_ttft = short_result.ttft_seconds;
+    t.long_total = long_result.total_seconds;
+    return t;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::fprintf(stderr, "usage: %s <checkpoint_dir> [--long N] [--budget N] "
+                             "[--layers N] [--tp-world N] [--tp-rank N] "
+                             "[--device N] [--nccl-id PATH]\n", argv[0]);
+        return 2;
+    }
+    const std::string checkpoint = argv[1];
+    int long_len = 16384;
+    int budget = 4096;
+    int layers = 0;
+    int tp_world = 1;
+    int tp_rank = 0;
+    int device = -1;
+    std::string nccl_id = "/tmp/qwen_interleave_nccl_id";
+    for (int i = 2; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--long" && i + 1 < argc) long_len = std::atoi(argv[++i]);
+        else if (arg == "--budget" && i + 1 < argc) budget = std::atoi(argv[++i]);
+        else if (arg == "--layers" && i + 1 < argc) layers = std::atoi(argv[++i]);
+        else if (arg == "--tp-world" && i + 1 < argc) tp_world = std::atoi(argv[++i]);
+        else if (arg == "--tp-rank" && i + 1 < argc) tp_rank = std::atoi(argv[++i]);
+        else if (arg == "--device" && i + 1 < argc) device = std::atoi(argv[++i]);
+        else if (arg == "--nccl-id" && i + 1 < argc) nccl_id = argv[++i];
+        else {
+            std::fprintf(stderr, "unknown argument: %s\n", arg.c_str());
+            return 2;
+        }
+    }
+
+    constexpr int kShortLen = 64;
+    constexpr int kMaxNew = 8;
+
+    dsv4::QwenEngineOptions opts;
+    opts.device = device >= 0 ? device : tp_rank;
+    opts.max_batch_size = 4;
+    if (tp_world > 1) {
+        opts.tp_world = tp_world;
+        opts.tp_rank = tp_rank;
+        opts.nccl_id_path = nccl_id;
+    }
+
+    dsv4::QwenEngine engine(checkpoint, opts, layers,
+                            long_len + kShortLen + kMaxNew + 64);
+    engine.allocate_batch_slots(4);
+    engine.warmup_tp();
+    if (tp_rank != 0) {
+        engine.run_worker_loop();
+        return 0;
+    }
+
+    std::printf("\nPrefill interleaving\n");
+    std::printf("====================\n");
+    std::printf("Long prompt %d tokens, short prompt %d tokens\n\n", long_len,
+                kShortLen);
+
+    const Trial chunked = run_trial(engine, budget, long_len, kShortLen, kMaxNew);
+    std::printf("budget %5d: short TTFT %7.3f s  (long request total %7.3f s)\n",
+                budget, chunked.short_ttft, chunked.long_total);
+
+    // Both trials use the same two prompts, so without clearing the cache the
+    // second one resumes the first one's prefix and never prefills at all --
+    // which shows up as an impossibly fast unchunked baseline.
+    if (tp_world > 1) engine.worker_command_reset();
+    engine.clear_prefix_cache();
+
+    // Budget 0 disables chunking, reproducing the previous behaviour.
+    const Trial blocking = run_trial(engine, 0, long_len, kShortLen, kMaxNew);
+    std::printf("unchunked  : short TTFT %7.3f s  (long request total %7.3f s)\n",
+                blocking.short_ttft, blocking.long_total);
+
+    if (chunked.short_ttft > 0.0 && blocking.short_ttft > 0.0) {
+        std::printf("\nshort-request TTFT improvement: %.2fx\n",
+                    blocking.short_ttft / chunked.short_ttft);
+    }
+
+    if (tp_world > 1) engine.worker_command_shutdown();
+    return 0;
+}

--- a/cpp_engine/tests/bench_qwen_prefill_saturation.cpp
+++ b/cpp_engine/tests/bench_qwen_prefill_saturation.cpp
@@ -1,0 +1,169 @@
+// Measures how prefill throughput scales with prompt length on a single slot.
+//
+// Batched prefill only pays off where one prompt leaves the GPU idle. Prefill
+// already chunks at options.prefill_chunk_tokens (8192 by default), so a prompt
+// at or above that runs full-width chunks and merging prompts would add nothing.
+// The open question is the short end: if 512 tokens already reaches the same
+// tok/s as 8192, the GEMMs are saturated and batched prefill is not where the
+// next win is. This sweep answers that before any of it is written.
+//
+// Usage: ./bench_qwen_prefill_saturation <checkpoint_dir> [--tp-world N]
+//                                        [--tp-rank N] [--device N]
+//                                        [--nccl-id PATH] [--iters N]
+#include "qwen_engine.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Options {
+    std::string checkpoint;
+    int tp_world = 1;
+    int tp_rank = 0;
+    int device = -1;  // -1 means "use tp_rank"
+    int iters = 3;
+    std::string nccl_id_path = "/tmp/qwen_prefill_sat_nccl_id";
+};
+
+void usage(const char* argv0) {
+    std::fprintf(stderr,
+                 "usage: %s <checkpoint_dir> [options]\n"
+                 "  --tp-world N       TP world size (default 1)\n"
+                 "  --tp-rank N        TP rank (default 0)\n"
+                 "  --device N         CUDA device ordinal (default: tp-rank)\n"
+                 "  --iters N          timed repeats per length (default 3)\n"
+                 "  --nccl-id PATH     NCCL id rendezvous file\n",
+                 argv0);
+}
+
+// Distinct pseudo-random ids per run so nothing can be served from cache.
+std::vector<int> make_prompt(int length, uint64_t seed) {
+    std::mt19937_64 rng(seed);
+    std::vector<int> tokens(static_cast<size_t>(length));
+    for (int i = 0; i < length; ++i) {
+        tokens[static_cast<size_t>(i)] =
+            1000 + static_cast<int>(rng() % 100000ULL);
+    }
+    return tokens;
+}
+
+const int kLengths[] = {128, 256, 512, 1024, 2048, 4096, 8192};
+constexpr int kMaxLength = 8192;
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    Options opts;
+    if (argc < 2) {
+        usage(argv[0]);
+        return 2;
+    }
+    opts.checkpoint = argv[1];
+    for (int i = 2; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--tp-world" && i + 1 < argc) {
+            opts.tp_world = std::atoi(argv[++i]);
+        } else if (arg == "--tp-rank" && i + 1 < argc) {
+            opts.tp_rank = std::atoi(argv[++i]);
+        } else if (arg == "--device" && i + 1 < argc) {
+            opts.device = std::atoi(argv[++i]);
+        } else if (arg == "--iters" && i + 1 < argc) {
+            opts.iters = std::atoi(argv[++i]);
+        } else if (arg == "--nccl-id" && i + 1 < argc) {
+            opts.nccl_id_path = argv[++i];
+        } else {
+            usage(argv[0]);
+            return 2;
+        }
+    }
+
+    dsv4::QwenEngineOptions engine_opts;
+    engine_opts.device = opts.device >= 0 ? opts.device : opts.tp_rank;
+    engine_opts.max_batch_size = 1;
+    // Prefix reuse would let a repeat return cached logits instead of computing,
+    // which is exactly what this benchmark must not measure. It also keeps every
+    // prefill starting from position 0 with a zeroed recurrent state.
+    engine_opts.prefix_cache = false;
+    if (opts.tp_world > 1) {
+        engine_opts.tp_world = opts.tp_world;
+        engine_opts.tp_rank = opts.tp_rank;
+        engine_opts.nccl_id_path = opts.nccl_id_path;
+    }
+
+    dsv4::QwenEngine engine(opts.checkpoint, engine_opts, 0, kMaxLength + 64);
+    engine.allocate_batch_slots(1);
+
+    const bool is_rank0 = opts.tp_rank == 0;
+    if (is_rank0) {
+        std::printf("\nQwen prefill saturation sweep\n");
+        std::printf("=============================\n");
+        std::printf("Checkpoint: %s\n", opts.checkpoint.c_str());
+        std::printf("TP: %d (rank %d)\n", opts.tp_world, opts.tp_rank);
+        std::printf("Timed repeats per length: %d\n\n", opts.iters);
+        std::printf("%8s %12s %12s\n", "tokens", "ms", "tok/s");
+    }
+
+    std::vector<double> tok_per_s;
+    for (int length : kLengths) {
+        const uint64_t seed =
+            0x9E3779B97F4A7C15ULL ^ static_cast<uint64_t>(length);
+
+        // One untimed pass so allocator growth and any autotuning are not
+        // charged to the first measured iteration.
+        (void)engine.prefill(make_prompt(length, seed), 0);
+
+        double total_seconds = 0.0;
+        for (int iter = 0; iter < opts.iters; ++iter) {
+            const std::vector<int> prompt =
+                make_prompt(length, seed + 1 + static_cast<uint64_t>(iter));
+            const auto start = std::chrono::steady_clock::now();
+            (void)engine.prefill(prompt, 0);
+            const auto end = std::chrono::steady_clock::now();
+            total_seconds += std::chrono::duration<double>(end - start).count();
+        }
+
+        const double seconds = total_seconds / opts.iters;
+        tok_per_s.push_back(static_cast<double>(length) / seconds);
+        if (is_rank0) {
+            std::printf("%8d %12.3f %12.1f\n", length, seconds * 1000.0,
+                        tok_per_s.back());
+            std::fflush(stdout);
+        }
+    }
+
+    if (is_rank0) {
+        const double saturated = tok_per_s.back();
+        const size_t count = tok_per_s.size();
+        std::printf("\nThroughput relative to the %d-token chunk\n", kMaxLength);
+        std::printf("----------------------------------------\n");
+        for (size_t i = 0; i < count; ++i) {
+            std::printf("%8d %11.1f tok/s  %5.2fx\n", kLengths[i], tok_per_s[i],
+                        tok_per_s[i] / saturated);
+        }
+
+        // tok_per_s[2] is the 512-token row: a plausible chat prompt, and the
+        // length where a scheduler would most want to merge requests.
+        const double short_ratio = tok_per_s[2] / saturated;
+        std::printf("\nInterpretation\n--------------\n");
+        if (short_ratio < 0.75) {
+            std::printf(
+                "512-token prefill runs at %.2fx the 8192-token rate, so short\n"
+                "prompts leave the GEMMs underfed. Merging several into one\n"
+                "forward has roughly %.2fx of headroom to recover.\n",
+                short_ratio, saturated / tok_per_s[2]);
+        } else {
+            std::printf(
+                "512-token prefill already reaches %.2fx the 8192-token rate,\n"
+                "so a single short prompt nearly saturates the GEMMs and batched\n"
+                "prefill would mostly add bookkeeping. Prefer paged KV instead.\n",
+                short_ratio);
+        }
+    }
+    return 0;
+}

--- a/cpp_engine/tests/test_qwen_chunked_prefill.cpp
+++ b/cpp_engine/tests/test_qwen_chunked_prefill.cpp
@@ -1,0 +1,214 @@
+// Verifies that bounded (chunked) prefill computes the same thing as one
+// unbounded prefill of the same prompt.
+//
+// Chunked prefill exists so a long prompt cannot hold the GPU while other
+// requests wait, but it is only usable if splitting a prompt is unobservable in
+// the output. The risk is entirely in resumption: prefill_partial leaves the
+// slot position and the cached prompt at the boundary it reached, and the next
+// call finds its resume point by matching against exactly those. An off-by-one
+// there silently skips or repeats prompt tokens, which shows up as different
+// logits rather than as a crash.
+//
+// Usage: ./test_qwen_chunked_prefill <checkpoint_dir> [--tp-world N]
+//                                    [--tp-rank N] [--device N] [--nccl-id PATH]
+#include "qwen_engine.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Options {
+    std::string checkpoint;
+    int tp_world = 1;
+    int tp_rank = 0;
+    int device = -1;
+    // 0 loads every layer. A smaller count lets this run on a single card.
+    int layers = 0;
+    // Prompt tokens per bounded step. The engine's chunk width is set to match,
+    // so the reference prefill and the chunked run do identical arithmetic.
+    int budget = 512;
+    std::string nccl_id_path = "/tmp/qwen_chunked_prefill_nccl_id";
+};
+
+std::vector<int> make_prompt(int length, uint64_t seed) {
+    std::mt19937_64 rng(seed);
+    std::vector<int> tokens(static_cast<size_t>(length));
+    for (int i = 0; i < length; ++i) {
+        tokens[static_cast<size_t>(i)] =
+            1000 + static_cast<int>(rng() % 100000ULL);
+    }
+    return tokens;
+}
+
+int failures = 0;
+
+void expect(bool ok, const std::string& what) {
+    std::printf("  %s %s\n", ok ? "[ok]  " : "[FAIL]", what.c_str());
+    if (!ok) ++failures;
+}
+
+// Compares the sampled token plus checksum and top logit. The token alone would
+// miss a drift that has not yet moved the argmax; the checksum covers the whole
+// logit row, so it catches a difference anywhere in the vocabulary.
+void expect_same_result(const dsv4::QwenForwardResult& chunked,
+                        const dsv4::QwenForwardResult& whole,
+                        const std::string& label) {
+    if (chunked.top_token != whole.top_token) {
+        std::printf("  [FAIL] %s: token %d vs %d\n", label.c_str(),
+                    chunked.top_token, whole.top_token);
+        ++failures;
+        return;
+    }
+    // Both paths run the same kernels over the same rows in the same order, so
+    // the expectation is exact equality rather than a tolerance.
+    if (chunked.checksum != whole.checksum ||
+        chunked.top_logit != whole.top_logit) {
+        std::printf("  [FAIL] %s: checksum %.9g vs %.9g, top logit %.9g vs %.9g\n",
+                    label.c_str(), chunked.checksum, whole.checksum,
+                    chunked.top_logit, whole.top_logit);
+        ++failures;
+        return;
+    }
+    if (chunked.position != whole.position) {
+        std::printf("  [FAIL] %s: position %d vs %d\n", label.c_str(),
+                    chunked.position, whole.position);
+        ++failures;
+        return;
+    }
+    std::printf("  [ok]   %s: token %d, checksum %.9g identical\n", label.c_str(),
+                chunked.top_token, chunked.checksum);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    Options opts;
+    if (argc < 2) {
+        std::fprintf(stderr, "usage: %s <checkpoint_dir> [--budget N] "
+                             "[--layers N] [--tp-world N] [--tp-rank N] "
+                             "[--device N] [--nccl-id PATH]\n",
+                     argv[0]);
+        return 2;
+    }
+    opts.checkpoint = argv[1];
+    for (int i = 2; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--tp-world" && i + 1 < argc) {
+            opts.tp_world = std::atoi(argv[++i]);
+        } else if (arg == "--tp-rank" && i + 1 < argc) {
+            opts.tp_rank = std::atoi(argv[++i]);
+        } else if (arg == "--device" && i + 1 < argc) {
+            opts.device = std::atoi(argv[++i]);
+        } else if (arg == "--nccl-id" && i + 1 < argc) {
+            opts.nccl_id_path = argv[++i];
+        } else if (arg == "--layers" && i + 1 < argc) {
+            opts.layers = std::atoi(argv[++i]);
+        } else if (arg == "--budget" && i + 1 < argc) {
+            opts.budget = std::max(1, std::atoi(argv[++i]));
+        } else {
+            std::fprintf(stderr, "unknown argument: %s\n", arg.c_str());
+            return 2;
+        }
+    }
+
+    constexpr int kPromptLength = 2600;  // Not a multiple of any chunk tested.
+    constexpr int kMaxContext = 4096;
+
+    dsv4::QwenEngineOptions engine_opts;
+    engine_opts.device = opts.device >= 0 ? opts.device : opts.tp_rank;
+    engine_opts.max_batch_size = 2;
+    // Match the chunk width to the budget so the only difference between the
+    // reference and the chunked run is whether prefill returned between chunks.
+    engine_opts.prefill_chunk_tokens = opts.budget;
+    if (opts.tp_world > 1) {
+        engine_opts.tp_world = opts.tp_world;
+        engine_opts.tp_rank = opts.tp_rank;
+        engine_opts.nccl_id_path = opts.nccl_id_path;
+    }
+
+    dsv4::QwenEngine engine(opts.checkpoint, engine_opts, opts.layers, kMaxContext);
+    engine.allocate_batch_slots(2);
+    engine.warmup_tp();
+
+    // Workers spend the rest of their life in the command loop, executing the
+    // prefills rank 0 announces. Only rank 0 runs the checks below.
+    const bool is_rank0 = opts.tp_rank == 0;
+    if (!is_rank0) {
+        engine.run_worker_loop();
+        return 0;
+    }
+
+    const std::vector<int> prompt = make_prompt(kPromptLength, 0xC0FFEE);
+
+    std::printf("\nChunked prefill equivalence\n");
+    std::printf("===========================\n");
+    std::printf("Prompt: %d tokens, TP %d\n\n", kPromptLength, opts.tp_world);
+
+    // The reference is an unbounded prefill on this same engine, so it runs the
+    // configured chunk width -- which the caller sets equal to the budget under
+    // test via --budget.
+    //
+    // Why the widths must match, since it is easy to mistake for a bug here:
+    // chunk width alone already moves the logits. With this prompt on 4 layers,
+    // an unmodified engine at prefill_chunk_tokens=512 returns checksum
+    // 6.58258438 where 8192 returns 6.58369541. The FP8 projections dequantize
+    // per call and reduce over a different row count per chunk, so a narrower
+    // chunk reassociates the arithmetic. That predates this change, and is why
+    // prefill_chunk_tokens is a tuning knob and not a correctness one.
+    //
+    // The invariant that actually pins resumption down is therefore: stopping and
+    // resuming at token N equals never having stopped, at one fixed chunk width.
+    const int budget = opts.budget;
+    std::printf("Budget %d, engine chunk width %d\n\n", budget,
+                engine_opts.prefill_chunk_tokens);
+
+    if (opts.tp_world > 1) engine.worker_command_prefill(prompt, 1, 0);
+    const dsv4::QwenForwardResult whole = engine.prefill(prompt, 1);
+
+    int steps = 0;
+    int consumed = 0;
+    dsv4::QwenPartialPrefillResult step;
+    do {
+        if (opts.tp_world > 1) {
+            engine.worker_command_prefill(prompt, 0, budget);
+        }
+        step = engine.prefill_partial(prompt, 0, budget);
+        ++steps;
+        // Progress must be strictly monotonic, or a scheduler driving this loop
+        // would spin forever.
+        if (step.consumed_tokens <= consumed) {
+            std::printf("  [FAIL] stalled at %d tokens\n", step.consumed_tokens);
+            ++failures;
+            break;
+        }
+        consumed = step.consumed_tokens;
+        if (steps > kPromptLength) {
+            std::printf("  [FAIL] did not terminate\n");
+            ++failures;
+            break;
+        }
+    } while (!step.complete);
+
+    std::printf("chunked prefill: %d steps\n", steps);
+    expect(step.complete, "reported complete");
+    expect(step.consumed_tokens == kPromptLength, "consumed the whole prompt");
+    // A budget below the prompt length must actually have yielded, or nothing
+    // was interleavable and the feature does not work.
+    if (budget < kPromptLength) {
+        expect(steps > 1, "took more than one step");
+    }
+    expect_same_result(step.result, whole, "final logits");
+    std::printf("\n");
+
+    // Release the workers from their command loop, or they never exit.
+    if (opts.tp_world > 1) engine.worker_command_shutdown();
+
+    std::printf("%s\n", failures == 0 ? "PASS" : "FAIL");
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## What

A long prompt held the GPU for its entire prefill, stalling every running decode behind it. At TP4 on the 27B checkpoint a 65K prompt holds for roughly 56s.

`QwenEngine::prefill_partial()` consumes at most a given number of prompt tokens and returns; `batch_prefill()` takes a `token_budget` that bounds each row the same way. `QwenBatchScheduler` drives it with a 4096-token budget by default, and `set_prefill_token_budget(0)` restores the previous run-to-completion behaviour.

## How resumption works

It rides the existing growing-prompt prefix path, so callers pass the same full prompt every call and the engine skips what the slot already holds. Two details that path forces:

- A partial call commits its cached prompt **truncated to the boundary actually reached**. An over-long entry would make the remainder look already computed and silently skip those tokens.
- `has_cached_result` stays false until the prompt completes, since interior logits predict the next *prompt* token rather than the prompt's continuation.

Two caller-visible consequences: don't sample a row flagged in `QwenBatchPrefillResult::incomplete`, and the scheduler now gates decode on `prefill_complete` rather than `seq_len > 0` — a half-prefilled request also satisfies the latter.

Under TP the budget travels to the workers in the previously unused `header[1]` of the Prefill command. Every rank has to stop at the same token, or a worker that ran the whole prompt meets rank 0 at the next collective with a mismatched row count.

## Why not batch the prompts together

Requests still prefill one at a time. `bench_qwen_prefill_saturation` measured 1890 tok/s at a 4096-token chunk against 1330 at 512 on TP4, so one chunk of a few thousand rows already feeds the GEMMs — merging prompts into a variable-length forward would buy about 1.06x at 2048. Holding the device was the actual problem, not GEMM shape.

## Verification

Full 27B checkpoint. `test_qwen_chunked_prefill` asserts that stopping and resuming equals never having stopped, at one fixed chunk width, matching **exactly** rather than within a tolerance. Passes for 6-step, 3-step and 1-step splits, at TP1 on 4 layers and TP4 on all layers.

The width has to be held fixed because chunk width alone already moves the logits: an unmodified engine at `prefill_chunk_tokens=512` returns checksum 6.58258438 on this prompt where 8192 returns 6.58369541. The FP8 projections dequantize per call and reduce over a different row count per chunk, so a narrower chunk reassociates the arithmetic. That predates this change, and is why `prefill_chunk_tokens` is a tuning knob rather than a correctness one. Comparing against a single wide chunk instead produces a failure that looks like a resumption bug but isn't.

`bench_qwen_prefill_interleave` measures the payoff at TP4 — with a 16K prompt in flight, a 64-token request arriving 20ms later:

| budget | short-request TTFT | long request total |
|---|---|---|
| 1024 | 1.67 s | 12.1 s |
| 2048 | 2.48 s | 10.9 s |
| 4096 | 4.99 s | 10.0 s |
| unchunked | 9.43 s | 9.7 s |

TTFT tracks the budget, as bounded prefill should. The unchunked baseline matches the long prefill's own 9.62s, confirming the short request really waits out the whole prompt. The long request pays 12.1s vs 9.7s at budget 1024 — the throughput cost of narrower chunks, and the tradeoff behind the 4096 default.

Full build is clean and 21 existing tests pass. `test_qwen_dflash2` and `test_persistent_engine` return non-zero: the first prints usage without arguments, and the second fails on `missing tensor: embed.weight` because it expects the DSv4 checkpoint layout, not Qwen. Both reproduce with these changes stashed.

## Not covered

Token-level scheduler parity across ranks at TP4. The scheduler is exercised there by the interleave bench, but generated tokens are not compared rank-to-rank.
