### PR TITLE
Stop generation on EOS instead of always filling max_new_tokens

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -726,6 +726,10 @@ add_executable(test_qwen_chunked_prefill tests/test_qwen_chunked_prefill.cpp)
 target_link_libraries(test_qwen_chunked_prefill PRIVATE dsv4_cpp_core)
 set_target_properties(test_qwen_chunked_prefill PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_qwen_eos_stop tests/test_qwen_eos_stop.cpp)
+target_link_libraries(test_qwen_eos_stop PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_eos_stop PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(bench_qwen_prefill_interleave tests/bench_qwen_prefill_interleave.cpp)
 target_link_libraries(bench_qwen_prefill_interleave PRIVATE dsv4_cpp_core)
 set_target_properties(bench_qwen_prefill_interleave PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)

--- a/cpp_engine/core/qwen_config.cpp
+++ b/cpp_engine/core/qwen_config.cpp
@@ -2,6 +2,7 @@
 
 #include "json_lite.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <fstream>
 #include <sstream>
@@ -16,6 +17,57 @@ std::string read_file(const std::string& path) {
     std::ostringstream out;
     out << in.rdbuf();
     return out.str();
+}
+
+// generation_config.json is optional: a checkpoint without one simply has no
+// stop tokens, so this returns false rather than throwing.
+bool try_read_file(const std::string& path, std::string* out) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) return false;
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    *out = buffer.str();
+    return true;
+}
+
+int checked_token_id(const JsonValue& value, uint64_t vocab_size) {
+    if (!value.is_number()) {
+        throw std::runtime_error("Qwen eos_token_id entry is not a number");
+    }
+    const double number = value.number();
+    const double rounded = std::round(number);
+    if (number < 0.0 || std::fabs(number - rounded) > 1.0e-9) {
+        throw std::runtime_error("Qwen eos_token_id is not a non-negative integer");
+    }
+    const uint64_t id = static_cast<uint64_t>(rounded);
+    // An out-of-range stop id can never be produced by sampling, so it would
+    // silently never fire. Fail loudly instead of shipping a dead stop token.
+    if (id >= vocab_size) {
+        throw std::runtime_error("Qwen eos_token_id is outside the vocabulary");
+    }
+    return static_cast<int>(id);
+}
+
+// Accepts both shapes HF uses: a bare id, or a list of them.
+std::vector<int> parse_eos_token_ids(const std::string& ckpt_dir,
+                                    uint64_t vocab_size) {
+    std::string text;
+    if (!try_read_file(ckpt_dir + "/generation_config.json", &text)) return {};
+    const JsonValue root_value = parse_json(text);
+    if (!root_value.is_object()) return {};
+    const JsonValue* eos = object_get(root_value.object(), "eos_token_id");
+    if (eos == nullptr || eos->is_null()) return {};
+
+    std::vector<int> ids;
+    if (eos->is_array()) {
+        for (const JsonValue& entry : eos->array()) {
+            const int id = checked_token_id(entry, vocab_size);
+            if (std::find(ids.begin(), ids.end(), id) == ids.end()) ids.push_back(id);
+        }
+    } else {
+        ids.push_back(checked_token_id(*eos, vocab_size));
+    }
+    return ids;
 }
 
 const JsonObject& text_config(const JsonObject& root) {
@@ -154,6 +206,8 @@ QwenConfig QwenConfig::from_hf_config(const std::string& ckpt_dir) {
             throw std::runtime_error("unsupported Qwen layer type at " + std::to_string(i) + ": " + value.string());
         }
     }
+
+    cfg.eos_token_ids = parse_eos_token_ids(ckpt_dir, cfg.vocab_size);
 
     if (!cfg.is_qwen3_5()) throw std::runtime_error("config is not a Qwen3.5 text checkpoint");
     if (cfg.hidden_size == 0 || cfg.num_hidden_layers == 0 || cfg.vocab_size == 0 || cfg.max_position_embeddings == 0) {

--- a/cpp_engine/engine/qwen_batch_scheduler.cpp
+++ b/cpp_engine/engine/qwen_batch_scheduler.cpp
@@ -285,6 +285,12 @@ bool QwenBatchScheduler::run_prefill_batch() {
             req->last_token = result.results[i].top_token;
             req->generated_tokens.push_back(req->last_token);
             req->seq_len = req->prefilled_tokens;
+            // batch_prefill flags a prompt whose very first predicted token is a
+            // stop token; such a request must never reach the decode batch.
+            if (prefill_batch[i]->finished) {
+                req->finished = true;
+                req->stopped_on_token = true;
+            }
 
             // Record TTFT
             if (req->first_token_time == std::chrono::steady_clock::time_point{}) {
@@ -362,6 +368,9 @@ bool QwenBatchScheduler::run_decode_batch() {
                 if (i < result.finished.size() && result.finished[i]) {
                     req->finished = true;
                 }
+                if (i < result.hit_stop_token.size() && result.hit_stop_token[i]) {
+                    req->stopped_on_token = true;
+                }
 
                 // Check max_new_tokens
                 if (req->generated_tokens.size() >=
@@ -403,6 +412,10 @@ void QwenBatchScheduler::handle_completions() {
                 // The cancelled set is erased below and is guarded by this mutex,
                 // so the stats pass outside the lock cannot re-derive this.
                 cancelled_completions.push_back(is_cancelled);
+                // notify_result runs after the erase, so it cannot consult the
+                // cancelled set either; record the reason on the request while
+                // the answer is still available.
+                if (is_cancelled && !req->finished) req->cancelled = true;
 
                 // Record completion time
                 req->completion_time = std::chrono::steady_clock::now();
@@ -453,7 +466,14 @@ void QwenBatchScheduler::notify_result(SchedulerRequest* req) {
     SchedulerGenerationResult result;
     result.request_id = req->request_id;
     result.generated_tokens = req->generated_tokens;
-    result.finish_reason = req->finished ? "length" : "stop";
+    // Previously `finished ? "length" : "stop"`, which was backwards: `finished`
+    // was only ever set by the length cap, so a normal completion reported
+    // "length" and "stop" was reachable only via cancellation.
+    if (req->cancelled) {
+        result.finish_reason = "cancelled";
+    } else {
+        result.finish_reason = req->stopped_on_token ? "stop" : "length";
+    }
     result.prompt_tokens = static_cast<int>(req->prompt_tokens.size());
     result.completion_tokens = static_cast<int>(req->generated_tokens.size());
 

--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -4491,6 +4491,10 @@ QwenBatchPrefillResult QwenEngine::batch_prefill(
         if (step.complete) {
             // Only a finished prompt yields a token to generate from.
             req->last_token = step.result.top_token;
+            // The prompt's first predicted token can itself be a stop token, so
+            // the flag has to be set here too; a scheduler that only checked it
+            // during decode would emit one spurious token past the stop.
+            if (is_stop_token(req->sampling, req->last_token)) req->finished = true;
             // Freeing the prompt is safe only once nothing needs to resume from
             // it; a partial row is resumed by re-matching these same tokens.
             req->prompt_tokens.clear();
@@ -4563,12 +4567,22 @@ std::vector<QwenForwardResult> QwenEngine::batch_decode_tokens(
     return results;
 }
 
+bool QwenEngine::is_stop_token(const QwenBatchSamplingParams& sampling,
+                               int token) const {
+    if (sampling.ignore_eos) return false;
+    const std::vector<int>& stops = sampling.stop_token_ids.empty()
+        ? config_.eos_token_ids
+        : sampling.stop_token_ids;
+    return std::find(stops.begin(), stops.end(), token) != stops.end();
+}
+
 QwenBatchDecodeResult QwenEngine::batch_decode_step(
     const std::vector<QwenBatchedRequest*>& requests) {
 
     QwenBatchDecodeResult result;
     result.next_tokens.reserve(requests.size());
     result.finished.reserve(requests.size());
+    result.hit_stop_token.reserve(requests.size());
 
     if (requests.empty()) {
         return result;
@@ -4603,14 +4617,18 @@ QwenBatchDecodeResult QwenEngine::batch_decode_step(
         req->seq_len++;
         req->generated_tokens.push_back(forward.top_token);
 
-        // Check finish conditions
-        bool finished = (static_cast<int>(req->generated_tokens.size()) >=
-                        req->sampling.max_new_tokens);
-        // TODO: Add EOS token check
+        // A stop token is the last token of the output, so it is still appended
+        // above and counted: truncating it here would make the returned
+        // sequence disagree with the KV cache this slot now holds, and a
+        // resumed request would then diverge. Callers strip it when detokenizing.
+        const bool stopped = is_stop_token(req->sampling, forward.top_token);
+        const bool length_capped = static_cast<int>(req->generated_tokens.size()) >=
+                                   req->sampling.max_new_tokens;
 
-        req->finished = finished;
+        req->finished = stopped || length_capped;
         result.next_tokens.push_back(forward.top_token);
-        result.finished.push_back(finished);
+        result.finished.push_back(req->finished);
+        result.hit_stop_token.push_back(stopped);
     }
 
     auto end = std::chrono::steady_clock::now();
@@ -4884,7 +4902,14 @@ QwenForwardResult QwenEngine::decode_step(int token_id, int slot_id) {
 }
 
 std::vector<QwenForwardResult> QwenEngine::generate(
-    const std::vector<int>& prompt_ids, int max_new_tokens) {
+    const std::vector<int>& prompt_ids, int max_new_tokens, bool stop_at_eos) {
+    // Checked against config_.eos_token_ids directly: this path has no
+    // per-request sampling params, and an empty list makes this always false.
+    const auto is_eos = [&](int token) {
+        return stop_at_eos &&
+               std::find(config_.eos_token_ids.begin(), config_.eos_token_ids.end(),
+                         token) != config_.eos_token_ids.end();
+    };
     if (max_new_tokens <= 0) return {};
     if (prompt_ids.empty()) {
         throw std::runtime_error("Qwen generation requires a non-empty prompt");
@@ -4912,6 +4937,9 @@ std::vector<QwenForwardResult> QwenEngine::generate(
         if (impl_->range_profile) range_decode.emplace("qwen.decode_loop");
         for (int index = 0; index < max_new_tokens; ++index) {
             results.push_back(next);
+            // The stop token stays in `results` as its last element, matching
+            // the batched path.
+            if (is_eos(next.top_token)) break;
             if (index + 1 < max_new_tokens) next = decode_step(next.top_token);
         }
         range_decode.reset();
@@ -4924,6 +4952,10 @@ std::vector<QwenForwardResult> QwenEngine::generate(
     // any correct drafts, then returns a bonus token which remains unconsumed
     // until the next transaction.
     results.push_back(next);
+    if (is_eos(next.top_token)) {
+        impl_->report_phase_profile("spec_decode");
+        return results;
+    }
     int current_token = next.top_token;
     const bool use_dspark = !options_.dspark_checkpoint.empty();
     const bool use_dflash2 = !options_.dflash2_checkpoint.empty();
@@ -4947,6 +4979,7 @@ std::vector<QwenForwardResult> QwenEngine::generate(
             while (static_cast<int>(results.size()) < max_new_tokens) {
                 next = decode_step(current_token);
                 results.push_back(next);
+                if (is_eos(next.top_token)) break;
                 current_token = next.top_token;
             }
             break;
@@ -4989,6 +5022,7 @@ std::vector<QwenForwardResult> QwenEngine::generate(
             prefix.has_cached_result = true;
         }
 
+        bool stop_in_block = false;
         for (size_t index = 0; index < next.accept_tokens.size(); ++index) {
             if (static_cast<int>(results.size()) == max_new_tokens) break;
             QwenForwardResult token_result = next;
@@ -4996,10 +5030,23 @@ std::vector<QwenForwardResult> QwenEngine::generate(
             token_result.top_logit = next.accept_logits[index];
             token_result.checksum = next.accept_checksums[index];
             token_result.position = position_ - correct + static_cast<int>(index);
+            const bool token_is_eos = is_eos(token_result.top_token);
             results.push_back(std::move(token_result));
+            // A verified block can contain a stop token before its end. The rest
+            // of the block is dropped from the output, but the KV cache and
+            // position_ have already advanced over the whole block, so this
+            // session must not be reused for further decoding after an early
+            // stop here. generate() is a whole-generation call, so that only
+            // matters to a caller that continues from the same session.
+            if (token_is_eos) {
+                stop_in_block = true;
+                break;
+            }
         }
+        if (stop_in_block) break;
         if (static_cast<int>(results.size()) < max_new_tokens) {
             results.push_back(next);
+            if (is_eos(next.top_token)) break;
         }
         current_token = next.bonus_token;
     }

--- a/cpp_engine/include/qwen_batch_scheduler.hpp
+++ b/cpp_engine/include/qwen_batch_scheduler.hpp
@@ -43,6 +43,12 @@ struct SchedulerRequest {
     int prefilled_tokens = 0;
     bool prefill_complete = false;
     bool finished = false;
+    // Whether generation ended on a stop token rather than on max_new_tokens.
+    // `finished` is true for both, so it cannot distinguish them on its own.
+    bool stopped_on_token = false;
+    // Cancelled before finishing. Recorded here because the cancelled set is
+    // erased before results are reported.
+    bool cancelled = false;
     int last_token = 0;
     std::vector<int> generated_tokens;
 

--- a/cpp_engine/include/qwen_config.hpp
+++ b/cpp_engine/include/qwen_config.hpp
@@ -58,6 +58,12 @@ struct QwenConfig {
     QwenFullAttentionConfig full_attention;
     QwenDenseMlpConfig mlp;
     std::vector<QwenLayerType> layer_types;
+    // Tokens that end generation. Read from generation_config.json, whose
+    // eos_token_id is a list on the published Qwen3.5 checkpoints
+    // ([248046, 248044] on 27B), so this is a set rather than one id. Empty when
+    // the checkpoint ships no generation_config.json, which leaves generation
+    // bounded only by max_new_tokens as it was before.
+    std::vector<int> eos_token_ids;
 
     bool is_qwen3_5() const;
     uint64_t linear_attention_layers() const;

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -200,6 +200,12 @@ struct QwenBatchSamplingParams {
     int top_k = 20;
     unsigned long long seed = 0;
     int max_new_tokens = 128;
+    // Tokens that end this request. Left empty, the engine falls back to the
+    // checkpoint's eos ids from generation_config.json; set it to override for
+    // this request only. `ignore_eos` runs to max_new_tokens regardless, which
+    // is what benchmarks want so their token counts stay fixed.
+    std::vector<int> stop_token_ids;
+    bool ignore_eos = false;
 };
 
 // Per-request state for batched continuous execution
@@ -241,6 +247,10 @@ struct QwenPartialPrefillResult {
 struct QwenBatchDecodeResult {
     std::vector<int> next_tokens;
     std::vector<bool> finished;
+    // Rows that stopped on a stop token rather than on max_new_tokens, parallel
+    // to `next_tokens`. Callers need the distinction to report finish_reason,
+    // which cannot be recovered from `finished` alone.
+    std::vector<bool> hit_stop_token;
     double seconds = 0.0;
 };
 
@@ -301,8 +311,14 @@ public:
     QwenPartialPrefillResult prefill_partial(const std::vector<int>& token_ids,
                                              int slot_id, int max_tokens);
     QwenForwardResult decode_step(int token_id, int slot_id = 0);
+    // `stop_at_eos` ends generation on one of the checkpoint's eos ids, keeping
+    // that token as the last element. It defaults to false so existing callers
+    // and benchmarks keep returning exactly max_new_tokens results; under TP
+    // every rank runs this loop and decides independently, so the flag has to be
+    // the same on all of them or they stop at different lengths.
     std::vector<QwenForwardResult> generate(const std::vector<int>& prompt_ids,
-                                             int max_new_tokens);
+                                             int max_new_tokens,
+                                             bool stop_at_eos = false);
 
     // ========== Batched API (Phase 3.1) ==========
 
@@ -382,6 +398,10 @@ private:
     // the same work it was before the bounded entry point existed.
     QwenPartialPrefillResult prefill_bounded(const std::vector<int>& token_ids,
                                              int slot_id, int max_tokens);
+
+    // Whether `token` ends generation under these params: the request's own
+    // stop_token_ids when set, otherwise the checkpoint's eos ids.
+    bool is_stop_token(const QwenBatchSamplingParams& sampling, int token) const;
 
     std::string ckpt_dir_;
     QwenEngineOptions options_;

--- a/cpp_engine/python/bindings.cpp
+++ b/cpp_engine/python/bindings.cpp
@@ -406,7 +406,12 @@ PYBIND11_MODULE(pocketllm_cpp, module) {
         .def_readwrite("top_p", &QwenBatchSamplingParams::top_p)
         .def_readwrite("top_k", &QwenBatchSamplingParams::top_k)
         .def_readwrite("seed", &QwenBatchSamplingParams::seed)
-        .def_readwrite("max_new_tokens", &QwenBatchSamplingParams::max_new_tokens);
+        .def_readwrite("max_new_tokens", &QwenBatchSamplingParams::max_new_tokens)
+        // Exposed so a Python benchmark can keep its token counts fixed
+        // (ignore_eos) or stop on its own tokenizer's ids (stop_token_ids)
+        // instead of the checkpoint's.
+        .def_readwrite("stop_token_ids", &QwenBatchSamplingParams::stop_token_ids)
+        .def_readwrite("ignore_eos", &QwenBatchSamplingParams::ignore_eos);
 
     py::class_<SchedulerGenerationResult>(module, "SchedulerGenerationResult")
         .def(py::init<>())

--- a/cpp_engine/tests/test_qwen_batch_scheduler.cpp
+++ b/cpp_engine/tests/test_qwen_batch_scheduler.cpp
@@ -6,6 +6,8 @@
 #include <chrono>
 #include <thread>
 #include <cassert>
+#include <cstdlib>
+#include <string>
 
 using namespace dsv4;
 
@@ -48,7 +50,7 @@ int main(int argc, char** argv) {
     std::cout << "==============================" << std::endl;
 
     if (argc < 2) {
-        std::cout << "\nUsage: " << argv[0] << " <checkpoint_dir>" << std::endl;
+        std::cout << "\nUsage: " << argv[0] << " <checkpoint_dir> [layers]" << std::endl;
         std::cout << "\nRunning API validation tests only...\n" << std::endl;
 
         test_stats();
@@ -59,6 +61,10 @@ int main(int argc, char** argv) {
     }
 
     std::string ckpt_dir = argv[1];
+    // Optional layer count. The full 64-layer checkpoint does not fit on one
+    // 22 GB card at TP1, which this test is, so a subset is the only way to run
+    // it on a single GPU. 0 keeps the previous behaviour of loading every layer.
+    const int layers = argc > 2 ? std::atoi(argv[2]) : 0;
 
     try {
         // Initialize engine
@@ -68,9 +74,15 @@ int main(int argc, char** argv) {
         options.device = 0;
         options.prefill_chunk_tokens = 512;
         options.max_state_snapshots = 10;
+        // The KV cache is sized at construction, so this has to match the
+        // scheduler's max_batch_size below or allocate_batch_slots throws.
+        options.max_batch_size = 4;
 
-        std::cout << "Loading checkpoint: " << ckpt_dir << std::endl;
-        QwenEngine engine(ckpt_dir, options, 0, 8192);
+        std::cout << "Loading checkpoint: " << ckpt_dir
+                  << " (layers: " << (layers == 0 ? std::string("all")
+                                                  : std::to_string(layers))
+                  << ")" << std::endl;
+        QwenEngine engine(ckpt_dir, options, layers, 8192);
 
         std::cout << "Creating scheduler with max_batch_size=4" << std::endl;
         QwenBatchScheduler scheduler(&engine, 4);

--- a/cpp_engine/tests/test_qwen_eos_stop.cpp
+++ b/cpp_engine/tests/test_qwen_eos_stop.cpp
@@ -1,0 +1,244 @@
+// Verifies that generation stops on a stop token instead of running to
+// max_new_tokens.
+//
+// Before this, batched decode's only finish condition was the length cap, so
+// every request occupied its slot for the full max_new_tokens and the tokens
+// past the model's EOS were kept in the output. The slots are a fixed pool, so
+// that directly caps concurrency.
+//
+// The model will not emit EOS on cue, so these checks drive the stop through
+// QwenBatchSamplingParams::stop_token_ids: run once unrestricted, note a token
+// the model actually produces at a known step, then re-run with that token as
+// the stop and require generation to end exactly there. That tests the stop
+// machinery, which is what changed; it does not depend on the checkpoint's own
+// eos ids, which are covered separately by the config check below.
+//
+// Usage: ./test_qwen_eos_stop <checkpoint_dir> [--layers N] [--tp-world N]
+//                             [--tp-rank N] [--device N] [--nccl-id PATH]
+#include "qwen_engine.hpp"
+#include "qwen_config.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Options {
+    std::string checkpoint;
+    int tp_world = 1;
+    int tp_rank = 0;
+    int device = -1;
+    int layers = 0;
+    std::string nccl_id_path = "/tmp/qwen_eos_stop_nccl_id";
+};
+
+int failures = 0;
+
+void expect(bool ok, const std::string& what) {
+    std::printf("  %s %s\n", ok ? "[ok]  " : "[FAIL]", what.c_str());
+    if (!ok) ++failures;
+}
+
+std::vector<int> make_prompt(int length, uint64_t seed) {
+    std::mt19937_64 rng(seed);
+    std::vector<int> tokens(static_cast<size_t>(length));
+    for (int i = 0; i < length; ++i) {
+        tokens[static_cast<size_t>(i)] = 1000 + static_cast<int>(rng() % 100000ULL);
+    }
+    return tokens;
+}
+
+// Drives one request through batch_prefill plus batch_decode_step, the same way
+// the scheduler does, and returns every token including the prefill's.
+struct RunOutcome {
+    std::vector<int> tokens;
+    bool finished_early = false;   // stopped before the length cap
+    bool stop_flag_seen = false;   // hit_stop_token reported by the engine
+};
+
+// Each run takes its own slot: a slot carries both KV state and a prefix cache
+// after a run, so re-prefilling the same prompt on a used slot would resume from
+// that state instead of starting clean.
+RunOutcome run_request(dsv4::QwenEngine& engine, const std::vector<int>& prompt,
+                       int slot_id,
+                       const dsv4::QwenBatchSamplingParams& sampling) {
+    RunOutcome out;
+    auto req = std::make_unique<dsv4::QwenBatchedRequest>();
+    req->request_id = static_cast<uint64_t>(slot_id) + 1;
+    req->prompt_tokens = prompt;
+    req->slot_id = slot_id;
+    req->sampling = sampling;
+
+    std::vector<dsv4::QwenBatchedRequest*> batch{req.get()};
+    const dsv4::QwenBatchPrefillResult prefilled = engine.batch_prefill(batch, 0);
+    out.tokens.push_back(prefilled.results[0].top_token);
+
+    // batch_prefill marks the request finished when the prompt's first predicted
+    // token is itself a stop token.
+    if (req->finished) {
+        out.finished_early = true;
+        out.stop_flag_seen = true;
+        return out;
+    }
+
+    while (static_cast<int>(out.tokens.size()) < sampling.max_new_tokens) {
+        // batch_decode_step and batch_prefill announce their own collectives to
+        // the workers, so this loop is the same at TP1 and TP4.
+        const dsv4::QwenBatchDecodeResult step = engine.batch_decode_step(batch);
+        out.tokens.push_back(step.next_tokens[0]);
+        if (step.hit_stop_token[0]) out.stop_flag_seen = true;
+        if (step.finished[0]) {
+            out.finished_early =
+                static_cast<int>(out.tokens.size()) < sampling.max_new_tokens;
+            break;
+        }
+    }
+    return out;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    Options opts;
+    if (argc < 2) {
+        std::fprintf(stderr, "usage: %s <checkpoint_dir> [--layers N] "
+                             "[--tp-world N] [--tp-rank N] [--device N] "
+                             "[--nccl-id PATH]\n", argv[0]);
+        return 2;
+    }
+    opts.checkpoint = argv[1];
+    for (int i = 2; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--tp-world" && i + 1 < argc) {
+            opts.tp_world = std::atoi(argv[++i]);
+        } else if (arg == "--tp-rank" && i + 1 < argc) {
+            opts.tp_rank = std::atoi(argv[++i]);
+        } else if (arg == "--device" && i + 1 < argc) {
+            opts.device = std::atoi(argv[++i]);
+        } else if (arg == "--nccl-id" && i + 1 < argc) {
+            opts.nccl_id_path = argv[++i];
+        } else if (arg == "--layers" && i + 1 < argc) {
+            opts.layers = std::atoi(argv[++i]);
+        } else {
+            std::fprintf(stderr, "unknown argument: %s\n", arg.c_str());
+            return 2;
+        }
+    }
+
+    constexpr int kPromptLength = 64;
+    constexpr int kMaxNewTokens = 24;
+    constexpr int kMaxContext = 2048;
+
+    dsv4::QwenEngineOptions engine_opts;
+    engine_opts.device = opts.device >= 0 ? opts.device : opts.tp_rank;
+    // Three slots: one per run, since a used slot carries KV and prefix state.
+    engine_opts.max_batch_size = 3;
+    if (opts.tp_world > 1) {
+        engine_opts.tp_world = opts.tp_world;
+        engine_opts.tp_rank = opts.tp_rank;
+        engine_opts.nccl_id_path = opts.nccl_id_path;
+    }
+
+    dsv4::QwenEngine engine(opts.checkpoint, engine_opts, opts.layers, kMaxContext);
+    engine.allocate_batch_slots(3);
+    engine.warmup_tp();
+
+    if (opts.tp_rank != 0) {
+        engine.run_worker_loop();
+        return 0;
+    }
+
+    std::printf("\nStop-token handling\n");
+    std::printf("===================\n\n");
+
+    // The checkpoint's own eos ids, which is what a request with no explicit
+    // stop_token_ids falls back to.
+    const std::vector<int>& eos_ids = engine.config().eos_token_ids;
+    std::printf("checkpoint eos_token_ids:");
+    for (int id : eos_ids) std::printf(" %d", id);
+    std::printf("%s\n\n", eos_ids.empty() ? " (none)" : "");
+    expect(!eos_ids.empty(), "checkpoint declares at least one eos token");
+
+    const std::vector<int> prompt = make_prompt(kPromptLength, 0xE05);
+
+    // Baseline: ignore_eos, so this must produce exactly max_new_tokens and
+    // gives the reference token sequence.
+    dsv4::QwenBatchSamplingParams baseline_params;
+    baseline_params.max_new_tokens = kMaxNewTokens;
+    baseline_params.ignore_eos = true;
+    const RunOutcome baseline = run_request(engine, prompt, 0, baseline_params);
+    expect(static_cast<int>(baseline.tokens.size()) == kMaxNewTokens,
+           "ignore_eos runs to max_new_tokens");
+    expect(!baseline.finished_early, "ignore_eos does not stop early");
+    expect(!baseline.stop_flag_seen, "ignore_eos never reports a stop token");
+
+    // Stop on a token from the baseline, and expect the stop at its *first*
+    // occurrence. Picking baseline.tokens[k] and expecting to stop at k would be
+    // wrong whenever that token also appeared earlier, which is common: a
+    // layer-truncated model repeats itself heavily (token 220 filled most of the
+    // baseline on 4 layers).
+    int stop_index = -1;
+    for (size_t i = 1; i < baseline.tokens.size(); ++i) {
+        const auto first = std::find(baseline.tokens.begin(), baseline.tokens.end(),
+                                     baseline.tokens[i]);
+        if (first == baseline.tokens.begin() + static_cast<long>(i)) {
+            stop_index = static_cast<int>(i);
+            break;
+        }
+    }
+    if (stop_index < 0) {
+        // Every token after the first is a repeat, so no interior stop point
+        // exists to test. Rather than assert something vacuous, say so: run with
+        // more --layers for a model that does not collapse to one token.
+        std::printf("  [FAIL] baseline has no token whose first occurrence is "
+                    "past index 0; cannot place a stop\n");
+        return 1;
+    }
+    const int kStopIndex = stop_index;
+    const int stop_token = baseline.tokens[static_cast<size_t>(kStopIndex)];
+    std::printf("\nstop token %d, expected at output index %d\n", stop_token,
+                kStopIndex);
+
+    dsv4::QwenBatchSamplingParams stop_params;
+    stop_params.max_new_tokens = kMaxNewTokens;
+    stop_params.stop_token_ids = {stop_token};
+    const RunOutcome stopped = run_request(engine, prompt, 1, stop_params);
+
+    // The token stream must be identical up to the stop: the stop check decides
+    // when to halt and must not perturb the arithmetic.
+    const bool prefix_matches =
+        static_cast<int>(stopped.tokens.size()) == kStopIndex + 1 &&
+        std::equal(stopped.tokens.begin(), stopped.tokens.end(),
+                   baseline.tokens.begin());
+    std::printf("  produced %zu tokens\n", stopped.tokens.size());
+    expect(static_cast<int>(stopped.tokens.size()) == kStopIndex + 1,
+           "stopped at the stop token, not at max_new_tokens");
+    expect(prefix_matches, "tokens up to the stop match the baseline exactly");
+    expect(stopped.finished_early, "reported finished before the length cap");
+    expect(stopped.stop_flag_seen, "reported hit_stop_token");
+    expect(!stopped.tokens.empty() && stopped.tokens.back() == stop_token,
+           "stop token is kept as the last output token");
+
+    // A stop id the model does not produce must not shorten anything: this
+    // catches a stop check that fires on the wrong comparison.
+    dsv4::QwenBatchSamplingParams absent_params;
+    absent_params.max_new_tokens = kMaxNewTokens;
+    absent_params.stop_token_ids = {-424242};
+    const RunOutcome absent = run_request(engine, prompt, 2, absent_params);
+    std::printf("\n");
+    expect(static_cast<int>(absent.tokens.size()) == kMaxNewTokens,
+           "an unreachable stop id runs to max_new_tokens");
+    expect(absent.tokens == baseline.tokens,
+           "an unreachable stop id leaves the tokens unchanged");
+
+    if (opts.tp_world > 1) engine.worker_command_shutdown();
+
+    std::printf("\n%s\n", failures == 0 ? "PASS" : "FAIL");
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

Batched decode's only finish condition was the length cap, so every request held its slot for the full `max_new_tokens` and kept the tokens past the model's EOS in its output. Slots are a fixed pool, so that directly capped concurrency.

## Changes

**Stop tokens come from the checkpoint.** `QwenConfig` parses `eos_token_id` out of `generation_config.json`, accepting both shapes HF publishes (a bare id or a list) — the 27B checkpoint ships `[248046, 248044]`, which is why this is a set and not one id. An id outside the vocabulary throws rather than becoming a stop that can never fire; a checkpoint with no `generation_config.json` yields an empty list and keeps the previous length-only behavior.

**Batched decode.** `batch_decode_step` reports `hit_stop_token` alongside `finished`. Per-request `stop_token_ids` overrides the checkpoint's ids; `ignore_eos` runs to the cap regardless, which is what benchmarks want so their token counts stay fixed. Both are exposed through the Python bindings, since stopping is now the default there.

The stop token stays in the output and is counted: truncating it would make the returned sequence disagree with the KV cache the slot now holds, and a resumed request would diverge. Callers strip it when detokenizing.

`batch_prefill` has to check too — a prompt's first predicted token can itself be a stop token, so a scheduler checking only during decode would emit one spurious token past the stop.

**The scheduler's `finish_reason` was backwards.** It read `finished ? "length" : "stop"`, but `finished` was only ever set by the length cap, so every normal completion reported `"length"` and `"stop"` was reachable only via cancellation. It now distinguishes stop, length and cancelled. That needs two new fields on `SchedulerRequest`, because `finished` is true for all three and the cancelled set is erased before `notify_result` runs.

**Single-session `generate()`** takes an opt-in `stop_at_eos`, defaulting to false so the four existing callers and the benchmarks keep returning exactly `max_new_tokens` results. Under TP every rank runs that loop and decides independently, so the flag has to agree across ranks; all four call sites including the worker command loop use the default.

The speculative path needed separate handling: a verified draft block can contain a stop token in its interior, and while the block's tail is dropped from the output, `position_` and the KV cache have already advanced over the whole block, so that session cannot be resumed after an early stop there. `generate()` is a whole-generation call, so this only constrains a caller that continues from the same session; noted at the break.

## Testing

On the 27B checkpoint:

- **`test_qwen_eos_stop`** (new) drives the stop through `stop_token_ids` rather than the checkpoint's eos ids, since the model will not emit EOS on cue: run once with `ignore_eos`, pick a token the model actually produced, then require the re-run to end at exactly that token with an identical prefix. Also asserts an unreachable stop id changes nothing, and that the checkpoint declares eos ids at all. Passes at 16 layers TP1 and at all 64 layers TP4.
- The stop point is chosen by **first occurrence, not by index**: a layer-truncated model repeats heavily, and at 4 layers it collapses to a single token entirely, where the test fails with an explicit message instead of asserting something vacuous.
- No regressions in `test_qwen_batched_engine_parity`, `test_qwen_chunked_prefill`, `test_qwen_batched_decode`.
- `dsv4_cpp_engine --generate-token` still reports `generated_tokens=6` for `--max-new-tokens 6`, confirming the default-off path is unchanged.

## Prerequisite fix

`test_qwen_batch_scheduler` was unrunnable before this: it never set `max_batch_size`, so `allocate_batch_slots(4)` threw on every run, and it hardcoded all 64 layers at TP1, which does not fit on a 22 GB card. It now takes an optional layer count and passes, reporting `finish_reason "length"` at 10/10 tokens. Outside this PR's scope, but the `finish_reason` fix could not be verified without it.

## Not covered

No test asserts a stop on the checkpoint's own eos ids end-to-end, because no prompt is known to make the model emit one. The fallback from empty `stop_token_ids` to `config_.eos_token_ids` is exercised only by the `ignore_eos` and unreachable-id cases.
