### PR TITLE
Add paged KV cache for Qwen full-attention layers

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -39,6 +39,8 @@ set(POCKET_CORE_SOURCES
     core/weight_source.cpp
     core/model_config.cpp
     core/qwen_config.cpp
+    core/qwen_block_pool.cpp
+    core/qwen_block_table.cpp
     core/qwen_weight_map.cpp
     core/tokenizer.cpp
     core/tensor.cpp
@@ -729,6 +731,18 @@ set_target_properties(test_qwen_chunked_prefill PROPERTIES RUNTIME_OUTPUT_DIRECT
 add_executable(test_qwen_eos_stop tests/test_qwen_eos_stop.cpp)
 target_link_libraries(test_qwen_eos_stop PRIVATE dsv4_cpp_core)
 set_target_properties(test_qwen_eos_stop PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_block_pool tests/test_qwen_block_pool.cpp)
+target_link_libraries(test_qwen_block_pool PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_block_pool PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_paged_kv_kernels tests/test_qwen_paged_kv_kernels.cpp)
+target_link_libraries(test_qwen_paged_kv_kernels PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_paged_kv_kernels PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_qwen_paged_engine_parity tests/test_qwen_paged_engine_parity.cpp)
+target_link_libraries(test_qwen_paged_engine_parity PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_paged_engine_parity PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(bench_qwen_prefill_interleave tests/bench_qwen_prefill_interleave.cpp)
 target_link_libraries(bench_qwen_prefill_interleave PRIVATE dsv4_cpp_core)

--- a/cpp_engine/backends/cuda/kernels/qwen_gqa_optimized.cu
+++ b/cpp_engine/backends/cuda/kernels/qwen_gqa_optimized.cu
@@ -1638,7 +1638,13 @@ __global__ void gqa_prefill_tiled_f16_kernel(
 // inside it -- and therefore the result for a given split count -- is identical
 // to the single-row instantiation. `kBatched=false` keeps the original codegen
 // with no extra registers for the unused row indirection.
-template <int kHPG, bool kBatched = false>
+//
+// `kPaged` selects the paged KV cache, where a sequence's positions live in
+// fixed-size blocks scattered through one shared arena instead of in a
+// contiguous per-slot reservation. It is a separate template parameter rather
+// than a runtime null check so the contiguous instantiation keeps its exact
+// register count and address arithmetic.
+template <int kHPG, bool kBatched = false, bool kPaged = false>
 __global__ void gqa_decode_split_f16_kernel(
     const uint16_t* __restrict__ q,
     const uint16_t* __restrict__ k_cache,
@@ -1654,7 +1660,10 @@ __global__ void gqa_decode_split_f16_kernel(
     int sink,
     const int* __restrict__ context_lens = nullptr,
     const int* __restrict__ slot_ids = nullptr,
-    size_t kv_slot_stride = 0) {
+    size_t kv_slot_stride = 0,
+    const int* __restrict__ block_table = nullptr,
+    int block_size = 0,
+    int max_blocks_per_seq = 0) {
     const int q_per_kv = q_heads / kv_heads;
     const int groups_per_kv = (q_per_kv + kHPG - 1) / kHPG;
     const int grouped = static_cast<int>(blockIdx.x) / splits;
@@ -1667,13 +1676,22 @@ __global__ void gqa_decode_split_f16_kernel(
     // some splits dry and publish the neutral partial the merge already handles.
     // The slot is not the batch index: slots are allocated as requests arrive,
     // so a four-row batch can hold slots 1/3/5/6.
+    const int* __restrict__ slot_blocks = nullptr;
     if constexpr (kBatched) {
         const int row = static_cast<int>(blockIdx.y);
         context_len = context_lens[row];
-        const size_t slot = static_cast<size_t>(
-            slot_ids != nullptr ? slot_ids[row] : row) * kv_slot_stride;
-        k_cache += slot;
-        v_cache += slot;
+        const int slot_index = slot_ids != nullptr ? slot_ids[row] : row;
+        if constexpr (kPaged) {
+            // Paged rows share one arena, so the row's base is the table it
+            // indexes through rather than an offset added to the pointer.
+            slot_blocks = block_table +
+                static_cast<size_t>(slot_index) * max_blocks_per_seq;
+        } else {
+            const size_t slot =
+                static_cast<size_t>(slot_index) * kv_slot_stride;
+            k_cache += slot;
+            v_cache += slot;
+        }
         q += static_cast<size_t>(row) * q_heads * head_dim;
         partial_output += static_cast<size_t>(row) * q_heads * splits *
             (head_dim + 2);
@@ -1722,10 +1740,31 @@ __global__ void gqa_decode_split_f16_kernel(
 
     const float attention_scale = rsqrtf(static_cast<float>(head_dim));
     const size_t kv_stride = static_cast<size_t>(kv_heads) * head_dim;
+    // Paged translation is loop-invariant within a block, so the block id is
+    // cached and refetched only when the scan leaves it. The sparse ranges walk
+    // positions in ascending order within a split, and the sink-to-window jump
+    // is the only discontinuity, so a one-entry cache covers the whole scan with
+    // one table read per `block_size` positions rather than one per position.
+    int cached_block_index = -1;
+    size_t cached_block_base = 0;
     for (int logical = start; logical < end; ++logical) {
         const int position = ranges.position(logical);
-        const size_t kv_base = static_cast<size_t>(position) * kv_stride +
-            static_cast<size_t>(kv_head) * head_dim;
+        size_t kv_base;
+        if constexpr (kPaged) {
+            const int block_index = position / block_size;
+            if (block_index != cached_block_index) {
+                cached_block_index = block_index;
+                cached_block_base =
+                    static_cast<size_t>(slot_blocks[block_index]) *
+                    block_size * kv_stride;
+            }
+            kv_base = cached_block_base +
+                static_cast<size_t>(position % block_size) * kv_stride +
+                static_cast<size_t>(kv_head) * head_dim;
+        } else {
+            kv_base = static_cast<size_t>(position) * kv_stride +
+                static_cast<size_t>(kv_head) * head_dim;
+        }
         float key[kValuesPerThread];
         float value[kValuesPerThread];
 #pragma unroll
@@ -3116,11 +3155,24 @@ bool qwen_gqa_decode_attention_f16_batched_cuda(
     const int* d_context_lens, const int* d_slot_ids, int rows,
     int max_context_len, size_t kv_slot_stride, int q_heads, int kv_heads,
     int head_dim, int max_context, int attention_window, int sink_tokens,
+    const int* d_block_table, int block_size, int max_blocks_per_seq,
     void* stream) {
     if (!q || !k_cache || !v_cache || !output || !partial_scratch ||
         !d_context_lens || rows <= 0 || max_context_len <= 0 ||
-        max_context_len > max_context || attention_window < 0 ||
+        attention_window < 0 ||
         sink_tokens < 0 || !valid_shape(q_heads, kv_heads, head_dim)) {
+        return false;
+    }
+    // A paged cache holds no per-slot reservation, so `max_context` bounds the
+    // logical sequence rather than the arena and the block table supplies the
+    // extent. The contiguous path keeps its arena bound.
+    const bool paged = d_block_table != nullptr;
+    if (paged) {
+        if (block_size <= 0 || max_blocks_per_seq <= 0 ||
+            max_context_len > block_size * max_blocks_per_seq) {
+            return false;
+        }
+    } else if (max_context_len > max_context) {
         return false;
     }
     // One grid covers every sequence. The split count comes from the longest
@@ -3139,20 +3191,29 @@ bool qwen_gqa_decode_attention_f16_batched_cuda(
     const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
     const dim3 grid(static_cast<unsigned>(kv_heads * groups_per_kv * splits),
                     static_cast<unsigned>(rows), 1);
-#define DSV4_LAUNCH_DECODE_SPLIT_BATCHED(HPG) \
-    gqa_decode_split_f16_kernel<HPG, true><<<grid, kThreads, 0, cuda_stream>>>( \
+#define DSV4_LAUNCH_DECODE_SPLIT_BATCHED(HPG, PAGED) \
+    gqa_decode_split_f16_kernel<HPG, true, PAGED> \
+        <<<grid, kThreads, 0, cuda_stream>>>( \
         q, k_cache, v_cache, partial_scratch, q_heads, kv_heads, head_dim, \
         max_context_len, splits, positions_per_split, attention_window, \
-        sink_tokens, d_context_lens, d_slot_ids, kv_slot_stride)
-    switch (group_heads) {
-        case 1: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(1); break;
-        case 2: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(2); break;
-        case 3: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(3); break;
-        case 4: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(4); break;
-        case 5: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(5); break;
-        case 6: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(6); break;
-        default: return false;
+        sink_tokens, d_context_lens, d_slot_ids, kv_slot_stride, \
+        d_block_table, block_size, max_blocks_per_seq)
+#define DSV4_LAUNCH_DECODE_SPLIT_BATCHED_WIDTH(PAGED) \
+    switch (group_heads) { \
+        case 1: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(1, PAGED); break; \
+        case 2: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(2, PAGED); break; \
+        case 3: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(3, PAGED); break; \
+        case 4: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(4, PAGED); break; \
+        case 5: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(5, PAGED); break; \
+        case 6: DSV4_LAUNCH_DECODE_SPLIT_BATCHED(6, PAGED); break; \
+        default: return false; \
     }
+    if (paged) {
+        DSV4_LAUNCH_DECODE_SPLIT_BATCHED_WIDTH(true);
+    } else {
+        DSV4_LAUNCH_DECODE_SPLIT_BATCHED_WIDTH(false);
+    }
+#undef DSV4_LAUNCH_DECODE_SPLIT_BATCHED_WIDTH
 #undef DSV4_LAUNCH_DECODE_SPLIT_BATCHED
     if (cudaGetLastError() != cudaSuccess) return false;
     const dim3 merge_grid(static_cast<unsigned>(q_heads),

--- a/cpp_engine/backends/cuda/kernels/qwen_half_ops.cu
+++ b/cpp_engine/backends/cuda/kernels/qwen_half_ops.cu
@@ -2766,11 +2766,70 @@ __global__ void append_kv_f16_kernel(
 // The slot a row occupies is not its index in the batch: slots are allocated and
 // freed as requests arrive and finish, so a four-row batch can hold slots
 // 1/3/5/6. `slot_ids` carries that mapping; passing null means slot == row.
+// Paged single-sequence append: consecutive tokens of one sequence, scattered
+// across that sequence's blocks. `block_table` is the one sequence's row, so it
+// needs no slot indirection; the caller offsets into the table itself.
+__global__ void append_kv_f16_paged_kernel(
+    const uint16_t* k_rows, const uint16_t* v_rows,
+    uint16_t* k_cache, uint16_t* v_cache, int total,
+    int kv_heads, int head_dim, int start_pos, const int* block_table,
+    int block_size) {
+    const int index = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index >= total) return;
+    const int kv_stride = kv_heads * head_dim;
+    const int token = index / kv_stride;
+    const int within = index % kv_stride;
+    const int destination_token = start_pos + token;
+    const int block = block_table[destination_token / block_size];
+    const size_t destination =
+        (static_cast<size_t>(block) * block_size +
+         static_cast<size_t>(destination_token % block_size)) * kv_stride +
+        within;
+    k_cache[destination] = k_rows[index];
+    v_cache[destination] = v_rows[index];
+}
+
+// Collects one sequence's paged K/V history into the dense
+// `[context_len, kv_heads, head_dim]` layout the attention kernels already read.
+// The prefill and single-row decode kernels have five tuned variants between
+// them, all of which compute addresses from that layout; gathering once per
+// layer keeps every one of them untouched, and it is the same dequant-once
+// architecture the FP8 and TurboQuant caches use for the same reason.
+__global__ void gather_kv_f16_paged_kernel(
+    const uint16_t* __restrict__ k_cache,
+    const uint16_t* __restrict__ v_cache,
+    uint16_t* __restrict__ k_dense, uint16_t* __restrict__ v_dense,
+    int context_len, int kv_heads, int head_dim, const int* block_table,
+    int block_size) {
+    const int position = static_cast<int>(blockIdx.x);
+    const int kv_head = static_cast<int>(blockIdx.y);
+    if (position >= context_len || kv_head >= kv_heads) return;
+    const size_t kv_stride = static_cast<size_t>(kv_heads) * head_dim;
+    const int block = block_table[position / block_size];
+    const size_t source =
+        (static_cast<size_t>(block) * block_size +
+         static_cast<size_t>(position % block_size)) * kv_stride +
+        static_cast<size_t>(kv_head) * head_dim;
+    const size_t destination =
+        (static_cast<size_t>(position) * kv_heads + kv_head) * head_dim;
+    for (int channel = static_cast<int>(threadIdx.x); channel < head_dim;
+         channel += static_cast<int>(blockDim.x)) {
+        k_dense[destination + channel] = k_cache[source + channel];
+        v_dense[destination + channel] = v_cache[source + channel];
+    }
+}
+
+//
+// Under a paged cache the slot owns scattered blocks in one shared arena rather
+// than a contiguous reservation, so `block_table` replaces the slot stride: the
+// row's block list is read at `slot * max_blocks_per_seq` and the destination
+// token's block supplies the base.
 __global__ void append_kv_f16_batched_kernel(
     const uint16_t* k_rows, const uint16_t* v_rows,
     uint16_t* k_cache, uint16_t* v_cache, const int* start_positions,
     const int* slot_ids, int rows, int kv_heads, int head_dim, int max_context,
-    size_t kv_slot_stride) {
+    size_t kv_slot_stride, const int* block_table, int block_size,
+    int max_blocks_per_seq) {
     const int index = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
     const int total = rows * kv_heads * head_dim;
     if (index >= total) return;
@@ -2779,8 +2838,19 @@ __global__ void append_kv_f16_batched_kernel(
     const int destination_token = start_positions[row];
     if (destination_token >= max_context) return;
     const int slot = slot_ids != nullptr ? slot_ids[row] : row;
-    const size_t destination = static_cast<size_t>(slot) * kv_slot_stride +
-        static_cast<size_t>(destination_token) * kv_heads * head_dim + within;
+    const size_t kv_stride = static_cast<size_t>(kv_heads) * head_dim;
+    size_t destination;
+    if (block_table != nullptr) {
+        const int block = block_table[
+            static_cast<size_t>(slot) * max_blocks_per_seq +
+            destination_token / block_size];
+        destination = (static_cast<size_t>(block) * block_size +
+                       static_cast<size_t>(destination_token % block_size)) *
+                      kv_stride + within;
+    } else {
+        destination = static_cast<size_t>(slot) * kv_slot_stride +
+            static_cast<size_t>(destination_token) * kv_stride + within;
+    }
     k_cache[destination] = k_rows[index];
     v_cache[destination] = v_rows[index];
 }
@@ -4299,15 +4369,54 @@ bool qwen_append_kv_cache_f16_batched_cuda(
     const uint16_t* k_rows, const uint16_t* v_rows,
     uint16_t* k_cache, uint16_t* v_cache, int rows,
     int kv_heads, int head_dim, const int* start_positions,
-    const int* slot_ids, int max_context, size_t kv_slot_stride, void* stream) {
+    const int* slot_ids, int max_context, size_t kv_slot_stride,
+    const int* block_table, int block_size, int max_blocks_per_seq,
+    void* stream) {
     if (!k_rows || !v_rows || !k_cache || !v_cache || !start_positions ||
         rows <= 0 || kv_heads <= 0 || head_dim <= 0 ||
-        max_context <= 0 || kv_slot_stride == 0) return false;
+        max_context <= 0) return false;
+    // The paged cache has no per-slot stride to validate; the block table and
+    // its geometry take that role.
+    if (block_table != nullptr) {
+        if (block_size <= 0 || max_blocks_per_seq <= 0) return false;
+    } else if (kv_slot_stride == 0) {
+        return false;
+    }
     const int total = rows * kv_heads * head_dim;
     append_kv_f16_batched_kernel<<<(total + kThreads - 1) / kThreads, kThreads, 0,
         static_cast<cudaStream_t>(stream)>>>(k_rows, v_rows, k_cache, v_cache,
         start_positions, slot_ids, rows, kv_heads, head_dim, max_context,
-        kv_slot_stride);
+        kv_slot_stride, block_table, block_size, max_blocks_per_seq);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_append_kv_cache_f16_paged_cuda(
+    const uint16_t* k_rows, const uint16_t* v_rows,
+    uint16_t* k_cache, uint16_t* v_cache, int seq_len, int kv_heads,
+    int head_dim, int start_pos, const int* block_table, int block_size,
+    void* stream) {
+    if (!k_rows || !v_rows || !k_cache || !v_cache || !block_table ||
+        seq_len <= 0 || kv_heads <= 0 || head_dim <= 0 || start_pos < 0 ||
+        block_size <= 0) return false;
+    const int total = seq_len * kv_heads * head_dim;
+    append_kv_f16_paged_kernel<<<(total + kThreads - 1) / kThreads, kThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(k_rows, v_rows, k_cache, v_cache,
+        total, kv_heads, head_dim, start_pos, block_table, block_size);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gather_kv_cache_f16_paged_cuda(
+    const uint16_t* k_cache, const uint16_t* v_cache,
+    uint16_t* k_dense, uint16_t* v_dense, int context_len, int kv_heads,
+    int head_dim, const int* block_table, int block_size, void* stream) {
+    if (!k_cache || !v_cache || !k_dense || !v_dense || !block_table ||
+        context_len <= 0 || kv_heads <= 0 || head_dim <= 0 ||
+        block_size <= 0) return false;
+    const dim3 grid(static_cast<unsigned>(context_len),
+                    static_cast<unsigned>(kv_heads), 1);
+    gather_kv_f16_paged_kernel<<<grid, 256, 0,
+        static_cast<cudaStream_t>(stream)>>>(k_cache, v_cache, k_dense, v_dense,
+        context_len, kv_heads, head_dim, block_table, block_size);
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/core/qwen_block_pool.cpp
+++ b/cpp_engine/core/qwen_block_pool.cpp
@@ -1,0 +1,99 @@
+#include "qwen_block_pool.hpp"
+
+#include <stdexcept>
+#include <string>
+
+namespace dsv4 {
+
+QwenBlockPool::QwenBlockPool(int num_blocks, int block_size)
+    : num_blocks_(num_blocks), block_size_(block_size) {
+    if (num_blocks <= 0) {
+        throw std::runtime_error(
+            "QwenBlockPool: num_blocks must be >= 1, got " +
+            std::to_string(num_blocks));
+    }
+    if (block_size <= 0) {
+        throw std::runtime_error(
+            "QwenBlockPool: block_size must be >= 1, got " +
+            std::to_string(block_size));
+    }
+    refcounts_.assign(static_cast<size_t>(num_blocks), 0);
+    free_list_.reserve(static_cast<size_t>(num_blocks));
+    // Seeded in descending order so the first allocations come back as 0, 1, 2,
+    // which keeps a fresh pool's block tables readable in a debugger and makes
+    // the fragmentation test's interleaving reproducible.
+    for (int block = num_blocks - 1; block >= 0; --block) {
+        free_list_.push_back(block);
+    }
+}
+
+std::vector<int> QwenBlockPool::allocate(int count) {
+    if (count < 0) {
+        throw std::runtime_error(
+            "QwenBlockPool::allocate: count must be >= 0, got " +
+            std::to_string(count));
+    }
+    std::vector<int> blocks;
+    if (count == 0) return blocks;
+    if (static_cast<size_t>(count) > free_list_.size()) return blocks;
+
+    blocks.reserve(static_cast<size_t>(count));
+    for (int taken = 0; taken < count; ++taken) {
+        const int block = free_list_.back();
+        free_list_.pop_back();
+        refcounts_[static_cast<size_t>(block)] = 1;
+        blocks.push_back(block);
+    }
+    return blocks;
+}
+
+void QwenBlockPool::free(const std::vector<int>& block_ids) {
+    for (const int block : block_ids) {
+        if (block == kInvalidBlock) continue;
+        validate(block);
+        int& count = refcounts_[static_cast<size_t>(block)];
+        if (count == 0) {
+            throw std::runtime_error(
+                "QwenBlockPool::free: block " + std::to_string(block) +
+                " is already free");
+        }
+        if (--count == 0) {
+            free_list_.push_back(block);
+        }
+    }
+}
+
+void QwenBlockPool::retain(int block_id) {
+    validate(block_id);
+    int& count = refcounts_[static_cast<size_t>(block_id)];
+    if (count == 0) {
+        throw std::runtime_error(
+            "QwenBlockPool::retain: block " + std::to_string(block_id) +
+            " is not allocated");
+    }
+    ++count;
+}
+
+int QwenBlockPool::refcount(int block_id) const {
+    validate(block_id);
+    return refcounts_[static_cast<size_t>(block_id)];
+}
+
+int QwenBlockPool::blocks_for_tokens(int tokens) const {
+    if (tokens < 0) {
+        throw std::runtime_error(
+            "QwenBlockPool::blocks_for_tokens: tokens must be >= 0, got " +
+            std::to_string(tokens));
+    }
+    return (tokens + block_size_ - 1) / block_size_;
+}
+
+void QwenBlockPool::validate(int block_id) const {
+    if (block_id < 0 || block_id >= num_blocks_) {
+        throw std::runtime_error(
+            "QwenBlockPool: block id " + std::to_string(block_id) +
+            " out of range [0, " + std::to_string(num_blocks_) + ")");
+    }
+}
+
+}  // namespace dsv4

--- a/cpp_engine/core/qwen_block_table.cpp
+++ b/cpp_engine/core/qwen_block_table.cpp
@@ -1,0 +1,130 @@
+#include "qwen_block_table.hpp"
+
+#include <stdexcept>
+#include <string>
+
+namespace dsv4 {
+
+QwenBlockTable::QwenBlockTable(QwenBlockPool* pool, int max_slots,
+                              int max_context)
+    : pool_(pool), max_slots_(max_slots), max_context_(max_context) {
+    if (pool_ == nullptr) {
+        throw std::runtime_error("QwenBlockTable: pool must not be null");
+    }
+    if (max_slots <= 0) {
+        throw std::runtime_error(
+            "QwenBlockTable: max_slots must be >= 1, got " +
+            std::to_string(max_slots));
+    }
+    if (max_context <= 0) {
+        throw std::runtime_error(
+            "QwenBlockTable: max_context must be >= 1, got " +
+            std::to_string(max_context));
+    }
+    max_blocks_per_seq_ = pool_->blocks_for_tokens(max_context);
+    rows_.assign(static_cast<size_t>(max_slots), {});
+    image_.assign(static_cast<size_t>(max_slots) *
+                      static_cast<size_t>(max_blocks_per_seq_),
+                  QwenBlockPool::kInvalidBlock);
+}
+
+bool QwenBlockTable::ensure_capacity(int slot, int tokens) {
+    validate_slot(slot);
+    if (tokens < 0) {
+        throw std::runtime_error(
+            "QwenBlockTable::ensure_capacity: tokens must be >= 0, got " +
+            std::to_string(tokens));
+    }
+    if (tokens > max_context_) {
+        throw std::runtime_error(
+            "QwenBlockTable::ensure_capacity: " + std::to_string(tokens) +
+            " tokens exceeds max_context " + std::to_string(max_context_));
+    }
+    std::vector<int>& row = rows_[static_cast<size_t>(slot)];
+    const int needed = pool_->blocks_for_tokens(tokens);
+    const int have = static_cast<int>(row.size());
+    if (needed <= have) return true;
+
+    // All-or-nothing: a sequence backed to fewer positions than it will write
+    // cannot run, so partial growth would only have to be undone.
+    std::vector<int> fresh = pool_->allocate(needed - have);
+    if (fresh.empty()) return false;
+
+    row.insert(row.end(), fresh.begin(), fresh.end());
+    dirty_ = true;
+    return true;
+}
+
+void QwenBlockTable::release(int slot) {
+    validate_slot(slot);
+    std::vector<int>& row = rows_[static_cast<size_t>(slot)];
+    if (row.empty()) return;
+    pool_->free(row);
+    row.clear();
+    dirty_ = true;
+}
+
+void QwenBlockTable::release_all() {
+    for (int slot = 0; slot < max_slots_; ++slot) release(slot);
+}
+
+size_t QwenBlockTable::element_offset(int slot, int position,
+                                     size_t kv_stride) const {
+    validate_slot(slot);
+    if (position < 0) {
+        throw std::runtime_error(
+            "QwenBlockTable::element_offset: negative position " +
+            std::to_string(position));
+    }
+    const int block_size = pool_->block_size();
+    const size_t index = static_cast<size_t>(position) /
+                         static_cast<size_t>(block_size);
+    const std::vector<int>& row = rows_[static_cast<size_t>(slot)];
+    if (index >= row.size()) {
+        throw std::runtime_error(
+            "QwenBlockTable::element_offset: position " +
+            std::to_string(position) + " is not backed for slot " +
+            std::to_string(slot));
+    }
+    const size_t within = static_cast<size_t>(position) %
+                          static_cast<size_t>(block_size);
+    return (static_cast<size_t>(row[index]) *
+                static_cast<size_t>(block_size) +
+            within) * kv_stride;
+}
+
+const std::vector<int>& QwenBlockTable::row(int slot) const {
+    validate_slot(slot);
+    return rows_[static_cast<size_t>(slot)];
+}
+
+int QwenBlockTable::capacity_tokens(int slot) const {
+    validate_slot(slot);
+    return static_cast<int>(rows_[static_cast<size_t>(slot)].size()) *
+           pool_->block_size();
+}
+
+const std::vector<int32_t>& QwenBlockTable::device_image() {
+    if (!dirty_) return image_;
+    image_.assign(image_.size(), QwenBlockPool::kInvalidBlock);
+    for (int slot = 0; slot < max_slots_; ++slot) {
+        const std::vector<int>& row = rows_[static_cast<size_t>(slot)];
+        const size_t base = static_cast<size_t>(slot) *
+                            static_cast<size_t>(max_blocks_per_seq_);
+        for (size_t index = 0; index < row.size(); ++index) {
+            image_[base + index] = static_cast<int32_t>(row[index]);
+        }
+    }
+    dirty_ = false;
+    return image_;
+}
+
+void QwenBlockTable::validate_slot(int slot) const {
+    if (slot < 0 || slot >= max_slots_) {
+        throw std::runtime_error(
+            "QwenBlockTable: slot " + std::to_string(slot) +
+            " out of range [0, " + std::to_string(max_slots_) + ")");
+    }
+}
+
+}  // namespace dsv4

--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -6,6 +6,8 @@
 #include "cmd_channel.hpp"
 #include "cuda_ops.hpp"
 #include "device_runtime.hpp"
+#include "qwen_block_pool.hpp"
+#include "qwen_block_table.hpp"
 #include "qwen_ops.hpp"
 #include "qwen_dspark.hpp"
 #include "qwen_dflash2.hpp"
@@ -22,6 +24,7 @@
 #include <chrono>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <optional>
 #include <random>
 #include <stdexcept>
@@ -592,6 +595,73 @@ struct QwenEngine::Impl {
         return static_cast<size_t>(slot_id) * max_context * local_kv_heads * head_dim;
     }
 
+    // ========== Paged KV cache ==========
+    // Present only when options.kv_paged is set. The pool owns the block
+    // bookkeeping and the table owns the per-slot logical-to-physical map; the
+    // device arenas stay in the per-layer k_cache/v_cache tensors, sized to the
+    // pool rather than to max_batch_size * max_context.
+    std::unique_ptr<QwenBlockPool> block_pool;
+    std::unique_ptr<QwenBlockTable> block_table;
+    // Device mirror of the table, `[max_slots, max_blocks_per_seq]` int32.
+    QwenDeviceTensor block_table_device;
+
+    bool kv_paged() const { return block_table != nullptr; }
+
+    // Grows `slot` to cover `tokens` logical positions, throwing when the pool
+    // is exhausted. The scheduler-facing entry points convert that into
+    // backpressure; inside a forward there is nothing to fall back to, since the
+    // K/V for those positions has to land somewhere.
+    void reserve_paged_slot(int slot_id, int tokens) {
+        if (!kv_paged()) return;
+        if (!block_table->ensure_capacity(slot_id, tokens)) {
+            throw std::runtime_error(
+                "Qwen paged KV cache exhausted: slot " +
+                std::to_string(slot_id) + " needs " + std::to_string(tokens) +
+                " tokens but only " +
+                std::to_string(block_pool->free_blocks()) +
+                " of " + std::to_string(block_pool->total_blocks()) +
+                " blocks are free");
+        }
+    }
+
+    // Uploads the table when a row changed. A decode step that crosses no block
+    // boundary leaves it clean and pays nothing.
+    void sync_block_table() {
+        if (!kv_paged()) return;
+        if (!block_table->dirty()) return;
+        const std::vector<int32_t>& image = block_table->device_image();
+        check_device(memcpy_h2d(block_table_device.data, image.data(),
+                                image.size() * sizeof(int32_t)),
+                     "Qwen block table upload");
+    }
+
+    const int* block_table_data() const {
+        return kv_paged()
+            ? static_cast<const int*>(block_table_device.data) : nullptr;
+    }
+
+    int paged_block_size() const {
+        return kv_paged() ? block_table->block_size() : 0;
+    }
+
+    int paged_blocks_per_seq() const {
+        return kv_paged() ? block_table->max_blocks_per_seq() : 0;
+    }
+
+    // One slot's row of the device image, which is what the single-sequence
+    // paged kernels take: they address one sequence and need no slot
+    // indirection.
+    const int* block_table_row(int slot_id) const {
+        if (!kv_paged()) return nullptr;
+        return static_cast<const int*>(block_table_device.data) +
+               static_cast<size_t>(slot_id) * block_table->max_blocks_per_seq();
+    }
+
+    void release_paged_slot(int slot_id) {
+        if (!kv_paged()) return;
+        block_table->release(slot_id);
+    }
+
     // Phase 3.4: Element offsets into the per-slot recurrent state arenas. Both
     // tensors carry the slot count as their leading dimension, so the stride is
     // whatever remains. Deriving it from the shape keeps these correct without
@@ -806,6 +876,69 @@ struct QwenEngine::Impl {
         const bool fuse_kv_projection = speculative_target &&
             qwen_env_enabled("QWEN_FUSE_KV_PROJECTION");
 
+        // The paged pool is sized before any layer is uploaded, because every
+        // full-attention layer then allocates its arena from the same block
+        // count. Counting the layers up front rather than growing per layer is
+        // what makes the budget a single decision.
+        if (options.kv_paged) {
+            size_t full_attention_layers = 0;
+            for (size_t index = 0; index < layer_limit; ++index) {
+                if (!map.layers()[index].linear_attention.in_proj_qkv.weight.found) {
+                    ++full_attention_layers;
+                }
+            }
+            const size_t elements_per_token =
+                static_cast<size_t>(local_kv_heads) * head_dim;
+            // Bytes one block costs across every full-attention layer, K and V
+            // together. That is the unit the budget divides.
+            const size_t bytes_per_block = static_cast<size_t>(
+                options.kv_block_size) * elements_per_token * sizeof(uint16_t) *
+                2 * full_attention_layers;
+            if (full_attention_layers == 0 || bytes_per_block == 0) {
+                throw std::runtime_error(
+                    "Qwen paged KV cache requires at least one full-attention "
+                    "layer");
+            }
+            // A zero budget reproduces what the contiguous arena would have
+            // reserved, so turning paging on is memory-neutral and only changes
+            // how the same bytes are handed out.
+            const uint64_t budget = options.kv_cache_bytes != 0
+                ? options.kv_cache_bytes
+                : static_cast<uint64_t>(options.max_batch_size) * max_context *
+                      elements_per_token * sizeof(uint16_t) * 2 *
+                      full_attention_layers;
+            const int num_blocks = static_cast<int>(budget / bytes_per_block);
+            // A slot must be able to reach max_context, or a long request would
+            // fail at a boundary no scheduler could anticipate.
+            const int blocks_per_seq =
+                (max_context + options.kv_block_size - 1) /
+                options.kv_block_size;
+            if (num_blocks < blocks_per_seq) {
+                throw std::runtime_error(
+                    "Qwen paged KV cache budget covers " +
+                    std::to_string(num_blocks) + " blocks but a single " +
+                    std::to_string(max_context) +
+                    "-token sequence needs " + std::to_string(blocks_per_seq) +
+                    "; raise QwenEngineOptions::kv_cache_bytes");
+            }
+            block_pool = std::make_unique<QwenBlockPool>(
+                num_blocks, options.kv_block_size);
+            block_table = std::make_unique<QwenBlockTable>(
+                block_pool.get(), options.max_batch_size, max_context);
+            const size_t image_elements =
+                static_cast<size_t>(block_table->max_slots()) *
+                block_table->max_blocks_per_seq();
+            allocate(block_table_device, image_elements * sizeof(int32_t),
+                     {static_cast<uint64_t>(block_table->max_slots()),
+                      static_cast<uint64_t>(block_table->max_blocks_per_seq())},
+                     // Tagged like the other int row buffers in this engine
+                     // (batch_positions, batch_slot_ids): the allocation is
+                     // sized in bytes and nothing reads the dtype back.
+                     SafeDType::I64);
+            telemetry.kv_paged_blocks = num_blocks;
+            telemetry.kv_paged_block_size = options.kv_block_size;
+        }
+
         for (size_t layer_index = 0; layer_index < layer_limit; ++layer_index) {
             const QwenLayerWeights& source = map.layers()[layer_index];
             for (const QwenTensorRef* ref : {
@@ -949,7 +1082,28 @@ struct QwenEngine::Impl {
                     static_cast<uint64_t>(local_kv_heads),
                     static_cast<uint64_t>(head_dim)};
 
-                if (options.kv_cache_dtype == QwenKvCacheDType::Fp16) {
+                if (block_pool != nullptr) {
+                    // Paged: one arena of blocks shared by every slot. The
+                    // leading dimension is the block count, not the slot count,
+                    // which is the whole difference: a slot's extent is now what
+                    // it has been handed rather than what it reserved.
+                    // Construction rejects the quantized dtypes, so this branch
+                    // is FP16 by definition.
+                    const size_t paged_elements =
+                        static_cast<size_t>(block_pool->total_blocks()) *
+                        block_pool->block_size() * local_kv_heads * head_dim;
+                    const std::vector<uint64_t> paged_shape = {
+                        static_cast<uint64_t>(block_pool->total_blocks()),
+                        static_cast<uint64_t>(block_pool->block_size()),
+                        static_cast<uint64_t>(local_kv_heads),
+                        static_cast<uint64_t>(head_dim)};
+                    allocate_half(destination.full.k_cache, paged_elements,
+                                  paged_shape);
+                    allocate_half(destination.full.v_cache, paged_elements,
+                                  paged_shape);
+                    cache_data_bytes += destination.full.k_cache.nbytes +
+                                        destination.full.v_cache.nbytes;
+                } else if (options.kv_cache_dtype == QwenKvCacheDType::Fp16) {
                     allocate_half(destination.full.k_cache, cache_elements, cache_shape);
                     allocate_half(destination.full.v_cache, cache_elements, cache_shape);
                     cache_data_bytes += destination.full.k_cache.nbytes +
@@ -2552,12 +2706,25 @@ struct QwenEngine::Impl {
 
         if (batch_rows != nullptr) {
             // Each row appends its new K/V at its own position in its own slot.
+            // Under paging the slot stride is replaced by the block table, which
+            // the caller has already grown and uploaded for these positions.
             require_launch(qwen_append_kv_cache_f16_batched_cuda(
                 k_norm.f16_data(), v.f16_data(),
                 layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
                 rows, kv_heads, head_dim, batch_rows->positions,
-                batch_rows->slot_ids, max_context, kv_slot_stride),
+                batch_rows->slot_ids, max_context, kv_slot_stride,
+                block_table_data(), paged_block_size(),
+                paged_blocks_per_seq()),
                 "append batched FP16 full KV cache");
+        } else if (kv_paged()) {
+            // Single-sequence paged append: consecutive positions of one
+            // sequence, scattered across the blocks its row names.
+            require_launch(qwen_append_kv_cache_f16_paged_cuda(
+                k_norm.f16_data(), v.f16_data(),
+                layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
+                rows, kv_heads, head_dim, position_offset,
+                block_table_row(slot_id), paged_block_size()),
+                "append paged FP16 full KV cache");
         } else if (cache_dtype == QwenKvCacheDType::Fp8) {
             require_launch(qwen_append_kv_cache_fp8_cuda(
                 k_norm.f16_data(), v.f16_data(),
@@ -2597,6 +2764,45 @@ struct QwenEngine::Impl {
                 position_offset, max_context), "append FP16 full KV cache");
         }
 
+        // Where the read kernels find this sequence's history. Contiguous, that
+        // is the slot's own span of the arena. Paged and single-sequence, the
+        // blocks are gathered once per layer into the dense
+        // `[context, kv_heads, head_dim]` layout every read kernel already
+        // indexes, so the five tuned prefill and decode variants stay untouched.
+        // This is the same dequant-once trade the FP8 and TurboQuant paths make:
+        // one O(context) pass instead of translating inside O(rows * context)
+        // inner loops. Batched decode does not come through here; it reads the
+        // blocks natively, which is the path that has to scale with batch size.
+        // Only the FP16 cache stores halves here; the quantized caches keep
+        // their own packed buffers and reach for them inside their own branches
+        // below, so binding these eagerly would trip f16_data()'s dtype check.
+        const bool fp16_cache = cache_dtype == QwenKvCacheDType::Fp16;
+        const uint16_t* k_read = fp16_cache
+            ? layer.full.k_cache.f16_data() + slot_offset : nullptr;
+        const uint16_t* v_read = fp16_cache
+            ? layer.full.v_cache.f16_data() + slot_offset : nullptr;
+        if (kv_paged() && batch_rows == nullptr) {
+            const int context_length = position_offset + rows;
+            const std::vector<uint64_t> dense_shape = {
+                static_cast<uint64_t>(context_length),
+                static_cast<uint64_t>(kv_heads),
+                static_cast<uint64_t>(head_dim)};
+            const size_t dense_elements =
+                static_cast<size_t>(context_length) * kv_heads * head_dim;
+            QwenDeviceTensor& k_dense =
+                workspace_half(dense_elements, dense_shape);
+            QwenDeviceTensor& v_dense =
+                workspace_half(dense_elements, dense_shape);
+            PhaseScope sub(this, "full.kv_gather");
+            require_launch(qwen_gather_kv_cache_f16_paged_cuda(
+                layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
+                k_dense.f16_data(), v_dense.f16_data(), context_length,
+                kv_heads, head_dim, block_table_row(slot_id),
+                paged_block_size()), "gather paged FP16 KV cache");
+            k_read = k_dense.f16_data();
+            v_read = v_dense.f16_data();
+        }
+
         if (batch_rows != nullptr) {
             // One launch for the whole batch. The split geometry comes from the
             // longest row, so the scratch is sized from that same query the
@@ -2618,7 +2824,9 @@ struct QwenEngine::Impl {
                 partials.f32_data(), batch_rows->context_lens,
                 batch_rows->slot_ids, rows, batch_rows->max_context_len,
                 kv_slot_stride, q_heads, kv_heads, head_dim, max_context,
-                attention_window, sink_tokens), "batched decode FP16-cache GQA");
+                attention_window, sink_tokens, block_table_data(),
+                paged_block_size(), paged_blocks_per_seq()),
+                "batched decode FP16-cache GQA");
         } else if (rows == 1) {
             const int context_length = position_offset + 1;
             const bool optimized_attention =
@@ -2692,8 +2900,8 @@ struct QwenEngine::Impl {
             } else if (optimized_decode) {
                 require_launch(qwen_gqa_decode_attention_f16_fused_cuda(
                     q_norm.f16_data(),
-                    layer.full.k_cache.f16_data() + slot_offset,
-                    layer.full.v_cache.f16_data() + slot_offset,
+                    k_read,
+                    v_read,
                     attention.f16_data(),
                     scores.f32_data(), q_heads, kv_heads, head_dim,
                     context_length, max_context, attention_window, sink_tokens),
@@ -2701,8 +2909,8 @@ struct QwenEngine::Impl {
             } else {
                 require_launch(qwen_gqa_decode_attention_f16(
                     q_norm.f16_data(),
-                    layer.full.k_cache.f16_data() + slot_offset,
-                    layer.full.v_cache.f16_data() + slot_offset,
+                    k_read,
+                    v_read,
                     attention.f16_data(),
                     scores.f32_data(), q_heads, kv_heads, head_dim,
                     context_length, max_context), "decode FP16-cache GQA");
@@ -2835,8 +3043,8 @@ struct QwenEngine::Impl {
                 PhaseScope sub(this, "full.attn_kernel");
                 require_launch(qwen_gqa_verify_attention_f16_cublas_qk_cuda(
                     q_norm.f16_data(),
-                    layer.full.k_cache.f16_data() + slot_offset,
-                    layer.full.v_cache.f16_data() + slot_offset,
+                    k_read,
+                    v_read,
                     attention.f16_data(),
                     scores.f32_data(), rows, q_heads, kv_heads, head_dim,
                     position_offset, max_context),
@@ -2867,8 +3075,8 @@ struct QwenEngine::Impl {
                 PhaseScope sub(this, "full.attn_kernel");
                 require_launch(qwen_gqa_verify_attention_f16(
                     q_norm.f16_data(),
-                    layer.full.k_cache.f16_data() + slot_offset,
-                    layer.full.v_cache.f16_data() + slot_offset,
+                    k_read,
+                    v_read,
                     attention.f16_data(),
                     partials.f32_data(), rows, q_heads, kv_heads, head_dim,
                     position_offset, max_context, verify_splits),
@@ -2883,8 +3091,8 @@ struct QwenEngine::Impl {
                      static_cast<uint64_t>(context_length)});
                 { PhaseScope sub(this, "full.attn_kernel"); require_launch(qwen_gqa_verify_attention_f16_exact_cuda(
                     q_norm.f16_data(),
-                    layer.full.k_cache.f16_data() + slot_offset,
-                    layer.full.v_cache.f16_data() + slot_offset,
+                    k_read,
+                    v_read,
                     attention.f16_data(),
                     scores.f32_data(), rows, q_heads, kv_heads, head_dim,
                     position_offset, max_context),
@@ -2897,8 +3105,8 @@ struct QwenEngine::Impl {
                    attention_window > 0) {
             require_launch(qwen_gqa_prefill_attention_f16_tiled_cuda(
                 q_norm.f16_data(),
-                layer.full.k_cache.f16_data() + slot_offset,
-                layer.full.v_cache.f16_data() + slot_offset,
+                k_read,
+                v_read,
                 attention.f16_data(), rows,
                 q_heads, kv_heads, head_dim, position_offset, max_context,
                 attention_window, sink_tokens),
@@ -2906,8 +3114,8 @@ struct QwenEngine::Impl {
         } else {
             require_launch(qwen_gqa_prefill_attention_f16(
                 q_norm.f16_data(),
-                layer.full.k_cache.f16_data() + slot_offset,
-                layer.full.v_cache.f16_data() + slot_offset,
+                k_read,
+                v_read,
                 attention.f16_data(), rows,
                 q_heads, kv_heads, head_dim, position_offset, max_context),
                 "prefill FP16-cache GQA");
@@ -4227,6 +4435,22 @@ QwenEngine::QwenEngine(const std::string& ckpt_dir,
         throw std::runtime_error(
             "Qwen sparse attention currently requires an FP16 KV cache");
     }
+    if (options_.kv_paged) {
+        // FP16 only. The quantized caches carry their own scale and packed-slot
+        // offset arithmetic, and paging them would mean reworking each one's
+        // addressing with no coverage from the batched path, which is FP16
+        // already. Refusing is what keeps the restriction visible instead of
+        // silently degrading to a contiguous cache.
+        if (options_.kv_cache_dtype != QwenKvCacheDType::Fp16) {
+            throw std::runtime_error(
+                std::string("Qwen paged KV cache requires an FP16 cache; got ") +
+                qwen_kv_cache_dtype_name(options_.kv_cache_dtype));
+        }
+        if (options_.kv_block_size <= 0) {
+            throw std::runtime_error(
+                "Qwen paged KV block size must be positive");
+        }
+    }
 #ifdef POCKET_BACKEND_ASCEND
     // full_attention only compiles the FP16 cache path on this backend, so the
     // rejection belongs here where the option is still reportable rather than
@@ -4368,6 +4592,14 @@ void QwenEngine::clear_prefix_cache() {
     }
     // KV storage is overwritten before it is read. Avoid clearing several GiB
     // on every request; position_ bounds all attention reads.
+    //
+    // A paged cache is the exception: its blocks are a finite pool, so clearing
+    // the positions without returning the blocks would leak the whole pool over
+    // a few requests. The bytes still are not touched, only the bookkeeping.
+    if (impl_->kv_paged()) {
+        impl_->block_table->release_all();
+        impl_->sync_block_table();
+    }
 }
 
 // ========== Batch API implementation (Phase 3.1) ==========
@@ -4444,6 +4676,21 @@ void QwenEngine::free_slot(uint64_t request_id) {
     int slot_id = it->second;
     impl_->request_to_slot.erase(it);
     impl_->free_slots.push_back(slot_id);
+    // Returning the slot returns its blocks. Under paging this is what makes
+    // capacity dynamic: the next request draws from a pool the finished one has
+    // already given back, rather than inheriting a fixed reservation.
+    impl_->release_paged_slot(slot_id);
+    impl_->sync_block_table();
+    // The slot's reuse state described KV that is no longer backed by these
+    // blocks, so it must not survive into the next request on this slot.
+    if (impl_->kv_paged()) {
+        Impl::SlotPrefixState& prefix = impl_->prefix_for(slot_id);
+        prefix.cached_prompt.clear();
+        prefix.snapshots.clear();
+        prefix.cached_result = QwenForwardResult{};
+        prefix.has_cached_result = false;
+        impl_->set_slot_position(slot_id, 0, position_);
+    }
 }
 
 QwenBatchPrefillResult QwenEngine::batch_prefill(
@@ -4536,6 +4783,15 @@ std::vector<QwenForwardResult> QwenEngine::batch_decode_tokens(
         }
         positions[static_cast<size_t>(row)] = position;
     }
+
+    // Every row grows by one token. Reserving all of them before the forward
+    // keeps the failure at a batch boundary: a mid-forward throw would leave
+    // some rows appended and others not.
+    for (int row = 0; row < rows; ++row) {
+        impl_->reserve_paged_slot(slot_ids[static_cast<size_t>(row)],
+                                  positions[static_cast<size_t>(row)] + 1);
+    }
+    impl_->sync_block_table();
 
     QwenVerifyBatch batch = impl_->run_batched_decode(
         tokens, positions, slot_ids, active_layers_);
@@ -4781,6 +5037,13 @@ QwenPartialPrefillResult QwenEngine::prefill_bounded(
         max_tokens > 0
             ? std::min(target_position, start_position + std::max(1, max_tokens))
             : target_position;
+    // Blocks for everything this call will write, taken before the first chunk
+    // so an exhausted pool surfaces here rather than part-way through a prompt
+    // whose earlier chunks already advanced the recurrent state. The block table
+    // is uploaded once for the whole prefill: it does not change again until the
+    // next call, so the per-chunk forwards read the same rows.
+    impl_->reserve_paged_slot(slot_id, budget_limit);
+    impl_->sync_block_table();
     for (int offset = start_position; offset < budget_limit;) {
         int end = std::min(budget_limit, offset + chunk_size);
         // Split at exact snapshot boundaries even when a request begins at an
@@ -4881,6 +5144,10 @@ QwenForwardResult QwenEngine::decode_step(int token_id, int slot_id) {
     if (current_position >= max_context_) {
         throw std::runtime_error("Qwen context length exceeded");
     }
+    // One more token to hold. This is a no-op except on the step that crosses a
+    // block boundary, and the table upload is skipped when nothing changed.
+    impl_->reserve_paged_slot(slot_id, current_position + 1);
+    impl_->sync_block_table();
     QwenForwardResult result = impl_->run_chunk(
         {token_id}, current_position, active_layers_, true, nullptr, nullptr, slot_id);
 

--- a/cpp_engine/include/qwen_block_pool.hpp
+++ b/cpp_engine/include/qwen_block_pool.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace dsv4 {
+
+// Host-side bookkeeping for a paged KV cache.
+//
+// The contiguous arena reserves `max_context` tokens per slot at construction,
+// so a batch of short requests at a large context still pays for the worst case.
+// This pool owns a fixed number of fixed-size blocks instead and hands them out
+// as tokens actually arrive, which is what lets batch size scale with real token
+// use rather than with `max_batch_size * max_context`.
+//
+// Only the block *indices* live here. The device memory is one arena per layer
+// owned by the engine, and a block id is an offset into it, so this class has no
+// device dependency and is testable without a model.
+//
+// Blocks are refcounted even though nothing shares them yet: prefix sharing
+// across sequences needs exactly this counter, and retrofitting it later would
+// mean revisiting every free site.
+class QwenBlockPool {
+public:
+    static constexpr int kInvalidBlock = -1;
+
+    // `block_size` is tokens per block; `num_blocks` is the pool extent. Both
+    // must be positive.
+    QwenBlockPool(int num_blocks, int block_size);
+
+    // Takes `count` blocks, or returns empty when the pool cannot satisfy the
+    // whole request. Partial allocation is deliberately not offered: a sequence
+    // that gets some of the blocks it needs cannot run, and the caller would
+    // have to hand them straight back. Failure is backpressure, not an error,
+    // so it does not throw.
+    std::vector<int> allocate(int count);
+
+    // Drops one reference per id and returns any block whose count reaches zero
+    // to the free list. Ignores kInvalidBlock so a caller can free a partially
+    // built table. Throws on an out-of-range or already-free id, which is a
+    // bookkeeping bug rather than a runtime condition.
+    void free(const std::vector<int>& block_ids);
+
+    // Adds a reference, for a block that a second sequence begins to share.
+    void retain(int block_id);
+
+    int refcount(int block_id) const;
+
+    int free_blocks() const { return static_cast<int>(free_list_.size()); }
+    int total_blocks() const { return num_blocks_; }
+    int block_size() const { return block_size_; }
+
+    // Blocks needed to hold `tokens`, i.e. the ceiling division. A sequence
+    // holding exactly `block_size` tokens needs one block, and one more token
+    // needs two.
+    int blocks_for_tokens(int tokens) const;
+
+private:
+    void validate(int block_id) const;
+
+    int num_blocks_;
+    int block_size_;
+    // Free ids, taken and returned at the back. LIFO reuse keeps a just-freed
+    // block hot in cache rather than cycling through the whole pool.
+    std::vector<int> free_list_;
+    std::vector<int> refcounts_;
+};
+
+}  // namespace dsv4

--- a/cpp_engine/include/qwen_block_table.hpp
+++ b/cpp_engine/include/qwen_block_table.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "qwen_block_pool.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace dsv4 {
+
+// Logical-to-physical position mapping for the paged KV cache, one row per slot.
+//
+// Row `slot` holds the block ids backing that sequence in logical order, so
+// logical position `pos` lives in block `rows[slot][pos / block_size]` at offset
+// `pos % block_size` within it. This is the paged replacement for
+// `slot * max_context * kv_heads * head_dim`, and it is the only place the
+// translation is written down on the host side.
+//
+// The device mirror is a dense `[max_slots, max_blocks_per_seq]` int32 image of
+// the same rows, which is what the kernels index. It is kept as host memory here
+// and uploaded by the engine, so this class stays free of device calls and can
+// be tested without a GPU.
+class QwenBlockTable {
+public:
+    QwenBlockTable(QwenBlockPool* pool, int max_slots, int max_context);
+
+    // Ensures `slot` is backed to at least `tokens` logical positions, taking
+    // blocks from the pool as needed. Returns false without changing anything
+    // when the pool cannot cover the growth, so the caller can leave the request
+    // waiting instead of failing it. Shrinking is not supported: a sequence only
+    // ever grows until it is released.
+    bool ensure_capacity(int slot, int tokens);
+
+    // Returns every block held by `slot` to the pool and clears the row.
+    void release(int slot);
+
+    void release_all();
+
+    // Physical element offset of a logical position within the layer arena,
+    // measured in cache elements rather than bytes so it composes with the
+    // existing `+ slot_offset` pointer arithmetic. `kv_stride` is
+    // `kv_heads * head_dim`, the elements per token.
+    size_t element_offset(int slot, int position, size_t kv_stride) const;
+
+    // Blocks currently backing `slot`.
+    const std::vector<int>& row(int slot) const;
+
+    // Logical positions currently backed for `slot`, i.e. blocks * block_size.
+    int capacity_tokens(int slot) const;
+
+    // Flat `[max_slots, max_blocks_per_seq]` image for upload, padded with
+    // kInvalidBlock. Rebuilt only when a row changed since the last call, since
+    // a decode step that crosses no block boundary should not pay for an
+    // upload. `dirty()` reports whether that is the case.
+    const std::vector<int32_t>& device_image();
+    bool dirty() const { return dirty_; }
+
+    int max_blocks_per_seq() const { return max_blocks_per_seq_; }
+    int max_slots() const { return max_slots_; }
+    int block_size() const { return pool_->block_size(); }
+
+private:
+    void validate_slot(int slot) const;
+
+    QwenBlockPool* pool_;
+    int max_slots_;
+    int max_context_;
+    int max_blocks_per_seq_;
+    std::vector<std::vector<int>> rows_;
+    std::vector<int32_t> image_;
+    bool dirty_ = true;
+};
+
+}  // namespace dsv4

--- a/cpp_engine/include/qwen_cuda_ops.hpp
+++ b/cpp_engine/include/qwen_cuda_ops.hpp
@@ -837,11 +837,34 @@ bool qwen_append_kv_cache_f16_cuda(
 // `d_slot_ids` maps each row to the cache slot it owns, because slots are
 // allocated as requests arrive: a four-row batch can hold slots 1/3/5/6. Pass
 // null when the rows occupy slots 0..rows-1 in order.
+// A non-null `d_block_table` selects the paged cache: the arena is shared and
+// `[max_slots, max_blocks_per_seq]` int32 block ids replace the per-slot stride,
+// so position `p` of slot `s` lives at
+// `(table[s][p / block_size] * block_size + p % block_size) * kv_heads *
+// head_dim`. `kv_slot_stride` is then unused.
 bool qwen_append_kv_cache_f16_batched_cuda(
     const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
     uint16_t* d_k_cache_fp16, uint16_t* d_v_cache_fp16, int rows,
     int kv_heads, int head_dim, const int* d_start_positions,
     const int* d_slot_ids, int max_context, size_t kv_slot_stride,
+    const int* d_block_table = nullptr, int block_size = 0,
+    int max_blocks_per_seq = 0, void* stream = nullptr);
+// Paged single-sequence append. `d_block_table` is one sequence's row of block
+// ids, so consecutive tokens land in whichever blocks that row names.
+bool qwen_append_kv_cache_f16_paged_cuda(
+    const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
+    uint16_t* d_k_cache_fp16, uint16_t* d_v_cache_fp16, int seq_len,
+    int kv_heads, int head_dim, int start_pos, const int* d_block_table,
+    int block_size, void* stream = nullptr);
+// Collects one sequence's paged history into a dense
+// `[context_len, kv_heads, head_dim]` buffer, which is the layout every prefill
+// and single-row decode kernel already indexes. Gathering once per layer keeps
+// those five tuned variants unchanged, the same way the FP8 and TurboQuant
+// caches dequantize once before calling them.
+bool qwen_gather_kv_cache_f16_paged_cuda(
+    const uint16_t* d_k_cache_fp16, const uint16_t* d_v_cache_fp16,
+    uint16_t* d_k_dense_fp16, uint16_t* d_v_dense_fp16, int context_len,
+    int kv_heads, int head_dim, const int* d_block_table, int block_size,
     void* stream = nullptr);
 bool qwen_append_kv_cache_fp8_cuda(
     const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
@@ -912,6 +935,11 @@ int qwen_gqa_decode_batched_split_count(
     int sink_tokens = 0);
 // `d_slot_ids` maps each row to the KV slot it owns; pass null when the rows
 // occupy slots 0..rows-1 in order.
+// A non-null `d_block_table` selects the paged cache, translating each scanned
+// position through the same block table the append above writes into. The
+// translation is loop-invariant within a block, so it costs one table read per
+// `block_size` positions rather than one per position. `max_context` then bounds
+// only the logical sequence; the arena extent comes from the pool.
 bool qwen_gqa_decode_attention_f16_batched_cuda(
     const uint16_t* d_q_fp16, const uint16_t* d_k_cache_fp16,
     const uint16_t* d_v_cache_fp16, uint16_t* d_out_fp16,
@@ -919,7 +947,8 @@ bool qwen_gqa_decode_attention_f16_batched_cuda(
     const int* d_slot_ids, int rows, int max_context_len,
     size_t kv_slot_stride, int q_heads, int kv_heads, int head_dim,
     int max_context, int attention_window = 0, int sink_tokens = 0,
-    void* stream = nullptr);
+    const int* d_block_table = nullptr, int block_size = 0,
+    int max_blocks_per_seq = 0, void* stream = nullptr);
 
 // Fused decode with the split kernel chosen explicitly. Returns false when the
 // requested variant does not support the shape (the tensor-core kernel requires

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -104,6 +104,29 @@ struct QwenEngineOptions {
     // at construction time. Memory scales linearly: 2-slot ≈ 2× single-session.
     // Recommended: 2 for most workloads, 4-8 for high-concurrency scenarios.
     int max_batch_size = 1;
+    // Paged KV cache. The arena above reserves max_context per slot whether the
+    // request holds 100 tokens or 100K, so at 128K context the reservation alone
+    // is 2 GiB per slot per rank and concurrency is capped by the reservation
+    // rather than by real token use. With this enabled the cache is one pool of
+    // fixed-size blocks handed out as tokens arrive, so batch size scales with
+    // what the requests actually hold.
+    //
+    // FP16 only: batched decode already routes to the FP16 kernels before the
+    // dtype branches are reached, so paging FP16 covers all of batched decode
+    // while the quantized caches keep their validated scale and packed-slot
+    // arithmetic untouched. Construction rejects the other dtypes rather than
+    // silently falling back.
+    bool kv_paged = false;
+    // Tokens per block. 16 follows vLLM; at kv_heads * head_dim = 1024 FP16
+    // elements that is 32 KiB of contiguity per block, so reads stay coalesced
+    // within a block.
+    int kv_block_size = 16;
+    // Pool budget in bytes for the paged K and V arenas together, across all
+    // full-attention layers on this rank. 0 derives it from what
+    // max_batch_size * max_context would have reserved, which makes enabling
+    // paging alone memory-neutral and lets the block count be raised
+    // deliberately.
+    uint64_t kv_cache_bytes = 0;
 };
 
 struct QwenForwardResult {
@@ -172,6 +195,9 @@ struct QwenRuntimeTelemetry {
     std::string target_head_path = "unknown";
     uint64_t host_global_metadata_bytes = 0;
     uint64_t nvfp4_q8_workspace_peak_bytes = 0;
+    // Paged KV cache geometry. 0 blocks means the contiguous arena is in use.
+    int kv_paged_blocks = 0;
+    int kv_paged_block_size = 0;
 };
 
 struct QwenPrefixCacheStats {

--- a/cpp_engine/tests/qwen_parity_fixture.hpp
+++ b/cpp_engine/tests/qwen_parity_fixture.hpp
@@ -1,0 +1,244 @@
+#pragma once
+
+// Shared zero-weight Qwen3.5 checkpoint fixture for engine-level parity tests.
+//
+// The two-layer alternating config (one linear_attention, one full_attention)
+// over a 64-token vocab loads in well under a second, which is what lets a
+// parity test stand up two whole engine configurations instead of needing a real
+// checkpoint. Callers pass their own directory so concurrent tests do not share
+// one fixture.
+//
+// Extracted verbatim from test_qwen_batched_engine_parity.cpp, which now
+// includes this header, so the two parity tests cannot drift onto different
+// model geometries.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace qwen_fixture {
+
+struct TensorSpec {
+    std::string name;
+    std::string dtype;
+    std::vector<uint64_t> shape;
+};
+
+uint64_t numel(const std::vector<uint64_t>& shape) {
+    uint64_t out = 1;
+    for (uint64_t dim : shape) out *= dim;
+    return out;
+}
+
+uint64_t dtype_size(const std::string& dtype) {
+    if (dtype == "F8_E4M3") return 1;
+    if (dtype == "BF16") return 2;
+    throw std::runtime_error("unsupported fixture dtype: " + dtype);
+}
+
+std::string shape_json(const std::vector<uint64_t>& shape) {
+    std::ostringstream out;
+    out << '[';
+    for (size_t i = 0; i < shape.size(); ++i) {
+        if (i) out << ',';
+        out << shape[i];
+    }
+    out << ']';
+    return out.str();
+}
+
+// `name` distinguishes one test's fixture from another's, since two tests
+// running at once would otherwise write the same shard.
+std::string fixture_dir(const std::string& name) {
+    const char* base = std::getenv("CLAUDE_JOB_DIR");
+    const std::string root = base != nullptr ? std::string(base) + "/tmp"
+                                              : std::string("/tmp");
+    return root + "/" + name;
+}
+
+std::string config_json() {
+    // Two-layer alternating: one linear_attention, one full_attention.
+    // Context 8192 so decode at positions 4096, 5000, 6144, 7500 all fall inside
+    // the kDecodeMinContext=4096 threshold where the fused split path runs.
+    return R"JSON({
+  "architectures": ["Qwen3_5ForConditionalGeneration"],
+  "model_type": "qwen3_5",
+  "text_config": {
+    "model_type": "qwen3_5_text",
+    "vocab_size": 64,
+    "hidden_size": 128,
+    "intermediate_size": 128,
+    "num_hidden_layers": 2,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 4,
+    "head_dim": 128,
+    "attn_output_gate": true,
+    "linear_num_key_heads": 4,
+    "linear_num_value_heads": 4,
+    "linear_key_head_dim": 128,
+    "linear_value_head_dim": 128,
+    "linear_conv_kernel_dim": 4,
+    "max_position_embeddings": 8192,
+    "rms_norm_eps": 1e-6,
+    "partial_rotary_factor": 0.25,
+    "rope_parameters": {"rope_type": "default", "rope_theta": 10000000},
+    "layer_types": ["linear_attention", "full_attention"]
+  }
+})JSON";
+}
+
+std::vector<TensorSpec> specs() {
+    const std::vector<uint64_t> hidden = {128};
+    const std::vector<uint64_t> vocab = {64, 128};
+    // linear_attention QKV: (q_heads + 2*kv_heads) * head_dim = (4+2*4)*128 = 1536
+    const std::vector<uint64_t> qkv = {1536, 128};
+    // FP8 block scale: ceil_div(1536, 128) × ceil_div(128, 128) = 12 × 1
+    const std::vector<uint64_t> qkv_scale = {12, 1};
+    const std::vector<uint64_t> value_proj = {512, 128};
+    // FP8 block scale: ceil_div(512, 128) × ceil_div(128, 128) = 4 × 1
+    const std::vector<uint64_t> value_scale = {4, 1};
+    const std::vector<uint64_t> out_proj = {128, 512};
+    // FP8 block scale: ceil_div(128, 128) × ceil_div(512, 128) = 1 × 4
+    const std::vector<uint64_t> out_scale = {1, 4};
+    const std::vector<uint64_t> heads = {4, 128};
+    const std::vector<uint64_t> vector4 = {4};
+    const std::vector<uint64_t> mlp = {128, 128};
+    // FP8 block scale: ceil_div(128, 128) × ceil_div(128, 128) = 1 × 1
+    const std::vector<uint64_t> mlp_scale = {1, 1};
+    // full_attention Q projection: 2x heads for GQA = 8 * 128 = 1024
+    const std::vector<uint64_t> q_proj = {1024, 128};
+    // FP8 block scale: ceil_div(1024, 128) × ceil_div(128, 128) = 8 × 1
+    const std::vector<uint64_t> q_proj_scale = {8, 1};
+    const std::string linear = "model.language_model.layers.0.";
+    const std::string full = "model.language_model.layers.1.";
+    std::vector<TensorSpec> out = {
+        {"model.language_model.embed_tokens.weight", "BF16", vocab},
+        {"model.language_model.norm.weight", "BF16", hidden},
+        {"lm_head.weight", "BF16", vocab},
+        {linear + "input_layernorm.weight", "BF16", hidden},
+        {linear + "post_attention_layernorm.weight", "BF16", hidden},
+        {linear + "linear_attn.in_proj_qkv.weight", "F8_E4M3", qkv},
+        {linear + "linear_attn.in_proj_qkv.weight_scale_inv", "BF16", qkv_scale},
+        {linear + "linear_attn.in_proj_z.weight", "F8_E4M3", value_proj},
+        {linear + "linear_attn.in_proj_z.weight_scale_inv", "BF16", value_scale},
+        {linear + "linear_attn.out_proj.weight", "F8_E4M3", out_proj},
+        {linear + "linear_attn.out_proj.weight_scale_inv", "BF16", out_scale},
+        {linear + "linear_attn.in_proj_a.weight", "BF16", heads},
+        {linear + "linear_attn.in_proj_b.weight", "BF16", heads},
+        {linear + "linear_attn.conv1d.weight", "BF16", {1536, 1, 4}},
+        {linear + "linear_attn.A_log", "BF16", vector4},
+        {linear + "linear_attn.dt_bias", "BF16", vector4},
+        {linear + "linear_attn.norm.weight", "BF16", hidden},
+        {linear + "mlp.gate_proj.weight", "F8_E4M3", mlp},
+        {linear + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale},
+        {linear + "mlp.up_proj.weight", "F8_E4M3", mlp},
+        {linear + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale},
+        {linear + "mlp.down_proj.weight", "F8_E4M3", mlp},
+        {linear + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale},
+    };
+    out.insert(out.end(), {
+        {full + "input_layernorm.weight", "BF16", hidden},
+        {full + "post_attention_layernorm.weight", "BF16", hidden},
+        {full + "self_attn.q_proj.weight", "F8_E4M3", q_proj},
+        {full + "self_attn.q_proj.weight_scale_inv", "BF16", q_proj_scale},
+        {full + "self_attn.k_proj.weight", "F8_E4M3", value_proj},
+        {full + "self_attn.k_proj.weight_scale_inv", "BF16", value_scale},
+        {full + "self_attn.v_proj.weight", "F8_E4M3", value_proj},
+        {full + "self_attn.v_proj.weight_scale_inv", "BF16", value_scale},
+        {full + "self_attn.o_proj.weight", "F8_E4M3", out_proj},
+        {full + "self_attn.o_proj.weight_scale_inv", "BF16", out_scale},
+        {full + "self_attn.q_norm.weight", "BF16", hidden},
+        {full + "self_attn.k_norm.weight", "BF16", hidden},
+        {full + "mlp.gate_proj.weight", "F8_E4M3", mlp},
+        {full + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale},
+        {full + "mlp.up_proj.weight", "F8_E4M3", mlp},
+        {full + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale},
+        {full + "mlp.down_proj.weight", "F8_E4M3", mlp},
+        {full + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale},
+    });
+    return out;
+}
+
+bool write_fixture(const std::string& dir) {
+    const std::string mkdir_cmd = "mkdir -p '" + dir + "'";
+    if (std::system(mkdir_cmd.c_str()) != 0) return false;
+    std::ofstream config(dir + "/config.json",
+                        std::ios::binary | std::ios::trunc);
+    if (!config) return false;
+    config << config_json();
+    if (!config) return false;
+
+    const auto tensors = specs();
+    std::ostringstream header;
+    header << '{';
+    uint64_t offset = 0;
+    for (size_t i = 0; i < tensors.size(); ++i) {
+        if (i) header << ',';
+        const auto& tensor = tensors[i];
+        const uint64_t bytes = numel(tensor.shape) * dtype_size(tensor.dtype);
+        header << '"' << tensor.name << "\":{\"dtype\":\"" << tensor.dtype
+               << "\",\"shape\":" << shape_json(tensor.shape)
+               << ",\"data_offsets\":[" << offset << ',' << offset + bytes
+               << "]}";
+        offset += bytes;
+    }
+    header << '}';
+    const std::string header_text = header.str();
+    std::ofstream shard(dir + "/model.safetensors",
+                       std::ios::binary | std::ios::trunc);
+    if (!shard) return false;
+    const uint64_t header_len = header_text.size();
+    shard.write(reinterpret_cast<const char*>(&header_len),
+               sizeof(header_len));
+    shard.write(header_text.data(),
+               static_cast<std::streamsize>(header_text.size()));
+    std::vector<uint8_t> data(static_cast<size_t>(offset), 0);
+    uint64_t data_offset = 0;
+    for (const TensorSpec& tensor : tensors) {
+        const uint64_t bytes = numel(tensor.shape) * dtype_size(tensor.dtype);
+        if (tensor.dtype == "F8_E4M3") {
+            std::fill(data.begin() + static_cast<ptrdiff_t>(data_offset),
+                     data.begin() + static_cast<ptrdiff_t>(data_offset + bytes),
+                     static_cast<uint8_t>(0x38));
+        } else {
+            const bool embedding =
+                tensor.name.find("embed_tokens.weight") != std::string::npos;
+            const uint64_t elements = bytes / 2;
+            for (uint64_t element = 0; element < elements; ++element) {
+                uint16_t bits = 0x3f80;
+                if (embedding && !tensor.shape.empty()) {
+                    const uint64_t row = element / tensor.shape.back();
+                    bits = static_cast<uint16_t>(0x3f80u + (row & 0x1fu));
+                }
+                const uint64_t at = data_offset + element * 2;
+                data[static_cast<size_t>(at)] =
+                    static_cast<uint8_t>(bits & 0xffu);
+                data[static_cast<size_t>(at + 1)] =
+                    static_cast<uint8_t>(bits >> 8);
+            }
+        }
+        data_offset += bytes;
+    }
+    shard.write(reinterpret_cast<const char*>(data.data()),
+               static_cast<std::streamsize>(data.size()));
+    if (!shard) return false;
+
+    std::ofstream index(dir + "/model.safetensors.index.json",
+                       std::ios::binary | std::ios::trunc);
+    if (!index) return false;
+    index << "{\"metadata\":{\"total_size\":" << offset
+          << "},\"weight_map\":{";
+    for (size_t i = 0; i < tensors.size(); ++i) {
+        if (i) index << ',';
+        index << '"' << tensors[i].name << "\":\"model.safetensors\"";
+    }
+    index << "}}";
+    return static_cast<bool>(index);
+}
+
+}  // namespace qwen_fixture

--- a/cpp_engine/tests/test_qwen_batched_engine_parity.cpp
+++ b/cpp_engine/tests/test_qwen_batched_engine_parity.cpp
@@ -5,238 +5,23 @@
 
 #include "qwen_config.hpp"
 #include "qwen_engine.hpp"
+#include "qwen_parity_fixture.hpp"
 #include "cuda_ops.hpp"
 
 #include <cuda_runtime.h>
 
 #include <algorithm>
 #include <cmath>
-#include <cstdint>
-#include <cstdlib>
-#include <fstream>
 #include <iostream>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 namespace {
 
-struct TensorSpec {
-    std::string name;
-    std::string dtype;
-    std::vector<uint64_t> shape;
-};
-
-uint64_t numel(const std::vector<uint64_t>& shape) {
-    uint64_t out = 1;
-    for (uint64_t dim : shape) out *= dim;
-    return out;
-}
-
-uint64_t dtype_size(const std::string& dtype) {
-    if (dtype == "F8_E4M3") return 1;
-    if (dtype == "BF16") return 2;
-    throw std::runtime_error("unsupported fixture dtype: " + dtype);
-}
-
-std::string shape_json(const std::vector<uint64_t>& shape) {
-    std::ostringstream out;
-    out << '[';
-    for (size_t i = 0; i < shape.size(); ++i) {
-        if (i) out << ',';
-        out << shape[i];
-    }
-    out << ']';
-    return out.str();
-}
-
-std::string fixture_dir() {
-    const char* base = std::getenv("CLAUDE_JOB_DIR");
-    const std::string root = base != nullptr ? std::string(base) + "/tmp"
-                                              : std::string("/tmp");
-    return root + "/qwen_batched_engine_parity_fixture";
-}
-
-std::string config_json() {
-    // Two-layer alternating: one linear_attention, one full_attention.
-    // Context 8192 so decode at positions 4096, 5000, 6144, 7500 all fall inside
-    // the kDecodeMinContext=4096 threshold where the fused split path runs.
-    return R"JSON({
-  "architectures": ["Qwen3_5ForConditionalGeneration"],
-  "model_type": "qwen3_5",
-  "text_config": {
-    "model_type": "qwen3_5_text",
-    "vocab_size": 64,
-    "hidden_size": 128,
-    "intermediate_size": 128,
-    "num_hidden_layers": 2,
-    "num_attention_heads": 4,
-    "num_key_value_heads": 4,
-    "head_dim": 128,
-    "attn_output_gate": true,
-    "linear_num_key_heads": 4,
-    "linear_num_value_heads": 4,
-    "linear_key_head_dim": 128,
-    "linear_value_head_dim": 128,
-    "linear_conv_kernel_dim": 4,
-    "max_position_embeddings": 8192,
-    "rms_norm_eps": 1e-6,
-    "partial_rotary_factor": 0.25,
-    "rope_parameters": {"rope_type": "default", "rope_theta": 10000000},
-    "layer_types": ["linear_attention", "full_attention"]
-  }
-})JSON";
-}
-
-std::vector<TensorSpec> specs() {
-    const std::vector<uint64_t> hidden = {128};
-    const std::vector<uint64_t> vocab = {64, 128};
-    // linear_attention QKV: (q_heads + 2*kv_heads) * head_dim = (4+2*4)*128 = 1536
-    const std::vector<uint64_t> qkv = {1536, 128};
-    // FP8 block scale: ceil_div(1536, 128) × ceil_div(128, 128) = 12 × 1
-    const std::vector<uint64_t> qkv_scale = {12, 1};
-    const std::vector<uint64_t> value_proj = {512, 128};
-    // FP8 block scale: ceil_div(512, 128) × ceil_div(128, 128) = 4 × 1
-    const std::vector<uint64_t> value_scale = {4, 1};
-    const std::vector<uint64_t> out_proj = {128, 512};
-    // FP8 block scale: ceil_div(128, 128) × ceil_div(512, 128) = 1 × 4
-    const std::vector<uint64_t> out_scale = {1, 4};
-    const std::vector<uint64_t> heads = {4, 128};
-    const std::vector<uint64_t> vector4 = {4};
-    const std::vector<uint64_t> mlp = {128, 128};
-    // FP8 block scale: ceil_div(128, 128) × ceil_div(128, 128) = 1 × 1
-    const std::vector<uint64_t> mlp_scale = {1, 1};
-    // full_attention Q projection: 2x heads for GQA = 8 * 128 = 1024
-    const std::vector<uint64_t> q_proj = {1024, 128};
-    // FP8 block scale: ceil_div(1024, 128) × ceil_div(128, 128) = 8 × 1
-    const std::vector<uint64_t> q_proj_scale = {8, 1};
-    const std::string linear = "model.language_model.layers.0.";
-    const std::string full = "model.language_model.layers.1.";
-    std::vector<TensorSpec> out = {
-        {"model.language_model.embed_tokens.weight", "BF16", vocab},
-        {"model.language_model.norm.weight", "BF16", hidden},
-        {"lm_head.weight", "BF16", vocab},
-        {linear + "input_layernorm.weight", "BF16", hidden},
-        {linear + "post_attention_layernorm.weight", "BF16", hidden},
-        {linear + "linear_attn.in_proj_qkv.weight", "F8_E4M3", qkv},
-        {linear + "linear_attn.in_proj_qkv.weight_scale_inv", "BF16", qkv_scale},
-        {linear + "linear_attn.in_proj_z.weight", "F8_E4M3", value_proj},
-        {linear + "linear_attn.in_proj_z.weight_scale_inv", "BF16", value_scale},
-        {linear + "linear_attn.out_proj.weight", "F8_E4M3", out_proj},
-        {linear + "linear_attn.out_proj.weight_scale_inv", "BF16", out_scale},
-        {linear + "linear_attn.in_proj_a.weight", "BF16", heads},
-        {linear + "linear_attn.in_proj_b.weight", "BF16", heads},
-        {linear + "linear_attn.conv1d.weight", "BF16", {1536, 1, 4}},
-        {linear + "linear_attn.A_log", "BF16", vector4},
-        {linear + "linear_attn.dt_bias", "BF16", vector4},
-        {linear + "linear_attn.norm.weight", "BF16", hidden},
-        {linear + "mlp.gate_proj.weight", "F8_E4M3", mlp},
-        {linear + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale},
-        {linear + "mlp.up_proj.weight", "F8_E4M3", mlp},
-        {linear + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale},
-        {linear + "mlp.down_proj.weight", "F8_E4M3", mlp},
-        {linear + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale},
-    };
-    out.insert(out.end(), {
-        {full + "input_layernorm.weight", "BF16", hidden},
-        {full + "post_attention_layernorm.weight", "BF16", hidden},
-        {full + "self_attn.q_proj.weight", "F8_E4M3", q_proj},
-        {full + "self_attn.q_proj.weight_scale_inv", "BF16", q_proj_scale},
-        {full + "self_attn.k_proj.weight", "F8_E4M3", value_proj},
-        {full + "self_attn.k_proj.weight_scale_inv", "BF16", value_scale},
-        {full + "self_attn.v_proj.weight", "F8_E4M3", value_proj},
-        {full + "self_attn.v_proj.weight_scale_inv", "BF16", value_scale},
-        {full + "self_attn.o_proj.weight", "F8_E4M3", out_proj},
-        {full + "self_attn.o_proj.weight_scale_inv", "BF16", out_scale},
-        {full + "self_attn.q_norm.weight", "BF16", hidden},
-        {full + "self_attn.k_norm.weight", "BF16", hidden},
-        {full + "mlp.gate_proj.weight", "F8_E4M3", mlp},
-        {full + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale},
-        {full + "mlp.up_proj.weight", "F8_E4M3", mlp},
-        {full + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale},
-        {full + "mlp.down_proj.weight", "F8_E4M3", mlp},
-        {full + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale},
-    });
-    return out;
-}
-
-bool write_fixture(const std::string& dir) {
-    const std::string mkdir_cmd = "mkdir -p '" + dir + "'";
-    if (std::system(mkdir_cmd.c_str()) != 0) return false;
-    std::ofstream config(dir + "/config.json",
-                        std::ios::binary | std::ios::trunc);
-    if (!config) return false;
-    config << config_json();
-    if (!config) return false;
-
-    const auto tensors = specs();
-    std::ostringstream header;
-    header << '{';
-    uint64_t offset = 0;
-    for (size_t i = 0; i < tensors.size(); ++i) {
-        if (i) header << ',';
-        const auto& tensor = tensors[i];
-        const uint64_t bytes = numel(tensor.shape) * dtype_size(tensor.dtype);
-        header << '"' << tensor.name << "\":{\"dtype\":\"" << tensor.dtype
-               << "\",\"shape\":" << shape_json(tensor.shape)
-               << ",\"data_offsets\":[" << offset << ',' << offset + bytes
-               << "]}";
-        offset += bytes;
-    }
-    header << '}';
-    const std::string header_text = header.str();
-    std::ofstream shard(dir + "/model.safetensors",
-                       std::ios::binary | std::ios::trunc);
-    if (!shard) return false;
-    const uint64_t header_len = header_text.size();
-    shard.write(reinterpret_cast<const char*>(&header_len),
-               sizeof(header_len));
-    shard.write(header_text.data(),
-               static_cast<std::streamsize>(header_text.size()));
-    std::vector<uint8_t> data(static_cast<size_t>(offset), 0);
-    uint64_t data_offset = 0;
-    for (const TensorSpec& tensor : tensors) {
-        const uint64_t bytes = numel(tensor.shape) * dtype_size(tensor.dtype);
-        if (tensor.dtype == "F8_E4M3") {
-            std::fill(data.begin() + static_cast<ptrdiff_t>(data_offset),
-                     data.begin() + static_cast<ptrdiff_t>(data_offset + bytes),
-                     static_cast<uint8_t>(0x38));
-        } else {
-            const bool embedding =
-                tensor.name.find("embed_tokens.weight") != std::string::npos;
-            const uint64_t elements = bytes / 2;
-            for (uint64_t element = 0; element < elements; ++element) {
-                uint16_t bits = 0x3f80;
-                if (embedding && !tensor.shape.empty()) {
-                    const uint64_t row = element / tensor.shape.back();
-                    bits = static_cast<uint16_t>(0x3f80u + (row & 0x1fu));
-                }
-                const uint64_t at = data_offset + element * 2;
-                data[static_cast<size_t>(at)] =
-                    static_cast<uint8_t>(bits & 0xffu);
-                data[static_cast<size_t>(at + 1)] =
-                    static_cast<uint8_t>(bits >> 8);
-            }
-        }
-        data_offset += bytes;
-    }
-    shard.write(reinterpret_cast<const char*>(data.data()),
-               static_cast<std::streamsize>(data.size()));
-    if (!shard) return false;
-
-    std::ofstream index(dir + "/model.safetensors.index.json",
-                       std::ios::binary | std::ios::trunc);
-    if (!index) return false;
-    index << "{\"metadata\":{\"total_size\":" << offset
-          << "},\"weight_map\":{";
-    for (size_t i = 0; i < tensors.size(); ++i) {
-        if (i) index << ',';
-        index << '"' << tensors[i].name << "\":\"model.safetensors\"";
-    }
-    index << "}}";
-    return static_cast<bool>(index);
-}
+// The checkpoint fixture lives in a shared header so this test and
+// test_qwen_paged_engine_parity cannot drift onto different model geometries.
+using qwen_fixture::write_fixture;
 
 void require(bool condition, const std::string& message) {
     if (!condition) throw std::runtime_error(message);
@@ -344,7 +129,8 @@ int main() {
         return 0;
     }
     try {
-        const std::string dir = fixture_dir();
+        const std::string dir = qwen_fixture::fixture_dir(
+            "qwen_batched_engine_parity_fixture");
         require(write_fixture(dir), "could not create batched parity fixture");
         test_batched_decode_parity(dir, dsv4::QwenKvCacheDType::Fp16);
         // FP8 and TurboQuant batched decode are not yet implemented

--- a/cpp_engine/tests/test_qwen_block_pool.cpp
+++ b/cpp_engine/tests/test_qwen_block_pool.cpp
@@ -1,0 +1,267 @@
+// Host-side checks for the paged KV block pool and block table. No model and no
+// device: the point is that the logical-to-physical translation and the free
+// list are exercised without a GPU, so a translation bug is caught here rather
+// than as a divergence in a 64-layer parity run.
+
+#include "qwen_block_pool.hpp"
+#include "qwen_block_table.hpp"
+
+#include <cstdio>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const std::string& what) {
+    if (condition) return;
+    std::printf("[FAIL] %s\n", what.c_str());
+    ++failures;
+}
+
+// Returns true when `call` threw, so a bookkeeping bug is asserted to be loud
+// rather than silently accepted.
+template <typename Fn>
+bool throws(Fn&& call) {
+    try {
+        call();
+    } catch (const std::exception&) {
+        return true;
+    }
+    return false;
+}
+
+void test_pool_basics() {
+    dsv4::QwenBlockPool pool(8, 16);
+    check(pool.total_blocks() == 8, "pool total_blocks");
+    check(pool.free_blocks() == 8, "fresh pool is fully free");
+    check(pool.block_size() == 16, "pool block_size");
+
+    check(pool.blocks_for_tokens(0) == 0, "0 tokens needs no block");
+    check(pool.blocks_for_tokens(1) == 1, "1 token needs one block");
+    check(pool.blocks_for_tokens(16) == 1, "a full block is one block");
+    check(pool.blocks_for_tokens(17) == 2, "one token past a block needs two");
+
+    std::vector<int> first = pool.allocate(3);
+    check(first.size() == 3, "allocate(3) returns three blocks");
+    check(pool.free_blocks() == 5, "allocation reduces the free count");
+    for (const int block : first) {
+        check(pool.refcount(block) == 1, "a fresh block has refcount 1");
+    }
+
+    pool.free(first);
+    check(pool.free_blocks() == 8, "free returns every block");
+}
+
+void test_pool_exhaustion() {
+    dsv4::QwenBlockPool pool(4, 16);
+    std::vector<int> all = pool.allocate(4);
+    check(all.size() == 4, "the pool can be drained exactly");
+    check(pool.free_blocks() == 0, "drained pool has nothing free");
+
+    // Over-request must not partially allocate: a caller that got 2 of 3 blocks
+    // would have to hand them back, and a leak here would be invisible.
+    check(pool.allocate(1).empty(), "an exhausted pool returns empty");
+    check(pool.free_blocks() == 0, "a failed allocation takes nothing");
+
+    pool.free(all);
+    check(pool.free_blocks() == 4, "the pool recovers fully");
+
+    std::vector<int> some = pool.allocate(3);
+    check(pool.allocate(2).empty(), "an over-request returns empty");
+    check(pool.free_blocks() == 1,
+          "a failed over-request leaves the free list untouched");
+    pool.free(some);
+}
+
+void test_pool_refcounts() {
+    dsv4::QwenBlockPool pool(4, 16);
+    std::vector<int> blocks = pool.allocate(1);
+    const int block = blocks[0];
+
+    pool.retain(block);
+    check(pool.refcount(block) == 2, "retain raises the refcount");
+    pool.free({block});
+    check(pool.refcount(block) == 1, "one free of a shared block keeps it live");
+    check(pool.free_blocks() == 3, "a still-referenced block is not free");
+    pool.free({block});
+    check(pool.refcount(block) == 0, "the last free drops the refcount to 0");
+    check(pool.free_blocks() == 4, "the last free returns the block");
+
+    check(throws([&] { pool.free({block}); }),
+          "freeing an already-free block throws");
+    check(throws([&] { pool.retain(block); }),
+          "retaining a free block throws");
+    check(throws([&] { pool.refcount(99); }), "an out-of-range id throws");
+    check(throws([&] { dsv4::QwenBlockPool(0, 16); }),
+          "a zero-block pool throws");
+    check(throws([&] { dsv4::QwenBlockPool(4, 0); }),
+          "a zero-size block throws");
+
+    // kInvalidBlock is skipped so a caller can free a partially built row.
+    pool.free({dsv4::QwenBlockPool::kInvalidBlock});
+    check(pool.free_blocks() == 4, "freeing kInvalidBlock is a no-op");
+}
+
+void test_table_growth() {
+    dsv4::QwenBlockPool pool(16, 16);
+    dsv4::QwenBlockTable table(&pool, 4, 256);
+    check(table.max_blocks_per_seq() == 16, "max_blocks_per_seq from context");
+    check(table.capacity_tokens(0) == 0, "a fresh slot backs no tokens");
+
+    check(table.ensure_capacity(0, 1), "one token is backed");
+    check(table.capacity_tokens(0) == 16, "one block backs a whole block");
+    check(pool.free_blocks() == 15, "growth takes from the pool");
+
+    // Already covered: no new block, and no pool traffic.
+    check(table.ensure_capacity(0, 16), "a full block needs no growth");
+    check(pool.free_blocks() == 15, "re-covering the same tokens is free");
+
+    check(table.ensure_capacity(0, 17), "crossing a boundary grows");
+    check(table.capacity_tokens(0) == 32, "the row is now two blocks");
+    check(pool.free_blocks() == 14, "the boundary took one more block");
+
+    table.release(0);
+    check(table.capacity_tokens(0) == 0, "release empties the row");
+    check(pool.free_blocks() == 16, "release returns every block");
+}
+
+void test_table_translation() {
+    dsv4::QwenBlockPool pool(8, 4);
+    dsv4::QwenBlockTable table(&pool, 2, 32);
+    const size_t kv_stride = 8;  // kv_heads * head_dim, small enough to check
+
+    check(table.ensure_capacity(0, 12), "slot 0 backed to 12 tokens");
+    const std::vector<int>& row = table.row(0);
+    check(row.size() == 3, "12 tokens over block_size 4 is three blocks");
+
+    // Position p lives at (block[p / 4] * 4 + p % 4) * kv_stride. Spot-check
+    // both ends of each block rather than trusting the first one.
+    for (int position = 0; position < 12; ++position) {
+        const int block = row[static_cast<size_t>(position / 4)];
+        const size_t expected =
+            (static_cast<size_t>(block) * 4 + static_cast<size_t>(position % 4)) *
+            kv_stride;
+        check(table.element_offset(0, position, kv_stride) == expected,
+              "offset for position " + std::to_string(position));
+    }
+
+    check(throws([&] { table.element_offset(0, 12, kv_stride); }),
+          "an unbacked position throws");
+    check(throws([&] { table.element_offset(5, 0, kv_stride); }),
+          "an out-of-range slot throws");
+    table.release_all();
+}
+
+// The trap this whole test file exists for: if every sequence happens to own one
+// contiguous run of blocks, a completely wrong translation still passes. Freeing
+// an interleaved slot forces slot 2's row to be non-monotonic, and the offsets
+// must follow the row rather than the position.
+void test_table_fragmentation() {
+    dsv4::QwenBlockPool pool(6, 4);
+    dsv4::QwenBlockTable table(&pool, 3, 32);
+
+    check(table.ensure_capacity(0, 8), "slot 0 takes two blocks");
+    check(table.ensure_capacity(1, 8), "slot 1 takes two blocks");
+    const std::vector<int> freed = table.row(1);
+    table.release(1);
+    check(table.ensure_capacity(2, 16), "slot 2 takes the recycled blocks");
+
+    const std::vector<int>& row = table.row(2);
+    check(row.size() == 4, "slot 2 holds four blocks");
+    bool contiguous = true;
+    for (size_t index = 1; index < row.size(); ++index) {
+        if (row[index] != row[index - 1] + 1) contiguous = false;
+    }
+    check(!contiguous,
+          "slot 2's blocks are non-contiguous, so the case is real");
+
+    std::set<int> distinct(row.begin(), row.end());
+    check(distinct.size() == row.size(), "no block is handed out twice");
+    for (const int block : freed) {
+        check(distinct.count(block) == 1, "a freed block is reused");
+    }
+
+    const size_t kv_stride = 4;
+    for (int position = 0; position < 16; ++position) {
+        const int block = row[static_cast<size_t>(position / 4)];
+        const size_t expected =
+            (static_cast<size_t>(block) * 4 + static_cast<size_t>(position % 4)) *
+            kv_stride;
+        check(table.element_offset(2, position, kv_stride) == expected,
+              "fragmented offset for position " + std::to_string(position));
+    }
+
+    // Slot 0 must be undisturbed by its neighbours' churn.
+    check(table.capacity_tokens(0) == 8, "slot 0 kept its blocks");
+    table.release_all();
+    check(pool.free_blocks() == 6, "release_all drains every row");
+}
+
+void test_table_backpressure() {
+    dsv4::QwenBlockPool pool(2, 4);
+    dsv4::QwenBlockTable table(&pool, 2, 64);
+
+    check(table.ensure_capacity(0, 8), "slot 0 drains the pool");
+    check(pool.free_blocks() == 0, "the pool is drained");
+    // Exhaustion is backpressure, not an error: the scheduler leaves the request
+    // waiting, so this returns false rather than throwing.
+    check(!table.ensure_capacity(1, 4), "growth fails when the pool is empty");
+    check(table.capacity_tokens(1) == 0, "a failed growth backs nothing");
+
+    table.release(0);
+    check(table.ensure_capacity(1, 8), "slot 1 succeeds once blocks return");
+    check(throws([&] { table.ensure_capacity(1, 65); }),
+          "exceeding max_context throws rather than reporting backpressure");
+    table.release_all();
+}
+
+void test_device_image() {
+    dsv4::QwenBlockPool pool(8, 4);
+    dsv4::QwenBlockTable table(&pool, 2, 16);
+    check(table.dirty(), "a fresh table needs its first upload");
+
+    check(table.ensure_capacity(0, 8), "slot 0 backed");
+    const std::vector<int32_t>& image = table.device_image();
+    check(image.size() == 2 * 4, "the image is max_slots x max_blocks_per_seq");
+    check(!table.dirty(), "building the image clears the dirty flag");
+
+    const std::vector<int>& row = table.row(0);
+    check(image[0] == row[0] && image[1] == row[1], "row 0 is mirrored");
+    // Unbacked entries must be kInvalidBlock, not zero: block 0 is a real block,
+    // so zero padding would alias a live block into every short row.
+    check(image[2] == dsv4::QwenBlockPool::kInvalidBlock,
+          "unbacked entries are kInvalidBlock");
+    check(image[4] == dsv4::QwenBlockPool::kInvalidBlock,
+          "an empty slot's row is all kInvalidBlock");
+
+    // A decode step that crosses no boundary must not force an upload.
+    check(table.ensure_capacity(0, 8), "no growth needed");
+    check(!table.dirty(), "a no-op growth leaves the image clean");
+    check(table.ensure_capacity(0, 9), "crossing a boundary grows");
+    check(table.dirty(), "growth marks the image dirty");
+    table.release_all();
+}
+
+}  // namespace
+
+int main() {
+    test_pool_basics();
+    test_pool_exhaustion();
+    test_pool_refcounts();
+    test_table_growth();
+    test_table_translation();
+    test_table_fragmentation();
+    test_table_backpressure();
+    test_device_image();
+
+    if (failures != 0) {
+        std::printf("%d block pool check(s) failed\n", failures);
+        return 1;
+    }
+    std::printf("All block pool and block table checks passed\n");
+    return 0;
+}

--- a/cpp_engine/tests/test_qwen_paged_engine_parity.cpp
+++ b/cpp_engine/tests/test_qwen_paged_engine_parity.cpp
@@ -1,0 +1,265 @@
+// End-to-end parity: a paged KV cache must produce the same tokens as the
+// contiguous arena, through the real engine entry points.
+//
+// The kernel-level test (test_qwen_paged_kv_kernels) pins the block arithmetic
+// against fragmented tables. This test covers what that one cannot: that the
+// engine reserves blocks at the right moments, uploads the table before the
+// forward that reads it, returns blocks when a request finishes, and that a slot
+// reusing another's freed blocks still decodes correctly. Those are ordering
+// properties of the engine, invisible to a kernel test.
+//
+// Both engines run the same prompts in the same slots, so any divergence is
+// attributable to paging alone.
+
+#include "qwen_config.hpp"
+#include "qwen_engine.hpp"
+#include "qwen_parity_fixture.hpp"
+#include "cuda_ops.hpp"
+
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const std::string& message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+constexpr int kMaxContext = 8192;
+constexpr int kSlots = 8;
+constexpr int kBlockSize = 256;
+
+dsv4::QwenEngineOptions base_options() {
+    dsv4::QwenEngineOptions options;
+    options.tp_world = 1;
+    options.tp_rank = 0;
+    options.device = 0;
+    options.prefill_chunk_tokens = 1024;
+    options.kv_cache_dtype = dsv4::QwenKvCacheDType::Fp16;
+    options.prefix_cache = false;
+    options.max_batch_size = kSlots;
+    return options;
+}
+
+dsv4::QwenEngineOptions paged_options() {
+    dsv4::QwenEngineOptions options = base_options();
+    options.kv_paged = true;
+    options.kv_block_size = kBlockSize;
+    return options;
+}
+
+std::vector<int> prompt_for(int seq, int length) {
+    std::vector<int> tokens(static_cast<size_t>(length));
+    for (int i = 0; i < length; ++i) {
+        tokens[static_cast<size_t>(i)] = (seq * 7 + i) % 64;
+    }
+    return tokens;
+}
+
+void compare(const dsv4::QwenForwardResult& contiguous,
+             const dsv4::QwenForwardResult& paged, const std::string& label) {
+    require(contiguous.top_token == paged.top_token,
+            label + " top_token mismatch: contiguous " +
+                std::to_string(contiguous.top_token) + " vs paged " +
+                std::to_string(paged.top_token));
+    require(contiguous.position == paged.position,
+            label + " position mismatch");
+    // Bit-exact is the right bar: both paths run the same kernels over the same
+    // values in the same order, so any difference in the reduction would be a
+    // real addressing or ordering bug rather than arithmetic noise.
+    require(contiguous.checksum == paged.checksum,
+            label + " checksum mismatch: contiguous " +
+                std::to_string(contiguous.checksum) + " vs paged " +
+                std::to_string(paged.checksum));
+    require(contiguous.top_logit == paged.top_logit,
+            label + " top_logit mismatch");
+}
+
+// ============================================================================
+// Prefill then a run of decode steps, on several slots. The decode run is long
+// enough to cross block boundaries, which is where a missing reservation or a
+// stale table upload shows up.
+// ============================================================================
+void test_prefill_decode_parity(const std::string& dir) {
+    const std::vector<int> prompt_lens = {700, 1024, 2049};
+    const std::vector<int> slots = {1, 3, 6};
+    const int decode_steps = 600;  // Crosses at least two 256-token blocks.
+
+    dsv4::QwenEngine contiguous(dir, base_options(), 2, kMaxContext);
+    contiguous.allocate_batch_slots(kSlots);
+    dsv4::QwenEngine paged(dir, paged_options(), 2, kMaxContext);
+    paged.allocate_batch_slots(kSlots);
+
+    require(paged.runtime_telemetry().kv_paged_blocks > 0,
+            "paged engine did not report a block pool");
+    require(paged.runtime_telemetry().kv_paged_block_size == kBlockSize,
+            "paged engine reported the wrong block size");
+    require(contiguous.runtime_telemetry().kv_paged_blocks == 0,
+            "contiguous engine reported a block pool");
+
+    for (size_t seq = 0; seq < prompt_lens.size(); ++seq) {
+        const int slot = slots[seq];
+        const std::vector<int> tokens =
+            prompt_for(static_cast<int>(seq), prompt_lens[seq]);
+        compare(contiguous.prefill(tokens, slot), paged.prefill(tokens, slot),
+                "prefill seq=" + std::to_string(seq));
+    }
+
+    for (int step = 0; step < decode_steps; ++step) {
+        for (size_t seq = 0; seq < slots.size(); ++seq) {
+            const int slot = slots[seq];
+            const int token = (static_cast<int>(seq) * 13 + step * 3 + 5) % 64;
+            compare(contiguous.decode_step(token, slot),
+                    paged.decode_step(token, slot),
+                    "decode step=" + std::to_string(step) +
+                        " seq=" + std::to_string(seq));
+        }
+    }
+    std::cout << "  prefill + " << decode_steps
+              << " decode steps on " << slots.size()
+              << " slots: token-exact PASS\n";
+}
+
+// ============================================================================
+// Batched decode. This is the path that reads blocks natively rather than
+// through the gather, so it is the one where a wrong block table produces wrong
+// attention rather than a crash.
+// ============================================================================
+void test_batched_decode_parity(const std::string& dir) {
+    const std::vector<int> prompt_lens = {4096, 5000, 6144, 7500};
+    const std::vector<int> slots = {1, 3, 5, 6};
+    const int steps = 40;
+
+    dsv4::QwenEngine contiguous(dir, base_options(), 2, kMaxContext);
+    contiguous.allocate_batch_slots(kSlots);
+    dsv4::QwenEngine paged(dir, paged_options(), 2, kMaxContext);
+    paged.allocate_batch_slots(kSlots);
+
+    for (size_t seq = 0; seq < prompt_lens.size(); ++seq) {
+        const std::vector<int> tokens =
+            prompt_for(static_cast<int>(seq), prompt_lens[seq]);
+        (void)contiguous.prefill(tokens, slots[seq]);
+        (void)paged.prefill(tokens, slots[seq]);
+    }
+
+    for (int step = 0; step < steps; ++step) {
+        std::vector<int> tokens(slots.size());
+        for (size_t seq = 0; seq < slots.size(); ++seq) {
+            tokens[seq] = (static_cast<int>(seq) * 13 + step * 7 + 42) % 64;
+        }
+        const std::vector<dsv4::QwenForwardResult> reference =
+            contiguous.batch_decode_tokens(tokens, slots);
+        const std::vector<dsv4::QwenForwardResult> actual =
+            paged.batch_decode_tokens(tokens, slots);
+        require(reference.size() == actual.size(),
+                "batch result count mismatch");
+        for (size_t seq = 0; seq < reference.size(); ++seq) {
+            compare(reference[seq], actual[seq],
+                    "batched step=" + std::to_string(step) +
+                        " seq=" + std::to_string(seq));
+        }
+    }
+    std::cout << "  batched decode: " << slots.size() << " rows x " << steps
+              << " steps at 4k-7.5k context: token-exact PASS\n";
+}
+
+// ============================================================================
+// Blocks are returned and reused. A long request runs, finishes, and a second
+// request on a different slot then runs on the blocks the first gave back. If
+// free_slot did not release them, the pool here is too small for the
+// second request and reservation fails.
+// ============================================================================
+void test_block_reuse(const std::string& dir) {
+    dsv4::QwenEngineOptions options = paged_options();
+    // Room for roughly one max-context sequence, so the second request can only
+    // succeed by reusing the first's blocks.
+    const int elements_per_token = 4 * 128;  // kv_heads * head_dim in the fixture
+    options.kv_cache_bytes = static_cast<uint64_t>(kMaxContext + kBlockSize) *
+                             elements_per_token * sizeof(uint16_t) * 2;
+    dsv4::QwenEngine engine(dir, options, 2, kMaxContext);
+    engine.allocate_batch_slots(kSlots);
+
+    const int blocks = engine.runtime_telemetry().kv_paged_blocks;
+    require(blocks > 0, "reuse fixture has no blocks");
+
+    // First request: most of the pool, on slot 0.
+    const int slot_a = engine.allocate_slot(1001);
+    require(slot_a >= 0, "could not acquire first slot");
+    const std::vector<int> long_prompt = prompt_for(0, 6000);
+    const dsv4::QwenForwardResult first = engine.prefill(long_prompt, slot_a);
+    require(first.position == 6000, "first prefill position");
+    engine.free_slot(1001);
+
+    // Second request of the same size on a different slot. Without the release
+    // this throws, since 6000 more tokens do not fit alongside the first.
+    const int slot_b = engine.allocate_slot(1002);
+    require(slot_b >= 0, "could not acquire second slot");
+    const dsv4::QwenForwardResult second = engine.prefill(long_prompt, slot_b);
+    require(second.position == 6000, "second prefill position");
+    // Same prompt, same weights, different slot: the result must not depend on
+    // which physical blocks happened to back it.
+    compare(first, second, "reused-block prefill");
+    engine.free_slot(1002);
+    std::cout << "  block reuse across requests (" << blocks
+              << "-block pool, 2 x 6000 tokens): PASS\n";
+}
+
+// ============================================================================
+// A pool too small for one max-context sequence is rejected at construction
+// rather than at the token that runs out, since no scheduler could recover from
+// the latter.
+// ============================================================================
+void test_undersized_pool_rejected(const std::string& dir) {
+    dsv4::QwenEngineOptions options = paged_options();
+    options.kv_cache_bytes = 64 * 1024;  // Far below one sequence.
+    bool threw = false;
+    try {
+        dsv4::QwenEngine engine(dir, options, 2, kMaxContext);
+    } catch (const std::exception&) {
+        threw = true;
+    }
+    require(threw, "undersized block pool was accepted");
+
+    // A quantized cache cannot be paged, and saying so beats silently running
+    // contiguous.
+    dsv4::QwenEngineOptions fp8 = paged_options();
+    fp8.kv_cache_dtype = dsv4::QwenKvCacheDType::Fp8;
+    threw = false;
+    try {
+        dsv4::QwenEngine engine(dir, fp8, 2, kMaxContext);
+    } catch (const std::exception&) {
+        threw = true;
+    }
+    require(threw, "paged FP8 cache was accepted");
+    std::cout << "  undersized pool and paged-FP8 both rejected: PASS\n";
+}
+
+}  // namespace
+
+int main() {
+    if (!dsv4::cuda_runtime_available()) {
+        std::cout << "[SKIP] test_qwen_paged_engine_parity requires CUDA\n";
+        return 0;
+    }
+    try {
+        const std::string dir =
+            qwen_fixture::fixture_dir("qwen_paged_engine_parity_fixture");
+        require(qwen_fixture::write_fixture(dir),
+                "could not create paged parity fixture");
+        test_prefill_decode_parity(dir);
+        test_batched_decode_parity(dir);
+        test_block_reuse(dir);
+        test_undersized_pool_rejected(dir);
+        std::cout << "[PASS] test_qwen_paged_engine_parity\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cout << "[FAIL] test_qwen_paged_engine_parity " << ex.what()
+                  << "\n";
+        return 1;
+    }
+}

--- a/cpp_engine/tests/test_qwen_paged_kv_kernels.cpp
+++ b/cpp_engine/tests/test_qwen_paged_kv_kernels.cpp
@@ -1,0 +1,525 @@
+// Bit-exact parity between the paged KV kernels and their contiguous
+// equivalents: append, batched append, batched decode attention, and the gather
+// that feeds the single-sequence read path.
+//
+// The block tables here are deliberately fragmented and shuffled, so a slot's
+// logical positions map to non-monotonic physical blocks interleaved with other
+// slots'. A kernel that quietly kept contiguous arithmetic, or that translated
+// only the first position of a block, produces different numbers under such a
+// table; one tested against an identity mapping would not notice either bug.
+//
+// Random K/V and Q are used rather than the near-uniform weights of the engine
+// fixtures, so that a misaddressed token changes the softmax result instead of
+// being averaged away.
+
+#include "qwen_block_pool.hpp"
+#include "qwen_block_table.hpp"
+#include "qwen_cuda_ops.hpp"
+#include "cuda_ops.hpp"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void check(cudaError_t error, const char* what) {
+    if (error != cudaSuccess) {
+        throw std::runtime_error(std::string(what) + ": " +
+                                 cudaGetErrorString(error));
+    }
+}
+
+void require(bool condition, const std::string& message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+uint16_t to_half(float value) {
+    uint16_t bits = 0;
+    const __half h = __float2half(value);
+    std::memcpy(&bits, &h, sizeof(bits));
+    return bits;
+}
+
+float from_half(uint16_t bits) {
+    __half h;
+    std::memcpy(&h, &bits, sizeof(h));
+    return __half2float(h);
+}
+
+// Device buffer that frees itself, so a failing require() does not leak.
+template <typename T>
+class DeviceBuffer {
+public:
+    explicit DeviceBuffer(size_t elements) : elements_(elements) {
+        check(cudaMalloc(&data_, elements * sizeof(T)), "cudaMalloc");
+        check(cudaMemset(data_, 0, elements * sizeof(T)), "cudaMemset");
+    }
+    ~DeviceBuffer() { if (data_ != nullptr) cudaFree(data_); }
+    DeviceBuffer(const DeviceBuffer&) = delete;
+    DeviceBuffer& operator=(const DeviceBuffer&) = delete;
+
+    T* get() { return static_cast<T*>(data_); }
+    const T* get() const { return static_cast<const T*>(data_); }
+
+    void upload(const std::vector<T>& host) {
+        check(cudaMemcpy(data_, host.data(), host.size() * sizeof(T),
+                         cudaMemcpyHostToDevice), "upload");
+    }
+
+    std::vector<T> download() const {
+        std::vector<T> host(elements_);
+        check(cudaMemcpy(host.data(), data_, elements_ * sizeof(T),
+                         cudaMemcpyDeviceToHost), "download");
+        return host;
+    }
+
+private:
+    void* data_ = nullptr;
+    size_t elements_;
+};
+
+struct Geometry {
+    int q_heads = 8;
+    int kv_heads = 2;
+    int head_dim = 128;
+    int block_size = 16;
+
+    int kv_stride() const { return kv_heads * head_dim; }
+};
+
+// A table whose rows interleave: slot 0 takes blocks 0, 2, 4..., slot 1 takes
+// 1, 3, 5..., then each row is shuffled. Nothing about a slot's physical layout
+// is then contiguous or ordered, which is the case the arena arithmetic cannot
+// express.
+std::vector<int32_t> fragmented_table(const std::vector<int>& context_lens,
+                                      int block_size, int max_blocks_per_seq,
+                                      unsigned seed) {
+    const size_t slots = context_lens.size();
+    std::vector<int32_t> image(slots * static_cast<size_t>(max_blocks_per_seq),
+                              dsv4::QwenBlockPool::kInvalidBlock);
+    std::mt19937 rng(seed);
+    int next = 0;
+    std::vector<std::vector<int>> rows(slots);
+    // Round-robin one block at a time across slots, so consecutive physical
+    // blocks belong to different sequences.
+    bool progress = true;
+    std::vector<int> needed(slots);
+    for (size_t slot = 0; slot < slots; ++slot) {
+        needed[slot] = (context_lens[slot] + block_size - 1) / block_size;
+    }
+    while (progress) {
+        progress = false;
+        for (size_t slot = 0; slot < slots; ++slot) {
+            if (static_cast<int>(rows[slot].size()) < needed[slot]) {
+                rows[slot].push_back(next++);
+                progress = true;
+            }
+        }
+    }
+    for (size_t slot = 0; slot < slots; ++slot) {
+        std::shuffle(rows[slot].begin(), rows[slot].end(), rng);
+        for (size_t index = 0; index < rows[slot].size(); ++index) {
+            image[slot * static_cast<size_t>(max_blocks_per_seq) + index] =
+                static_cast<int32_t>(rows[slot][index]);
+        }
+    }
+    return image;
+}
+
+int total_blocks(const std::vector<int32_t>& image) {
+    int highest = -1;
+    for (const int32_t block : image) highest = std::max(highest, block);
+    return highest + 1;
+}
+
+std::vector<uint16_t> random_half(size_t count, unsigned seed) {
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<uint16_t> out(count);
+    for (size_t i = 0; i < count; ++i) out[i] = to_half(dist(rng));
+    return out;
+}
+
+// ============================================================================
+// The host-side reference for a paged read. Deliberately written from the block
+// table rather than from the kernel's arithmetic, so it fails if the two agree
+// on a wrong answer.
+// ============================================================================
+size_t paged_offset(const std::vector<int32_t>& image, int slot, int position,
+                    int max_blocks_per_seq, int block_size, int kv_stride) {
+    const int32_t block = image[static_cast<size_t>(slot) * max_blocks_per_seq +
+                                position / block_size];
+    return (static_cast<size_t>(block) * block_size + position % block_size) *
+           static_cast<size_t>(kv_stride);
+}
+
+// ============================================================================
+// Test 1: single-sequence paged append lands every token where the table says.
+// ============================================================================
+void test_paged_append(const Geometry& geometry) {
+    const int context = 300;  // Not a block multiple: exercises the partial tail.
+    const int block_size = geometry.block_size;
+    const int max_blocks = (context + block_size - 1) / block_size;
+    const std::vector<int32_t> image =
+        fragmented_table({context}, block_size, max_blocks, 11u);
+    const int blocks = total_blocks(image);
+
+    const size_t arena = static_cast<size_t>(blocks) * block_size *
+                         geometry.kv_stride();
+    const std::vector<uint16_t> k_host =
+        random_half(static_cast<size_t>(context) * geometry.kv_stride(), 12u);
+    const std::vector<uint16_t> v_host =
+        random_half(static_cast<size_t>(context) * geometry.kv_stride(), 13u);
+
+    DeviceBuffer<uint16_t> k_rows(k_host.size());
+    DeviceBuffer<uint16_t> v_rows(v_host.size());
+    DeviceBuffer<uint16_t> k_cache(arena);
+    DeviceBuffer<uint16_t> v_cache(arena);
+    DeviceBuffer<int32_t> table(image.size());
+    k_rows.upload(k_host);
+    v_rows.upload(v_host);
+    table.upload(image);
+
+    // Two appends, so the second starts at a non-zero and non-block-aligned
+    // offset the way a decode step after a prefill does.
+    const int first = 291;
+    require(dsv4::qwen_append_kv_cache_f16_paged_cuda(
+                k_rows.get(), v_rows.get(), k_cache.get(), v_cache.get(),
+                first, geometry.kv_heads, geometry.head_dim, 0, table.get(),
+                block_size),
+            "paged append (prefill) launch");
+    require(dsv4::qwen_append_kv_cache_f16_paged_cuda(
+                k_rows.get() + static_cast<size_t>(first) * geometry.kv_stride(),
+                v_rows.get() + static_cast<size_t>(first) * geometry.kv_stride(),
+                k_cache.get(), v_cache.get(), context - first,
+                geometry.kv_heads, geometry.head_dim, first, table.get(),
+                block_size),
+            "paged append (decode) launch");
+    check(cudaDeviceSynchronize(), "paged append sync");
+
+    const std::vector<uint16_t> k_arena = k_cache.download();
+    const std::vector<uint16_t> v_arena = v_cache.download();
+    for (int position = 0; position < context; ++position) {
+        const size_t at = paged_offset(image, 0, position, max_blocks,
+                                       block_size, geometry.kv_stride());
+        for (int element = 0; element < geometry.kv_stride(); ++element) {
+            const size_t source =
+                static_cast<size_t>(position) * geometry.kv_stride() + element;
+            require(k_arena[at + element] == k_host[source],
+                    "paged append K mismatch at position " +
+                        std::to_string(position));
+            require(v_arena[at + element] == v_host[source],
+                    "paged append V mismatch at position " +
+                        std::to_string(position));
+        }
+    }
+    std::cout << "  paged append: " << context
+              << " tokens across a shuffled table PASS\n";
+}
+
+// ============================================================================
+// Test 2: the gather reproduces the dense layout the read kernels index, so the
+// single-sequence prefill and decode paths see exactly what a contiguous cache
+// would have given them.
+// ============================================================================
+void test_paged_gather(const Geometry& geometry) {
+    const int context = 517;
+    const int block_size = geometry.block_size;
+    const int max_blocks = (context + block_size - 1) / block_size;
+    const std::vector<int32_t> image =
+        fragmented_table({context}, block_size, max_blocks, 21u);
+    const int blocks = total_blocks(image);
+
+    const size_t arena = static_cast<size_t>(blocks) * block_size *
+                         geometry.kv_stride();
+    const size_t dense_elements =
+        static_cast<size_t>(context) * geometry.kv_stride();
+    const std::vector<uint16_t> k_host = random_half(dense_elements, 22u);
+    const std::vector<uint16_t> v_host = random_half(dense_elements, 23u);
+
+    // Scatter through the append kernel, gather back, and require the round trip
+    // to be the identity on the dense layout.
+    DeviceBuffer<uint16_t> k_rows(dense_elements);
+    DeviceBuffer<uint16_t> v_rows(dense_elements);
+    DeviceBuffer<uint16_t> k_cache(arena);
+    DeviceBuffer<uint16_t> v_cache(arena);
+    DeviceBuffer<uint16_t> k_dense(dense_elements);
+    DeviceBuffer<uint16_t> v_dense(dense_elements);
+    DeviceBuffer<int32_t> table(image.size());
+    k_rows.upload(k_host);
+    v_rows.upload(v_host);
+    table.upload(image);
+
+    require(dsv4::qwen_append_kv_cache_f16_paged_cuda(
+                k_rows.get(), v_rows.get(), k_cache.get(), v_cache.get(),
+                context, geometry.kv_heads, geometry.head_dim, 0, table.get(),
+                block_size),
+            "gather test append launch");
+    require(dsv4::qwen_gather_kv_cache_f16_paged_cuda(
+                k_cache.get(), v_cache.get(), k_dense.get(), v_dense.get(),
+                context, geometry.kv_heads, geometry.head_dim, table.get(),
+                block_size),
+            "paged gather launch");
+    check(cudaDeviceSynchronize(), "paged gather sync");
+
+    const std::vector<uint16_t> k_out = k_dense.download();
+    const std::vector<uint16_t> v_out = v_dense.download();
+    for (size_t element = 0; element < dense_elements; ++element) {
+        require(k_out[element] == k_host[element],
+                "gather K round-trip mismatch at " + std::to_string(element));
+        require(v_out[element] == v_host[element],
+                "gather V round-trip mismatch at " + std::to_string(element));
+    }
+    std::cout << "  paged gather: " << context
+              << " tokens round-trip bit-exact PASS\n";
+}
+
+// ============================================================================
+// Test 3: batched append, where each row has its own slot and its own position,
+// and the slots' blocks are interleaved in the arena.
+// ============================================================================
+void test_paged_batched_append(const Geometry& geometry) {
+    const std::vector<int> positions = {0, 15, 16, 4095, 137};
+    const std::vector<int> slots = {3, 0, 4, 1, 2};
+    const int rows = static_cast<int>(positions.size());
+    const int max_context = 4096;
+    const int block_size = geometry.block_size;
+    const int max_blocks = (max_context + block_size - 1) / block_size;
+
+    // Every slot is backed for the whole context, so position 4095 is reachable.
+    std::vector<int> lens(5, max_context);
+    const std::vector<int32_t> image =
+        fragmented_table(lens, block_size, max_blocks, 31u);
+    const int blocks = total_blocks(image);
+
+    const size_t arena = static_cast<size_t>(blocks) * block_size *
+                         geometry.kv_stride();
+    const size_t row_elements =
+        static_cast<size_t>(rows) * geometry.kv_stride();
+    const std::vector<uint16_t> k_host = random_half(row_elements, 32u);
+    const std::vector<uint16_t> v_host = random_half(row_elements, 33u);
+
+    DeviceBuffer<uint16_t> k_rows(row_elements);
+    DeviceBuffer<uint16_t> v_rows(row_elements);
+    DeviceBuffer<uint16_t> k_cache(arena);
+    DeviceBuffer<uint16_t> v_cache(arena);
+    DeviceBuffer<int32_t> table(image.size());
+    DeviceBuffer<int32_t> d_positions(positions.size());
+    DeviceBuffer<int32_t> d_slots(slots.size());
+    k_rows.upload(k_host);
+    v_rows.upload(v_host);
+    table.upload(image);
+    d_positions.upload(std::vector<int32_t>(positions.begin(), positions.end()));
+    d_slots.upload(std::vector<int32_t>(slots.begin(), slots.end()));
+
+    require(dsv4::qwen_append_kv_cache_f16_batched_cuda(
+                k_rows.get(), v_rows.get(), k_cache.get(), v_cache.get(), rows,
+                geometry.kv_heads, geometry.head_dim, d_positions.get(),
+                d_slots.get(), max_context, /*kv_slot_stride=*/0, table.get(),
+                block_size, max_blocks),
+            "paged batched append launch");
+    check(cudaDeviceSynchronize(), "paged batched append sync");
+
+    const std::vector<uint16_t> k_arena = k_cache.download();
+    const std::vector<uint16_t> v_arena = v_cache.download();
+    for (int row = 0; row < rows; ++row) {
+        const size_t at = paged_offset(image, slots[static_cast<size_t>(row)],
+                                       positions[static_cast<size_t>(row)],
+                                       max_blocks, block_size,
+                                       geometry.kv_stride());
+        for (int element = 0; element < geometry.kv_stride(); ++element) {
+            const size_t source =
+                static_cast<size_t>(row) * geometry.kv_stride() + element;
+            require(k_arena[at + element] == k_host[source],
+                    "batched paged append K mismatch on row " +
+                        std::to_string(row));
+            require(v_arena[at + element] == v_host[source],
+                    "batched paged append V mismatch on row " +
+                        std::to_string(row));
+        }
+    }
+    std::cout << "  paged batched append: " << rows
+              << " rows in interleaved slots PASS\n";
+}
+
+// ============================================================================
+// Test 4: batched decode attention. The same K/V history and the same queries
+// are laid out both ways, and the two launches must agree to the bit. This is
+// the load-bearing case: batched decode reads the blocks natively rather than
+// going through the gather.
+// ============================================================================
+void test_paged_batched_decode(const Geometry& geometry, int attention_window,
+                               int sink_tokens, const char* label) {
+    // Context lengths that straddle the split-kernel threshold and land both on
+    // and off block boundaries.
+    const std::vector<int> context_lens = {4096, 63, 5000, 16, 1};
+    const std::vector<int> slots = {2, 4, 0, 3, 1};
+    const int rows = static_cast<int>(context_lens.size());
+    const int max_context = 8192;
+    const int block_size = geometry.block_size;
+    const int max_blocks = (max_context + block_size - 1) / block_size;
+    const int max_context_len =
+        *std::max_element(context_lens.begin(), context_lens.end());
+
+    // Contiguous reference: slot s owns [s * max_context, (s+1) * max_context).
+    const size_t slot_stride =
+        static_cast<size_t>(max_context) * geometry.kv_stride();
+    const int slot_count = 5;
+    const size_t contiguous_elements =
+        static_cast<size_t>(slot_count) * slot_stride;
+
+    std::vector<int> lens(static_cast<size_t>(slot_count), 0);
+    for (int row = 0; row < rows; ++row) {
+        lens[static_cast<size_t>(slots[static_cast<size_t>(row)])] =
+            context_lens[static_cast<size_t>(row)];
+    }
+    const std::vector<int32_t> image =
+        fragmented_table(lens, block_size, max_blocks, 41u);
+    const int blocks = total_blocks(image);
+    const size_t arena = static_cast<size_t>(blocks) * block_size *
+                         geometry.kv_stride();
+
+    // One K/V history per slot, written into both layouts from the same host
+    // data so the only difference is the addressing.
+    std::vector<uint16_t> k_contiguous(contiguous_elements, 0);
+    std::vector<uint16_t> v_contiguous(contiguous_elements, 0);
+    std::vector<uint16_t> k_paged(arena, 0);
+    std::vector<uint16_t> v_paged(arena, 0);
+    std::mt19937 rng(42u);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    for (int slot = 0; slot < slot_count; ++slot) {
+        for (int position = 0; position < lens[static_cast<size_t>(slot)];
+             ++position) {
+            const size_t dense = static_cast<size_t>(slot) * slot_stride +
+                static_cast<size_t>(position) * geometry.kv_stride();
+            const size_t paged = paged_offset(image, slot, position, max_blocks,
+                                              block_size, geometry.kv_stride());
+            for (int element = 0; element < geometry.kv_stride(); ++element) {
+                const uint16_t k_value = to_half(dist(rng));
+                const uint16_t v_value = to_half(dist(rng));
+                k_contiguous[dense + element] = k_value;
+                v_contiguous[dense + element] = v_value;
+                k_paged[paged + element] = k_value;
+                v_paged[paged + element] = v_value;
+            }
+        }
+    }
+
+    const size_t q_elements =
+        static_cast<size_t>(rows) * geometry.q_heads * geometry.head_dim;
+    const std::vector<uint16_t> q_host = random_half(q_elements, 43u);
+
+    DeviceBuffer<uint16_t> d_q(q_elements);
+    DeviceBuffer<uint16_t> d_k_contiguous(contiguous_elements);
+    DeviceBuffer<uint16_t> d_v_contiguous(contiguous_elements);
+    DeviceBuffer<uint16_t> d_k_paged(arena);
+    DeviceBuffer<uint16_t> d_v_paged(arena);
+    DeviceBuffer<uint16_t> d_out_contiguous(q_elements);
+    DeviceBuffer<uint16_t> d_out_paged(q_elements);
+    DeviceBuffer<int32_t> d_context_lens(context_lens.size());
+    DeviceBuffer<int32_t> d_slots(slots.size());
+    DeviceBuffer<int32_t> d_table(image.size());
+
+    d_q.upload(q_host);
+    d_k_contiguous.upload(k_contiguous);
+    d_v_contiguous.upload(v_contiguous);
+    d_k_paged.upload(k_paged);
+    d_v_paged.upload(v_paged);
+    d_context_lens.upload(
+        std::vector<int32_t>(context_lens.begin(), context_lens.end()));
+    d_slots.upload(std::vector<int32_t>(slots.begin(), slots.end()));
+    d_table.upload(image);
+
+    const int splits = dsv4::qwen_gqa_decode_batched_split_count(
+        max_context_len, geometry.kv_heads, attention_window, sink_tokens);
+    require(splits > 0, "split geometry");
+    const size_t partial_elements = static_cast<size_t>(rows) *
+        geometry.q_heads * splits * (geometry.head_dim + 2);
+    DeviceBuffer<float> d_partials_contiguous(partial_elements);
+    DeviceBuffer<float> d_partials_paged(partial_elements);
+
+    require(dsv4::qwen_gqa_decode_attention_f16_batched_cuda(
+                d_q.get(), d_k_contiguous.get(), d_v_contiguous.get(),
+                d_out_contiguous.get(), d_partials_contiguous.get(),
+                d_context_lens.get(), d_slots.get(), rows, max_context_len,
+                slot_stride, geometry.q_heads, geometry.kv_heads,
+                geometry.head_dim, max_context, attention_window, sink_tokens),
+            "contiguous batched decode launch");
+    require(dsv4::qwen_gqa_decode_attention_f16_batched_cuda(
+                d_q.get(), d_k_paged.get(), d_v_paged.get(), d_out_paged.get(),
+                d_partials_paged.get(), d_context_lens.get(), d_slots.get(),
+                rows, max_context_len, /*kv_slot_stride=*/0, geometry.q_heads,
+                geometry.kv_heads, geometry.head_dim, max_context,
+                attention_window, sink_tokens, d_table.get(), block_size,
+                max_blocks),
+            "paged batched decode launch");
+    check(cudaDeviceSynchronize(), "batched decode sync");
+
+    const std::vector<uint16_t> out_contiguous = d_out_contiguous.download();
+    const std::vector<uint16_t> out_paged = d_out_paged.download();
+    // Both launches sum the same values in the same order, so they must agree
+    // exactly; a tolerance here would hide a wrong-token read whose contribution
+    // happens to be small.
+    size_t mismatches = 0;
+    float worst = 0.0f;
+    for (size_t element = 0; element < q_elements; ++element) {
+        if (out_contiguous[element] != out_paged[element]) {
+            ++mismatches;
+            worst = std::max(worst, std::fabs(from_half(out_contiguous[element]) -
+                                              from_half(out_paged[element])));
+        }
+    }
+    require(mismatches == 0,
+            std::string(label) + ": " + std::to_string(mismatches) + " of " +
+                std::to_string(q_elements) +
+                " outputs differ from the contiguous cache, worst delta " +
+                std::to_string(worst));
+
+    // Guard against both paths being trivially zero, which would make the
+    // comparison meaningless.
+    bool nonzero = false;
+    for (size_t element = 0; element < q_elements && !nonzero; ++element) {
+        nonzero = from_half(out_paged[element]) != 0.0f;
+    }
+    require(nonzero, std::string(label) + ": output is entirely zero");
+
+    std::cout << "  paged batched decode (" << label << "): " << rows
+              << " rows, contexts up to " << max_context_len
+              << ", bit-exact vs contiguous PASS\n";
+}
+
+}  // namespace
+
+int main() {
+    if (!dsv4::cuda_runtime_available()) {
+        std::cout << "[SKIP] test_qwen_paged_kv_kernels requires CUDA\n";
+        return 0;
+    }
+    try {
+        const Geometry geometry;
+        test_paged_append(geometry);
+        test_paged_gather(geometry);
+        test_paged_batched_append(geometry);
+        test_paged_batched_decode(geometry, 0, 0, "dense");
+        // Sparse attention keeps its own window and sink ranges; the block
+        // translation has to hold for the positions those ranges actually visit.
+        test_paged_batched_decode(geometry, 1024, 64, "windowed+sink");
+        std::cout << "[PASS] test_qwen_paged_kv_kernels\n";
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cout << "[FAIL] test_qwen_paged_kv_kernels " << ex.what() << "\n";
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

The contiguous KV arena reserves `max_batch_size * max_context` per rank up front, so a slot holding a 200-token request still pins the bytes for a max-context one. This replaces that reservation with a block pool for the FP16 full-attention cache, so capacity tracks what requests actually hold.

Paging is **off by default**, and a zero budget reproduces exactly what the contiguous arena would have reserved — enabling it alone is memory-neutral and only changes how the same bytes are handed out.

## Implementation

- **`QwenBlockPool`** — fixed-size block allocator with free-list reuse.
- **`QwenBlockTable`** — per-slot logical-to-physical mapping, mirrored to device as an `int32` image the kernels index.
- **Paged kernels** — append, batched append, gather, plus a batched-decode attention variant that reads blocks natively, since that is the path that has to scale with batch size.
- **Single-sequence prefill/decode** gather their blocks once per layer into the dense `[context, kv_heads, head_dim]` layout the read kernels already index. This is the same dequant-once trade the FP8 and TurboQuant paths already make: one O(context) pass instead of translating inside O(rows × context) inner loops, which leaves all five tuned read variants untouched.

### Scope and guardrails

**FP16 only.** Batched decode routes to the FP16 kernels before the dtype branches are reached, so paging FP16 covers all of batched decode while the quantized caches keep their validated scale and packed-slot arithmetic. Construction rejects the other dtypes rather than silently falling back to contiguous.

A budget that cannot cover one max-context sequence is rejected **at construction**, not at the token that runs out — no scheduler could recover from the latter.

## Bug found and fixed

The paged read path bound `k_read`/`v_read` through `f16_data()` before the cache-dtype branch, which throws for FP8 and TurboQuant. This broke the **contiguous** quantized paths, unrelated to paging.

Worth flagging that the new paged tests could not have caught this: they only exercise FP16, and paged construction rejects the other dtypes. It surfaced from running the existing suite, and I confirmed it was mine rather than pre-existing by checking `test_qwen_engine` against a stashed clean tree.

## Testing

- **`test_qwen_block_pool`** — allocator and table invariants.
- **`test_qwen_paged_kv_kernels`** — all four paged kernels bit-exact against the contiguous path over deliberately **fragmented** block tables (blocks handed out round-robin across slots, then shuffled within each row) using **random** K/V/Q. Both choices matter: an identity-ish mapping lets contiguous arithmetic pass by accident, and near-uniform values let softmax average a misaddressed token away. Batched decode is covered in dense and windowed+sink configurations, with an all-zero guard so an empty comparison cannot pass.
- **`test_qwen_paged_engine_parity`** — covers ordering properties a kernel test cannot see: reservation timing, table upload before the reading forward, and release on completion. Prefill plus 600 decode steps across three slots, and 40 batched-decode steps at 4k–7.5k context, compared token- and checksum-exact against a contiguous engine. Block reuse runs two 6000-token requests (48 blocks needed) through a 33-block / 8448-token pool, so it only passes if completion actually returns blocks. Also asserts the undersized-pool and paged-FP8 rejections.
- The checkpoint fixture is extracted into a shared header so the two engine parity tests cannot drift onto different model geometries.

**Suite status: 23 of 30 `test_qwen_*` pass.** The 7 failures are pre-existing and unrelated — 5 exit with a usage message because they require a real checkpoint argument, and 2 Ascend argument-rejection failures (`test_qwen_ascend_ops`, `test_qwen_ascend_group_b`) reproduce identically on a clean tree.

No throughput or memory-headroom benchmark yet: the parity work above establishes correctness, and the win this is meant to unlock should be measured on a real checkpoint at TP4 rather than on the zero-weight fixture.

## Checklist

- [x] Block pool, block table, and device mirroring
- [x] Paged append / gather / batched-decode kernels
- [x] Engine integration behind `kv_paged`, off by default
- [x] Kernel-level and engine-level parity tests
- [x] Unsupported configurations rejected at construction
- [ ] Scheduler integration to admit requests against free blocks rather than slots
- [ ] Throughput and memory-headroom benchmark on a real checkpoint at TP4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
