### PR TITLE
Expose paged KV to Python and fix the TP worker block leak

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -744,6 +744,10 @@ add_executable(test_qwen_paged_engine_parity tests/test_qwen_paged_engine_parity
 target_link_libraries(test_qwen_paged_engine_parity PRIVATE dsv4_cpp_core)
 set_target_properties(test_qwen_paged_engine_parity PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
+add_executable(test_qwen_paged_tp_slot_free tests/test_qwen_paged_tp_slot_free.cpp)
+target_link_libraries(test_qwen_paged_tp_slot_free PRIVATE dsv4_cpp_core)
+set_target_properties(test_qwen_paged_tp_slot_free PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 add_executable(test_qwen_scheduler_paged_admission tests/test_qwen_scheduler_paged_admission.cpp)
 target_link_libraries(test_qwen_scheduler_paged_admission PRIVATE dsv4_cpp_core)
 set_target_properties(test_qwen_scheduler_paged_admission PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
@@ -755,6 +759,10 @@ set_target_properties(bench_qwen_prefill_interleave PROPERTIES RUNTIME_OUTPUT_DI
 add_executable(bench_qwen_paged_admission tests/bench_qwen_paged_admission.cpp)
 target_link_libraries(bench_qwen_paged_admission PRIVATE dsv4_cpp_core)
 set_target_properties(bench_qwen_paged_admission PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(bench_qwen_paged_tp_parity tests/bench_qwen_paged_tp_parity.cpp)
+target_link_libraries(bench_qwen_paged_tp_parity PRIVATE dsv4_cpp_core)
+set_target_properties(bench_qwen_paged_tp_parity PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(test_qwen_nvfp4 tests/test_qwen_nvfp4.cpp)
 target_link_libraries(test_qwen_nvfp4 PRIVATE dsv4_cpp_core)

--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -662,6 +662,25 @@ struct QwenEngine::Impl {
         block_table->release(slot_id);
     }
 
+    // Tears down one slot's paged state as a unit: returns its blocks to the
+    // pool, uploads the table, and clears the reuse state that described KV no
+    // longer backed by those blocks. Rank 0's free_slot and the worker loop's
+    // FreeSlot command both call this, so a slot ends up in exactly the same
+    // state on every rank. A stale cached_prompt on a worker would otherwise let
+    // an exact-repeat prompt hit the previous request's logits while rank 0
+    // recomputes, silently desynchronizing the two.
+    void release_slot_paged_state(int slot_id, int& engine_position) {
+        if (!kv_paged()) return;
+        release_paged_slot(slot_id);
+        sync_block_table();
+        SlotPrefixState& prefix = prefix_for(slot_id);
+        prefix.cached_prompt.clear();
+        prefix.snapshots.clear();
+        prefix.cached_result = QwenForwardResult{};
+        prefix.has_cached_result = false;
+        set_slot_position(slot_id, 0, engine_position);
+    }
+
     // Phase 3.4: Element offsets into the per-slot recurrent state arenas. Both
     // tensors carry the slot count as their leading dimension, so the stride is
     // whatever remains. Deriving it from the shape keeps these correct without
@@ -4695,18 +4714,13 @@ void QwenEngine::free_slot(uint64_t request_id) {
     // Returning the slot returns its blocks. Under paging this is what makes
     // capacity dynamic: the next request draws from a pool the finished one has
     // already given back, rather than inheriting a fixed reservation.
-    impl_->release_paged_slot(slot_id);
-    impl_->sync_block_table();
-    // The slot's reuse state described KV that is no longer backed by these
-    // blocks, so it must not survive into the next request on this slot.
-    if (impl_->kv_paged()) {
-        Impl::SlotPrefixState& prefix = impl_->prefix_for(slot_id);
-        prefix.cached_prompt.clear();
-        prefix.snapshots.clear();
-        prefix.cached_result = QwenForwardResult{};
-        prefix.has_cached_result = false;
-        impl_->set_slot_position(slot_id, 0, position_);
-    }
+    //
+    // Under TP the workers hold their own copies of the block table, so they
+    // have to release the same slot too or their pools leak one row per freed
+    // slot and eventually run out. The command is a no-op unless a channel
+    // exists and paging is on, which keeps the contiguous path unchanged.
+    impl_->release_slot_paged_state(slot_id, position_);
+    worker_command_free_slot(slot_id);
 }
 
 QwenBatchPrefillResult QwenEngine::batch_prefill(
@@ -5404,6 +5418,12 @@ void QwenEngine::run_worker_loop() {
             case WorkerCommand::Reset:
                 reset();
                 break;
+            case WorkerCommand::FreeSlot:
+                // slot_id is header[2]. Releases this rank's copy of the slot's
+                // blocks and clears its reuse state, mirroring rank 0's
+                // free_slot, so the pool does not leak one row per freed slot.
+                impl_->release_slot_paged_state(slot_id, position_);
+                break;
             default:
                 throw std::runtime_error(
                     "run_worker_loop: unknown command " + std::to_string(header[0]));
@@ -5521,6 +5541,31 @@ void QwenEngine::worker_command_shutdown() {
         static_cast<int32_t>(WorkerCommand::Shutdown),
         0,
         0,
+        0
+    };
+    impl_->cmd->send_to_workers(header, 4);
+}
+
+void QwenEngine::worker_command_free_slot(int32_t slot_id) {
+    // No-op at world size 1: the scheduler's free_slot already released this
+    // rank's blocks, and there is no worker to keep in step.
+    if (options_.tp_world <= 1) return;
+    if (options_.tp_rank != 0) {
+        throw std::runtime_error("worker_command_free_slot: rank 0 only");
+    }
+    // Contiguous arena: a slot already owns max_context implicitly, so there is
+    // no per-slot block state for a worker to release. A worker's position and
+    // prefix state are re-derived at the next prefill on that slot, so leaving
+    // the command unsent keeps the non-paged path byte-for-byte unchanged.
+    if (!impl_->kv_paged()) return;
+    if (!impl_->cmd) {
+        throw std::runtime_error("worker_command_free_slot: command channel not initialized (call warmup_tp first)");
+    }
+
+    int32_t header[4] = {
+        static_cast<int32_t>(WorkerCommand::FreeSlot),
+        0,
+        slot_id,
         0
     };
     impl_->cmd->send_to_workers(header, 4);

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -419,6 +419,10 @@ public:
         Reset = 2,
         Shutdown = 3,
         BatchDecodeStep = 4,
+        // Releases one slot's paged blocks on every rank. Under the contiguous
+        // arena a slot owns max_context implicitly, so there is nothing to
+        // broadcast and this command is only sent when paging is on.
+        FreeSlot = 5,
     };
     // slot_id selects the KV cache slot the workers must use, so it has to match
     // the slot rank 0 computes into.  It defaults to 0 for the single-session
@@ -432,6 +436,7 @@ public:
                                      const std::vector<int>& slot_ids);
     void worker_command_reset();
     void worker_command_shutdown();
+    void worker_command_free_slot(int32_t slot_id);
 
 private:
     struct Impl;

--- a/cpp_engine/python/bindings.cpp
+++ b/cpp_engine/python/bindings.cpp
@@ -96,6 +96,9 @@ py::dict telemetry_dict(const QwenRuntimeTelemetry& telemetry) {
     out["target_head_path"] = telemetry.target_head_path;
     out["host_global_metadata_bytes"] = telemetry.host_global_metadata_bytes;
     out["nvfp4_q8_workspace_peak_bytes"] = telemetry.nvfp4_q8_workspace_peak_bytes;
+    out["kv_paged"] = telemetry.kv_paged_blocks > 0;
+    out["kv_paged_blocks"] = telemetry.kv_paged_blocks;
+    out["kv_paged_block_size"] = telemetry.kv_paged_block_size;
     return out;
 }
 
@@ -217,7 +220,10 @@ PYBIND11_MODULE(pocketllm_cpp, module) {
         .def_readwrite("temperature", &QwenEngineOptions::temperature)
         .def_readwrite("top_p", &QwenEngineOptions::top_p)
         .def_readwrite("top_k", &QwenEngineOptions::top_k)
-        .def_readwrite("sampling_seed", &QwenEngineOptions::sampling_seed);
+        .def_readwrite("sampling_seed", &QwenEngineOptions::sampling_seed)
+        .def_readwrite("kv_paged", &QwenEngineOptions::kv_paged)
+        .def_readwrite("kv_block_size", &QwenEngineOptions::kv_block_size)
+        .def_readwrite("kv_cache_bytes", &QwenEngineOptions::kv_cache_bytes);
 
     py::class_<QwenForwardResult>(module, "QwenForwardResult")
         .def(py::init<>())
@@ -321,6 +327,9 @@ PYBIND11_MODULE(pocketllm_cpp, module) {
         .def_property_readonly("activation_workspace_peak_bytes", &QwenEngine::activation_workspace_peak_bytes)
         .def_property_readonly("kv_cache_bytes", &QwenEngine::kv_cache_bytes)
         .def_property_readonly("kv_cache_scale_bytes", &QwenEngine::kv_cache_scale_bytes)
+        .def_property_readonly("kv_paged", &QwenEngine::kv_paged)
+        .def_property_readonly("kv_free_blocks", &QwenEngine::kv_free_blocks)
+        .def_property_readonly("kv_total_blocks", &QwenEngine::kv_total_blocks)
         .def_property_readonly("config", [](const QwenEngine& engine) {
             return qwen_config_dict(engine.config());
         })

--- a/cpp_engine/tests/bench_qwen_paged_tp_parity.cpp
+++ b/cpp_engine/tests/bench_qwen_paged_tp_parity.cpp
@@ -1,0 +1,271 @@
+// TP paged-versus-contiguous parity and throughput on a real model.
+//
+// Drives the Qwen3.5 engine through the batch API under tensor parallelism and
+// runs exactly ONE KV mode per process. The launcher spawns a contiguous run
+// and a paged run (same checkpoint, same prompts, same seed) and diffs the
+// emitted token checksums: paged KV must produce byte-identical output to the
+// contiguous arena, and the decode throughput must not regress.
+//
+// The batch API is used throughout because it is the one TP-safe path:
+// batch_prefill() and batch_decode_step() auto-announce the collective the
+// workers join, so rank 0 needs no manual worker_command_* calls (world size 1
+// makes those a no-op anyway, so the single-GPU admission runs work unchanged).
+//
+// Running one mode per process also sidesteps two hazards of alternating modes
+// inside a single TP group: the workspace is a single buffer per engine and is
+// reconstructed per construction anyway, and a worker loop exits at Shutdown
+// and cannot be re-entered.
+
+#include "qwen_engine.hpp"
+#include "cuda_ops.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Options {
+    std::string checkpoint;
+    int layers = 0;          // 0 = all layers
+    int max_context = 1024;  // per-sequence ceiling; bounds the pool/arena
+    int tp_world = 1;
+    int tp_rank = 0;
+    int device = -1;         // -1 = same as tp_rank
+    std::string nccl_id_path;
+    int batch_size = 4;
+    int decode_steps = 16;
+    // "contiguous" or "paged". One process runs exactly one.
+    std::string mode = "contiguous";
+    int kv_block_size = 16;
+    // 0 = derive the paged budget from what the contiguous arena would reserve.
+    uint64_t kv_cache_mb = 0;
+    unsigned seed = 42;
+};
+
+void usage(const char* prog) {
+    std::printf(
+        "usage: %s <checkpoint_dir> [options]\n"
+        "  --layers N        layer count (0 = all, default 0)\n"
+        "  --max-context N   per-sequence ceiling (default 1024)\n"
+        "  --tp-world N      TP world size (default 1)\n"
+        "  --tp-rank N       TP rank (default 0)\n"
+        "  --device N        CUDA device ordinal (default: same as tp-rank)\n"
+        "  --nccl-id PATH    NCCL ID file path\n"
+        "  --batch-size N    requests per run (default 4)\n"
+        "  --decode N        decode steps per request (default 16)\n"
+        "  --mode MODE       contiguous | paged (default contiguous)\n"
+        "  --kv-block-size N paged block size (default 16)\n"
+        "  --kv-cache-mb N   paged pool budget MiB (0 = match contiguous arena)\n"
+        "  --seed N          prompt generation seed (default 42)\n",
+        prog);
+}
+
+Options parse_args(int argc, char** argv) {
+    if (argc < 2) {
+        usage(argv[0]);
+        std::exit(2);
+    }
+    Options opts;
+    opts.checkpoint = argv[1];
+    for (int i = 2; i < argc; ++i) {
+        const std::string arg = argv[i];
+        auto next_int = [&](int& out) {
+            if (i + 1 < argc) out = std::atoi(argv[++i]);
+        };
+        auto next_u64 = [&](uint64_t& out) {
+            if (i + 1 < argc) out = std::strtoull(argv[++i], nullptr, 10);
+        };
+        auto next_string = [&](std::string& out) {
+            if (i + 1 < argc) out = argv[++i];
+        };
+        if (arg == "--layers") next_int(opts.layers);
+        else if (arg == "--max-context") next_int(opts.max_context);
+        else if (arg == "--tp-world") next_int(opts.tp_world);
+        else if (arg == "--tp-rank") next_int(opts.tp_rank);
+        else if (arg == "--device") next_int(opts.device);
+        else if (arg == "--batch-size") next_int(opts.batch_size);
+        else if (arg == "--decode") next_int(opts.decode_steps);
+        else if (arg == "--kv-block-size") next_int(opts.kv_block_size);
+        else if (arg == "--kv-cache-mb") next_u64(opts.kv_cache_mb);
+        else if (arg == "--seed") next_int(reinterpret_cast<int&>(opts.seed));
+        else if (arg == "--nccl-id") next_string(opts.nccl_id_path);
+        else if (arg == "--mode") next_string(opts.mode);
+        else {
+            std::fprintf(stderr, "unknown argument: %s\n", arg.c_str());
+            usage(argv[0]);
+            std::exit(2);
+        }
+    }
+    return opts;
+}
+
+// A deterministic prompt. Identical across ranks and across runs so the
+// contiguous and paged arms see exactly the same tokens.
+std::vector<int> make_prompt(int length, unsigned seed, int request_index) {
+    std::mt19937 rng(seed + static_cast<unsigned>(request_index));
+    std::uniform_int_distribution<int> dist(1, 1000);
+    std::vector<int> prompt;
+    prompt.reserve(static_cast<size_t>(length));
+    for (int i = 0; i < length; ++i) prompt.push_back(dist(rng));
+    return prompt;
+}
+
+// A cheap but order-sensitive digest of the token stream. Two runs that agree
+// on this are, to all practical purposes, token-exact.
+uint64_t digest_tokens(const std::vector<std::vector<int>>& per_request) {
+    uint64_t h = 1469598103934665603ULL;  // FNV offset basis
+    for (const auto& tokens : per_request) {
+        for (int t : tokens) {
+            h ^= static_cast<uint64_t>(static_cast<uint32_t>(t));
+            h *= 1099511628211ULL;
+        }
+        // Separate requests so reordering a whole request would still differ.
+        h ^= 0xFF00ULL;
+        h *= 1099511628211ULL;
+    }
+    return h;
+}
+
+// The contiguous KV arena cost for this batch/context combination, in bytes.
+// We need it to size the paged pool to the same budget; building a probe
+// engine reads the model once, which is exactly what the real run does anyway.
+uint64_t derive_arena_bytes(const Options& opts) {
+    dsv4::QwenEngineOptions probe;
+    probe.device = opts.device >= 0 ? opts.device : opts.tp_rank;
+    probe.max_batch_size = opts.batch_size;
+    probe.kv_cache_dtype = dsv4::QwenKvCacheDType::Fp16;
+    probe.prefix_cache = false;
+    probe.kv_paged = false;
+    if (opts.tp_world > 1) {
+        probe.tp_world = opts.tp_world;
+        probe.tp_rank = opts.tp_rank;
+        probe.nccl_id_path = opts.nccl_id_path;
+    }
+    dsv4::QwenEngine probe_engine(opts.checkpoint, probe, opts.layers,
+                                  opts.max_context);
+    return probe_engine.kv_cache_bytes();
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (!dsv4::cuda_runtime_available()) {
+        std::fprintf(stderr, "CUDA runtime not available\n");
+        return 1;
+    }
+
+    try {
+        const Options opts = parse_args(argc, argv);
+        if (opts.mode != "contiguous" && opts.mode != "paged") {
+            std::fprintf(stderr, "unknown --mode %s\n", opts.mode.c_str());
+            return 2;
+        }
+
+        dsv4::QwenEngineOptions engine_opts;
+        engine_opts.device = opts.device >= 0 ? opts.device : opts.tp_rank;
+        engine_opts.max_batch_size = opts.batch_size;
+        engine_opts.kv_cache_dtype = dsv4::QwenKvCacheDType::Fp16;
+        engine_opts.prefix_cache = false;
+        if (opts.tp_world > 1) {
+            engine_opts.tp_world = opts.tp_world;
+            engine_opts.tp_rank = opts.tp_rank;
+            engine_opts.nccl_id_path = opts.nccl_id_path;
+        }
+        if (opts.mode == "paged") {
+            // Budget the pool to the contiguous arena so the arms are
+            // byte-for-byte comparable: the paged arm gets a block pool of the
+            // same total bytes the arena reserves, just handed out per block.
+            const uint64_t arena = derive_arena_bytes(opts);
+            const uint64_t budget = opts.kv_cache_mb != 0
+                ? opts.kv_cache_mb << 20
+                : arena;
+            engine_opts.kv_paged = true;
+            engine_opts.kv_block_size = opts.kv_block_size;
+            engine_opts.kv_cache_bytes = budget;
+        }
+
+        dsv4::QwenEngine engine(opts.checkpoint, engine_opts, opts.layers,
+                                opts.max_context);
+        engine.allocate_batch_slots(opts.batch_size);
+        engine.warmup_tp();
+
+        if (opts.tp_rank != 0) {
+            // Workers exist to join collectives. Every command rank 0 issues is
+            // something they execute; Shutdown is the last one, and it returns
+            // here. No assertion is needed: the slot-free regression covers the
+            // worker-side pool lifecycle, this bench only exercises throughput.
+            engine.run_worker_loop();
+            return 0;
+        }
+
+        // Deterministic, identical prompts across both arms.
+        std::vector<std::unique_ptr<dsv4::QwenBatchedRequest>> owned;
+        std::vector<dsv4::QwenBatchedRequest*> batch;
+        std::vector<std::vector<int>> generated;
+        const int prompt_len = std::min(256, opts.max_context - 1);
+        const int decode = opts.decode_steps;
+        for (int i = 0; i < opts.batch_size; ++i) {
+            auto req = std::make_unique<dsv4::QwenBatchedRequest>();
+            req->request_id = static_cast<uint64_t>(1000 + i);
+            req->slot_id = engine.allocate_slot(req->request_id);
+            if (req->slot_id < 0) {
+                throw std::runtime_error("slot allocation failed");
+            }
+            req->prompt_tokens = make_prompt(prompt_len, opts.seed, i);
+            req->sampling.max_new_tokens = decode;  // never the stopping bound
+            req->sampling.ignore_eos = true;
+            batch.push_back(req.get());
+            owned.push_back(std::move(req));
+            generated.emplace_back();
+        }
+
+        engine.batch_prefill(batch, 0);
+
+        // Prefill's predicted token is part of the output stream (it lands in
+        // req->last_token, the seed of the first decode step), so it must be in
+        // the digest too or a prefill-only divergence would pass unnoticed.
+        for (size_t i = 0; i < batch.size(); ++i) {
+            generated[i].push_back(batch[i]->last_token);
+        }
+
+        // Measure decode: aggregate wall-time, then per-request token streams.
+        double decode_seconds = 0.0;
+        for (int step = 0; step < decode; ++step) {
+            const dsv4::QwenBatchDecodeResult dec = engine.batch_decode_step(batch);
+            decode_seconds += dec.seconds;
+            for (size_t i = 0; i < batch.size(); ++i) {
+                generated[i].push_back(dec.next_tokens[i]);
+            }
+        }
+
+        const uint64_t digest = digest_tokens(generated);
+        const double decode_s_per_step = decode_seconds / std::max(1, decode);
+        const double req_per_sec =
+            static_cast<double>(opts.batch_size) / decode_seconds;
+
+        std::printf(
+            "\nTP paged-vs-contiguous parity  mode=%s  batch=%d  tp=%d  "
+            "context=%d  layers=%d\n"
+            "  prompt_tokens=%d  decode_steps=%d  decode_ms/step=%.3f  "
+            "req/s=%.2f\n"
+            "  checksum=%016llx\n",
+            opts.mode.c_str(), opts.batch_size, opts.tp_world, opts.max_context,
+            opts.layers == 0 ? 64 : opts.layers, prompt_len, decode,
+            decode_s_per_step * 1000.0, req_per_sec,
+            static_cast<unsigned long long>(digest));
+        std::fflush(stdout);
+
+        engine.worker_command_shutdown();
+        return 0;
+    } catch (const std::exception& ex) {
+        std::fprintf(stderr, "Error: %s\n", ex.what());
+        return 1;
+    }
+}

--- a/cpp_engine/tests/qwen_parity_fixture.hpp
+++ b/cpp_engine/tests/qwen_parity_fixture.hpp
@@ -92,7 +92,7 @@ std::string config_json() {
 })JSON";
 }
 
-std::vector<TensorSpec> specs() {
+std::vector<TensorSpec> specs(bool bf16_mlp = false) {
     const std::vector<uint64_t> hidden = {128};
     const std::vector<uint64_t> vocab = {64, 128};
     // linear_attention QKV: (q_heads + 2*kv_heads) * head_dim = (4+2*4)*128 = 1536
@@ -134,13 +134,18 @@ std::vector<TensorSpec> specs() {
         {linear + "linear_attn.A_log", "BF16", vector4},
         {linear + "linear_attn.dt_bias", "BF16", vector4},
         {linear + "linear_attn.norm.weight", "BF16", hidden},
-        {linear + "mlp.gate_proj.weight", "F8_E4M3", mlp},
-        {linear + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale},
-        {linear + "mlp.up_proj.weight", "F8_E4M3", mlp},
-        {linear + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale},
-        {linear + "mlp.down_proj.weight", "F8_E4M3", mlp},
-        {linear + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale},
+        {linear + "mlp.gate_proj.weight", bf16_mlp ? "BF16" : "F8_E4M3", mlp},
+        {linear + "mlp.up_proj.weight", bf16_mlp ? "BF16" : "F8_E4M3", mlp},
+        {linear + "mlp.down_proj.weight", bf16_mlp ? "BF16" : "F8_E4M3", mlp},
     };
+    if (!bf16_mlp) {
+        // FP8 block scales, swept into the list order above. BF16 MLPs need no
+        // scale tensor: require_linear only takes the FP8 path when a matching
+        // weight_scale_inv exists.
+        out.push_back({linear + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale});
+        out.push_back({linear + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale});
+        out.push_back({linear + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale});
+    }
     out.insert(out.end(), {
         {full + "input_layernorm.weight", "BF16", hidden},
         {full + "post_attention_layernorm.weight", "BF16", hidden},
@@ -154,17 +159,19 @@ std::vector<TensorSpec> specs() {
         {full + "self_attn.o_proj.weight_scale_inv", "BF16", out_scale},
         {full + "self_attn.q_norm.weight", "BF16", hidden},
         {full + "self_attn.k_norm.weight", "BF16", hidden},
-        {full + "mlp.gate_proj.weight", "F8_E4M3", mlp},
-        {full + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale},
-        {full + "mlp.up_proj.weight", "F8_E4M3", mlp},
-        {full + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale},
-        {full + "mlp.down_proj.weight", "F8_E4M3", mlp},
-        {full + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale},
+        {full + "mlp.gate_proj.weight", bf16_mlp ? "BF16" : "F8_E4M3", mlp},
+        {full + "mlp.up_proj.weight", bf16_mlp ? "BF16" : "F8_E4M3", mlp},
+        {full + "mlp.down_proj.weight", bf16_mlp ? "BF16" : "F8_E4M3", mlp},
     });
+    if (!bf16_mlp) {
+        out.push_back({full + "mlp.gate_proj.weight_scale_inv", "BF16", mlp_scale});
+        out.push_back({full + "mlp.up_proj.weight_scale_inv", "BF16", mlp_scale});
+        out.push_back({full + "mlp.down_proj.weight_scale_inv", "BF16", mlp_scale});
+    }
     return out;
 }
 
-bool write_fixture(const std::string& dir) {
+bool write_fixture(const std::string& dir, bool bf16_mlp = false) {
     const std::string mkdir_cmd = "mkdir -p '" + dir + "'";
     if (std::system(mkdir_cmd.c_str()) != 0) return false;
     std::ofstream config(dir + "/config.json",
@@ -173,7 +180,7 @@ bool write_fixture(const std::string& dir) {
     config << config_json();
     if (!config) return false;
 
-    const auto tensors = specs();
+    const auto tensors = specs(bf16_mlp);
     std::ostringstream header;
     header << '{';
     uint64_t offset = 0;

--- a/cpp_engine/tests/test_qwen_paged_tp_slot_free.cpp
+++ b/cpp_engine/tests/test_qwen_paged_tp_slot_free.cpp
@@ -1,0 +1,240 @@
+// TP worker block-leak regression: freeing a paged slot on rank 0 must also
+// release that slot's blocks on every worker rank.
+//
+// The paged block pool lives per rank, and a slot's table row and KV blocks
+// live on whatever rank runs the forward. So when rank 0's scheduler calls
+// free_slot() it broadcasts a FreeSlot command; each worker releases its own
+// copy of the slot's blocks. Before that command existed, workers kept a slot's
+// blocks for the life of the process: rank 0's pool returned to full after each
+// free while the workers' pools drained one slot per free, until a worker ran
+// out at some later prefill -- asynchronously, and only under TP.
+//
+// The single-process tests cannot see this (there is no worker to leak), and
+// the TP paged admission bench does not free slots. So the only way to pin the
+// leak is a TP run that repeatedly allocate -> prefill -> decode -> free and
+// forces the worker pool small enough that a worker-side leak exhausts it
+// within the loop.
+//
+// Engineering the pool to be that tight is the whole trick. The fixed pool
+// keeps enough blocks for the working set, so a correct engine passes every
+// cycle; a leaky worker crosses the pool the moment its cumulative leaked
+// blocks exceed the budget, and the failure surfaces as the next command's
+// reserve_paged_slot() throwing inside run_worker_loop().
+
+#include "qwen_engine.hpp"
+#include "qwen_parity_fixture.hpp"
+#include "cuda_ops.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+struct Options {
+    int layers = 2;
+    int max_context = 128;
+    int tp_world = 1;
+    int tp_rank = 0;
+    int device = -1;
+    std::string nccl_id_path;
+};
+
+void expect(bool ok, const std::string& what) {
+    std::printf("  %s %s\n", ok ? "[ok]  " : "[FAIL]", what.c_str());
+}
+
+// Number of alloc->prefill->decode->free cycles. The working set per cycle is
+// a single 16-token block (2-token prompt + one decode step never crosses a
+// block boundary), so with the fix the pool sees a constant 1-block demand and
+// never approaches the budget. A worker that retains one slot's blocks per
+// freed slot leaks that 1 block every cycle and must run the pool dry inside
+// this loop.
+constexpr int kCycles = 24;
+
+// The fixture has kv_heads=4, head_dim=128, one full-attention layer (layer 0
+// is linear_attention and carries the qkv weight, layer 1 has none), so
+//   bytes_per_block = block_size * local_kv_heads * head_dim * K,V * full_layers
+// Under TP2 each rank owns 2 KV heads: 16 * 2 * 128 * 2 * 1 = 16384 B/block.
+constexpr int kBlockSize = 16;
+constexpr int kBlocksPerSeq =
+    (128 + kBlockSize - 1) / kBlockSize;  // 8 blocks to reach max_context
+// A pool of 16 blocks (262144 B) sits 2x above the one-max-context floor, so a
+// worker that retains one slot's blocks per freed slot leaks ~1-2 blocks every
+// cycle and exhausts the pool inside this loop.
+constexpr uint64_t kPoolBytes = 16 * 16384;
+
+static_assert(kPoolBytes >= kBlocksPerSeq * 16384ULL,
+              "pool must hold a lone max-context sequence under TP2");
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    Options opts;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--layers" && i + 1 < argc) {
+            opts.layers = std::atoi(argv[++i]);
+        } else if (arg == "--max-context" && i + 1 < argc) {
+            opts.max_context = std::atoi(argv[++i]);
+        } else if (arg == "--tp-world" && i + 1 < argc) {
+            opts.tp_world = std::atoi(argv[++i]);
+        } else if (arg == "--tp-rank" && i + 1 < argc) {
+            opts.tp_rank = std::atoi(argv[++i]);
+        } else if (arg == "--device" && i + 1 < argc) {
+            opts.device = std::atoi(argv[++i]);
+        } else if (arg == "--nccl-id" && i + 1 < argc) {
+            opts.nccl_id_path = argv[++i];
+        } else {
+            std::fprintf(stderr, "unknown argument: %s\n", arg.c_str());
+            return 2;
+        }
+    }
+
+    if (!dsv4::cuda_runtime_available()) {
+        std::printf("[SKIP] test_qwen_paged_tp_slot_free requires CUDA\n");
+        return 0;
+    }
+
+    try {
+        // Fixture path is deterministic per name; build it once on rank 0
+        // before the engine is constructed, so the worker ranks read the same
+        // directory without racing rank 0's write. warmup_tp() synchronises all
+        // ranks afterwards, but it runs after this write (see below).
+        const std::string checkpoint =
+            qwen_fixture::fixture_dir("qwen_paged_engine_parity_fixture");
+        if (opts.tp_rank == 0) {
+            // The parity fixture's FP8 MLP (128 columns) does not shard onto the
+            // FP8 scale block at TP2, so this regression uses the BF16-MLP
+            // variant. Geometry is identical; the KV-pool behaviour under test
+            // is unaffected by the MLP dtype.
+            if (!qwen_fixture::write_fixture(checkpoint, /*bf16_mlp=*/true)) {
+                throw std::runtime_error("could not create paged parity fixture");
+            }
+        } else {
+            // Worker ranks start while rank 0 is still writing. wait for the
+            // two files the engine opens at construction; rank 0's write is
+            // small and completes in milliseconds, so a bounded poll is enough
+            // and avoids a startup race that is otherwise flaky.
+            const std::string shard = checkpoint + "/model.safetensors";
+            const std::string config = checkpoint + "/config.json";
+            for (int attempt = 0; attempt < 2000; ++attempt) {
+                if (access(shard.c_str(), F_OK) == 0 &&
+                    access(config.c_str(), F_OK) == 0) {
+                    break;
+                }
+                usleep(1000);
+            }
+        }
+
+        dsv4::QwenEngineOptions engine_opts;
+        engine_opts.device = opts.device >= 0 ? opts.device : opts.tp_rank;
+        engine_opts.max_batch_size = 2;
+        engine_opts.kv_cache_dtype = dsv4::QwenKvCacheDType::Fp16;
+        engine_opts.prefix_cache = false;
+        engine_opts.kv_paged = true;
+        engine_opts.kv_block_size = kBlockSize;
+        engine_opts.kv_cache_bytes = kPoolBytes;
+        if (opts.tp_world > 1) {
+            engine_opts.tp_world = opts.tp_world;
+            engine_opts.tp_rank = opts.tp_rank;
+            engine_opts.nccl_id_path = opts.nccl_id_path;
+        }
+
+        dsv4::QwenEngine engine(checkpoint, engine_opts, opts.layers,
+                                opts.max_context);
+        engine.allocate_batch_slots(2);
+        engine.warmup_tp();
+
+        // Workers spend the rest of their life in the command loop, then check
+        // their OWN pool. This is the assertion that matters: rank 0 cannot read
+        // a worker's pool over any channel, so the leak is only visible from
+        // inside the worker process. run_worker_loop returns on Shutdown, by
+        // which point rank 0 has freed every slot it allocated; a worker that
+        // honoured each FreeSlot is back to a full pool, and a worker that
+        // ignored them is short one row per freed slot.
+        if (opts.tp_rank != 0) {
+            engine.run_worker_loop();
+            const int free_blocks = engine.kv_free_blocks();
+            const int total_blocks = engine.kv_total_blocks();
+            std::printf("rank %d after shutdown: %d/%d blocks free\n",
+                        opts.tp_rank, free_blocks, total_blocks);
+            if (free_blocks != total_blocks) {
+                std::printf(
+                    "[FAIL] rank %d leaked %d block(s): FreeSlot did not "
+                    "release worker-side paged state\n",
+                    opts.tp_rank, total_blocks - free_blocks);
+                return 1;
+            }
+            return 0;
+        }
+
+        std::printf("\nTP paged slot-free regression\n");
+        std::printf("=============================\n");
+        std::printf("TP %d, pool %d blocks of %d, %d cycles\n\n", opts.tp_world,
+                    engine.kv_total_blocks(), kBlockSize, kCycles);
+
+        const int total = engine.kv_total_blocks();
+
+        // A 2-token prompt plus one decode step needs a single block at any
+        // point: the sequence stays inside one 16-token block, so the working
+        // set is one block and the pool floor is what dominates.
+        const std::vector<int> prompt = {1, 2};
+        dsv4::QwenBatchSamplingParams sampling;
+        sampling.max_new_tokens = kCycles;  // never the stopping bound
+        sampling.ignore_eos = true;
+
+        for (int cycle = 0; cycle < kCycles; ++cycle) {
+            const uint64_t request_id = 1000 + static_cast<uint64_t>(cycle);
+            const int slot = engine.allocate_slot(request_id);
+            if (slot < 0) {
+                expect(false, "slot could not be allocated");
+                engine.worker_command_shutdown();
+                return 1;
+            }
+
+            auto req = std::make_unique<dsv4::QwenBatchedRequest>();
+            req->request_id = request_id;
+            req->prompt_tokens = prompt;
+            req->slot_id = slot;
+            req->sampling = sampling;
+            std::vector<dsv4::QwenBatchedRequest*> batch{req.get()};
+
+            const dsv4::QwenBatchPrefillResult prefilled =
+                engine.batch_prefill(batch, 0);
+            if (prefilled.results.empty()) {
+                expect(false, "prefill returned no result");
+                engine.worker_command_shutdown();
+                return 1;
+            }
+            engine.batch_decode_step(batch);
+
+            // Rank 0's pool must return to full here. This catches a rank-0
+            // block leak directly. A worker-only leak is caught by the loop
+            // failing below instead -- that is the regression this test exists
+            // to guard.
+            engine.free_slot(request_id);
+            if (engine.kv_free_blocks() != total) {
+                expect(false, "slot free returned pool to full");
+                engine.worker_command_shutdown();
+                return 1;
+            }
+        }
+
+        expect(true, "pool never exhausted across cycles");
+        expect(engine.kv_free_blocks() == total,
+               "pool is back to its total after every free");
+
+        engine.worker_command_shutdown();
+
+        std::printf("\nPASS\n");
+        return 0;
+    } catch (const std::exception& ex) {
+        std::printf("[FAIL] test_qwen_paged_tp_slot_free %s\n", ex.what());
+        return 1;
+    }
+}

--- a/pocketllm/backends/cpp_backend.py
+++ b/pocketllm/backends/cpp_backend.py
@@ -310,6 +310,7 @@ class CppBackend(BackendBase):
                 "eos_token_ids": sorted(self._eos_ids),
                 "eos_source": self._eos_source or "none",
                 "max_batch_size": self._configured_max_batch_size() if self._batching_enabled else 1,
+                "kv_paged": bool(self.args.backend_options.get("kv_paged", False)),
             },
         )
 
@@ -397,6 +398,14 @@ class CppBackend(BackendBase):
             "dspark_checkpoint": str(self.args.backend_options.get("dspark_checkpoint", "")),
             "dflash2_checkpoint": str(self.args.backend_options.get("dflash2_checkpoint", "")),
             "nccl_id_path": nccl_id_path,
+            # Paged KV (Phase 3.7). Off by default; the contiguous arena
+            # reproduces the max_batch_size * max_context reservation. A zero
+            # kv_cache_bytes derives the pool from that same reservation, so
+            # turning paging on alone is memory-neutral until the budget is
+            # raised deliberately.
+            "kv_paged": bool(self.args.backend_options.get("kv_paged", False)),
+            "kv_block_size": int(self.args.backend_options.get("kv_block_size", 16)),
+            "kv_cache_bytes": int(self.args.backend_options.get("kv_cache_bytes", 0)),
         }
         for name, value in mappings.items():
             if hasattr(options, name):
@@ -654,6 +663,13 @@ class CppBackend(BackendBase):
                 sampling.temperature = request.sampling_params.temperature or 0.0
                 sampling.top_p = request.sampling_params.top_p or 1.0
                 sampling.top_k = request.sampling_params.top_k or 20
+                # The batch scheduler runs the model to max_new_tokens unless
+                # told otherwise. EOS truncation is the default for serving, but
+                # a benchmark (or any caller that wants the full budget) opts in
+                # through extra["ignore_eos"], mirroring the native parity driver
+                # which sets req.sampling.ignore_eos = true.
+                if bool(request.sampling_params.extra.get("ignore_eos", False)):
+                    sampling.ignore_eos = True
 
                 # Submit to scheduler
                 native_req_id = self._scheduler.submit_request(prompt_ids, sampling, None)

--- a/scripts/bench_concurrent_throughput.py
+++ b/scripts/bench_concurrent_throughput.py
@@ -11,6 +11,7 @@ with concurrent requests. Target improvements:
 
 import argparse
 import json
+import os
 import sys
 import time
 import threading
@@ -30,12 +31,12 @@ class ConcurrentBenchmark:
         self.sampling_params = sampling_params
         self.results_queue = Queue()
 
-    def run_request(self, request_id: int):
+    def run_request(self, request_id: int, prompt_tokens: List[int]):
         """Run a single generation request."""
         start = time.perf_counter()
         try:
             result = self.llm.generate(
-                [self.prompt_tokens],
+                [prompt_tokens],
                 sampling_params=self.sampling_params
             )
             end = time.perf_counter()
@@ -57,14 +58,24 @@ class ConcurrentBenchmark:
                 "latency": end - start,
             })
 
-    def run_concurrent(self, num_requests: int) -> List[Dict[str, Any]]:
-        """Run multiple requests concurrently."""
+    def run_concurrent(self, num_requests: int, prompt_tokens: List[int] | None = None) -> List[Dict[str, Any]]:
+        """Run multiple requests concurrently.
+
+        ``prompt_tokens`` may be supplied per call.  This is what makes the
+        measurement honest: the native engine keeps a slot's KV across runs, so
+        re-submitting byte-identical prompts means every run after the first
+        only pays decode and the numbers are not comparable across paged and
+        contiguous modes (contiguous reuses, paged re-allocates).  Each call
+        here uses a distinct prompt so both arms pay a full prefill every run.
+        """
+        if prompt_tokens is None:
+            prompt_tokens = self.prompt_tokens
         threads = []
 
         # Start all threads
         start_time = time.perf_counter()
         for i in range(num_requests):
-            thread = threading.Thread(target=self.run_request, args=(i,))
+            thread = threading.Thread(target=self.run_request, args=(i, prompt_tokens))
             thread.start()
             threads.append(thread)
 
@@ -94,7 +105,9 @@ def benchmark_concurrent(
     test_runs: int = 3,
     prompt_length: int = 32,
     tensor_parallel_size: int = 1,
+    tensor_parallel_rank: int = 0,
     max_model_len: int = 4096,
+    backend_options: dict | None = None,
 ):
     """Benchmark concurrent request throughput."""
 
@@ -104,21 +117,49 @@ def benchmark_concurrent(
     print(f"{'='*60}")
 
     # Create LLM with specified mode
+    extra_options = dict(backend_options) if backend_options else {}
+    # enable_prefix_caching is a top-level EngineArgs field, not a backend
+    # option, even though the CLI surface exposes it as --backend-option.
+    # The native engine (qwen_engine.cpp) honours this directly; an identical
+    # warmup prompt is otherwise prefix-reused, so the test run only pays decode
+    # and the contiguous arm looks ~4x too fast.  Pop it out of the option dict
+    # before merging so it does not get passed down twice.
+    prefix_caching = bool(extra_options.pop("enable_prefix_caching", True))
     args = EngineArgs(
         model=checkpoint,
         backend="cpp",
         tensor_parallel_size=tensor_parallel_size,
+        tensor_parallel_rank=tensor_parallel_rank,
         max_model_len=max_model_len,
+        enable_prefix_caching=prefix_caching,
         backend_options={
             "enable_batching": enable_batching,
             # Size the arena to this level's concurrency rather than a fixed 8.
             # max(8, n) made the 2-concurrent run reserve 8 slots' worth of KV
             # cache, so the low levels paid memory they never used.
             "max_batch_size": num_concurrent if enable_batching else 1,
+            # kv_paged / kv_block_size / kv_cache_bytes and anything else come
+            # from --backend-option KEY=VALUE (JSON-typed, like the server CLI).
+            **extra_options,
         }
     )
 
     llm = LLM(args)
+
+    # A nonzero TensorParallel rank is a worker: the engine is constructed here
+    # (so it joins the warmup_tp() barrier with rank 0), then this process
+    # enters the native command channel and does no driving of its own.
+    # run_worker() blocks until rank 0 sends shutdown, which happens when rank
+    # 0's LLM.close() for *this* level runs.  On return, close the engine here
+    # too so the worker does not linger across levels, then leave the function.
+    if tensor_parallel_rank > 0:
+        try:
+            llm.backend.run_worker()
+            print(f"[TP rank {tensor_parallel_rank}] worker loop exited for "
+                  f"{mode} mode, {num_concurrent} concurrent")
+        finally:
+            llm.close()
+        return None
 
     # Check capabilities
     caps = llm.backend.capabilities
@@ -126,6 +167,32 @@ def benchmark_concurrent(
     print(f"Scheduler: {caps.details.get('scheduler')}")
     print(f"Supports batch: {caps.supports_batch}")
     print(f"Max batch size: {caps.details.get('max_batch_size', 1)}")
+
+    # Realized KV footprint.  kv_cache_bytes() reports the arena/pool budget the
+    # engine committed at construction; kv_paged_blocks is nonzero for paged.
+    # This is what makes the two arms directly comparable: the paged pool can be
+    # bounded below the contiguous arena's `batch * max_context` reservation and
+    # still admit the same requests, because the solver only allocates blocks for
+    # tokens actually used.
+    engine = getattr(llm.backend, "_engine", None)
+    if engine is not None:
+        kv_bytes_attr = getattr(engine, "kv_cache_bytes", None)
+        if kv_bytes_attr is not None:
+            kv_bytes_value = kv_bytes_attr() if callable(kv_bytes_attr) else kv_bytes_attr
+            try:
+                kv_bytes_value = int(kv_bytes_value)
+                print(f"KV cache bytes: {kv_bytes_value} ({kv_bytes_value / (1024 * 1024):.1f} MiB)")
+            except (TypeError, ValueError):
+                print(f"KV cache bytes: {kv_bytes_value}")
+        for name in ("kv_total_blocks", "kv_free_blocks"):
+            attr = getattr(engine, name, None)
+            if attr is not None:
+                try:
+                    print(f"KV {name}: {attr() if callable(attr) else attr}")
+                except Exception:
+                    pass
+    else:
+        print("KV cache bytes: (no native engine exposed)")
 
     # A silent fall back to the serial path would be reported as a batch result
     # and make the comparison meaningless, so fail loudly instead.
@@ -138,8 +205,33 @@ def benchmark_concurrent(
         )
 
     # Create test configuration
-    prompt_tokens = list(range(1, prompt_length + 1))
-    sampling = SamplingParams(max_tokens=max_tokens, temperature=0.0)
+    # A real, tokenizer-produced prompt rather than the synthetic id range
+    # [1..n]: a model fed arbitrary vocab ids almost always emits EOS on the
+    # first step, which truncated every run to 2 tokens and made the timing
+    # meaningless (~10x too fast).  Natural text also exercises the KV cache
+    # through the same code path a server would.  The prompt is built to
+    # `prompt_length` tokens by repeating a natural sentence.
+    sampler = getattr(llm.backend, "_tokenizer", None)
+    if getattr(sampler, "encode", None) is not None:
+        sentence = "The quick brown fox jumps over the lazy dog and the party never ends. "
+        encoding = sampler.encode(sentence)
+        if not encoding:
+            raise SystemExit("tokenizer returned no tokens for the filler sentence")
+        prompt_tokens = []
+        while len(prompt_tokens) < prompt_length:
+            prompt_tokens.extend(encoding)
+        prompt_tokens = prompt_tokens[:prompt_length]
+    else:
+        # Fallback for a backend without a tokenizer: raw ids are better than a
+        # crash, but the numbers will not be meaningful.
+        prompt_tokens = list(range(1, prompt_length + 1))
+    # ignore_eos makes the model run the full max_tokens budget instead of
+    # stopping at whatever token it happens to emit first (which is what the
+    # synthetic prompt triggered).  This mirrors the native parity driver,
+    # which sets req.sampling.ignore_eos = true for exactly this reason.
+    sampling = SamplingParams(
+        max_tokens=max_tokens, temperature=0.0, extra={"ignore_eos": True}
+    )
 
     print(f"\nConfiguration:")
     print(f"  Prompt length: {prompt_length} tokens")
@@ -150,6 +242,16 @@ def benchmark_concurrent(
 
     benchmark = ConcurrentBenchmark(llm, prompt_tokens, sampling)
 
+    # Every measurement run gets a *distinct* prompt of the same length.  The
+    # native engine keeps a batch slot's KV across runs, so resubmitting the
+    # identical prompt means runs 2..N only pay decode; only the contiguous arm
+    # can reuse that (paged re-allocates), which is exactly what produced the
+    # false ~10x gap above.  Prepend a unique marker token and shave the tail so
+    # the length is held constant.
+    def _prompt_for(run_index: int) -> List[int]:
+        marker = [1_000_000 + run_index]
+        return marker + prompt_tokens[: max(0, prompt_length - len(marker))]
+
     all_total_times = []
     all_request_latencies = []
     failures = 0
@@ -157,15 +259,21 @@ def benchmark_concurrent(
         # Warmup
         print(f"\nWarmup ({warmup_runs} runs)...")
         for i in range(warmup_runs):
-            results, total_time = benchmark.run_concurrent(num_concurrent)
+            results, total_time = benchmark.run_concurrent(num_concurrent, _prompt_for(i))
             successful = sum(1 for r in results if r["success"])
-            print(f"  Run {i+1}: {total_time:.3f}s ({successful}/{num_concurrent} successful)")
+            detail = "; ".join(
+                f"req{r['request_id']}={r.get('tokens', '?')}tok/{r.get('finish_reason', '?')}"
+                for r in results
+            )
+            print(f"  Run {i+1}: {total_time:.3f}s ({successful}/{num_concurrent} successful) [{detail}]")
 
         # Benchmark
         print(f"\nBenchmark ({test_runs} runs)...")
 
         for i in range(test_runs):
-            results, total_time = benchmark.run_concurrent(num_concurrent)
+            results, total_time = benchmark.run_concurrent(
+                num_concurrent, _prompt_for(warmup_runs + i)
+            )
             all_total_times.append(total_time)
 
             successful = sum(1 for r in results if r["success"])
@@ -176,7 +284,11 @@ def benchmark_concurrent(
             for failed in (r for r in results if not r["success"]):
                 print(f"    request {failed['request_id']} failed: {failed.get('error')}")
 
-            print(f"  Run {i+1}: {total_time:.3f}s total, {avg_latency:.3f}s avg latency ({successful}/{num_concurrent} successful)")
+            detail = "; ".join(
+                f"req{r['request_id']}={r.get('tokens', '?')}tok/{r.get('finish_reason', '?')}"
+                for r in results if r["success"]
+            )
+            print(f"  Run {i+1}: {total_time:.3f}s total, {avg_latency:.3f}s avg latency ({successful}/{num_concurrent} successful) [{detail}]")
     finally:
         # Each concurrency level builds its own LLM.  Without an explicit close
         # the engine is only reclaimed at interpreter exit, so rank 0 never sends
@@ -225,6 +337,25 @@ def benchmark_concurrent(
     }
 
 
+def parse_backend_options(items) -> dict:
+    """Turn --backend-option KEY=VALUE pairs into a typed dict.
+
+    VALUE is JSON-parsed so numbers, booleans, and nested values stay typed; a
+    bare string that is not valid JSON stays a string, matching the server CLI.
+    """
+    options: dict = {}
+    for item in items or []:
+        key, sep, raw = str(item).partition("=")
+        if not sep or not key.strip():
+            raise SystemExit(f"--backend-option expects KEY=VALUE, got {item!r}")
+        try:
+            value = json.loads(raw)
+        except ValueError:
+            value = raw
+        options[key.strip()] = value
+    return options
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Benchmark concurrent request throughput"
@@ -247,6 +378,14 @@ def main():
     parser.add_argument(
         "--json-out",
         help="Write the --single measurement here as JSON"
+    )
+    parser.add_argument(
+        "--backend-option",
+        action="append",
+        default=None,
+        metavar="KEY=VALUE",
+        help="Backend option (JSON-typed VALUE). May repeat, e.g. "
+             "--backend-option kv_paged=True --backend-option kv_block_size=16"
     )
     parser.add_argument(
         "--num-concurrent",
@@ -293,12 +432,21 @@ def main():
     )
 
     args = parser.parse_args()
+    backend_options = parse_backend_options(args.backend_option)
+    # Set by the TP launcher; each process runs this script with a distinct rank.
+    # From_env also honours this, but we pass it explicitly so the worker branch
+    # and EngineArgs agree even when TP_WORLD is unset in a single-rank run.
+    tensor_parallel_rank = int(os.environ.get("TP_RANK", "0"))
+    tensor_parallel_size = max(args.tensor_parallel_size, int(os.environ.get("TP_WORLD", "1")))
 
     print("="*60)
     print("Concurrent Request Throughput Benchmark")
     print("="*60)
     print(f"Checkpoint: {args.checkpoint}")
-    print(f"Tensor parallel size: {args.tensor_parallel_size}")
+    print(f"Tensor parallel size: {tensor_parallel_size}")
+    print(f"Tensor parallel rank: {tensor_parallel_rank}")
+    if backend_options:
+        print(f"Backend options: {backend_options}")
 
     if args.single:
         if len(args.num_concurrent) != 1:
@@ -311,8 +459,10 @@ def main():
             warmup_runs=args.warmup_runs,
             test_runs=args.test_runs,
             prompt_length=args.prompt_length,
-            tensor_parallel_size=args.tensor_parallel_size,
+            tensor_parallel_size=tensor_parallel_size,
+            tensor_parallel_rank=tensor_parallel_rank,
             max_model_len=args.max_model_len,
+            backend_options=backend_options,
         )
         if args.json_out:
             Path(args.json_out).write_text(json.dumps(result, indent=2))
@@ -338,8 +488,10 @@ def main():
             warmup_runs=args.warmup_runs,
             test_runs=args.test_runs,
             prompt_length=args.prompt_length,
-            tensor_parallel_size=args.tensor_parallel_size,
+            tensor_parallel_size=tensor_parallel_size,
+            tensor_parallel_rank=tensor_parallel_rank,
             max_model_len=args.max_model_len,
+            backend_options=backend_options,
         )
 
         # Batch mode
@@ -351,8 +503,10 @@ def main():
             warmup_runs=args.warmup_runs,
             test_runs=args.test_runs,
             prompt_length=args.prompt_length,
-            tensor_parallel_size=args.tensor_parallel_size,
+            tensor_parallel_size=tensor_parallel_size,
+            tensor_parallel_rank=tensor_parallel_rank,
             max_model_len=args.max_model_len,
+            backend_options=backend_options,
         )
 
         all_results[num_concurrent] = {

--- a/scripts/run_qwen_concurrent_tp4.py
+++ b/scripts/run_qwen_concurrent_tp4.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""TP4 launcher for bench_concurrent_throughput.py on the real model.
+
+Each invocation runs ONE measurement as a four-rank TensorParallel process
+group: rank 0 drives the throughput loop through the batch scheduler, ranks
+1-3 enter the native worker command channel. Rank 0's LLM.close() broadcasts
+the shutdown that unwinds the workers, and the launcher waits on all four PIDs.
+
+Usage:
+  run_qwen_concurrent_tp4.py --mode serial|batch --num-concurrent N \
+      [--max-context C] [--max-tokens T] [--prompt-length P] \
+      [--kv-paged] [--kv-block-size B] [--kv-cache-mb M] \
+      [--warmup-runs W] [--test-runs R] [--checkpoint DIR] \
+      [--json-out PATH]
+
+Runs under the same TCP/NCCL contract as the C++ parity launcher: every rank
+shares one NCCL id path, created by rank 0 and passed on the command line.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "bench_concurrent_throughput.py"
+PYTHON = os.environ.get("BENCH_PYTHON", "/home/lvyufeng/miniconda3/bin/python")
+
+
+def build_rank_cmd(args, rank: int, nccl_path: str) -> list[str]:
+    cmd = [PYTHON, str(SCRIPT)]
+    cmd += [args.checkpoint, "--single", args.mode]
+    cmd += ["--num-concurrent", str(args.num_concurrent)]
+    cmd += ["--max-model-len", str(args.max_context)]
+    cmd += ["--max-tokens", str(args.max_tokens)]
+    cmd += ["--prompt-length", str(args.prompt_length)]
+    cmd += ["--warmup-runs", str(args.warmup_runs)]
+    cmd += ["--test-runs", str(args.test_runs)]
+    cmd += ["--tensor-parallel-size", "4"]
+    # Each rank must drive the engine with the same KV layout as rank 0.
+    cmd += ["--backend-option", f"nccl_id_path={nccl_path}"]
+    if args.kv_paged:
+        cmd += ["--backend-option", "kv_paged=True"]
+        cmd += ["--backend-option", f"kv_block_size={args.kv_block_size}"]
+    if args.kv_cache_mb:
+        cmd += ["--backend-option", f"kv_cache_bytes={args.kv_cache_mb * 1024 * 1024}"]
+    if args.no_prefix_cache:
+        cmd += ["--backend-option", "enable_prefix_caching=False"]
+    if args.json_out:
+        cmd += ["--json-out", str(args.json_out) if rank == 0 else f"{args.json_out}.r{rank}"]
+    return cmd
+
+
+def parse_backend_options(cmd: list[str]) -> dict:
+    """Extract the --backend-option pairs from a rank command into a dict."""
+    out: dict[str, str] = {}
+    it = iter(cmd)
+    for tok in it:
+        if tok == "--backend-option":
+            key, _, value = next(it).partition("=")
+            out[key] = value
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("checkpoint", help="Path to Qwen3.8 checkpoint directory")
+    parser.add_argument("--mode", choices=["serial", "batch"], required=True)
+    parser.add_argument("--num-concurrent", type=int, required=True)
+    parser.add_argument("--max-context", type=int, default=4096)
+    parser.add_argument("--max-tokens", type=int, default=128)
+    parser.add_argument("--prompt-length", type=int, default=32)
+    parser.add_argument("--warmup-runs", type=int, default=1)
+    parser.add_argument("--test-runs", type=int, default=3)
+    parser.add_argument("--kv-paged", action="store_true")
+    parser.add_argument("--kv-block-size", type=int, default=16)
+    parser.add_argument("--kv-cache-mb", type=int, default=0,
+                        help="Paged pool budget in MiB; 0 derives it from the "
+                             "contiguous arena reservation")
+    parser.add_argument("--no-prefix-cache", action="store_true",
+                        help="Disable prefix caching so every run does a full "
+                             "prefill; otherwise the identical warmup prompt is "
+                             "reused and the test run only pays decode, which "
+                             "makes the contiguous arm look 4x faster than paged")
+    parser.add_argument("--json-out", help="Write rank 0's single measurement here")
+    parser.add_argument("--log-dir", default="/tmp/qwen_concurrent_tp4")
+    args = parser.parse_args()
+
+    log_dir = Path(args.log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    nccl = f"{log_dir}/nccl_{args.mode}_{args.num_concurrent}_{int(time.time())}.id"
+
+    try:
+        if not Path(PYTHON).exists():
+            print(f"[launcher] {PYTHON} not found; set BENCH_PYTHON", file=sys.stderr)
+            return 1
+
+        procs: list[subprocess.Popen] = []
+        for rank in range(4):
+            cmd = build_rank_cmd(args, rank, nccl)
+            log_path = log_dir / f"r{rank}.log"
+            env = dict(os.environ)
+            # The benchmark reads TP_RANK/TP_WORLD from the environment; ensure
+            # each process sees the same TP world but its own rank. The NCCL id
+            # path is handed to the engine by argument (--backend-option) and by
+            # env; the first rank to mount creates the rendezvous file.
+            # Pin each rank to one GPU; _native_rank_device() renumbers that to
+            # device 0 for this process, so no rank-offset stacking happens.
+            env["TP_RANK"] = str(rank)
+            env["TP_WORLD"] = "4"
+            env["CUDA_VISIBLE_DEVICES"] = str(rank)
+            env["POCKETLLM_NCCL_ID_PATH"] = nccl
+            log_handle = open(log_path, "w")
+            proc = subprocess.Popen(cmd, env=env, stdout=log_handle, stderr=subprocess.STDOUT)
+            procs.append(proc)
+
+        status = 0
+        for proc in procs:
+            rc = proc.wait()
+            if rc != 0:
+                status = rc
+
+        for rank in range(4):
+            log_path = log_dir / f"r{rank}.log"
+            suffix = f" (rank {rank})" if rank else ""
+            print(f"\n===== log{suffix} =====")
+            with open(log_path) as fh:
+                print(fh.read(), end="")
+    finally:
+        try:
+            Path(nccl).unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_qwen_paged_tp_parity.sh
+++ b/scripts/run_qwen_paged_tp_parity.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# TP4 paged-vs-contiguous parity and throughput on the real model.
+#
+# Each KV mode is run as a SEPARATE TP4 process group (one mode per group, all
+# four ranks together), so the parity diff reflects KV layout only and no
+# per-mode engine construction is shared. The checksum over the token stream is
+# diffed across modes: paged KV must produce byte-identical output to the
+# contiguous arena, and its decode throughput must not regress.
+#
+# Usage: run_qwen_paged_tp_parity.sh [checkpoint] [layers] [batch-sizes...]
+#   e.g. run_qwen_paged_tp_parity.sh /mnt/data2/Qwen3.8-27B-FP8 4 1 4 8
+
+CHECKPOINT="${1:-/mnt/data2/Qwen3.8-27B-FP8}"
+LAYERS="${2:-4}"
+shift 2 2>/dev/null || true
+BATCHES=("$@")
+[ ${#BATCHES[@]} -eq 0 ] && BATCHES=(1 4 8)
+
+BIN="$(cd "$(dirname "$0")/.." && pwd)/cpp_engine/build/tests/bench_qwen_paged_tp_parity"
+CONTEXT="${CONTEXT:-1024}"
+DECODE="${DECODE:-16}"
+BLOCK="${BLOCK:-16}"
+DIR="${DIR:-/tmp/qwen_paged_tp_parity}"
+mkdir -p "$DIR"
+
+run_mode() {
+    local mode="$1" batch="$2"
+    local nccl="/tmp/qwen_paged_tp_parity_nccl_${mode}_${batch}_$(date +%s)_$$"
+    local r0="$DIR/${mode}_b${batch}_r0.log"
+
+    # Rank 0 in the foreground so its output (with the checksum) is captured.
+    CUDA_VISIBLE_DEVICES=0 "$BIN" "$CHECKPOINT" \
+        --layers "$LAYERS" --max-context "$CONTEXT" --decode "$DECODE" \
+        --tp-world 4 --tp-rank 0 --device 0 --nccl-id "$nccl" \
+        --batch-size "$batch" --mode "$mode" --kv-block-size "$BLOCK" \
+        >"$r0" 2>&1 &
+    local p0=$!
+    local pids=("$p0")
+    for rank in 1 2 3; do
+        CUDA_VISIBLE_DEVICES=$rank "$BIN" "$CHECKPOINT" \
+            --layers "$LAYERS" --max-context "$CONTEXT" --decode "$DECODE" \
+            --tp-world 4 --tp-rank $rank --device 0 --nccl-id "$nccl" \
+            --batch-size "$batch" --mode "$mode" --kv-block-size "$BLOCK" \
+            >"$DIR/${mode}_b${batch}_r${rank}.log" 2>&1 &
+        pids+=($!)
+    done
+
+    local status=0
+    for pid in "${pids[@]}"; do
+        wait "$pid" || status=1
+    done
+    rm -f "$nccl"
+    return $status
+}
+
+parse_arm() {
+    local mode="$1" batch="$2"
+    local r0="$DIR/${mode}_b${batch}_r0.log"
+    echo "----- $mode batch=$batch (rank 0) -----"
+    grep -E "checksum=|decode_ms/step=|prompt_tokens=" "$r0" || echo "(no summary line)"
+    # Emit machine-readable values on `<name>=<value>` lines for the caller.
+    grep -E "^  checksum=" "$r0" | sed -E 's/.*checksum=([0-9a-f]+)/checksum=\1/'
+    grep -E "decode_ms/step=" "$r0" | sed -E 's/.*decode_ms\/step=([0-9.]+).*/ms_per_step=\1/'
+}
+
+fail=0
+for batch in "${BATCHES[@]}"; do
+    echo "=================================================="
+    echo "batch=$batch"
+    echo "=================================================="
+
+    run_mode contiguous "$batch" || { echo "contiguous arm failed"; fail=1; }
+    run_mode paged "$batch" || { echo "paged arm failed"; fail=1; }
+
+    cs="$(parse_arm contiguous "$batch")"
+    ps="$(parse_arm paged "$batch")"
+    echo "$cs"; echo "$ps"
+
+    c_checksum="$(echo "$cs" | grep '^checksum=' | cut -d= -f2)"
+    p_checksum="$(echo "$ps" | grep '^checksum=' | cut -d= -f2)"
+    if [ -z "$c_checksum" ] || [ -z "$p_checksum" ]; then
+        echo "MISSING CHECKSUM"; fail=1; continue
+    fi
+    if [ "$c_checksum" = "$p_checksum" ]; then
+        echo "PARITY: OK"
+    else
+        echo "PARITY: MISMATCH contiguous=$c_checksum paged=$p_checksum"
+        fail=1
+    fi
+    echo ""
+done
+
+echo "=================================================="
+echo "result: $([ $fail -eq 0 ] && echo PASS || echo FAIL)"
+exit $fail

--- a/scripts/run_qwen_paged_tp_slot_free.sh
+++ b/scripts/run_qwen_paged_tp_slot_free.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Launch the TP paged slot-free regression test.
+#
+# TP is the only place the worker-side block leak is observable. Rank 0's pool
+# returns to full after every free_slot (it releases its own blocks directly),
+# so rank 0 alone can never prove a worker leaked. The decisive assertion lives
+# on rank 1: after it receives Shutdown it checks its OWN pool and exits
+# non-zero if FreeSlot was ignored. So this launcher must wait on BOTH ranks and
+# fail if either does.
+#
+# TP2 suffices: the fixture's 4 KV heads split to 2 per rank (TP4 would give 0
+# and paging breaks).
+#
+# The test builds its own fixture checkpoint (deterministic path under /tmp),
+# so it needs no checkpoint argument.
+
+NCCL_ID="/tmp/qwen_paged_tp_slot_free_nccl_$(date +%s)"
+TEST_BIN="$(dirname "$0")/../cpp_engine/build/tests/test_qwen_paged_tp_slot_free"
+
+echo "Launching TP2 paged slot-free regression"
+echo "NCCL ID: $NCCL_ID"
+
+# Rank 0 in the foreground (drives the loop; its own output is the test log).
+CUDA_VISIBLE_DEVICES=0 "$TEST_BIN" \
+    --tp-world 2 \
+    --tp-rank 0 \
+    --device 0 \
+    --nccl-id "$NCCL_ID" &
+PID0=$!
+
+# Rank 1 in the background. Its verdict is the worker-side assertion; capture it
+# to a log and read its exit code.
+CUDA_VISIBLE_DEVICES=1 "$TEST_BIN" \
+    --tp-world 2 \
+    --tp-rank 1 \
+    --device 0 \
+    --nccl-id "$NCCL_ID" >"/tmp/qwen_paged_tp_slot_free_rank1.log" 2>&1 &
+PID1=$!
+
+wait "$PID0"
+STATUS0=$?
+wait "$PID1"
+STATUS1=$?
+
+rm -f "$NCCL_ID"
+
+echo "----- rank 1 (worker) output -----"
+cat "/tmp/qwen_paged_tp_slot_free_rank1.log" 2>/dev/null
+
+echo "rank0=$STATUS0 rank1=$STATUS1"
+if [ "$STATUS0" -ne 0 ] || [ "$STATUS1" -ne 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Paged KV landed in the engine (#134, #135) but was reachable only from C++, and `free_slot()` released blocks on rank 0 alone. This PR closes both gaps and validates the result on the real model under TP4.

## Changes

**1. Expose the paged options through Python.** `QwenEngineOptions` gains `kv_paged` / `kv_block_size` / `kv_cache_bytes`; `QwenEngine` gains `kv_paged` / `kv_free_blocks` / `kv_total_blocks` plus paged fields in the telemetry dict. `cpp_backend` maps all three from `backend_options`, so `--backend-option kv_paged=True` works end to end. A zero `kv_cache_bytes` reproduces the contiguous arena's reservation, so enabling paging alone is memory-neutral.

**2. Fix the TP worker block leak.** Under TP every rank owns a block pool and rank 0 cannot observe a worker's. `free_slot()` released only its own row, so each worker leaked one row per freed slot until its pool ran dry. A new `FreeSlot` worker command broadcasts the release; both sides call one shared `release_slot_paged_state()`. The command is not sent when paging is off, so the contiguous path is byte-for-byte unchanged.

**3. Real-model validation** via two new drivers plus launchers.

## Why the regression test asserts inside the worker

The obvious test does not catch this bug. Rank 0's `kv_free_blocks()` cannot see a worker's pool, and `ensure_capacity()` returns early when a retained row is already large enough — so the worker silently *reuses* the stale row instead of re-allocating. `test_qwen_paged_tp_slot_free` therefore asserts in the **worker** process, comparing its own pool after `Shutdown`.

Verified both directions: it FAILS on the leaky build (`15/16 blocks free`) and PASSES on the fix (`16/16`).

## Testing

| Test | Result |
|---|---|
| `test_qwen_paged_tp_slot_free` (TP2, synthetic fixture) | PASS — `rank0=0 rank1=0`, worker reports 16/16 free |
| `bench_qwen_paged_tp_parity` (TP4, real model, 64 layers) | PARITY OK at batch 1/4/8 — paged output byte-identical to contiguous, no decode regression |
| `run_qwen_concurrent_tp4.py` (TP4, real model) | see below |

Real model is `/mnt/data2/Qwen3.8-27B-FP8` on 4x 2080 Ti.

## What paging buys (TP4, measured)

| Config | Contiguous | Paged |
|---|---|---|
| batch 8, ctx 32768, prompt 4096 | 18.4 s/run, 0.43 req/s, **4 GiB** reserved | 18.4 s/run, 0.43 req/s, **2 GiB** pool |
| batch 8, ctx 131072 | **OOM** (`device_malloc`, all 4 ranks; 16 GiB reservation) | **8/8 admitted**, 2.60 req/s on a **2 GiB** pool |

Boundary: the contiguous arena fits at ctx 98304 (12 GiB) and fails at 131072 (16 GiB). The pool sizes on tokens actually used; the arena reserves `batch x max_context` up front.

## Two measurement bugs fixed along the way

Both inflated results before they were found, so they are worth recording:

1. **Early-EOS truncation.** The benchmark fed the model synthetic ids `[1..n]`, which it stopped on at token 2 — every run reported "successful" in ~0.05 s, ~10x too fast. Fixed with a real tokenized prompt plus `sampling_params.extra["ignore_eos"]`, which `_generate_batched` previously dropped on the floor.
2. **Prompt-reuse artifact.** The engine keeps a slot's KV across runs, so resubmitting an identical prompt let runs 2..N skip prefill — something only the contiguous arm could exploit, inventing a 10x gap. Each run now uses a distinct prompt, and both arms pay a full prefill every run.

## Checklist

- [x] Paged options exposed through pybind11 + Python backend
- [x] TP worker leak fixed, with a test proven to fail on the leaky build
- [x] TP4 token-level parity on the real model at batch 1/4/8
- [x] Long-context memory advantage measured end to end
- [x] Contiguous path unchanged when paging is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)