### PR TITLE
Move model-agnostic runtime components out of the Qwen namespace

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -39,8 +39,8 @@ set(POCKET_CORE_SOURCES
     core/weight_source.cpp
     core/model_config.cpp
     core/qwen_config.cpp
-    core/qwen_block_pool.cpp
-    core/qwen_block_table.cpp
+    core/block_pool.cpp
+    core/block_table.cpp
     core/qwen_weight_map.cpp
     core/tokenizer.cpp
     core/tensor.cpp
@@ -143,7 +143,7 @@ if(POCKET_BACKEND STREQUAL "cuda")
         backends/cuda/kernels/qwen_int8_per_token_head_ops.cu
         backends/cuda/kernels/qwen_dspark_ops.cu
         backends/cuda/kernels/qwen_dflash2_ops.cu
-        backends/cuda/kernels/qwen_sampler.cu
+        backends/cuda/kernels/sampler_ops.cu
         backends/cuda/kernels/q2_ops.cu
         backends/cuda/kernels/iq1_ops.cu
         backends/cuda/kernels/rmsnorm_rope.cu
@@ -680,9 +680,9 @@ add_executable(test_qwen_dflash2_ops tests/test_qwen_dflash2_ops.cpp)
 target_link_libraries(test_qwen_dflash2_ops PRIVATE pocket_cpp_core)
 set_target_properties(test_qwen_dflash2_ops PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
-add_executable(test_qwen_sampler tests/test_qwen_sampler.cpp)
-target_link_libraries(test_qwen_sampler PRIVATE pocket_cpp_core)
-set_target_properties(test_qwen_sampler PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+add_executable(test_sampler_ops tests/test_sampler_ops.cpp)
+target_link_libraries(test_sampler_ops PRIVATE pocket_cpp_core)
+set_target_properties(test_sampler_ops PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(test_qwen_fp8_online tests/test_qwen_fp8_online.cpp)
 target_link_libraries(test_qwen_fp8_online PRIVATE pocket_cpp_core)
@@ -732,9 +732,9 @@ add_executable(test_qwen_eos_stop tests/test_qwen_eos_stop.cpp)
 target_link_libraries(test_qwen_eos_stop PRIVATE pocket_cpp_core)
 set_target_properties(test_qwen_eos_stop PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
-add_executable(test_qwen_block_pool tests/test_qwen_block_pool.cpp)
-target_link_libraries(test_qwen_block_pool PRIVATE pocket_cpp_core)
-set_target_properties(test_qwen_block_pool PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+add_executable(test_block_pool tests/test_block_pool.cpp)
+target_link_libraries(test_block_pool PRIVATE pocket_cpp_core)
+set_target_properties(test_block_pool PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(test_qwen_paged_kv_kernels tests/test_qwen_paged_kv_kernels.cpp)
 target_link_libraries(test_qwen_paged_kv_kernels PRIVATE pocket_cpp_core)

--- a/cpp_engine/backends/cuda/collective/tp_comm.cpp
+++ b/cpp_engine/backends/cuda/collective/tp_comm.cpp
@@ -1,12 +1,12 @@
 #include "tp_comm.hpp"
 
 #ifdef POCKET_HAVE_TP_COMM
-// Both are required: qwen_sampler.hpp for the sampler uniforms and
+// Both are required: sampler_ops.hpp for the sampler uniforms and
 // qwen_cuda_ops.hpp for the DFlash2 top-k pack/merge kernels used by the
 // global-top1 collective below. The latter is only visible in NCCL builds,
 // which is why dropping it still compiled with NCCL off.
 #include "qwen_cuda_ops.hpp"
-#include "qwen_sampler.hpp"
+#include "sampler_ops.hpp"
 
 #include <cuda_runtime.h>
 #include <nccl.h>
@@ -304,10 +304,10 @@ void tp_global_topk_rows_device(int world, int rank, int device,
                              ncclFloat, comm, cuda_stream),
                "ncclAllGather device top-k logits");
     check_nccl(ncclGroupEnd(), "ncclGroupEnd device top-k");
-    if (!qwen_merge_topk_candidates(
+    if (!merge_topk_candidates(
             workspace.d_tokens, workspace.d_logits, d_global_tokens,
             d_global_logits, world, rows, top_k, cuda_stream)) {
-        throw std::runtime_error("Qwen sampling device top-k merge launch failed");
+        throw std::runtime_error("sampling device top-k merge launch failed");
     }
 }
 

--- a/cpp_engine/backends/cuda/kernels/sampler_ops.cu
+++ b/cpp_engine/backends/cuda/kernels/sampler_ops.cu
@@ -1,4 +1,4 @@
-#include "qwen_sampler.hpp"
+#include "sampler_ops.hpp"
 
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
@@ -300,9 +300,9 @@ __global__ void init_curand_kernel(curandState* states, int count,
 
 }  // namespace
 
-size_t qwen_sampler_rng_state_size() { return sizeof(curandState); }
+size_t sampler_rng_state_size() { return sizeof(curandState); }
 
-bool qwen_init_rng_states(DeviceRngState* states, int count,
+bool init_rng_states(DeviceRngState* states, int count,
                           unsigned long long seed, void* stream) {
     if (states == nullptr || count <= 0) return false;
     const int threads = 256;
@@ -312,7 +312,7 @@ bool qwen_init_rng_states(DeviceRngState* states, int count,
     return cudaGetLastError() == cudaSuccess;
 }
 
-bool qwen_sample_top_k_top_p_rows(
+bool sample_top_k_top_p_rows(
     const float* logits, int* out_tokens, float* out_logits, int rows,
     int vocab, int vocab_start, float temperature, float top_p, int top_k,
     DeviceRngState* rng_states, const float* uniforms, void* stream) {
@@ -328,7 +328,7 @@ bool qwen_sample_top_k_top_p_rows(
     return cudaGetLastError() == cudaSuccess;
 }
 
-bool qwen_local_topk_candidates(
+bool local_topk_candidates(
     const float* logits, int* out_tokens, float* out_logits, int rows,
     int vocab, int vocab_start, int top_k, void* stream) {
     if (logits == nullptr || out_tokens == nullptr || out_logits == nullptr) {
@@ -343,7 +343,7 @@ bool qwen_local_topk_candidates(
     return cudaGetLastError() == cudaSuccess;
 }
 
-bool qwen_merge_topk_candidates(
+bool merge_topk_candidates(
     const int* gathered_tokens, const float* gathered_logits,
     int* out_tokens, float* out_logits, int world, int rows, int top_k,
     void* stream) {
@@ -361,7 +361,7 @@ bool qwen_merge_topk_candidates(
     return cudaGetLastError() == cudaSuccess;
 }
 
-bool qwen_sample_from_candidates(
+bool sample_from_candidates(
     const int* cand_tokens, const float* cand_logits, int* out_tokens,
     float* out_logits, int rows, int cand_stride, float temperature,
     float top_p, int top_k, DeviceRngState* rng_states, const float* uniforms,
@@ -380,6 +380,6 @@ bool qwen_sample_from_candidates(
     return cudaGetLastError() == cudaSuccess;
 }
 
-int qwen_sampler_max_top_k() { return kMaxTopK; }
+int sampler_max_top_k() { return kMaxTopK; }
 
 }  // namespace pocket

--- a/cpp_engine/cmake/CheckLayering.cmake
+++ b/cpp_engine/cmake/CheckLayering.cmake
@@ -67,7 +67,7 @@ if(violations)
     message(FATAL_ERROR
         "Vendor SDK headers leaked into a device-agnostic layer:\n  ${pretty}\n"
         "Move the vendor dependency into backends/<vendor>/ and expose an "
-        "opaque handle instead (see include/qwen_sampler.hpp for the pattern).")
+        "opaque handle instead (see include/sampler_ops.hpp for the pattern).")
 endif()
 
 # Vendor runtime entry points the shared layers must call through

--- a/cpp_engine/core/block_pool.cpp
+++ b/cpp_engine/core/block_pool.cpp
@@ -1,20 +1,20 @@
-#include "qwen_block_pool.hpp"
+#include "block_pool.hpp"
 
 #include <stdexcept>
 #include <string>
 
 namespace pocket {
 
-QwenBlockPool::QwenBlockPool(int num_blocks, int block_size)
+BlockPool::BlockPool(int num_blocks, int block_size)
     : num_blocks_(num_blocks), block_size_(block_size) {
     if (num_blocks <= 0) {
         throw std::runtime_error(
-            "QwenBlockPool: num_blocks must be >= 1, got " +
+            "BlockPool: num_blocks must be >= 1, got " +
             std::to_string(num_blocks));
     }
     if (block_size <= 0) {
         throw std::runtime_error(
-            "QwenBlockPool: block_size must be >= 1, got " +
+            "BlockPool: block_size must be >= 1, got " +
             std::to_string(block_size));
     }
     refcounts_.assign(static_cast<size_t>(num_blocks), 0);
@@ -27,10 +27,10 @@ QwenBlockPool::QwenBlockPool(int num_blocks, int block_size)
     }
 }
 
-std::vector<int> QwenBlockPool::allocate(int count) {
+std::vector<int> BlockPool::allocate(int count) {
     if (count < 0) {
         throw std::runtime_error(
-            "QwenBlockPool::allocate: count must be >= 0, got " +
+            "BlockPool::allocate: count must be >= 0, got " +
             std::to_string(count));
     }
     std::vector<int> blocks;
@@ -47,14 +47,14 @@ std::vector<int> QwenBlockPool::allocate(int count) {
     return blocks;
 }
 
-void QwenBlockPool::free(const std::vector<int>& block_ids) {
+void BlockPool::free(const std::vector<int>& block_ids) {
     for (const int block : block_ids) {
         if (block == kInvalidBlock) continue;
         validate(block);
         int& count = refcounts_[static_cast<size_t>(block)];
         if (count == 0) {
             throw std::runtime_error(
-                "QwenBlockPool::free: block " + std::to_string(block) +
+                "BlockPool::free: block " + std::to_string(block) +
                 " is already free");
         }
         if (--count == 0) {
@@ -63,35 +63,35 @@ void QwenBlockPool::free(const std::vector<int>& block_ids) {
     }
 }
 
-void QwenBlockPool::retain(int block_id) {
+void BlockPool::retain(int block_id) {
     validate(block_id);
     int& count = refcounts_[static_cast<size_t>(block_id)];
     if (count == 0) {
         throw std::runtime_error(
-            "QwenBlockPool::retain: block " + std::to_string(block_id) +
+            "BlockPool::retain: block " + std::to_string(block_id) +
             " is not allocated");
     }
     ++count;
 }
 
-int QwenBlockPool::refcount(int block_id) const {
+int BlockPool::refcount(int block_id) const {
     validate(block_id);
     return refcounts_[static_cast<size_t>(block_id)];
 }
 
-int QwenBlockPool::blocks_for_tokens(int tokens) const {
+int BlockPool::blocks_for_tokens(int tokens) const {
     if (tokens < 0) {
         throw std::runtime_error(
-            "QwenBlockPool::blocks_for_tokens: tokens must be >= 0, got " +
+            "BlockPool::blocks_for_tokens: tokens must be >= 0, got " +
             std::to_string(tokens));
     }
     return (tokens + block_size_ - 1) / block_size_;
 }
 
-void QwenBlockPool::validate(int block_id) const {
+void BlockPool::validate(int block_id) const {
     if (block_id < 0 || block_id >= num_blocks_) {
         throw std::runtime_error(
-            "QwenBlockPool: block id " + std::to_string(block_id) +
+            "BlockPool: block id " + std::to_string(block_id) +
             " out of range [0, " + std::to_string(num_blocks_) + ")");
     }
 }

--- a/cpp_engine/core/block_table.cpp
+++ b/cpp_engine/core/block_table.cpp
@@ -1,43 +1,43 @@
-#include "qwen_block_table.hpp"
+#include "block_table.hpp"
 
 #include <stdexcept>
 #include <string>
 
 namespace pocket {
 
-QwenBlockTable::QwenBlockTable(QwenBlockPool* pool, int max_slots,
+BlockTable::BlockTable(BlockPool* pool, int max_slots,
                               int max_context)
     : pool_(pool), max_slots_(max_slots), max_context_(max_context) {
     if (pool_ == nullptr) {
-        throw std::runtime_error("QwenBlockTable: pool must not be null");
+        throw std::runtime_error("BlockTable: pool must not be null");
     }
     if (max_slots <= 0) {
         throw std::runtime_error(
-            "QwenBlockTable: max_slots must be >= 1, got " +
+            "BlockTable: max_slots must be >= 1, got " +
             std::to_string(max_slots));
     }
     if (max_context <= 0) {
         throw std::runtime_error(
-            "QwenBlockTable: max_context must be >= 1, got " +
+            "BlockTable: max_context must be >= 1, got " +
             std::to_string(max_context));
     }
     max_blocks_per_seq_ = pool_->blocks_for_tokens(max_context);
     rows_.assign(static_cast<size_t>(max_slots), {});
     image_.assign(static_cast<size_t>(max_slots) *
                       static_cast<size_t>(max_blocks_per_seq_),
-                  QwenBlockPool::kInvalidBlock);
+                  BlockPool::kInvalidBlock);
 }
 
-bool QwenBlockTable::ensure_capacity(int slot, int tokens) {
+bool BlockTable::ensure_capacity(int slot, int tokens) {
     validate_slot(slot);
     if (tokens < 0) {
         throw std::runtime_error(
-            "QwenBlockTable::ensure_capacity: tokens must be >= 0, got " +
+            "BlockTable::ensure_capacity: tokens must be >= 0, got " +
             std::to_string(tokens));
     }
     if (tokens > max_context_) {
         throw std::runtime_error(
-            "QwenBlockTable::ensure_capacity: " + std::to_string(tokens) +
+            "BlockTable::ensure_capacity: " + std::to_string(tokens) +
             " tokens exceeds max_context " + std::to_string(max_context_));
     }
     std::vector<int>& row = rows_[static_cast<size_t>(slot)];
@@ -55,7 +55,7 @@ bool QwenBlockTable::ensure_capacity(int slot, int tokens) {
     return true;
 }
 
-void QwenBlockTable::release(int slot) {
+void BlockTable::release(int slot) {
     validate_slot(slot);
     std::vector<int>& row = rows_[static_cast<size_t>(slot)];
     if (row.empty()) return;
@@ -64,16 +64,16 @@ void QwenBlockTable::release(int slot) {
     dirty_ = true;
 }
 
-void QwenBlockTable::release_all() {
+void BlockTable::release_all() {
     for (int slot = 0; slot < max_slots_; ++slot) release(slot);
 }
 
-size_t QwenBlockTable::element_offset(int slot, int position,
+size_t BlockTable::element_offset(int slot, int position,
                                      size_t kv_stride) const {
     validate_slot(slot);
     if (position < 0) {
         throw std::runtime_error(
-            "QwenBlockTable::element_offset: negative position " +
+            "BlockTable::element_offset: negative position " +
             std::to_string(position));
     }
     const int block_size = pool_->block_size();
@@ -82,7 +82,7 @@ size_t QwenBlockTable::element_offset(int slot, int position,
     const std::vector<int>& row = rows_[static_cast<size_t>(slot)];
     if (index >= row.size()) {
         throw std::runtime_error(
-            "QwenBlockTable::element_offset: position " +
+            "BlockTable::element_offset: position " +
             std::to_string(position) + " is not backed for slot " +
             std::to_string(slot));
     }
@@ -93,20 +93,20 @@ size_t QwenBlockTable::element_offset(int slot, int position,
             within) * kv_stride;
 }
 
-const std::vector<int>& QwenBlockTable::row(int slot) const {
+const std::vector<int>& BlockTable::row(int slot) const {
     validate_slot(slot);
     return rows_[static_cast<size_t>(slot)];
 }
 
-int QwenBlockTable::capacity_tokens(int slot) const {
+int BlockTable::capacity_tokens(int slot) const {
     validate_slot(slot);
     return static_cast<int>(rows_[static_cast<size_t>(slot)].size()) *
            pool_->block_size();
 }
 
-const std::vector<int32_t>& QwenBlockTable::device_image() {
+const std::vector<int32_t>& BlockTable::device_image() {
     if (!dirty_) return image_;
-    image_.assign(image_.size(), QwenBlockPool::kInvalidBlock);
+    image_.assign(image_.size(), BlockPool::kInvalidBlock);
     for (int slot = 0; slot < max_slots_; ++slot) {
         const std::vector<int>& row = rows_[static_cast<size_t>(slot)];
         const size_t base = static_cast<size_t>(slot) *
@@ -119,10 +119,10 @@ const std::vector<int32_t>& QwenBlockTable::device_image() {
     return image_;
 }
 
-void QwenBlockTable::validate_slot(int slot) const {
+void BlockTable::validate_slot(int slot) const {
     if (slot < 0 || slot >= max_slots_) {
         throw std::runtime_error(
-            "QwenBlockTable: slot " + std::to_string(slot) +
+            "BlockTable: slot " + std::to_string(slot) +
             " out of range [0, " + std::to_string(max_slots_) + ")");
     }
 }

--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -6,12 +6,12 @@
 #include "cmd_channel.hpp"
 #include "cuda_ops.hpp"
 #include "device_runtime.hpp"
-#include "qwen_block_pool.hpp"
-#include "qwen_block_table.hpp"
+#include "block_pool.hpp"
+#include "block_table.hpp"
 #include "qwen_ops.hpp"
 #include "qwen_dspark.hpp"
 #include "qwen_dflash2.hpp"
-#include "qwen_sampler.hpp"
+#include "sampler_ops.hpp"
 #include "qwen_target_head.hpp"
 #include "tp_comm.hpp"
 
@@ -600,8 +600,8 @@ struct QwenEngine::Impl {
     // bookkeeping and the table owns the per-slot logical-to-physical map; the
     // device arenas stay in the per-layer k_cache/v_cache tensors, sized to the
     // pool rather than to max_batch_size * max_context.
-    std::unique_ptr<QwenBlockPool> block_pool;
-    std::unique_ptr<QwenBlockTable> block_table;
+    std::unique_ptr<BlockPool> block_pool;
+    std::unique_ptr<BlockTable> block_table;
     // Device mirror of the table, `[max_slots, max_blocks_per_seq]` int32.
     QwenDeviceTensor block_table_device;
 
@@ -940,9 +940,9 @@ struct QwenEngine::Impl {
                     "-token sequence needs " + std::to_string(blocks_per_seq) +
                     "; raise QwenEngineOptions::kv_cache_bytes");
             }
-            block_pool = std::make_unique<QwenBlockPool>(
+            block_pool = std::make_unique<BlockPool>(
                 num_blocks, options.kv_block_size);
-            block_table = std::make_unique<QwenBlockTable>(
+            block_table = std::make_unique<BlockTable>(
                 block_pool.get(), options.max_batch_size, max_context);
             const size_t image_elements =
                 static_cast<size_t>(block_table->max_slots()) *
@@ -3340,12 +3340,12 @@ struct QwenEngine::Impl {
                                       int local_vocab, int vocab_start,
                                       int position_after) {
         int top_k = options.top_k;
-        const int max_top_k = qwen_sampler_max_top_k();
+        const int max_top_k = sampler_max_top_k();
         if (top_k <= 0 || top_k > max_top_k) top_k = max_top_k;
         if (top_k > local_vocab) top_k = local_vocab;
 
         allocate(sample_rng_states,
-                 static_cast<size_t>(rows) * qwen_sampler_rng_state_size(),
+                 static_cast<size_t>(rows) * sampler_rng_state_size(),
                  {static_cast<uint64_t>(rows)}, SafeDType::I8);
         allocate_float(sample_uniforms, static_cast<size_t>(rows),
                        {static_cast<uint64_t>(rows)});
@@ -3383,7 +3383,7 @@ struct QwenEngine::Impl {
             allocate_float(sample_merged_logit, cand,
                            {static_cast<uint64_t>(cand)});
 
-            require_launch(qwen_local_topk_candidates(
+            require_launch(local_topk_candidates(
                 local_logits.f32_data(),
                 static_cast<int*>(sample_cand_token.data),
                 sample_cand_logit.f32_data(), rows, local_vocab, vocab_start,
@@ -3398,7 +3398,7 @@ struct QwenEngine::Impl {
                 static_cast<int*>(sample_merged_token.data),
                 sample_merged_logit.f32_data());
 
-            require_launch(qwen_sample_from_candidates(
+            require_launch(sample_from_candidates(
                 static_cast<const int*>(sample_merged_token.data),
                 sample_merged_logit.f32_data(),
                 static_cast<int*>(argmax_token.data), argmax_logit.f32_data(),
@@ -3416,7 +3416,7 @@ struct QwenEngine::Impl {
                     "Qwen TP requires an NCCL-enabled build");
             }
 #endif
-            require_launch(qwen_sample_top_k_top_p_rows(
+            require_launch(sample_top_k_top_p_rows(
                 local_logits.f32_data(),
                 static_cast<int*>(argmax_token.data), argmax_logit.f32_data(),
                 rows, local_vocab, vocab_start, options.temperature,

--- a/cpp_engine/include/block_pool.hpp
+++ b/cpp_engine/include/block_pool.hpp
@@ -21,13 +21,13 @@ namespace pocket {
 // Blocks are refcounted even though nothing shares them yet: prefix sharing
 // across sequences needs exactly this counter, and retrofitting it later would
 // mean revisiting every free site.
-class QwenBlockPool {
+class BlockPool {
 public:
     static constexpr int kInvalidBlock = -1;
 
     // `block_size` is tokens per block; `num_blocks` is the pool extent. Both
     // must be positive.
-    QwenBlockPool(int num_blocks, int block_size);
+    BlockPool(int num_blocks, int block_size);
 
     // Takes `count` blocks, or returns empty when the pool cannot satisfy the
     // whole request. Partial allocation is deliberately not offered: a sequence

--- a/cpp_engine/include/block_table.hpp
+++ b/cpp_engine/include/block_table.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "qwen_block_pool.hpp"
+#include "block_pool.hpp"
 
 #include <cstdint>
 #include <vector>
@@ -19,9 +19,9 @@ namespace pocket {
 // the same rows, which is what the kernels index. It is kept as host memory here
 // and uploaded by the engine, so this class stays free of device calls and can
 // be tested without a GPU.
-class QwenBlockTable {
+class BlockTable {
 public:
-    QwenBlockTable(QwenBlockPool* pool, int max_slots, int max_context);
+    BlockTable(BlockPool* pool, int max_slots, int max_context);
 
     // Ensures `slot` is backed to at least `tokens` logical positions, taking
     // blocks from the pool as needed. Returns false without changing anything
@@ -61,7 +61,7 @@ public:
 private:
     void validate_slot(int slot) const;
 
-    QwenBlockPool* pool_;
+    BlockPool* pool_;
     int max_slots_;
     int max_context_;
     int max_blocks_per_seq_;

--- a/cpp_engine/include/sampler_ops.hpp
+++ b/cpp_engine/include/sampler_ops.hpp
@@ -6,12 +6,12 @@ namespace pocket {
 
 // Opaque per-row RNG state. The concrete type is backend-private (curandState on
 // CUDA), so callers only ever handle it as a byte buffer sized by
-// `qwen_sampler_rng_state_size()`. Keeping it opaque is what lets this header
+// `sampler_rng_state_size()`. Keeping it opaque is what lets this header
 // stay free of vendor SDK includes.
 struct DeviceRngState;
 
 // Byte size of one `DeviceRngState`, for allocating an [rows] array.
-size_t qwen_sampler_rng_state_size();
+size_t sampler_rng_state_size();
 
 // Device top-k -> temperature -> top-p sampling over FP32 logit rows.
 //
@@ -36,7 +36,7 @@ size_t qwen_sampler_rng_state_size();
 // TP note: with vocab sharding each rank sees only its own shard, so the
 // caller must still reduce across ranks to pick one global token. Passing a
 // shared `uniforms` row makes that reduction agree on every rank.
-bool qwen_sample_top_k_top_p_rows(
+bool sample_top_k_top_p_rows(
     const float* logits,
     int* out_tokens,
     float* out_logits,
@@ -53,7 +53,7 @@ bool qwen_sample_top_k_top_p_rows(
 // TP stage 1: reduce each sharded row to its local top-k, emitted as global ids
 // into [rows, top_k] buffers so NCCL can merge candidates across ranks. Short
 // rows are padded with token -1 and logit -inf.
-bool qwen_local_topk_candidates(
+bool local_topk_candidates(
     const float* logits,
     int* out_tokens,
     float* out_logits,
@@ -67,7 +67,7 @@ bool qwen_local_topk_candidates(
 // Input layout is world-major [world, rows, top_k], matching ncclAllGather;
 // output layout is row-major [rows, top_k]. Ordering is descending logit with
 // ascending global token id as the deterministic tie-break.
-bool qwen_merge_topk_candidates(
+bool merge_topk_candidates(
     const int* gathered_tokens,
     const float* gathered_logits,
     int* out_tokens,
@@ -80,7 +80,7 @@ bool qwen_merge_topk_candidates(
 // TP stage 2: sample from candidates already merged across ranks. `cand_tokens`
 // are global ids, so no vocab_start offset is applied. Pass the same `uniforms`
 // on every rank to make all ranks commit the same token.
-bool qwen_sample_from_candidates(
+bool sample_from_candidates(
     const int* cand_tokens,
     const float* cand_logits,
     int* out_tokens,
@@ -95,10 +95,10 @@ bool qwen_sample_from_candidates(
     void* stream = nullptr);
 
 // Largest supported top_k; callers must not request more.
-int qwen_sampler_max_top_k();
+int sampler_max_top_k();
 
 // Initialize one generator per row. Seed identically across TP ranks.
-bool qwen_init_rng_states(
+bool init_rng_states(
     DeviceRngState* states,
     int count,
     unsigned long long seed,

--- a/cpp_engine/tests/test_block_pool.cpp
+++ b/cpp_engine/tests/test_block_pool.cpp
@@ -3,8 +3,8 @@
 // list are exercised without a GPU, so a translation bug is caught here rather
 // than as a divergence in a 64-layer parity run.
 
-#include "qwen_block_pool.hpp"
-#include "qwen_block_table.hpp"
+#include "block_pool.hpp"
+#include "block_table.hpp"
 
 #include <cstdio>
 #include <set>
@@ -35,7 +35,7 @@ bool throws(Fn&& call) {
 }
 
 void test_pool_basics() {
-    pocket::QwenBlockPool pool(8, 16);
+    pocket::BlockPool pool(8, 16);
     check(pool.total_blocks() == 8, "pool total_blocks");
     check(pool.free_blocks() == 8, "fresh pool is fully free");
     check(pool.block_size() == 16, "pool block_size");
@@ -57,7 +57,7 @@ void test_pool_basics() {
 }
 
 void test_pool_exhaustion() {
-    pocket::QwenBlockPool pool(4, 16);
+    pocket::BlockPool pool(4, 16);
     std::vector<int> all = pool.allocate(4);
     check(all.size() == 4, "the pool can be drained exactly");
     check(pool.free_blocks() == 0, "drained pool has nothing free");
@@ -78,7 +78,7 @@ void test_pool_exhaustion() {
 }
 
 void test_pool_refcounts() {
-    pocket::QwenBlockPool pool(4, 16);
+    pocket::BlockPool pool(4, 16);
     std::vector<int> blocks = pool.allocate(1);
     const int block = blocks[0];
 
@@ -96,19 +96,19 @@ void test_pool_refcounts() {
     check(throws([&] { pool.retain(block); }),
           "retaining a free block throws");
     check(throws([&] { pool.refcount(99); }), "an out-of-range id throws");
-    check(throws([&] { pocket::QwenBlockPool(0, 16); }),
+    check(throws([&] { pocket::BlockPool(0, 16); }),
           "a zero-block pool throws");
-    check(throws([&] { pocket::QwenBlockPool(4, 0); }),
+    check(throws([&] { pocket::BlockPool(4, 0); }),
           "a zero-size block throws");
 
     // kInvalidBlock is skipped so a caller can free a partially built row.
-    pool.free({pocket::QwenBlockPool::kInvalidBlock});
+    pool.free({pocket::BlockPool::kInvalidBlock});
     check(pool.free_blocks() == 4, "freeing kInvalidBlock is a no-op");
 }
 
 void test_table_growth() {
-    pocket::QwenBlockPool pool(16, 16);
-    pocket::QwenBlockTable table(&pool, 4, 256);
+    pocket::BlockPool pool(16, 16);
+    pocket::BlockTable table(&pool, 4, 256);
     check(table.max_blocks_per_seq() == 16, "max_blocks_per_seq from context");
     check(table.capacity_tokens(0) == 0, "a fresh slot backs no tokens");
 
@@ -130,8 +130,8 @@ void test_table_growth() {
 }
 
 void test_table_translation() {
-    pocket::QwenBlockPool pool(8, 4);
-    pocket::QwenBlockTable table(&pool, 2, 32);
+    pocket::BlockPool pool(8, 4);
+    pocket::BlockTable table(&pool, 2, 32);
     const size_t kv_stride = 8;  // kv_heads * head_dim, small enough to check
 
     check(table.ensure_capacity(0, 12), "slot 0 backed to 12 tokens");
@@ -161,8 +161,8 @@ void test_table_translation() {
 // an interleaved slot forces slot 2's row to be non-monotonic, and the offsets
 // must follow the row rather than the position.
 void test_table_fragmentation() {
-    pocket::QwenBlockPool pool(6, 4);
-    pocket::QwenBlockTable table(&pool, 3, 32);
+    pocket::BlockPool pool(6, 4);
+    pocket::BlockTable table(&pool, 3, 32);
 
     check(table.ensure_capacity(0, 8), "slot 0 takes two blocks");
     check(table.ensure_capacity(1, 8), "slot 1 takes two blocks");
@@ -202,8 +202,8 @@ void test_table_fragmentation() {
 }
 
 void test_table_backpressure() {
-    pocket::QwenBlockPool pool(2, 4);
-    pocket::QwenBlockTable table(&pool, 2, 64);
+    pocket::BlockPool pool(2, 4);
+    pocket::BlockTable table(&pool, 2, 64);
 
     check(table.ensure_capacity(0, 8), "slot 0 drains the pool");
     check(pool.free_blocks() == 0, "the pool is drained");
@@ -220,8 +220,8 @@ void test_table_backpressure() {
 }
 
 void test_device_image() {
-    pocket::QwenBlockPool pool(8, 4);
-    pocket::QwenBlockTable table(&pool, 2, 16);
+    pocket::BlockPool pool(8, 4);
+    pocket::BlockTable table(&pool, 2, 16);
     check(table.dirty(), "a fresh table needs its first upload");
 
     check(table.ensure_capacity(0, 8), "slot 0 backed");
@@ -233,9 +233,9 @@ void test_device_image() {
     check(image[0] == row[0] && image[1] == row[1], "row 0 is mirrored");
     // Unbacked entries must be kInvalidBlock, not zero: block 0 is a real block,
     // so zero padding would alias a live block into every short row.
-    check(image[2] == pocket::QwenBlockPool::kInvalidBlock,
+    check(image[2] == pocket::BlockPool::kInvalidBlock,
           "unbacked entries are kInvalidBlock");
-    check(image[4] == pocket::QwenBlockPool::kInvalidBlock,
+    check(image[4] == pocket::BlockPool::kInvalidBlock,
           "an empty slot's row is all kInvalidBlock");
 
     // A decode step that crosses no boundary must not force an upload.

--- a/cpp_engine/tests/test_qwen_paged_kv_kernels.cpp
+++ b/cpp_engine/tests/test_qwen_paged_kv_kernels.cpp
@@ -12,8 +12,8 @@
 // fixtures, so that a misaddressed token changes the softmax result instead of
 // being averaged away.
 
-#include "qwen_block_pool.hpp"
-#include "qwen_block_table.hpp"
+#include "block_pool.hpp"
+#include "block_table.hpp"
 #include "qwen_cuda_ops.hpp"
 #include "cuda_ops.hpp"
 
@@ -108,7 +108,7 @@ std::vector<int32_t> fragmented_table(const std::vector<int>& context_lens,
                                       unsigned seed) {
     const size_t slots = context_lens.size();
     std::vector<int32_t> image(slots * static_cast<size_t>(max_blocks_per_seq),
-                              pocket::QwenBlockPool::kInvalidBlock);
+                              pocket::BlockPool::kInvalidBlock);
     std::mt19937 rng(seed);
     int next = 0;
     std::vector<std::vector<int>> rows(slots);

--- a/cpp_engine/tests/test_sampler_ops.cpp
+++ b/cpp_engine/tests/test_sampler_ops.cpp
@@ -1,12 +1,12 @@
 // Correctness tests for the device top-k -> temperature -> top-p sampler.
 //
-// The sampler is the only nondeterministic component in the Qwen decode path,
-// so these tests pin the properties the benchmark protocol depends on: greedy
+// The sampler is the only nondeterministic component in the decode path, so
+// these tests pin the properties the benchmark protocol depends on: greedy
 // equivalence at temperature 0, exact agreement with a CPU reference over the
 // top-k set, correct nucleus truncation, and identical draws across TP ranks
 // when the host supplies the uniforms.
 
-#include "qwen_sampler.hpp"
+#include "sampler_ops.hpp"
 
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
@@ -66,11 +66,11 @@ DeviceRun run_sampler(const std::vector<float>& host_logits, int rows,
     check(cudaMalloc(&d_logits, host_logits.size() * sizeof(float)), "malloc logits");
     check(cudaMalloc(&d_tokens, static_cast<size_t>(rows) * sizeof(int)), "malloc tokens");
     check(cudaMalloc(&d_out_logits, static_cast<size_t>(rows) * sizeof(float)), "malloc out logits");
-    check(cudaMalloc(&d_states, static_cast<size_t>(rows) * pocket::qwen_sampler_rng_state_size()), "malloc states");
+    check(cudaMalloc(&d_states, static_cast<size_t>(rows) * pocket::sampler_rng_state_size()), "malloc states");
     check(cudaMemcpy(d_logits, host_logits.data(),
                      host_logits.size() * sizeof(float), cudaMemcpyHostToDevice),
           "copy logits");
-    check(pocket::qwen_init_rng_states(d_states, rows, 1234ULL, nullptr), "init states");
+    check(pocket::init_rng_states(d_states, rows, 1234ULL, nullptr), "init states");
 
     if (!uniforms.empty()) {
         check(cudaMalloc(&d_uniforms, uniforms.size() * sizeof(float)), "malloc uniforms");
@@ -79,7 +79,7 @@ DeviceRun run_sampler(const std::vector<float>& host_logits, int rows,
               "copy uniforms");
     }
 
-    check(pocket::qwen_sample_top_k_top_p_rows(
+    check(pocket::sample_top_k_top_p_rows(
               d_logits, d_tokens, d_out_logits, rows, vocab, vocab_start,
               temperature, top_p, top_k, d_states, d_uniforms, nullptr),
           "launch sampler");
@@ -228,7 +228,7 @@ void test_topk40_world_major_merge() {
     check(cudaMemcpy(d_gathered_logits, gathered_logits.data(),
                      gathered_logits.size() * sizeof(float), cudaMemcpyHostToDevice),
           "merge copy gathered logits");
-    check(pocket::qwen_merge_topk_candidates(
+    check(pocket::merge_topk_candidates(
               d_gathered_tokens, d_gathered_logits, d_tokens, d_logits, world,
               rows, top_k, nullptr),
           "merge top-k=40 launch");
@@ -450,7 +450,7 @@ int main() {
             check(cudaMemcpy(d_logits, shard_logits.data(),
                              shard_logits.size() * sizeof(float), cudaMemcpyHostToDevice),
                   "tp copy logits");
-            check(pocket::qwen_local_topk_candidates(
+            check(pocket::local_topk_candidates(
                       d_logits, d_tokens, d_out, rows, shard, rank * shard,
                       top_k, nullptr),
                   "tp stage1 launch");
@@ -492,7 +492,7 @@ int main() {
         check(cudaMalloc(&d_tokens, static_cast<size_t>(rows) * sizeof(int)), "tp2 malloc tokens");
         check(cudaMalloc(&d_logits_out, static_cast<size_t>(rows) * sizeof(float)), "tp2 malloc logits");
         check(cudaMalloc(&d_uniforms, uniforms.size() * sizeof(float)), "tp2 malloc uniforms");
-        check(cudaMalloc(&d_states, static_cast<size_t>(rows) * pocket::qwen_sampler_rng_state_size()), "tp2 malloc states");
+        check(cudaMalloc(&d_states, static_cast<size_t>(rows) * pocket::sampler_rng_state_size()), "tp2 malloc states");
         check(cudaMemcpy(d_cand_tok, merged_tokens.data(),
                          merged_tokens.size() * sizeof(int), cudaMemcpyHostToDevice),
               "tp2 copy cand tok");
@@ -502,8 +502,8 @@ int main() {
         check(cudaMemcpy(d_uniforms, uniforms.data(),
                          uniforms.size() * sizeof(float), cudaMemcpyHostToDevice),
               "tp2 copy uniforms");
-        check(pocket::qwen_init_rng_states(d_states, rows, 7ULL, nullptr), "tp2 init states");
-        check(pocket::qwen_sample_from_candidates(
+        check(pocket::init_rng_states(d_states, rows, 7ULL, nullptr), "tp2 init states");
+        check(pocket::sample_from_candidates(
                   d_cand_tok, d_cand_lg, d_tokens, d_logits_out, rows,
                   top_k * tp, 1.0f, 0.95f, top_k, d_states, d_uniforms, nullptr),
               "tp2 launch");

--- a/docs/refactor/cpp_engine_multi_backend_plan.md
+++ b/docs/refactor/cpp_engine_multi_backend_plan.md
@@ -21,7 +21,7 @@ Three measured facts make the refactor tractable:
    boundary.
 2. **The kernel headers are already vendor-neutral.** `cuda_ops.hpp` and `qwen_cuda_ops.hpp` include
    only `<cstddef>` / `<cstdint>`, and 91 of 93 declarations take `void* stream`. Only
-   `qwen_sampler.hpp` leaks CUDA types.
+   `sampler_ops.hpp` leaks CUDA types.
 3. **Device memory is already funnelled.** In `deepseek_v4_engine.cpp`, 892 of ~934 CUDA call sites go
    through the `check_cuda(...)` wrapper; only 42 raw `cudaMalloc` sites bypass it.
 
@@ -106,7 +106,7 @@ Each phase ends in a buildable, testable state.
 
 ### Phase 0 — Neutralize leaks (no behavior change)
 
-- Remove the CUDA leak from `qwen_sampler.hpp`: `#include <cuda_runtime.h>` + 5x `cudaStream_t`
+- Remove the CUDA leak from `sampler_ops.hpp`: `#include <cuda_runtime.h>` + 5x `cudaStream_t`
   become `void* stream`, matching the other 91 declarations.
 - Rename `*_cuda` operator symbols to vendor-neutral names, keeping thin deprecated aliases so no
   call site breaks in this phase.


### PR DESCRIPTION
## Summary

The block pool, block table, and sampler are named as if they belong to Qwen, but none of them contains model logic:

| Component | Qwen-specific logic | What it actually is |
|---|---|---|
| `core/qwen_block_pool.cpp` | none | free list + refcounts over block ids |
| `include/qwen_block_table.hpp` | none | per-slot rows of block ids |
| `backends/cuda/kernels/qwen_sampler.cu` | none (only the symbol names) | `(logits, vocab, top_k, top_p, temperature) -> token` |

The name is the only thing tying them to one model, and it is what would stop a second engine from reusing them. This drops the prefix.

## Implementation

- `core/qwen_block_pool.*` → `core/block_pool.*`, `QwenBlockPool` → `BlockPool`
- `core/qwen_block_table.*` → `core/block_table.*`, `QwenBlockTable` → `BlockTable`
- `include/qwen_sampler.hpp` + `backends/cuda/kernels/qwen_sampler.cu` → `sampler_ops.hpp` / `sampler_ops.cu`; `qwen_sample_top_k_top_p_rows` → `sample_top_k_top_p_rows`, and the other six entry points likewise
- `tests/test_qwen_block_pool.cpp` → `tests/test_block_pool.cpp`, `tests/test_qwen_sampler.cpp` → `tests/test_sampler_ops.cpp`
- Call sites updated in `engine/qwen_engine.cpp`, `backends/cuda/collective/tp_comm.cpp`, and `tests/test_qwen_paged_kv_kernels.cpp`; two stale comments and the `CheckLayering.cmake` diagnostic follow the new header name

This is pure code motion. No kernel, no call sequence, and no allocation changed. The only object-code difference outside symbol names is the read-only string pool layout, because the exception messages lost their four-character `Qwen` prefix — `objdump -d` over `block_pool.cpp.o` and `block_table.cpp.o` is otherwise instruction-identical against the pre-change build.

`docs/models/qwen3.8-27b-nvfp4.md` keeps the old binary names: it is a past-tense record of a validation run, not live guidance.

## Testing

All comparisons are against a detached-HEAD build of `a4472b1`, on the real checkpoint `/mnt/data2/Qwen3.8-27B-FP8`, TP4 on 4×2080 Ti, one configuration per process.

**Token parity — 4-layer TP4 digest** (`bench_qwen_paged_tp_parity`, contiguous and paged, batch 1/4/8): all six checksums byte-identical to the baseline (`df92123420008a37`, `2c2fdc7199eb3f43`, `156efc37fb5e762a`).

**Token parity — full 64-layer TP4** at 8,192 and 65,536 prompt tokens: generated token sequences identical to the baseline, same input fixture sha256, `rank_token_parity=PASS`.

**Throughput A/B** — serial, fresh process per length, TG=64:

| Prompt | Prefill base → PR | Decode base → PR (TG=64) |
|---|---|---|
| 8,192 | 1851.91 → 1838.98 tok/s | 45.485 → 45.249 tok/s |
| 65,536 | 1468.16 → 1457.40 tok/s | 40.536 → 40.106 tok/s |

All within run-to-run noise; peak GPU bytes identical at both lengths.

**Existing suites:** all 81 C++ test binaries return exit codes identical to the baseline, the two renamed targets included. Zero Python files are touched, so the Python suite is unaffected.

## Checklist

- [x] Pure code motion, no behaviour change
- [x] Token-exact parity, 4-layer and full 64-layer
- [x] Serial short + long throughput A/B with TG length stated
- [x] Existing C++ suite diffed against a detached-HEAD baseline
- [ ] Follow-up: `InferenceEngine` interface and a generic scheduler (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)