### PR TITLE
Give the scheduler an engine interface instead of a model type

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -59,7 +59,7 @@ set(POCKET_ENGINE_SOURCES
     engine/qwen_weights.cpp
     engine/qwen_target_head.cpp
     engine/qwen_engine.cpp
-    engine/qwen_batch_scheduler.cpp
+    engine/batch_scheduler.cpp
 )
 
 # Engines that still call CUDA kernels by name. A runtime guard cannot help here:
@@ -884,9 +884,9 @@ add_executable(test_persistent_engine tests/test_persistent_engine.cpp)
 target_link_libraries(test_persistent_engine PRIVATE pocket_cpp_core)
 set_target_properties(test_persistent_engine PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
-add_executable(test_qwen_batch_scheduler tests/test_qwen_batch_scheduler.cpp)
-target_link_libraries(test_qwen_batch_scheduler PRIVATE pocket_cpp_core)
-set_target_properties(test_qwen_batch_scheduler PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+add_executable(test_batch_scheduler tests/test_batch_scheduler.cpp)
+target_link_libraries(test_batch_scheduler PRIVATE pocket_cpp_core)
+set_target_properties(test_batch_scheduler PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(bench_qwen_fp8_batch_crossover tests/bench_qwen_fp8_batch_crossover.cpp)
 target_link_libraries(bench_qwen_fp8_batch_crossover PRIVATE pocket_cpp_core)

--- a/cpp_engine/engine/batch_scheduler.cpp
+++ b/cpp_engine/engine/batch_scheduler.cpp
@@ -1,32 +1,32 @@
-#include "qwen_batch_scheduler.hpp"
-#include "qwen_engine.hpp"
+#include "batch_scheduler.hpp"
 #include "device_runtime.hpp"
-#include <iostream>
 #include <algorithm>
+#include <iostream>
+#include <stdexcept>
 
 namespace pocket {
 
-QwenBatchScheduler::QwenBatchScheduler(QwenEngine* engine, int max_batch_size)
+BatchScheduler::BatchScheduler(InferenceEngine* engine, int max_batch_size)
     : engine_(engine), max_batch_size_(max_batch_size) {
     if (!engine_) {
-        throw std::invalid_argument("QwenBatchScheduler: engine cannot be null");
+        throw std::invalid_argument("BatchScheduler: engine cannot be null");
     }
     if (max_batch_size_ <= 0) {
-        throw std::invalid_argument("QwenBatchScheduler: max_batch_size must be > 0");
+        throw std::invalid_argument("BatchScheduler: max_batch_size must be > 0");
     }
 
     // Allocate batch slots in the engine
     engine_->allocate_batch_slots(max_batch_size_);
 
     // Start scheduler thread
-    schedule_thread_ = std::thread(&QwenBatchScheduler::schedule_loop, this);
+    schedule_thread_ = std::thread(&BatchScheduler::schedule_loop, this);
 }
 
-QwenBatchScheduler::~QwenBatchScheduler() {
+BatchScheduler::~BatchScheduler() {
     stop();
 }
 
-void QwenBatchScheduler::stop() {
+void BatchScheduler::stop() {
     bool expected = true;
     if (!running_.compare_exchange_strong(expected, false)) {
         return;  // Already stopped
@@ -59,9 +59,9 @@ void QwenBatchScheduler::stop() {
     reserved_blocks_ = 0;
 }
 
-uint64_t QwenBatchScheduler::submit_request(
+uint64_t BatchScheduler::submit_request(
     const std::vector<int>& prompt_tokens,
-    const QwenBatchSamplingParams& sampling,
+    const BatchSamplingParams& sampling,
     std::function<void(const SchedulerGenerationResult&)> callback) {
 
     if (prompt_tokens.empty()) {
@@ -97,7 +97,7 @@ uint64_t QwenBatchScheduler::submit_request(
     return request_id;
 }
 
-bool QwenBatchScheduler::cancel_request(uint64_t request_id) {
+bool BatchScheduler::cancel_request(uint64_t request_id) {
     std::lock_guard<std::mutex> lock(queue_mutex_);
 
     // Check if request is waiting or running
@@ -115,7 +115,7 @@ bool QwenBatchScheduler::cancel_request(uint64_t request_id) {
     return true;
 }
 
-bool QwenBatchScheduler::poll_result(
+bool BatchScheduler::poll_result(
     uint64_t request_id, SchedulerGenerationResult* out, int timeout_ms) {
 
     if (!out) {
@@ -150,7 +150,7 @@ bool QwenBatchScheduler::poll_result(
     }
 }
 
-QwenBatchScheduler::Stats QwenBatchScheduler::get_stats() const {
+BatchScheduler::Stats BatchScheduler::get_stats() const {
     std::lock_guard<std::mutex> lock(queue_mutex_);
 
     Stats stats;
@@ -166,13 +166,13 @@ QwenBatchScheduler::Stats QwenBatchScheduler::get_stats() const {
     return stats;
 }
 
-void QwenBatchScheduler::schedule_loop() {
+void BatchScheduler::schedule_loop() {
     // The current device is per-thread, and the engine bound it on the thread
     // that constructed it.  This loop runs every forward pass from its own
     // thread, so it has to bind the same device before touching device memory.
-    if (!device_set(engine_->options().device)) {
-        std::cerr << "QwenBatchScheduler: failed to select device "
-                  << engine_->options().device
+    if (!device_set(engine_->device())) {
+        std::cerr << "BatchScheduler: failed to select device "
+                  << engine_->device()
                   << "; scheduler thread stopping" << std::endl;
         running_.store(false);
         return;
@@ -191,7 +191,7 @@ void QwenBatchScheduler::schedule_loop() {
             progressed |= run_decode_batch();
             handle_completions();
         } catch (const std::exception& e) {
-            std::cerr << "QwenBatchScheduler: exception in schedule loop: "
+            std::cerr << "BatchScheduler: exception in schedule loop: "
                      << e.what() << std::endl;
         }
 
@@ -209,7 +209,7 @@ void QwenBatchScheduler::schedule_loop() {
     }
 }
 
-int QwenBatchScheduler::worst_case_blocks(const SchedulerRequest& req) const {
+int BatchScheduler::worst_case_blocks(const SchedulerRequest& req) const {
     if (!engine_->kv_paged()) return 0;
     // Prompt plus every token the request is still allowed to generate. Charging
     // only the prompt would admit a request whose decode cannot be backed, and a
@@ -221,7 +221,7 @@ int QwenBatchScheduler::worst_case_blocks(const SchedulerRequest& req) const {
     return engine_->kv_blocks_for_tokens(max_context_tokens);
 }
 
-void QwenBatchScheduler::admit_requests() {
+void BatchScheduler::admit_requests() {
     std::lock_guard<std::mutex> lock(queue_mutex_);
 
     while (!waiting_queue_.empty() &&
@@ -277,8 +277,8 @@ void QwenBatchScheduler::admit_requests() {
     }
 }
 
-bool QwenBatchScheduler::run_prefill_batch() {
-    std::vector<QwenBatchedRequest*> prefill_batch;
+bool BatchScheduler::run_prefill_batch() {
+    std::vector<BatchedRequest*> prefill_batch;
     std::vector<SchedulerRequest*> prefill_requests;
 
     {
@@ -291,10 +291,10 @@ bool QwenBatchScheduler::run_prefill_batch() {
             }
 
             if (!req->prefill_complete) {
-                // Create QwenBatchedRequest wrapper. seq_len carries how far the
+                // Create BatchedRequest wrapper. seq_len carries how far the
                 // prompt already got so batch_prefill can charge only the new
                 // tokens to its token total.
-                auto* batch_req = new QwenBatchedRequest();
+                auto* batch_req = new BatchedRequest();
                 batch_req->request_id = req->request_id;
                 batch_req->prompt_tokens = req->prompt_tokens;
                 batch_req->slot_id = req->slot_id;
@@ -350,7 +350,7 @@ bool QwenBatchScheduler::run_prefill_batch() {
             }
         }
     } catch (const std::exception& e) {
-        std::cerr << "QwenBatchScheduler: prefill failed: " << e.what() << std::endl;
+        std::cerr << "BatchScheduler: prefill failed: " << e.what() << std::endl;
     }
 
     // Clean up temporary batch requests
@@ -361,8 +361,8 @@ bool QwenBatchScheduler::run_prefill_batch() {
     return true;
 }
 
-bool QwenBatchScheduler::run_decode_batch() {
-    std::vector<QwenBatchedRequest*> decode_batch;
+bool BatchScheduler::run_decode_batch() {
+    std::vector<BatchedRequest*> decode_batch;
     std::vector<SchedulerRequest*> decode_requests;
 
     {
@@ -379,8 +379,8 @@ bool QwenBatchScheduler::run_decode_batch() {
             // decoding there would append a generated token into the middle of
             // the prompt's own KV positions.
             if (req->prefill_complete && !req->finished) {
-                // Create QwenBatchedRequest wrapper
-                auto* batch_req = new QwenBatchedRequest();
+                // Create BatchedRequest wrapper
+                auto* batch_req = new BatchedRequest();
                 batch_req->request_id = req->request_id;
                 batch_req->slot_id = req->slot_id;
                 batch_req->seq_len = req->seq_len;
@@ -432,7 +432,7 @@ bool QwenBatchScheduler::run_decode_batch() {
             }
         }
     } catch (const std::exception& e) {
-        std::cerr << "QwenBatchScheduler: decode failed: " << e.what() << std::endl;
+        std::cerr << "BatchScheduler: decode failed: " << e.what() << std::endl;
     }
 
     // Clean up temporary batch requests
@@ -443,7 +443,7 @@ bool QwenBatchScheduler::run_decode_batch() {
     return true;
 }
 
-void QwenBatchScheduler::handle_completions() {
+void BatchScheduler::handle_completions() {
     std::vector<std::unique_ptr<SchedulerRequest>> completed;
     std::vector<bool> cancelled_completions;
 
@@ -517,7 +517,7 @@ void QwenBatchScheduler::handle_completions() {
     }
 }
 
-void QwenBatchScheduler::notify_result(SchedulerRequest* req) {
+void BatchScheduler::notify_result(SchedulerRequest* req) {
     if (!req || req->callback_invoked) {
         return;
     }
@@ -555,7 +555,7 @@ void QwenBatchScheduler::notify_result(SchedulerRequest* req) {
         try {
             req->callback(result);
         } catch (const std::exception& e) {
-            std::cerr << "QwenBatchScheduler: callback exception: " << e.what() << std::endl;
+            std::cerr << "BatchScheduler: callback exception: " << e.what() << std::endl;
         }
     }
 

--- a/cpp_engine/engine/main.cpp
+++ b/cpp_engine/engine/main.cpp
@@ -343,7 +343,7 @@ void run_qwen_persistent_worker(pocket::QwenEngine& qwen,
         } else if (command == QwenPersistentCommand::Decode) {
             (void)qwen.decode_step(header[1]);
         } else if (command == QwenPersistentCommand::Generate) {
-            const std::vector<pocket::QwenForwardResult> outputs =
+            const std::vector<pocket::ForwardResult> outputs =
                 qwen.generate(payload, header[1]);
             std::cout << "qwen_persistent_worker_result=1 tp_rank="
                       << qwen.options().tp_rank << " tokens=";
@@ -680,9 +680,9 @@ int main(int argc, char** argv) {
                                     !qwen.options().dflash2_checkpoint.empty()) {
                                     qwen_send_command(*channel, QwenPersistentCommand::Generate,
                                                       max_new_tokens, 0, &ids);
-                                    const std::vector<pocket::QwenForwardResult> outputs =
+                                    const std::vector<pocket::ForwardResult> outputs =
                                         qwen.generate(ids, max_new_tokens);
-                                    for (const pocket::QwenForwardResult& output : outputs) {
+                                    for (const pocket::ForwardResult& output : outputs) {
                                         generated.push_back(output.top_token);
                                     }
                                 } else {
@@ -690,7 +690,7 @@ int main(int argc, char** argv) {
                                                       0, 0, &ids);
                                     const auto prefill_started =
                                         std::chrono::steady_clock::now();
-                                    pocket::QwenForwardResult next = qwen.prefill(ids);
+                                    pocket::ForwardResult next = qwen.prefill(ids);
                                     plain_prefill_seconds = std::chrono::duration<double>(
                                         std::chrono::steady_clock::now() - prefill_started).count();
                                     generated.push_back(next.top_token);
@@ -774,7 +774,7 @@ int main(int argc, char** argv) {
                         using Clock = std::chrono::steady_clock;
                         const auto t_total0 = Clock::now();
                         const auto t_prefill0 = Clock::now();
-                        std::vector<pocket::QwenForwardResult> generated;
+                        std::vector<pocket::ForwardResult> generated;
                         generated.reserve(static_cast<size_t>(args.max_new_tokens));
                         pocket::QwenPrefixCacheStats prefix_stats;
                         Clock::time_point t_prefill1;
@@ -788,7 +788,7 @@ int main(int argc, char** argv) {
                                 std::chrono::duration<double>(qwen.mtp_stats().prefill_seconds));
                             t_decode0 = t_prefill1;
                         } else {
-                            pocket::QwenForwardResult next = qwen.prefill(prompt_ids);
+                            pocket::ForwardResult next = qwen.prefill(prompt_ids);
                             prefix_stats = qwen.prefix_cache_stats();
                             t_prefill1 = Clock::now();
                             t_decode0 = t_prefill1;
@@ -924,7 +924,7 @@ int main(int argc, char** argv) {
                                          process_started).count()
                                   << "\n";
                     } else {
-                        pocket::QwenForwardResult result = qwen.prefill(prompt_ids);
+                        pocket::ForwardResult result = qwen.prefill(prompt_ids);
                         qwen_telemetry = qwen.runtime_telemetry();
                         std::cout << "smoke_forward=1 qwen_runtime=1 token=" << prompt_ids.back()
                                   << " layers=" << result.layers

--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -325,7 +325,7 @@ struct QwenRecurrentSnapshot {
     bool periodic = false;
     // A request-boundary snapshot can answer an exact shorter-prefix prefill
     // without re-running its final token.
-    QwenForwardResult result;
+    ForwardResult result;
     bool has_result = false;
 
     uint64_t bytes() const {
@@ -542,7 +542,7 @@ struct QwenEngine::Impl {
         // Ordered by ascending position. Index 0 is always the implicit empty
         // state, which is not stored.
         std::vector<QwenRecurrentSnapshot> snapshots;
-        QwenForwardResult cached_result;
+        ForwardResult cached_result;
         bool has_cached_result = false;
     };
     std::vector<SlotPrefixState> slot_prefix;
@@ -676,7 +676,7 @@ struct QwenEngine::Impl {
         SlotPrefixState& prefix = prefix_for(slot_id);
         prefix.cached_prompt.clear();
         prefix.snapshots.clear();
-        prefix.cached_result = QwenForwardResult{};
+        prefix.cached_result = ForwardResult{};
         prefix.has_cached_result = false;
         set_slot_position(slot_id, 0, engine_position);
     }
@@ -1540,7 +1540,7 @@ struct QwenEngine::Impl {
     }
 
     QwenRecurrentSnapshot capture_recurrent_state(
-        int position, const QwenForwardResult* result = nullptr,
+        int position, const ForwardResult* result = nullptr,
         bool periodic = false, int slot_id = 0) {
         QwenRecurrentSnapshot snapshot;
         snapshot.position = position;
@@ -1680,7 +1680,7 @@ struct QwenEngine::Impl {
 
     // Keeps snapshots ordered and bounded. The newest position wins because a
     // monotonically growing prompt resumes from the deepest available point.
-    void record_snapshot(int position, const QwenForwardResult* result = nullptr,
+    void record_snapshot(int position, const ForwardResult* result = nullptr,
                          bool periodic = false, int slot_id = 0) {
         if (!options.prefix_cache ||
             options.state_snapshot_interval_tokens <= 0 ||
@@ -3625,13 +3625,13 @@ struct QwenEngine::Impl {
         return result;
     }
 
-    QwenForwardResult logits_for(const uint16_t* hidden, int last_row,
+    ForwardResult logits_for(const uint16_t* hidden, int last_row,
                                  int position_after, int active_layers) {
         const int hidden_size = static_cast<int>(config.hidden_size);
         QwenVerifyBatch batch = top_tokens_for(
             hidden + static_cast<size_t>(last_row) * hidden_size, 1,
             &final_norm, position_after);
-        QwenForwardResult result;
+        ForwardResult result;
         result.layers = active_layers;
         result.dim = hidden_size;
         result.logits = static_cast<int>(config.vocab_size);
@@ -3647,12 +3647,12 @@ struct QwenEngine::Impl {
         return top_tokens_for(hidden, rows, &final_norm, position_after);
     }
 
-    QwenForwardResult mtp_logits_for(const uint16_t* normalized_hidden,
+    ForwardResult mtp_logits_for(const uint16_t* normalized_hidden,
                                      int position_after) {
         const int hidden_size = static_cast<int>(config.hidden_size);
         QwenVerifyBatch batch = top_tokens_for(normalized_hidden, 1, nullptr,
                                                position_after);
-        QwenForwardResult result;
+        ForwardResult result;
         result.layers = 1;
         result.dim = hidden_size;
         result.logits = static_cast<int>(config.vocab_size);
@@ -3663,7 +3663,7 @@ struct QwenEngine::Impl {
         return result;
     }
 
-    QwenForwardResult mtp_forward_rows(const std::vector<int>& tokens,
+    ForwardResult mtp_forward_rows(const std::vector<int>& tokens,
                                        const uint16_t* hidden, int position) {
         if (!mtp_enabled) {
             throw std::runtime_error("Qwen MTP rows requested while disabled");
@@ -3712,7 +3712,7 @@ struct QwenEngine::Impl {
              mtp_normalized_output.f16_data(), rows, hidden_size);
         const uint16_t* last_hidden = mtp_normalized_output.f16_data() +
             static_cast<size_t>(rows - 1) * hidden_size;
-        QwenForwardResult result = mtp_logits_for(last_hidden, position + rows);
+        ForwardResult result = mtp_logits_for(last_hidden, position + rows);
         allocate_half(mtp_seed_hidden, hidden_size, {config.hidden_size});
         // Recursive Qwen3.5 MTP consumes the prior predictor's returned hidden,
         // and that return is after mtp.norm in both vLLM and SGLang.
@@ -3728,12 +3728,12 @@ struct QwenEngine::Impl {
         return result;
     }
 
-    QwenForwardResult mtp_forward_row(int token, const uint16_t* hidden,
+    ForwardResult mtp_forward_row(int token, const uint16_t* hidden,
                                       int position) {
         return mtp_forward_rows({token}, hidden, position);
     }
 
-    QwenForwardResult prime_target_mtp(const std::vector<int>& shifted_tokens,
+    ForwardResult prime_target_mtp(const std::vector<int>& shifted_tokens,
                                        int position) {
         const int rows = static_cast<int>(shifted_tokens.size());
         const int hidden_size = static_cast<int>(config.hidden_size);
@@ -3747,7 +3747,7 @@ struct QwenEngine::Impl {
                                 position);
     }
 
-    QwenForwardResult seed_mtp(int input_token) {
+    ForwardResult seed_mtp(int input_token) {
         if (!has_target_last_hidden) {
             throw std::runtime_error(
                 "Qwen MTP seed requires a committed target hidden");
@@ -3768,7 +3768,7 @@ struct QwenEngine::Impl {
                                   QwenMtpStats* stats) {
         if (count <= 0) return {};
         const auto started = std::chrono::steady_clock::now();
-        QwenForwardResult next;
+        ForwardResult next;
         if (mtp_seed_ready && mtp_seed_input_token == input_token) {
             next.top_token = mtp_next_token;
             next.top_logit = mtp_next_logit;
@@ -3792,7 +3792,7 @@ struct QwenEngine::Impl {
         return drafts;
     }
 
-    QwenForwardResult dflash2_speculative_step(int input_token,
+    ForwardResult dflash2_speculative_step(int input_token,
                                                QwenMtpStats* stats) {
         if (!dflash2_enabled) {
             throw std::runtime_error("Qwen DFlash2 speculative step is disabled");
@@ -3882,7 +3882,7 @@ struct QwenEngine::Impl {
                     std::chrono::steady_clock::now() - replay_started).count();
             }
         }
-        QwenForwardResult result;
+        ForwardResult result;
         result.top_token = bonus;
         result.bonus_token = bonus;
         result.correct_drafts = correct;
@@ -3901,7 +3901,7 @@ struct QwenEngine::Impl {
         return result;
     }
 
-    QwenForwardResult dspark_speculative_step(int input_token,
+    ForwardResult dspark_speculative_step(int input_token,
                                               QwenMtpStats* stats) {
         if (!dspark_enabled) {
             throw std::runtime_error("Qwen DSpark speculative step is disabled");
@@ -3980,7 +3980,7 @@ struct QwenEngine::Impl {
                     std::chrono::steady_clock::now() - replay_started).count();
             }
         }
-        QwenForwardResult result;
+        ForwardResult result;
         result.top_token = bonus;
         result.bonus_token = bonus;
         result.correct_drafts = correct;
@@ -3999,7 +3999,7 @@ struct QwenEngine::Impl {
         return result;
     }
 
-    QwenForwardResult speculative_step(int input_token, int draft_count,
+    ForwardResult speculative_step(int input_token, int draft_count,
                                        QwenMtpStats* stats) {
         if (!mtp_enabled || draft_count <= 0) {
             return run_chunk({input_token}, mtp_position,
@@ -4063,7 +4063,7 @@ struct QwenEngine::Impl {
         // The target state now ends after the accepted input sequence. The
         // bonus is the next input and must not be consumed by target yet. The
         // MTP boundary row is already primed with that bonus for the next round.
-        QwenForwardResult result;
+        ForwardResult result;
         result.top_token = bonus;
         result.bonus_token = bonus;
         result.correct_drafts = correct;
@@ -4086,7 +4086,7 @@ struct QwenEngine::Impl {
                config.vocab_size / options.tp_world;
     }
 
-    QwenForwardResult run_chunk(const std::vector<int>& token_ids,
+    ForwardResult run_chunk(const std::vector<int>& token_ids,
                                 int position_offset, int active_layers,
                                 bool compute_logits,
                                 QwenVerifyBatch* verify_batch = nullptr,
@@ -4247,7 +4247,7 @@ struct QwenEngine::Impl {
         }
         if (compute_logits) {
             if (verify_batch != nullptr) {
-                QwenForwardResult result;
+                ForwardResult result;
                 result.layers = active_layers;
                 result.dim = hidden_size;
                 result.logits = static_cast<int>(config.vocab_size);
@@ -4260,7 +4260,7 @@ struct QwenEngine::Impl {
             return logits_for(
                 hidden, rows - 1, position_offset + rows, active_layers);
         }
-        QwenForwardResult result;
+        ForwardResult result;
         result.layers = active_layers;
         result.dim = hidden_size;
         result.logits = static_cast<int>(config.vocab_size);
@@ -4541,7 +4541,7 @@ void QwenEngine::set_dflash2_debug_callback(
     impl_->dflash2->set_debug_callback(std::move(callback));
 }
 
-QwenForwardResult QwenEngine::debug_prefill_dflash2(
+ForwardResult QwenEngine::debug_prefill_dflash2(
     const std::vector<int>& token_ids,
     const std::vector<int>& target_layer_ids,
     QwenDFlash2DebugCallback callback) {
@@ -4559,7 +4559,7 @@ QwenForwardResult QwenEngine::debug_prefill_dflash2(
     impl_->dflash2_debug_target_layer_ids = target_layer_ids;
     impl_->dflash2_target_debug_callback = std::move(callback);
     try {
-        QwenForwardResult result = prefill(token_ids);
+        ForwardResult result = prefill(token_ids);
         impl_->dflash2_debug_target_layer_ids.clear();
         impl_->dflash2_target_debug_callback = {};
         return result;
@@ -4600,7 +4600,7 @@ void QwenEngine::clear_prefix_cache() {
     for (Impl::SlotPrefixState& slot : impl_->slot_prefix) {
         slot.cached_prompt.clear();
         slot.snapshots.clear();
-        slot.cached_result = QwenForwardResult{};
+        slot.cached_result = ForwardResult{};
         slot.has_cached_result = false;
     }
     std::fill(impl_->slot_positions.begin(), impl_->slot_positions.end(), 0);
@@ -4622,6 +4622,20 @@ void QwenEngine::clear_prefix_cache() {
 }
 
 // ========== Batch API implementation (Phase 3.1) ==========
+
+Capabilities QwenEngine::caps() const {
+    Capabilities c;
+    // Paging is a construction-time option, so this reports the configured
+    // cache rather than what the engine could be built to do.
+    c.paged_kv = impl_->kv_paged();
+    // Batched execution needs more than one slot; a single-slot engine still
+    // runs the batch API, but one request at a time.
+    c.continuous_batching = options_.max_batch_size > 1;
+    // batch_prefill honours its token budget on every configuration.
+    c.chunked_prefill = true;
+    c.max_slots = options_.max_batch_size;
+    return c;
+}
 
 bool QwenEngine::supports_batching() const {
     return true;  // Phase 3.1: always supported, opt-in via allocate_batch_slots
@@ -4723,8 +4737,8 @@ void QwenEngine::free_slot(uint64_t request_id) {
     worker_command_free_slot(slot_id);
 }
 
-QwenBatchPrefillResult QwenEngine::batch_prefill(
-    const std::vector<QwenBatchedRequest*>& requests, int token_budget) {
+BatchPrefillResult QwenEngine::batch_prefill(
+    const std::vector<BatchedRequest*>& requests, int token_budget) {
 
     // Requests still run one at a time: the saturation sweep
     // (bench_qwen_prefill_saturation) measured 1890 tok/s at a 4096-token chunk
@@ -4734,14 +4748,14 @@ QwenBatchPrefillResult QwenEngine::batch_prefill(
     // prompt holding the device: with `token_budget` set, each request advances
     // by at most that many tokens per call, so the scheduler regains control
     // between chunks and can interleave decode.
-    QwenBatchPrefillResult result;
+    BatchPrefillResult result;
     result.results.reserve(requests.size());
     result.incomplete.reserve(requests.size());
     result.total_tokens = 0;
 
     auto start = std::chrono::steady_clock::now();
 
-    for (QwenBatchedRequest* req : requests) {
+    for (BatchedRequest* req : requests) {
         if (!req || req->prompt_tokens.empty()) {
             throw std::runtime_error("QwenEngine::batch_prefill: invalid request");
         }
@@ -4755,7 +4769,7 @@ QwenBatchPrefillResult QwenEngine::batch_prefill(
         worker_command_prefill(req->prompt_tokens, req->slot_id, token_budget);
 
         // Phase 3.3: Use req->slot_id to isolate KV cache
-        QwenPartialPrefillResult step =
+        PartialPrefillResult step =
             prefill_bounded(req->prompt_tokens, req->slot_id,
                             std::max(0, token_budget));
 
@@ -4784,7 +4798,7 @@ QwenBatchPrefillResult QwenEngine::batch_prefill(
     return result;
 }
 
-std::vector<QwenForwardResult> QwenEngine::batch_decode_tokens(
+std::vector<ForwardResult> QwenEngine::batch_decode_tokens(
     const std::vector<int>& tokens, const std::vector<int>& slot_ids) {
     if (tokens.size() != slot_ids.size()) {
         throw std::runtime_error(
@@ -4826,12 +4840,12 @@ std::vector<QwenForwardResult> QwenEngine::batch_decode_tokens(
     QwenVerifyBatch batch = impl_->run_batched_decode(
         tokens, positions, slot_ids, active_layers_);
 
-    std::vector<QwenForwardResult> results(static_cast<size_t>(rows));
+    std::vector<ForwardResult> results(static_cast<size_t>(rows));
     for (int row = 0; row < rows; ++row) {
         const size_t index = static_cast<size_t>(row);
         const int slot = slot_ids[index];
         const int position_after = positions[index] + 1;
-        QwenForwardResult& forward = results[index];
+        ForwardResult& forward = results[index];
         forward.layers = active_layers_;
         forward.dim = static_cast<int>(config_.hidden_size);
         forward.logits = static_cast<int>(config_.vocab_size);
@@ -4853,7 +4867,7 @@ std::vector<QwenForwardResult> QwenEngine::batch_decode_tokens(
     return results;
 }
 
-bool QwenEngine::is_stop_token(const QwenBatchSamplingParams& sampling,
+bool QwenEngine::is_stop_token(const BatchSamplingParams& sampling,
                                int token) const {
     if (sampling.ignore_eos) return false;
     const std::vector<int>& stops = sampling.stop_token_ids.empty()
@@ -4862,10 +4876,10 @@ bool QwenEngine::is_stop_token(const QwenBatchSamplingParams& sampling,
     return std::find(stops.begin(), stops.end(), token) != stops.end();
 }
 
-QwenBatchDecodeResult QwenEngine::batch_decode_step(
-    const std::vector<QwenBatchedRequest*>& requests) {
+BatchDecodeResult QwenEngine::batch_decode_step(
+    const std::vector<BatchedRequest*>& requests) {
 
-    QwenBatchDecodeResult result;
+    BatchDecodeResult result;
     result.next_tokens.reserve(requests.size());
     result.finished.reserve(requests.size());
     result.hit_stop_token.reserve(requests.size());
@@ -4880,7 +4894,7 @@ QwenBatchDecodeResult QwenEngine::batch_decode_step(
     std::vector<int> slots;
     tokens.reserve(requests.size());
     slots.reserve(requests.size());
-    for (QwenBatchedRequest* req : requests) {
+    for (BatchedRequest* req : requests) {
         if (!req) {
             throw std::runtime_error("QwenEngine::batch_decode_step: null request");
         }
@@ -4893,11 +4907,11 @@ QwenBatchDecodeResult QwenEngine::batch_decode_step(
     // announces the batch before running it or the group deadlocks with rank 0
     // computing alone. No-op at world size 1.
     worker_command_batch_decode(tokens, slots);
-    std::vector<QwenForwardResult> forwards = batch_decode_tokens(tokens, slots);
+    std::vector<ForwardResult> forwards = batch_decode_tokens(tokens, slots);
 
     for (size_t index = 0; index < requests.size(); ++index) {
-        QwenBatchedRequest* req = requests[index];
-        const QwenForwardResult& forward = forwards[index];
+        BatchedRequest* req = requests[index];
+        const ForwardResult& forward = forwards[index];
         req->last_token = forward.top_token;
         req->last_result = forward;
         req->seq_len++;
@@ -4923,18 +4937,18 @@ QwenBatchDecodeResult QwenEngine::batch_decode_step(
     return result;
 }
 
-QwenForwardResult QwenEngine::prefill(const std::vector<int>& token_ids, int slot_id) {
+ForwardResult QwenEngine::prefill(const std::vector<int>& token_ids, int slot_id) {
     // Budget 0 means "no bound", so this is the whole prompt in one call and the
     // result is always complete.
     return prefill_bounded(token_ids, slot_id, 0).result;
 }
 
-QwenPartialPrefillResult QwenEngine::prefill_partial(
+PartialPrefillResult QwenEngine::prefill_partial(
     const std::vector<int>& token_ids, int slot_id, int max_tokens) {
     return prefill_bounded(token_ids, slot_id, std::max(0, max_tokens));
 }
 
-QwenPartialPrefillResult QwenEngine::prefill_bounded(
+PartialPrefillResult QwenEngine::prefill_bounded(
     const std::vector<int>& token_ids, int slot_id, int max_tokens) {
     std::optional<Impl::RangeScope> range;
     if (impl_->range_profile) range.emplace("qwen.prefill");
@@ -5053,7 +5067,7 @@ QwenPartialPrefillResult QwenEngine::prefill_bounded(
             token_ids[static_cast<size_t>(start_position)],
             start_position - 1);
     }
-    QwenForwardResult result;
+    ForwardResult result;
     // A budget both caps how far this call advances and shrinks the chunk, since
     // a budget under prefill_chunk_tokens would otherwise be rounded up to a
     // whole chunk and silently consume the entire prompt. Stopping at an
@@ -5160,7 +5174,7 @@ QwenPartialPrefillResult QwenEngine::prefill_bounded(
     return {result, budget_limit, complete};
 }
 
-QwenForwardResult QwenEngine::decode_step(int token_id, int slot_id) {
+ForwardResult QwenEngine::decode_step(int token_id, int slot_id) {
     std::optional<Impl::RangeScope> range;
     if (impl_->range_profile) range.emplace("qwen.decode_step");
 
@@ -5178,7 +5192,7 @@ QwenForwardResult QwenEngine::decode_step(int token_id, int slot_id) {
     // block boundary, and the table upload is skipped when nothing changed.
     impl_->reserve_paged_slot(slot_id, current_position + 1);
     impl_->sync_block_table();
-    QwenForwardResult result = impl_->run_chunk(
+    ForwardResult result = impl_->run_chunk(
         {token_id}, current_position, active_layers_, true, nullptr, nullptr, slot_id);
 
     ++current_position;
@@ -5198,7 +5212,7 @@ QwenForwardResult QwenEngine::decode_step(int token_id, int slot_id) {
     return result;
 }
 
-std::vector<QwenForwardResult> QwenEngine::generate(
+std::vector<ForwardResult> QwenEngine::generate(
     const std::vector<int>& prompt_ids, int max_new_tokens, bool stop_at_eos) {
     // Checked against config_.eos_token_ids directly: this path has no
     // per-request sampling params, and an empty list makes this always false.
@@ -5219,14 +5233,14 @@ std::vector<QwenForwardResult> QwenEngine::generate(
     if (impl_->range_profile) range_generate.emplace("qwen.generate");
     mtp_stats_ = QwenMtpStats{};
     const auto prefill_started = std::chrono::steady_clock::now();
-    QwenForwardResult next = prefill(prompt_ids);
+    ForwardResult next = prefill(prompt_ids);
     mtp_stats_.prefill_seconds = std::chrono::duration<double>(
         std::chrono::steady_clock::now() - prefill_started).count();
     // Prefill already reported; reset so the decode/verify phases are attributed
     // on their own rather than buried under the prompt pass.
     impl_->phase_seconds.clear();
     impl_->phase_calls.clear();
-    std::vector<QwenForwardResult> results;
+    std::vector<ForwardResult> results;
     results.reserve(static_cast<size_t>(max_new_tokens));
     if (!options_.mtp && options_.dspark_checkpoint.empty() &&
         options_.dflash2_checkpoint.empty()) {
@@ -5322,7 +5336,7 @@ std::vector<QwenForwardResult> QwenEngine::generate(
         bool stop_in_block = false;
         for (size_t index = 0; index < next.accept_tokens.size(); ++index) {
             if (static_cast<int>(results.size()) == max_new_tokens) break;
-            QwenForwardResult token_result = next;
+            ForwardResult token_result = next;
             token_result.top_token = next.accept_tokens[index];
             token_result.top_logit = next.accept_logits[index];
             token_result.checksum = next.accept_checksums[index];

--- a/cpp_engine/include/batch_scheduler.hpp
+++ b/cpp_engine/include/batch_scheduler.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "qwen_engine.hpp"
+#include "inference_engine.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -33,7 +33,7 @@ struct SchedulerGenerationResult {
 struct SchedulerRequest {
     uint64_t request_id = 0;
     std::vector<int> prompt_tokens;
-    QwenBatchSamplingParams sampling;
+    BatchSamplingParams sampling;
     int slot_id = -1;
     int seq_len = 0;  // Tokens processed (prompt + generated)
     // Prompt tokens prefilled so far. Chunked prefill advances this a bounded
@@ -62,7 +62,7 @@ struct SchedulerRequest {
     bool callback_invoked = false;
 };
 
-// Continuous batching scheduler for QwenEngine
+// Continuous batching scheduler over any InferenceEngine.
 //
 // This scheduler runs a background thread that:
 // 1. Admits waiting requests when slots are available
@@ -72,21 +72,21 @@ struct SchedulerRequest {
 // 5. Handles completions and frees slots
 //
 // Thread-safe: submit_request/cancel_request can be called concurrently
-class QwenBatchScheduler {
+class BatchScheduler {
 public:
-    explicit QwenBatchScheduler(QwenEngine* engine, int max_batch_size);
-    ~QwenBatchScheduler();
+    BatchScheduler(InferenceEngine* engine, int max_batch_size);
+    ~BatchScheduler();
 
     // No copy/move
-    QwenBatchScheduler(const QwenBatchScheduler&) = delete;
-    QwenBatchScheduler& operator=(const QwenBatchScheduler&) = delete;
+    BatchScheduler(const BatchScheduler&) = delete;
+    BatchScheduler& operator=(const BatchScheduler&) = delete;
 
     // Submit a new generation request
     // Returns request_id (> 0) on success, 0 on failure
     // The callback will be invoked from the scheduler thread when generation completes
     uint64_t submit_request(
         const std::vector<int>& prompt_tokens,
-        const QwenBatchSamplingParams& sampling,
+        const BatchSamplingParams& sampling,
         std::function<void(const SchedulerGenerationResult&)> callback = nullptr);
 
     // Cancel a pending or running request
@@ -154,7 +154,7 @@ private:
     void notify_result(SchedulerRequest* req);
 
     // Internal state
-    QwenEngine* engine_;
+    InferenceEngine* engine_;
     int max_batch_size_;
     // Default 4096: the largest chunk that still measured full prefill
     // throughput on TP4 27B, so interleaving costs nothing on the prefill side.

--- a/cpp_engine/include/inference_engine.hpp
+++ b/cpp_engine/include/inference_engine.hpp
@@ -1,0 +1,183 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace pocket {
+
+// What an engine can actually do, declared rather than inferred.
+//
+// The scheduler used to read `kv_total_blocks() == 0` as "this engine uses a
+// contiguous arena", which happens to be true for the one engine that existed
+// but is an inference from an accounting field, not a statement of capability.
+// An engine that supports neither paging nor batching reports the same zero,
+// and the scheduler would have gone on to treat it as a wide batched engine
+// with an unpaged cache. Declaring the answer keeps the scheduler honest about
+// engines it was not written against.
+struct Capabilities {
+    // KV cache is a pool of fixed-size blocks handed out as tokens arrive,
+    // rather than a per-slot arena reserving max_context up front. When false,
+    // the kv_*_blocks accounting carries no information and admission is bound
+    // by slots alone.
+    bool paged_kv = false;
+    // More than one request may occupy the engine at once. When false the
+    // scheduler must serialize, whatever max_slots says.
+    bool continuous_batching = false;
+    // batch_prefill() honours its token budget and can return a prompt that is
+    // still incomplete. When false the budget is ignored and every prompt runs
+    // to completion in one call, so a long prompt holds the device throughout.
+    bool chunked_prefill = false;
+    // Concurrent request slots. 1 means one mutable session at a time.
+    int max_slots = 1;
+};
+
+// One forward pass over one sequence.
+struct ForwardResult {
+    int token = 0;
+    int layers = 0;
+    int dim = 0;
+    int logits = 0;
+    int top_token = 0;
+    // Filled by native MTP speculative steps; plain forwards leave these zero.
+    int correct_drafts = 0;
+    int bonus_token = 0;
+    std::vector<int> accept_tokens;
+    std::vector<float> accept_logits;
+    std::vector<float> accept_checksums;
+    float top_logit = 0.0f;
+    float checksum = 0.0f;
+    int position = 0;
+};
+
+// Sampling parameters for one batched request.
+struct BatchSamplingParams {
+    float temperature = 0.0f;
+    float top_p = 1.0f;
+    int top_k = 20;
+    unsigned long long seed = 0;
+    int max_new_tokens = 128;
+    // Tokens that end this request. Left empty, the engine falls back to the
+    // checkpoint's eos ids from generation_config.json; set it to override for
+    // this request only. `ignore_eos` runs to max_new_tokens regardless, which
+    // is what benchmarks want so their token counts stay fixed.
+    std::vector<int> stop_token_ids;
+    bool ignore_eos = false;
+};
+
+// Per-request state for batched continuous execution.
+struct BatchedRequest {
+    uint64_t request_id = 0;
+    std::vector<int> prompt_tokens;
+    int seq_len = 0;
+    int slot_id = -1;
+    int cached_prefix_len = 0;
+    BatchSamplingParams sampling;
+    bool finished = false;
+    int last_token = 0;
+    std::vector<int> generated_tokens;
+    ForwardResult last_result;
+};
+
+// Result from batch_prefill.
+struct BatchPrefillResult {
+    std::vector<ForwardResult> results;
+    int total_tokens = 0;
+    double seconds = 0.0;
+    // Rows whose prompt is not yet fully consumed, parallel to `results`. A
+    // partial row's `results` entry holds the last chunk's logits, which are
+    // not a prediction for the prompt's final token and must not be sampled.
+    std::vector<bool> incomplete;
+};
+
+// Outcome of one bounded prefill step over a single sequence.
+struct PartialPrefillResult {
+    ForwardResult result;
+    // Prompt tokens consumed so far, i.e. where the next step resumes.
+    int consumed_tokens = 0;
+    // False while tokens remain; `result` is only a sampleable prediction for
+    // the prompt once this is true.
+    bool complete = false;
+};
+
+// Result from batch_decode_step.
+struct BatchDecodeResult {
+    std::vector<int> next_tokens;
+    std::vector<bool> finished;
+    // Rows that stopped on a stop token rather than on max_new_tokens, parallel
+    // to `next_tokens`. Callers need the distinction to report finish_reason,
+    // which cannot be recovered from `finished` alone.
+    std::vector<bool> hit_stop_token;
+    double seconds = 0.0;
+};
+
+// The surface a scheduler needs from a model runtime.
+//
+// This is deliberately the smallest set that BatchScheduler actually calls, not
+// a general model API: slot lifecycle, paged-KV accounting for admission, the
+// two batched forward entry points, and a capability declaration. Everything
+// model-specific -- weight layout, attention kind, speculative decoding, prefix
+// reuse, TP worker protocol -- stays on the concrete engine, where it can keep
+// its own types.
+//
+// Every method here is called once per scheduler iteration, never per token and
+// never per layer, so dispatching them virtually cannot show up against a
+// batched forward pass. Layer-level components are concrete types for the
+// opposite reason.
+class InferenceEngine {
+public:
+    virtual ~InferenceEngine() = default;
+
+    virtual Capabilities caps() const = 0;
+
+    // Per-sequence context ceiling.
+    virtual int max_context() const = 0;
+
+    // Device this engine bound at construction. The current device is
+    // per-thread, so a scheduler thread has to re-select it before touching
+    // device memory.
+    virtual int device() const = 0;
+
+    // ---- Slot lifecycle ----
+
+    // Prepare `max_batch_size` concurrent KV slots. Must precede any batched
+    // call. An engine declaring max_slots == 1 may reject a larger request.
+    virtual void allocate_batch_slots(int max_batch_size) = 0;
+
+    // Bind a request to a slot. Returns the slot id, or -1 when none is free.
+    virtual int allocate_slot(uint64_t request_id) = 0;
+
+    // Release the slot a request holds, and any blocks with it.
+    virtual void free_slot(uint64_t request_id) = 0;
+
+    // ---- Paged KV admission ----
+
+    // Whether the paged block pool is in use. Mirrors caps().paged_kv for
+    // engines that can be configured either way; false means the block counts
+    // below carry no information.
+    virtual bool kv_paged() const = 0;
+
+    // Blocks free right now, and the pool total. Both 0 when not paged.
+    virtual int kv_free_blocks() const = 0;
+    virtual int kv_total_blocks() const = 0;
+
+    // Blocks a sequence of `tokens` logical positions needs in total. This is
+    // the unit admission reasons in: a request's cost is set by the blocks its
+    // context will span, not by the single slot it occupies.
+    virtual int kv_blocks_for_tokens(int tokens) const = 0;
+
+    // ---- Batched execution ----
+
+    // Advance each request's prompt by at most `token_budget` tokens; 0 runs
+    // every prompt to completion. A row left unfinished is reported through
+    // `incomplete` and its logits must not be sampled. Engines that do not
+    // declare chunked_prefill ignore the budget.
+    virtual BatchPrefillResult batch_prefill(
+        const std::vector<BatchedRequest*>& requests, int token_budget) = 0;
+
+    // Advance every request one token. Requests may sit at different positions
+    // but must occupy distinct slots.
+    virtual BatchDecodeResult batch_decode_step(
+        const std::vector<BatchedRequest*>& requests) = 0;
+};
+
+}  // namespace pocket

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "inference_engine.hpp"
 #include "qwen_config.hpp"
 #include "qwen_dflash2.hpp"
 #include "qwen_weights.hpp"
@@ -129,23 +130,6 @@ struct QwenEngineOptions {
     uint64_t kv_cache_bytes = 0;
 };
 
-struct QwenForwardResult {
-    int token = 0;
-    int layers = 0;
-    int dim = 0;
-    int logits = 0;
-    int top_token = 0;
-    // Filled by native MTP speculative steps; plain forwards leave these zero.
-    int correct_drafts = 0;
-    int bonus_token = 0;
-    std::vector<int> accept_tokens;
-    std::vector<float> accept_logits;
-    std::vector<float> accept_checksums;
-    float top_logit = 0.0f;
-    float checksum = 0.0f;
-    int position = 0;
-};
-
 // Accounting for one native-MTP or external-DSpark generate call.
 struct QwenMtpStats {
     uint64_t verify_count = 0;
@@ -217,77 +201,21 @@ struct QwenPrefixCacheStats {
     int misses = 0;
 };
 
-// ========== Batched request types (Phase 3.1) ==========
-
-// Sampling parameters for one batched request
-struct QwenBatchSamplingParams {
-    float temperature = 0.0f;
-    float top_p = 1.0f;
-    int top_k = 20;
-    unsigned long long seed = 0;
-    int max_new_tokens = 128;
-    // Tokens that end this request. Left empty, the engine falls back to the
-    // checkpoint's eos ids from generation_config.json; set it to override for
-    // this request only. `ignore_eos` runs to max_new_tokens regardless, which
-    // is what benchmarks want so their token counts stay fixed.
-    std::vector<int> stop_token_ids;
-    bool ignore_eos = false;
-};
-
-// Per-request state for batched continuous execution
-struct QwenBatchedRequest {
-    uint64_t request_id = 0;
-    std::vector<int> prompt_tokens;
-    int seq_len = 0;
-    int slot_id = -1;
-    int cached_prefix_len = 0;
-    QwenBatchSamplingParams sampling;
-    bool finished = false;
-    int last_token = 0;
-    std::vector<int> generated_tokens;
-    QwenForwardResult last_result;
-};
-
-// Result from batch_prefill
-struct QwenBatchPrefillResult {
-    std::vector<QwenForwardResult> results;
-    int total_tokens = 0;
-    double seconds = 0.0;
-    // Rows whose prompt is not yet fully consumed, parallel to `results`. A
-    // partial row's `results` entry holds the last chunk's logits, which are
-    // not a prediction for the prompt's final token and must not be sampled.
-    std::vector<bool> incomplete;
-};
-
-// Outcome of one bounded prefill step.
-struct QwenPartialPrefillResult {
-    QwenForwardResult result;
-    // Prompt tokens consumed so far, i.e. where the next step resumes.
-    int consumed_tokens = 0;
-    // False while tokens remain; `result` is only a sampleable prediction for
-    // the prompt once this is true.
-    bool complete = false;
-};
-
-// Result from batch_decode_step
-struct QwenBatchDecodeResult {
-    std::vector<int> next_tokens;
-    std::vector<bool> finished;
-    // Rows that stopped on a stop token rather than on max_new_tokens, parallel
-    // to `next_tokens`. Callers need the distinction to report finish_reason,
-    // which cannot be recovered from `finished` alone.
-    std::vector<bool> hit_stop_token;
-    double seconds = 0.0;
-};
-
 // Independent Qwen3.5 hybrid dense runtime. Checkpoint BF16 tensors are
 // materialized as FP16 on Turing; FP8 projections retain their compressed
 // codes and BF16 block scales are uploaded as FP16 for online unpack.
-class QwenEngine {
+//
+// The batched request and result types this engine speaks -- ForwardResult,
+// BatchSamplingParams, BatchedRequest, BatchPrefillResult, BatchDecodeResult,
+// PartialPrefillResult -- live in inference_engine.hpp, because a scheduler has
+// to name them without naming a model. What stays here is what is genuinely
+// Qwen3.5's: its options, weight map, prefix-cache and MTP accounting, TP
+// worker protocol, and speculative-decoding entry points.
+class QwenEngine : public InferenceEngine {
 public:
     QwenEngine(const std::string& ckpt_dir, const QwenEngineOptions& options,
                int layer_count = 0, int max_context = 8192);
-    ~QwenEngine();
+    ~QwenEngine() override;
 
     QwenEngine(const QwenEngine&) = delete;
     QwenEngine& operator=(const QwenEngine&) = delete;
@@ -295,7 +223,9 @@ public:
     const QwenConfig& config() const { return config_; }
     const QwenWeightMap& weight_map() const { return weights_; }
     const QwenEngineOptions& options() const { return options_; }
-    int max_context() const { return max_context_; }
+    Capabilities caps() const override;
+    int max_context() const override { return max_context_; }
+    int device() const override { return options_.device; }
     int position() const { return position_; }
     uint64_t resident_weight_bytes() const { return resident_weight_bytes_; }
     uint64_t resident_scale_bytes() const { return resident_scale_bytes_; }
@@ -315,7 +245,7 @@ public:
     // captured [row, tap, hidden] DFlash2 feature matrix through the callback.
     // This path does not load the drafter and is therefore usable in TP=1 within
     // one 22 GiB card.
-    QwenForwardResult debug_prefill_dflash2(
+    ForwardResult debug_prefill_dflash2(
         const std::vector<int>& token_ids,
         const std::vector<int>& target_layer_ids,
         QwenDFlash2DebugCallback callback);
@@ -324,7 +254,7 @@ public:
     // Drops every cached prefix so the next prefill recomputes from zero.
     void clear_prefix_cache();
     void warmup_tp();
-    QwenForwardResult prefill(const std::vector<int>& token_ids, int slot_id = 0);
+    ForwardResult prefill(const std::vector<int>& token_ids, int slot_id = 0);
     // Prefill that consumes at most `max_tokens` prompt tokens and returns,
     // leaving the rest for a later call. This is what lets a scheduler keep a
     // long prompt from monopolising the GPU: a 65K prompt run in 8192-token
@@ -334,15 +264,15 @@ public:
     // Resumption rides the existing growing-prompt prefix path, so callers pass
     // the same full `token_ids` every time and the engine skips what this slot
     // already holds. `max_tokens <= 0` consumes the whole remainder.
-    QwenPartialPrefillResult prefill_partial(const std::vector<int>& token_ids,
+    PartialPrefillResult prefill_partial(const std::vector<int>& token_ids,
                                              int slot_id, int max_tokens);
-    QwenForwardResult decode_step(int token_id, int slot_id = 0);
+    ForwardResult decode_step(int token_id, int slot_id = 0);
     // `stop_at_eos` ends generation on one of the checkpoint's eos ids, keeping
     // that token as the last element. It defaults to false so existing callers
     // and benchmarks keep returning exactly max_new_tokens results; under TP
     // every rank runs this loop and decides independently, so the flag has to be
     // the same on all of them or they stop at different lengths.
-    std::vector<QwenForwardResult> generate(const std::vector<int>& prompt_ids,
+    std::vector<ForwardResult> generate(const std::vector<int>& prompt_ids,
                                              int max_new_tokens,
                                              bool stop_at_eos = false);
 
@@ -351,31 +281,31 @@ public:
     // Allocate KV cache slots for batched execution
     // Must be called before using batch_prefill/batch_decode_step
     // max_batch_size: maximum number of concurrent requests
-    void allocate_batch_slots(int max_batch_size);
+    void allocate_batch_slots(int max_batch_size) override;
 
     // Allocate a KV cache slot for a new request
     // Returns slot_id on success, -1 if no slots available
-    int allocate_slot(uint64_t request_id);
+    int allocate_slot(uint64_t request_id) override;
 
     // Free a KV cache slot when request completes
-    void free_slot(uint64_t request_id);
+    void free_slot(uint64_t request_id) override;
 
     // ========== Paged KV admission (for the scheduler) ==========
 
     // Whether the paged block pool is in use. False means the contiguous arena
     // is, in which case a slot already owns max_context tokens and the block
     // accounting below carries no information.
-    bool kv_paged() const;
+    bool kv_paged() const override;
 
     // Blocks free right now, and the pool total. Under the contiguous arena both
     // are 0.
-    int kv_free_blocks() const;
-    int kv_total_blocks() const;
+    int kv_free_blocks() const override;
+    int kv_total_blocks() const override;
 
     // Blocks a sequence of `tokens` logical positions needs in total. This is
     // the unit admission has to reason in: a request's cost is set by the blocks
     // its context will span, not by the single slot it occupies.
-    int kv_blocks_for_tokens(int tokens) const;
+    int kv_blocks_for_tokens(int tokens) const override;
 
     // Batch prefill: process multiple requests in their prefill phase.
     // Each request may have a different prompt length, and requests are still
@@ -386,23 +316,23 @@ public:
     // call; 0 runs every prompt to completion as before. With a budget, a row
     // whose prompt is unfinished is reported through `result.incomplete` and its
     // logits must not be sampled. Call again with the same requests to continue.
-    QwenBatchPrefillResult batch_prefill(
-        const std::vector<QwenBatchedRequest*>& requests,
-        int token_budget = 0);
+    BatchPrefillResult batch_prefill(
+        const std::vector<BatchedRequest*>& requests,
+        int token_budget) override;
 
     // Batch decode step: process one decode step for all active requests
     // Every request advances one token in a single batched forward, so the
     // requests may sit at different positions; they must occupy distinct slots.
     // Returns next token for each request
-    QwenBatchDecodeResult batch_decode_step(
-        const std::vector<QwenBatchedRequest*>& requests);
+    BatchDecodeResult batch_decode_step(
+        const std::vector<BatchedRequest*>& requests) override;
 
     // One batched decode step over raw tokens and the slots they belong to.
     // batch_decode_step is the request-oriented wrapper around this; tests and
     // the TP worker loop use this form because they carry no request objects.
     // Does not announce anything to the TP workers: callers on rank 0 drive that
     // themselves so a batch is announced exactly once.
-    std::vector<QwenForwardResult> batch_decode_tokens(
+    std::vector<ForwardResult> batch_decode_tokens(
         const std::vector<int>& tokens, const std::vector<int>& slot_ids);
 
     // Check if batched API is supported (depends on build config)
@@ -444,12 +374,12 @@ private:
     // Shared body behind prefill() and prefill_partial(). `max_tokens` of 0
     // means unbounded, which is what makes the full-prompt path byte-for-byte
     // the same work it was before the bounded entry point existed.
-    QwenPartialPrefillResult prefill_bounded(const std::vector<int>& token_ids,
+    PartialPrefillResult prefill_bounded(const std::vector<int>& token_ids,
                                              int slot_id, int max_tokens);
 
     // Whether `token` ends generation under these params: the request's own
     // stop_token_ids when set, otherwise the checkpoint's eos ids.
-    bool is_stop_token(const QwenBatchSamplingParams& sampling, int token) const;
+    bool is_stop_token(const BatchSamplingParams& sampling, int token) const;
 
     std::string ckpt_dir_;
     QwenEngineOptions options_;

--- a/cpp_engine/python/bindings.cpp
+++ b/cpp_engine/python/bindings.cpp
@@ -8,7 +8,7 @@
 #include "qwen_config.hpp"
 #include "qwen_engine.hpp"
 #include "qwen_weights.hpp"
-#include "qwen_batch_scheduler.hpp"
+#include "batch_scheduler.hpp"
 #include "device_runtime.hpp"
 
 #include <pybind11/functional.h>
@@ -22,7 +22,7 @@ using namespace pocket;
 
 namespace {
 
-py::dict forward_result_dict(const QwenForwardResult& result) {
+py::dict forward_result_dict(const ForwardResult& result) {
     py::dict out;
     out["token"] = result.token;
     out["layers"] = result.layers;
@@ -136,18 +136,18 @@ py::dict options_dict(const ForwardSmokeOptions& options) {
     return out;
 }
 
-QwenForwardResult qwen_prefill(QwenEngine& engine, const std::vector<int>& tokens,
+ForwardResult qwen_prefill(QwenEngine& engine, const std::vector<int>& tokens,
                                int slot_id) {
     py::gil_scoped_release release;
     return engine.prefill(tokens, slot_id);
 }
 
-QwenForwardResult qwen_decode(QwenEngine& engine, int token, int slot_id) {
+ForwardResult qwen_decode(QwenEngine& engine, int token, int slot_id) {
     py::gil_scoped_release release;
     return engine.decode_step(token, slot_id);
 }
 
-std::vector<QwenForwardResult> qwen_generate(QwenEngine& engine,
+std::vector<ForwardResult> qwen_generate(QwenEngine& engine,
                                              const std::vector<int>& tokens,
                                              int max_new_tokens) {
     py::gil_scoped_release release;
@@ -225,21 +225,21 @@ PYBIND11_MODULE(pocketllm_cpp, module) {
         .def_readwrite("kv_block_size", &QwenEngineOptions::kv_block_size)
         .def_readwrite("kv_cache_bytes", &QwenEngineOptions::kv_cache_bytes);
 
-    py::class_<QwenForwardResult>(module, "QwenForwardResult")
+    py::class_<ForwardResult>(module, "QwenForwardResult")
         .def(py::init<>())
-        .def_readwrite("token", &QwenForwardResult::token)
-        .def_readwrite("layers", &QwenForwardResult::layers)
-        .def_readwrite("dim", &QwenForwardResult::dim)
-        .def_readwrite("logits", &QwenForwardResult::logits)
-        .def_readwrite("top_token", &QwenForwardResult::top_token)
-        .def_readwrite("correct_drafts", &QwenForwardResult::correct_drafts)
-        .def_readwrite("bonus_token", &QwenForwardResult::bonus_token)
-        .def_readwrite("accept_tokens", &QwenForwardResult::accept_tokens)
-        .def_readwrite("accept_logits", &QwenForwardResult::accept_logits)
-        .def_readwrite("accept_checksums", &QwenForwardResult::accept_checksums)
-        .def_readwrite("top_logit", &QwenForwardResult::top_logit)
-        .def_readwrite("checksum", &QwenForwardResult::checksum)
-        .def_readwrite("position", &QwenForwardResult::position)
+        .def_readwrite("token", &ForwardResult::token)
+        .def_readwrite("layers", &ForwardResult::layers)
+        .def_readwrite("dim", &ForwardResult::dim)
+        .def_readwrite("logits", &ForwardResult::logits)
+        .def_readwrite("top_token", &ForwardResult::top_token)
+        .def_readwrite("correct_drafts", &ForwardResult::correct_drafts)
+        .def_readwrite("bonus_token", &ForwardResult::bonus_token)
+        .def_readwrite("accept_tokens", &ForwardResult::accept_tokens)
+        .def_readwrite("accept_logits", &ForwardResult::accept_logits)
+        .def_readwrite("accept_checksums", &ForwardResult::accept_checksums)
+        .def_readwrite("top_logit", &ForwardResult::top_logit)
+        .def_readwrite("checksum", &ForwardResult::checksum)
+        .def_readwrite("position", &ForwardResult::position)
         .def("as_dict", &forward_result_dict);
 
     py::class_<QwenMtpStats>(module, "QwenMtpStats")
@@ -408,19 +408,19 @@ PYBIND11_MODULE(pocketllm_cpp, module) {
         .def("worker_command_speculative_decode", &PersistentEngine::worker_command_speculative_decode)
         .def("worker_command_prime_draft_kv", &PersistentEngine::worker_command_prime_draft_kv);
 
-    // QwenBatchScheduler bindings (Phase 3.4)
-    py::class_<QwenBatchSamplingParams>(module, "QwenBatchSamplingParams")
+    // BatchScheduler bindings (Phase 3.4)
+    py::class_<BatchSamplingParams>(module, "QwenBatchSamplingParams")
         .def(py::init<>())
-        .def_readwrite("temperature", &QwenBatchSamplingParams::temperature)
-        .def_readwrite("top_p", &QwenBatchSamplingParams::top_p)
-        .def_readwrite("top_k", &QwenBatchSamplingParams::top_k)
-        .def_readwrite("seed", &QwenBatchSamplingParams::seed)
-        .def_readwrite("max_new_tokens", &QwenBatchSamplingParams::max_new_tokens)
+        .def_readwrite("temperature", &BatchSamplingParams::temperature)
+        .def_readwrite("top_p", &BatchSamplingParams::top_p)
+        .def_readwrite("top_k", &BatchSamplingParams::top_k)
+        .def_readwrite("seed", &BatchSamplingParams::seed)
+        .def_readwrite("max_new_tokens", &BatchSamplingParams::max_new_tokens)
         // Exposed so a Python benchmark can keep its token counts fixed
         // (ignore_eos) or stop on its own tokenizer's ids (stop_token_ids)
         // instead of the checkpoint's.
-        .def_readwrite("stop_token_ids", &QwenBatchSamplingParams::stop_token_ids)
-        .def_readwrite("ignore_eos", &QwenBatchSamplingParams::ignore_eos);
+        .def_readwrite("stop_token_ids", &BatchSamplingParams::stop_token_ids)
+        .def_readwrite("ignore_eos", &BatchSamplingParams::ignore_eos);
 
     py::class_<SchedulerGenerationResult>(module, "SchedulerGenerationResult")
         .def(py::init<>())
@@ -432,20 +432,20 @@ PYBIND11_MODULE(pocketllm_cpp, module) {
         .def_readwrite("total_seconds", &SchedulerGenerationResult::total_seconds)
         .def_readwrite("ttft_seconds", &SchedulerGenerationResult::ttft_seconds);
 
-    py::class_<QwenBatchScheduler::Stats>(module, "QwenBatchSchedulerStats")
+    py::class_<BatchScheduler::Stats>(module, "QwenBatchSchedulerStats")
         .def(py::init<>())
-        .def_readwrite("waiting_requests", &QwenBatchScheduler::Stats::waiting_requests)
-        .def_readwrite("running_requests", &QwenBatchScheduler::Stats::running_requests)
-        .def_readwrite("completed_requests", &QwenBatchScheduler::Stats::completed_requests)
-        .def_readwrite("cancelled_requests", &QwenBatchScheduler::Stats::cancelled_requests)
-        .def_readwrite("free_slots", &QwenBatchScheduler::Stats::free_slots);
+        .def_readwrite("waiting_requests", &BatchScheduler::Stats::waiting_requests)
+        .def_readwrite("running_requests", &BatchScheduler::Stats::running_requests)
+        .def_readwrite("completed_requests", &BatchScheduler::Stats::completed_requests)
+        .def_readwrite("cancelled_requests", &BatchScheduler::Stats::cancelled_requests)
+        .def_readwrite("free_slots", &BatchScheduler::Stats::free_slots);
 
-    py::class_<QwenBatchScheduler>(module, "QwenBatchScheduler")
+    py::class_<BatchScheduler>(module, "QwenBatchScheduler")
         .def(py::init<QwenEngine*, int>(),
              py::arg("engine"), py::arg("max_batch_size"))
-        .def("submit_request", [](QwenBatchScheduler& scheduler,
+        .def("submit_request", [](BatchScheduler& scheduler,
                                    const std::vector<int>& prompt_tokens,
-                                   const QwenBatchSamplingParams& sampling,
+                                   const BatchSamplingParams& sampling,
                                    py::object callback) {
             // Convert Python callback to C++ std::function
             std::function<void(const SchedulerGenerationResult&)> cpp_callback;
@@ -464,11 +464,11 @@ PYBIND11_MODULE(pocketllm_cpp, module) {
             py::gil_scoped_release release;
             return scheduler.submit_request(prompt_tokens, sampling, cpp_callback);
         }, py::arg("prompt_tokens"), py::arg("sampling"), py::arg("callback") = py::none())
-        .def("cancel_request", [](QwenBatchScheduler& scheduler, uint64_t request_id) {
+        .def("cancel_request", [](BatchScheduler& scheduler, uint64_t request_id) {
             py::gil_scoped_release release;
             return scheduler.cancel_request(request_id);
         }, py::arg("request_id"))
-        .def("poll_result", [](QwenBatchScheduler& scheduler, uint64_t request_id, int timeout_ms) -> py::object {
+        .def("poll_result", [](BatchScheduler& scheduler, uint64_t request_id, int timeout_ms) -> py::object {
             SchedulerGenerationResult result;
             bool success;
             {
@@ -481,11 +481,11 @@ PYBIND11_MODULE(pocketllm_cpp, module) {
                 return py::none();
             }
         }, py::arg("request_id"), py::arg("timeout_ms") = 30000)
-        .def("get_stats", [](QwenBatchScheduler& scheduler) {
+        .def("get_stats", [](BatchScheduler& scheduler) {
             return scheduler.get_stats();
         })
-        .def("is_running", &QwenBatchScheduler::is_running)
-        .def("stop", [](QwenBatchScheduler& scheduler) {
+        .def("is_running", &BatchScheduler::is_running)
+        .def("stop", [](BatchScheduler& scheduler) {
             py::gil_scoped_release release;
             scheduler.stop();
         });

--- a/cpp_engine/tests/bench_qwen_paged_admission.cpp
+++ b/cpp_engine/tests/bench_qwen_paged_admission.cpp
@@ -16,7 +16,7 @@
 //        [--decode N] [--slots N] [--block-size N] [--budget-mb N]
 //        [--prefill-budget N] [--layers N]
 
-#include "qwen_batch_scheduler.hpp"
+#include "batch_scheduler.hpp"
 #include "qwen_engine.hpp"
 
 #include <algorithm>
@@ -99,10 +99,10 @@ double percentile(std::vector<double> values, double q) {
 // oversized request is a permanent no, and retrying would hide that.
 Result run_arm(pocket::QwenEngine& engine, const Options& opts,
                const std::vector<std::vector<int>>& prompts) {
-    pocket::QwenBatchScheduler scheduler(&engine, opts.slots);
+    pocket::BatchScheduler scheduler(&engine, opts.slots);
     scheduler.set_prefill_token_budget(opts.prefill_budget);
 
-    pocket::QwenBatchSamplingParams sampling;
+    pocket::BatchSamplingParams sampling;
     sampling.temperature = 0.0f;  // greedy, so both arms do the same work
     sampling.max_new_tokens = opts.decode;
     sampling.ignore_eos = true;   // every request runs its full decode length

--- a/cpp_engine/tests/bench_qwen_paged_tp_parity.cpp
+++ b/cpp_engine/tests/bench_qwen_paged_tp_parity.cpp
@@ -206,13 +206,13 @@ int main(int argc, char** argv) {
         }
 
         // Deterministic, identical prompts across both arms.
-        std::vector<std::unique_ptr<pocket::QwenBatchedRequest>> owned;
-        std::vector<pocket::QwenBatchedRequest*> batch;
+        std::vector<std::unique_ptr<pocket::BatchedRequest>> owned;
+        std::vector<pocket::BatchedRequest*> batch;
         std::vector<std::vector<int>> generated;
         const int prompt_len = std::min(256, opts.max_context - 1);
         const int decode = opts.decode_steps;
         for (int i = 0; i < opts.batch_size; ++i) {
-            auto req = std::make_unique<pocket::QwenBatchedRequest>();
+            auto req = std::make_unique<pocket::BatchedRequest>();
             req->request_id = static_cast<uint64_t>(1000 + i);
             req->slot_id = engine.allocate_slot(req->request_id);
             if (req->slot_id < 0) {
@@ -238,7 +238,7 @@ int main(int argc, char** argv) {
         // Measure decode: aggregate wall-time, then per-request token streams.
         double decode_seconds = 0.0;
         for (int step = 0; step < decode; ++step) {
-            const pocket::QwenBatchDecodeResult dec = engine.batch_decode_step(batch);
+            const pocket::BatchDecodeResult dec = engine.batch_decode_step(batch);
             decode_seconds += dec.seconds;
             for (size_t i = 0; i < batch.size(); ++i) {
                 generated[i].push_back(dec.next_tokens[i]);

--- a/cpp_engine/tests/bench_qwen_prefill_interleave.cpp
+++ b/cpp_engine/tests/bench_qwen_prefill_interleave.cpp
@@ -14,7 +14,7 @@
 // Usage: ./bench_qwen_prefill_interleave <checkpoint_dir> [--long N] [--budget N]
 //                                        [--layers N] [--tp-world N] [--tp-rank N]
 //                                        [--device N] [--nccl-id PATH]
-#include "qwen_batch_scheduler.hpp"
+#include "batch_scheduler.hpp"
 #include "qwen_engine.hpp"
 
 #include <atomic>
@@ -47,10 +47,10 @@ struct Trial {
 // each got its first token.
 Trial run_trial(pocket::QwenEngine& engine, int budget, int long_len,
                 int short_len, int max_new) {
-    pocket::QwenBatchScheduler scheduler(&engine, 4);
+    pocket::BatchScheduler scheduler(&engine, 4);
     scheduler.set_prefill_token_budget(budget);
 
-    pocket::QwenBatchSamplingParams sampling;
+    pocket::BatchSamplingParams sampling;
     sampling.temperature = 0.0f;  // greedy
     sampling.max_new_tokens = max_new;
 

--- a/cpp_engine/tests/test_batch_scheduler.cpp
+++ b/cpp_engine/tests/test_batch_scheduler.cpp
@@ -1,5 +1,5 @@
-// Test QwenBatchScheduler with synthetic requests
-#include "qwen_batch_scheduler.hpp"
+// Test BatchScheduler with synthetic requests
+#include "batch_scheduler.hpp"
 #include "qwen_engine.hpp"
 #include <iostream>
 #include <vector>
@@ -36,8 +36,8 @@ void test_stats() {
     // Test scheduler without engine (will fail in constructor)
     // This demonstrates the API contract
     try {
-        QwenBatchScheduler* scheduler = nullptr;
-        // scheduler = new QwenBatchScheduler(nullptr, 8);  // Would throw
+        BatchScheduler* scheduler = nullptr;
+        // scheduler = new BatchScheduler(nullptr, 8);  // Would throw
 
         std::cout << "Stats API signature validated" << std::endl;
     } catch (const std::exception& e) {
@@ -46,7 +46,7 @@ void test_stats() {
 }
 
 int main(int argc, char** argv) {
-    std::cout << "QwenBatchScheduler Unit Tests" << std::endl;
+    std::cout << "BatchScheduler Unit Tests" << std::endl;
     std::cout << "==============================" << std::endl;
 
     if (argc < 2) {
@@ -85,13 +85,13 @@ int main(int argc, char** argv) {
         QwenEngine engine(ckpt_dir, options, layers, 8192);
 
         std::cout << "Creating scheduler with max_batch_size=4" << std::endl;
-        QwenBatchScheduler scheduler(&engine, 4);
+        BatchScheduler scheduler(&engine, 4);
 
         // Test 1: Single request
         std::cout << "\n=== Test 1: Single Request ===" << std::endl;
         {
             std::vector<int> prompt = {1, 2, 3, 4, 5};  // Dummy tokens
-            QwenBatchSamplingParams sampling;
+            BatchSamplingParams sampling;
             sampling.max_new_tokens = 10;
 
             bool completed = false;
@@ -130,7 +130,7 @@ int main(int argc, char** argv) {
             std::vector<int> prompt2 = {4, 5, 6, 7};
             std::vector<int> prompt3 = {8, 9};
 
-            QwenBatchSamplingParams sampling;
+            BatchSamplingParams sampling;
             sampling.max_new_tokens = 5;
 
             uint64_t req1 = scheduler.submit_request(prompt1, sampling, callback);

--- a/cpp_engine/tests/test_qwen_batched_engine_parity.cpp
+++ b/cpp_engine/tests/test_qwen_batched_engine_parity.cpp
@@ -55,12 +55,12 @@ void test_batched_decode_parity(const std::string& dir,
         for (int i = 0; i < len; ++i) {
             tokens[static_cast<size_t>(i)] = (seq * 7 + i) % 64;
         }
-        const pocket::QwenForwardResult prefill = engine.prefill(tokens, slot);
+        const pocket::ForwardResult prefill = engine.prefill(tokens, slot);
         require(prefill.position == len, "prefill position accounting");
     }
 
     // Sequential baseline: decode one step per sequence independently
-    std::vector<pocket::QwenForwardResult> sequential_results(
+    std::vector<pocket::ForwardResult> sequential_results(
         static_cast<size_t>(num_seqs));
     std::vector<int> sequential_tokens(static_cast<size_t>(num_seqs));
     for (int seq = 0; seq < num_seqs; ++seq) {
@@ -89,7 +89,7 @@ void test_batched_decode_parity(const std::string& dir,
     for (int seq = 0; seq < num_seqs; ++seq) {
         batch_tokens[static_cast<size_t>(seq)] = (seq * 13 + 42) % 128;
     }
-    const std::vector<pocket::QwenForwardResult> batched_results =
+    const std::vector<pocket::ForwardResult> batched_results =
         engine.batch_decode_tokens(batch_tokens, slots);
 
     // Compare: every sequence's top_token, top_logit, and checksum must match
@@ -97,8 +97,8 @@ void test_batched_decode_parity(const std::string& dir,
            "batch result count mismatch");
     for (int seq = 0; seq < num_seqs; ++seq) {
         const size_t index = static_cast<size_t>(seq);
-        const pocket::QwenForwardResult& seq_result = sequential_results[index];
-        const pocket::QwenForwardResult& batch_result = batched_results[index];
+        const pocket::ForwardResult& seq_result = sequential_results[index];
+        const pocket::ForwardResult& batch_result = batched_results[index];
         const int slot = slots[index];
         const int pos = prompt_lens[index] + 1;
         const std::string label = "seq=" + std::to_string(seq) +

--- a/cpp_engine/tests/test_qwen_chunked_prefill.cpp
+++ b/cpp_engine/tests/test_qwen_chunked_prefill.cpp
@@ -56,8 +56,8 @@ void expect(bool ok, const std::string& what) {
 // Compares the sampled token plus checksum and top logit. The token alone would
 // miss a drift that has not yet moved the argmax; the checksum covers the whole
 // logit row, so it catches a difference anywhere in the vocabulary.
-void expect_same_result(const pocket::QwenForwardResult& chunked,
-                        const pocket::QwenForwardResult& whole,
+void expect_same_result(const pocket::ForwardResult& chunked,
+                        const pocket::ForwardResult& whole,
                         const std::string& label) {
     if (chunked.top_token != whole.top_token) {
         std::printf("  [FAIL] %s: token %d vs %d\n", label.c_str(),
@@ -169,11 +169,11 @@ int main(int argc, char** argv) {
                 engine_opts.prefill_chunk_tokens);
 
     if (opts.tp_world > 1) engine.worker_command_prefill(prompt, 1, 0);
-    const pocket::QwenForwardResult whole = engine.prefill(prompt, 1);
+    const pocket::ForwardResult whole = engine.prefill(prompt, 1);
 
     int steps = 0;
     int consumed = 0;
-    pocket::QwenPartialPrefillResult step;
+    pocket::PartialPrefillResult step;
     do {
         if (opts.tp_world > 1) {
             engine.worker_command_prefill(prompt, 0, budget);

--- a/cpp_engine/tests/test_qwen_dflash2_parity.cpp
+++ b/cpp_engine/tests/test_qwen_dflash2_parity.cpp
@@ -113,7 +113,7 @@ int main(int argc, char** argv) {
                 target_checkpoint, options, 0,
                 static_cast<int>(tokens.size()) + draft_config.block_size + 1);
             target->warmup_tp();
-            const pocket::QwenForwardResult target_result =
+            const pocket::ForwardResult target_result =
                 target->debug_prefill_dflash2(
                     tokens, draft_config.target_layer_ids,
                     [&](const auto& tensor) {

--- a/cpp_engine/tests/test_qwen_engine.cpp
+++ b/cpp_engine/tests/test_qwen_engine.cpp
@@ -254,8 +254,8 @@ void require(bool condition, const std::string& message) {
 }
 
 void require_same_generation(
-    const std::vector<pocket::QwenForwardResult>& actual,
-    const std::vector<pocket::QwenForwardResult>& expected,
+    const std::vector<pocket::ForwardResult>& actual,
+    const std::vector<pocket::ForwardResult>& expected,
     const std::string& label) {
     require(actual.size() == expected.size(), label + " output count");
     for (size_t index = 0; index < actual.size(); ++index) {
@@ -277,7 +277,7 @@ void require_same_mtp_decisions(const pocket::QwenMtpStats& actual,
             label + " MTP decision parity");
 }
 
-std::vector<pocket::QwenForwardResult> require_cached_mtp_matches_cold(
+std::vector<pocket::ForwardResult> require_cached_mtp_matches_cold(
     const std::string& dir, pocket::QwenEngine& cached,
     const pocket::QwenEngineOptions& cached_options,
     const std::vector<int>& prompt, int max_new_tokens,
@@ -313,7 +313,7 @@ void exercise_prefix_cache(const std::string& dir,
     options.max_state_snapshots = 8;
     pocket::QwenEngine engine(dir, options, 2, 8);
 
-    const pocket::QwenForwardResult baseline = engine.prefill({1, 2, 3});
+    const pocket::ForwardResult baseline = engine.prefill({1, 2, 3});
     const pocket::QwenPrefixCacheStats first = engine.prefix_cache_stats();
     require(first.reused_tokens == 0 && first.computed_tokens == 3,
             "initial prefix cache accounting");
@@ -324,7 +324,7 @@ void exercise_prefix_cache(const std::string& dir,
                 appended.computed_tokens == 2,
             "appended prompt must reuse live recurrent state");
 
-    const pocket::QwenForwardResult shortened_result = engine.prefill({1, 2, 3});
+    const pocket::ForwardResult shortened_result = engine.prefill({1, 2, 3});
     const pocket::QwenPrefixCacheStats shortened = engine.prefix_cache_stats();
     require(shortened.resume_source == "snapshot" &&
                 shortened.reused_tokens == 3 && shortened.computed_tokens == 0,
@@ -334,14 +334,14 @@ void exercise_prefix_cache(const std::string& dir,
                 shortened_result.checksum == baseline.checksum,
             "snapshot result must match cold prefill");
 
-    const pocket::QwenForwardResult branched_result = engine.prefill({1, 2, 9});
+    const pocket::ForwardResult branched_result = engine.prefill({1, 2, 9});
     const pocket::QwenPrefixCacheStats branched = engine.prefix_cache_stats();
     require(branched.resume_source == "snapshot" && branched.reused_tokens == 2 &&
                 branched.computed_tokens == 1,
             "branched prompt must resume from interior snapshot");
 
     pocket::QwenEngine cold_engine(dir, options, 2, 8);
-    const pocket::QwenForwardResult cold_branch = cold_engine.prefill({1, 2, 9});
+    const pocket::ForwardResult cold_branch = cold_engine.prefill({1, 2, 9});
     require(branched_result.top_token == cold_branch.top_token &&
                 branched_result.top_logit == cold_branch.top_logit &&
                 branched_result.checksum == cold_branch.checksum,
@@ -376,10 +376,10 @@ void exercise_prefix_cache(const std::string& dir,
     wide_options.prefill_chunk_tokens = 8;
     wide_options.state_snapshot_interval_tokens = 4;
     pocket::QwenEngine wide(dir, wide_options, 2, 8);
-    const pocket::QwenForwardResult wide_baseline = wide.prefill({1, 2, 3, 4, 5, 6});
+    const pocket::ForwardResult wide_baseline = wide.prefill({1, 2, 3, 4, 5, 6});
     require(wide.prefix_cache_stats().computed_tokens == 6,
             "wide chunk prefill accounting");
-    const pocket::QwenForwardResult wide_again = wide.prefill({1, 2, 3, 4, 5, 6});
+    const pocket::ForwardResult wide_again = wide.prefill({1, 2, 3, 4, 5, 6});
     require(wide.prefix_cache_stats().resume_source == "live" &&
                 wide.prefix_cache_stats().computed_tokens == 0 &&
                 wide_again.top_token == wide_baseline.top_token,
@@ -388,7 +388,7 @@ void exercise_prefix_cache(const std::string& dir,
     pocket::QwenEngineOptions wide_cold = wide_options;
     wide_cold.prefix_cache = false;
     pocket::QwenEngine wide_cold_engine(dir, wide_cold, 2, 8);
-    const pocket::QwenForwardResult wide_expected =
+    const pocket::ForwardResult wide_expected =
         wide_cold_engine.prefill({1, 2, 3, 4, 5, 6});
     require(wide_baseline.top_token == wide_expected.top_token,
             "wide chunk prefill must match cold prefill");
@@ -530,19 +530,19 @@ void exercise_cache_lifecycle(const std::string& dir,
                 "TurboQuant K8V4 metadata is embedded in slots");
     }
 
-    const pocket::QwenForwardResult prefill = engine.prefill({1, 2, 3});
+    const pocket::ForwardResult prefill = engine.prefill({1, 2, 3});
     require(prefill.layers == 2 && prefill.dim == 128, "prefill metadata");
     require(prefill.position == 3, "chunked prefill position");
     require(prefill.top_token == 0, "zero fixture prefill greedy token");
     require(engine.activation_workspace_peak_bytes() > 0, "activation accounting");
 
-    const pocket::QwenForwardResult decoded = engine.decode_step(4);
+    const pocket::ForwardResult decoded = engine.decode_step(4);
     require(decoded.position == 4, "decode position");
     require(decoded.top_token == 0, "zero fixture decode greedy token");
 
     engine.reset();
     require(engine.position() == 0, "reset position");
-    const pocket::QwenForwardResult second = engine.prefill({4, 5});
+    const pocket::ForwardResult second = engine.prefill({4, 5});
     require(second.position == 2 && second.top_token == 0,
             "reset and second chunked prefill");
     std::cout << "  cache_dtype=" << pocket::qwen_kv_cache_dtype_name(cache_dtype)
@@ -566,12 +566,12 @@ void exercise_batch_isolation(const std::string& dir,
     pocket::QwenEngine engine(dir, options, 2, 8);
 
     // Slot 0: prompt [1, 2, 3]
-    const pocket::QwenForwardResult r0 = engine.prefill({1, 2, 3}, 0);
+    const pocket::ForwardResult r0 = engine.prefill({1, 2, 3}, 0);
     require(r0.position == 3, "slot 0 prefill position");
 
     // Slot 1: prompt [4, 5, 6] — different tokens, so the recurrent state
     // diverges immediately and the final checksum must differ.
-    const pocket::QwenForwardResult r1 = engine.prefill({4, 5, 6}, 1);
+    const pocket::ForwardResult r1 = engine.prefill({4, 5, 6}, 1);
     require(r1.position == 3, "slot 1 prefill position");
     // Phase 3.4: With zero weights, the output logits are deterministic zero
     // regardless of input, so checksums may match. The isolation test is that
@@ -579,8 +579,8 @@ void exercise_batch_isolation(const std::string& dir,
     // state. A non-zero-weight fixture would show different checksums here.
 
     // Decode step on each slot to verify state persists correctly
-    const pocket::QwenForwardResult d0 = engine.decode_step(r0.top_token, 0);
-    const pocket::QwenForwardResult d1 = engine.decode_step(r1.top_token, 1);
+    const pocket::ForwardResult d0 = engine.decode_step(r0.top_token, 0);
+    const pocket::ForwardResult d1 = engine.decode_step(r1.top_token, 1);
     require(d0.position == 4, "slot 0 decode position");
     require(d1.position == 4, "slot 1 decode position");
     // With zero weights, decode checksums also match; the test is successful

--- a/cpp_engine/tests/test_qwen_eos_stop.cpp
+++ b/cpp_engine/tests/test_qwen_eos_stop.cpp
@@ -7,7 +7,7 @@
 // that directly caps concurrency.
 //
 // The model will not emit EOS on cue, so these checks drive the stop through
-// QwenBatchSamplingParams::stop_token_ids: run once unrestricted, note a token
+// BatchSamplingParams::stop_token_ids: run once unrestricted, note a token
 // the model actually produces at a known step, then re-run with that token as
 // the stop and require generation to end exactly there. That tests the stop
 // machinery, which is what changed; it does not depend on the checkpoint's own
@@ -67,16 +67,16 @@ struct RunOutcome {
 // that state instead of starting clean.
 RunOutcome run_request(pocket::QwenEngine& engine, const std::vector<int>& prompt,
                        int slot_id,
-                       const pocket::QwenBatchSamplingParams& sampling) {
+                       const pocket::BatchSamplingParams& sampling) {
     RunOutcome out;
-    auto req = std::make_unique<pocket::QwenBatchedRequest>();
+    auto req = std::make_unique<pocket::BatchedRequest>();
     req->request_id = static_cast<uint64_t>(slot_id) + 1;
     req->prompt_tokens = prompt;
     req->slot_id = slot_id;
     req->sampling = sampling;
 
-    std::vector<pocket::QwenBatchedRequest*> batch{req.get()};
-    const pocket::QwenBatchPrefillResult prefilled = engine.batch_prefill(batch, 0);
+    std::vector<pocket::BatchedRequest*> batch{req.get()};
+    const pocket::BatchPrefillResult prefilled = engine.batch_prefill(batch, 0);
     out.tokens.push_back(prefilled.results[0].top_token);
 
     // batch_prefill marks the request finished when the prompt's first predicted
@@ -90,7 +90,7 @@ RunOutcome run_request(pocket::QwenEngine& engine, const std::vector<int>& promp
     while (static_cast<int>(out.tokens.size()) < sampling.max_new_tokens) {
         // batch_decode_step and batch_prefill announce their own collectives to
         // the workers, so this loop is the same at TP1 and TP4.
-        const pocket::QwenBatchDecodeResult step = engine.batch_decode_step(batch);
+        const pocket::BatchDecodeResult step = engine.batch_decode_step(batch);
         out.tokens.push_back(step.next_tokens[0]);
         if (step.hit_stop_token[0]) out.stop_flag_seen = true;
         if (step.finished[0]) {
@@ -169,7 +169,7 @@ int main(int argc, char** argv) {
 
     // Baseline: ignore_eos, so this must produce exactly max_new_tokens and
     // gives the reference token sequence.
-    pocket::QwenBatchSamplingParams baseline_params;
+    pocket::BatchSamplingParams baseline_params;
     baseline_params.max_new_tokens = kMaxNewTokens;
     baseline_params.ignore_eos = true;
     const RunOutcome baseline = run_request(engine, prompt, 0, baseline_params);
@@ -205,7 +205,7 @@ int main(int argc, char** argv) {
     std::printf("\nstop token %d, expected at output index %d\n", stop_token,
                 kStopIndex);
 
-    pocket::QwenBatchSamplingParams stop_params;
+    pocket::BatchSamplingParams stop_params;
     stop_params.max_new_tokens = kMaxNewTokens;
     stop_params.stop_token_ids = {stop_token};
     const RunOutcome stopped = run_request(engine, prompt, 1, stop_params);
@@ -227,7 +227,7 @@ int main(int argc, char** argv) {
 
     // A stop id the model does not produce must not shorten anything: this
     // catches a stop check that fires on the wrong comparison.
-    pocket::QwenBatchSamplingParams absent_params;
+    pocket::BatchSamplingParams absent_params;
     absent_params.max_new_tokens = kMaxNewTokens;
     absent_params.stop_token_ids = {-424242};
     const RunOutcome absent = run_request(engine, prompt, 2, absent_params);

--- a/cpp_engine/tests/test_qwen_paged_engine_parity.cpp
+++ b/cpp_engine/tests/test_qwen_paged_engine_parity.cpp
@@ -61,8 +61,8 @@ std::vector<int> prompt_for(int seq, int length) {
     return tokens;
 }
 
-void compare(const pocket::QwenForwardResult& contiguous,
-             const pocket::QwenForwardResult& paged, const std::string& label) {
+void compare(const pocket::ForwardResult& contiguous,
+             const pocket::ForwardResult& paged, const std::string& label) {
     require(contiguous.top_token == paged.top_token,
             label + " top_token mismatch: contiguous " +
                 std::to_string(contiguous.top_token) + " vs paged " +
@@ -152,9 +152,9 @@ void test_batched_decode_parity(const std::string& dir) {
         for (size_t seq = 0; seq < slots.size(); ++seq) {
             tokens[seq] = (static_cast<int>(seq) * 13 + step * 7 + 42) % 64;
         }
-        const std::vector<pocket::QwenForwardResult> reference =
+        const std::vector<pocket::ForwardResult> reference =
             contiguous.batch_decode_tokens(tokens, slots);
-        const std::vector<pocket::QwenForwardResult> actual =
+        const std::vector<pocket::ForwardResult> actual =
             paged.batch_decode_tokens(tokens, slots);
         require(reference.size() == actual.size(),
                 "batch result count mismatch");
@@ -191,7 +191,7 @@ void test_block_reuse(const std::string& dir) {
     const int slot_a = engine.allocate_slot(1001);
     require(slot_a >= 0, "could not acquire first slot");
     const std::vector<int> long_prompt = prompt_for(0, 6000);
-    const pocket::QwenForwardResult first = engine.prefill(long_prompt, slot_a);
+    const pocket::ForwardResult first = engine.prefill(long_prompt, slot_a);
     require(first.position == 6000, "first prefill position");
     engine.free_slot(1001);
 
@@ -199,7 +199,7 @@ void test_block_reuse(const std::string& dir) {
     // this throws, since 6000 more tokens do not fit alongside the first.
     const int slot_b = engine.allocate_slot(1002);
     require(slot_b >= 0, "could not acquire second slot");
-    const pocket::QwenForwardResult second = engine.prefill(long_prompt, slot_b);
+    const pocket::ForwardResult second = engine.prefill(long_prompt, slot_b);
     require(second.position == 6000, "second prefill position");
     // Same prompt, same weights, different slot: the result must not depend on
     // which physical blocks happened to back it.

--- a/cpp_engine/tests/test_qwen_paged_tp_slot_free.cpp
+++ b/cpp_engine/tests/test_qwen_paged_tp_slot_free.cpp
@@ -184,7 +184,7 @@ int main(int argc, char** argv) {
         // point: the sequence stays inside one 16-token block, so the working
         // set is one block and the pool floor is what dominates.
         const std::vector<int> prompt = {1, 2};
-        pocket::QwenBatchSamplingParams sampling;
+        pocket::BatchSamplingParams sampling;
         sampling.max_new_tokens = kCycles;  // never the stopping bound
         sampling.ignore_eos = true;
 
@@ -197,14 +197,14 @@ int main(int argc, char** argv) {
                 return 1;
             }
 
-            auto req = std::make_unique<pocket::QwenBatchedRequest>();
+            auto req = std::make_unique<pocket::BatchedRequest>();
             req->request_id = request_id;
             req->prompt_tokens = prompt;
             req->slot_id = slot;
             req->sampling = sampling;
-            std::vector<pocket::QwenBatchedRequest*> batch{req.get()};
+            std::vector<pocket::BatchedRequest*> batch{req.get()};
 
-            const pocket::QwenBatchPrefillResult prefilled =
+            const pocket::BatchPrefillResult prefilled =
                 engine.batch_prefill(batch, 0);
             if (prefilled.results.empty()) {
                 expect(false, "prefill returned no result");

--- a/cpp_engine/tests/test_qwen_scheduler_paged_admission.cpp
+++ b/cpp_engine/tests/test_qwen_scheduler_paged_admission.cpp
@@ -7,7 +7,7 @@
 // overcommit the pool. Correctness of the paged reads themselves is covered by
 // test_qwen_paged_kv_kernels and test_qwen_paged_engine_parity.
 
-#include "qwen_batch_scheduler.hpp"
+#include "batch_scheduler.hpp"
 #include "qwen_engine.hpp"
 #include "qwen_parity_fixture.hpp"
 
@@ -66,7 +66,7 @@ std::vector<int> prompt_of(int length) {
 // thread, so every assertion here has to be reached by polling rather than by
 // assuming a submit has taken effect yet.
 template <typename Predicate>
-bool wait_for(const pocket::QwenBatchScheduler& scheduler, Predicate pred,
+bool wait_for(const pocket::BatchScheduler& scheduler, Predicate pred,
               int timeout_ms = 30000) {
     const auto deadline = std::chrono::steady_clock::now() +
                           std::chrono::milliseconds(timeout_ms);
@@ -105,10 +105,10 @@ void test_admission_is_bounded_by_blocks(const std::string& dir) {
     const int prompt_len = per_request_tokens / 2;
     const int gen_len = per_request_tokens - prompt_len;
 
-    pocket::QwenBatchScheduler scheduler(&engine, kSlots);
+    pocket::BatchScheduler scheduler(&engine, kSlots);
     scheduler.set_prefill_token_budget(1024);
 
-    pocket::QwenBatchSamplingParams sampling;
+    pocket::BatchSamplingParams sampling;
     sampling.max_new_tokens = gen_len;
     sampling.ignore_eos = true;  // keep the footprint fixed
 
@@ -119,12 +119,12 @@ void test_admission_is_bounded_by_blocks(const std::string& dir) {
                 "submit should be accepted");
     }
 
-    require(wait_for(scheduler, [](const pocket::QwenBatchScheduler::Stats& s) {
+    require(wait_for(scheduler, [](const pocket::BatchScheduler::Stats& s) {
                 return s.running_requests == 2 && s.waiting_requests == 1;
             }),
             "exactly two requests should be admitted, the third held on blocks");
 
-    pocket::QwenBatchScheduler::Stats stats = scheduler.get_stats();
+    pocket::BatchScheduler::Stats stats = scheduler.get_stats();
     require(stats.free_slots >= 4,
             "slots must still be free, proving blocks and not slots bound "
             "admission (free_slots=" + std::to_string(stats.free_slots) + ")");
@@ -164,10 +164,10 @@ void test_completion_releases_blocks(const std::string& dir) {
     const int gen_len = 8;
     const int prompt_len = kMaxContext - 64;
 
-    pocket::QwenBatchScheduler scheduler(&engine, kSlots);
+    pocket::BatchScheduler scheduler(&engine, kSlots);
     scheduler.set_prefill_token_budget(1024);
 
-    pocket::QwenBatchSamplingParams sampling;
+    pocket::BatchSamplingParams sampling;
     sampling.max_new_tokens = gen_len;
     sampling.ignore_eos = true;
 
@@ -178,13 +178,13 @@ void test_completion_releases_blocks(const std::string& dir) {
     }
 
     // Only one fits at a time, so the queue can only drain if blocks come back.
-    require(wait_for(scheduler, [](const pocket::QwenBatchScheduler::Stats& s) {
+    require(wait_for(scheduler, [](const pocket::BatchScheduler::Stats& s) {
                 return s.completed_requests == kRequests;
             }),
             "all requests should complete, which requires freed blocks to be "
             "reused; a leak here stalls the queue permanently");
 
-    pocket::QwenBatchScheduler::Stats stats = scheduler.get_stats();
+    pocket::BatchScheduler::Stats stats = scheduler.get_stats();
     require(stats.waiting_requests == 0, "queue should be drained");
     require(stats.running_requests == 0, "no request should still be running");
     // Reservation and release must balance exactly; a drift would silently
@@ -215,10 +215,10 @@ void test_short_requests_fill_all_slots(const std::string& dir) {
     pocket::QwenEngine engine(dir, options, 2, kMaxContext);
     engine.allocate_batch_slots(kSlots);
 
-    pocket::QwenBatchScheduler scheduler(&engine, kSlots);
+    pocket::BatchScheduler scheduler(&engine, kSlots);
     scheduler.set_prefill_token_budget(1024);
 
-    pocket::QwenBatchSamplingParams sampling;
+    pocket::BatchSamplingParams sampling;
     sampling.max_new_tokens = 32;
     sampling.ignore_eos = true;
 
@@ -227,14 +227,14 @@ void test_short_requests_fill_all_slots(const std::string& dir) {
                 "submit should be accepted");
     }
 
-    require(wait_for(scheduler, [](const pocket::QwenBatchScheduler::Stats& s) {
+    require(wait_for(scheduler, [](const pocket::BatchScheduler::Stats& s) {
                 return s.running_requests == kSlots ||
                        s.completed_requests == kSlots;
             }),
             "short requests should reach full slot width, not be throttled by "
             "the block rule");
 
-    require(wait_for(scheduler, [](const pocket::QwenBatchScheduler::Stats& s) {
+    require(wait_for(scheduler, [](const pocket::BatchScheduler::Stats& s) {
                 return s.completed_requests == kSlots;
             }),
             "all short requests should complete");
@@ -259,10 +259,10 @@ void test_cancellation_releases_blocks(const std::string& dir) {
     pocket::QwenEngine engine(dir, options, 2, kMaxContext);
     engine.allocate_batch_slots(kSlots);
 
-    pocket::QwenBatchScheduler scheduler(&engine, kSlots);
+    pocket::BatchScheduler scheduler(&engine, kSlots);
     scheduler.set_prefill_token_budget(1024);
 
-    pocket::QwenBatchSamplingParams sampling;
+    pocket::BatchSamplingParams sampling;
     // Long enough to still be running when cancelled, and to reserve the pool.
     sampling.max_new_tokens = 64;
     sampling.ignore_eos = true;
@@ -270,7 +270,7 @@ void test_cancellation_releases_blocks(const std::string& dir) {
 
     const uint64_t first = scheduler.submit_request(prompt_of(prompt_len), sampling);
     require(first != 0, "first submit should be accepted");
-    require(wait_for(scheduler, [](const pocket::QwenBatchScheduler::Stats& s) {
+    require(wait_for(scheduler, [](const pocket::BatchScheduler::Stats& s) {
                 return s.reserved_blocks > 0;
             }),
             "first request should reserve blocks");
@@ -283,18 +283,18 @@ void test_cancellation_releases_blocks(const std::string& dir) {
 
     // The second request starting at all is the assertion: under a leak the
     // reservation would outlive the cancelled request and nothing could follow.
-    require(wait_for(scheduler, [](const pocket::QwenBatchScheduler::Stats& s) {
+    require(wait_for(scheduler, [](const pocket::BatchScheduler::Stats& s) {
                 return s.completed_requests == 1;
             }),
             "the queued request should run once cancellation freed the pool; a "
             "leaked reservation stalls it forever");
 
-    require(wait_for(scheduler, [](const pocket::QwenBatchScheduler::Stats& s) {
+    require(wait_for(scheduler, [](const pocket::BatchScheduler::Stats& s) {
                 return s.running_requests == 0 && s.waiting_requests == 0;
             }),
             "scheduler should drain");
 
-    pocket::QwenBatchScheduler::Stats stats = scheduler.get_stats();
+    pocket::BatchScheduler::Stats stats = scheduler.get_stats();
     require(stats.cancelled_requests == 1, "one request should be cancelled");
     require(stats.reserved_blocks == 0,
             "reservation should return to zero after cancel and completion, got " +
@@ -323,9 +323,9 @@ void test_oversized_request_rejected(const std::string& dir) {
     pocket::QwenEngine engine(dir, options, 2, kMaxContext);
     engine.allocate_batch_slots(kSlots);
 
-    pocket::QwenBatchScheduler scheduler(&engine, kSlots);
+    pocket::BatchScheduler scheduler(&engine, kSlots);
 
-    pocket::QwenBatchSamplingParams sampling;
+    pocket::BatchSamplingParams sampling;
     // Worst case is one block beyond what the whole pool can back.
     sampling.max_new_tokens = kMaxContext;
     sampling.ignore_eos = true;
@@ -335,12 +335,12 @@ void test_oversized_request_rejected(const std::string& dir) {
             "submit rather than queued forever");
 
     // A normal request behind it must still be servable.
-    pocket::QwenBatchSamplingParams ok;
+    pocket::BatchSamplingParams ok;
     ok.max_new_tokens = 16;
     ok.ignore_eos = true;
     require(scheduler.submit_request(prompt_of(64), ok) != 0,
             "a serviceable request should still be accepted");
-    require(wait_for(scheduler, [](const pocket::QwenBatchScheduler::Stats& s) {
+    require(wait_for(scheduler, [](const pocket::BatchScheduler::Stats& s) {
                 return s.completed_requests == 1;
             }),
             "the serviceable request should complete, proving the rejected one "
@@ -366,10 +366,10 @@ void test_contiguous_unaffected(const std::string& dir) {
     require(engine.kv_total_blocks() == 0,
             "contiguous arena should report no blocks");
 
-    pocket::QwenBatchScheduler scheduler(&engine, kSlots);
+    pocket::BatchScheduler scheduler(&engine, kSlots);
     scheduler.set_prefill_token_budget(1024);
 
-    pocket::QwenBatchSamplingParams sampling;
+    pocket::BatchSamplingParams sampling;
     // Together these reach max_context, a footprint the block rule would have
     // throttled to two concurrent requests if it applied here.
     sampling.max_new_tokens = 512;
@@ -381,18 +381,74 @@ void test_contiguous_unaffected(const std::string& dir) {
                 "submit should be accepted under the contiguous arena");
     }
 
-    require(wait_for(scheduler, [](const pocket::QwenBatchScheduler::Stats& s) {
+    require(wait_for(scheduler, [](const pocket::BatchScheduler::Stats& s) {
                 return s.running_requests == kSlots;
             }),
             "all slots should be admitted under the contiguous arena, showing "
             "the block rule is inert when paging is off");
 
-    pocket::QwenBatchScheduler::Stats stats = scheduler.get_stats();
+    pocket::BatchScheduler::Stats stats = scheduler.get_stats();
     require(stats.reserved_blocks == 0,
             "no blocks should be reserved when paging is off");
 
     scheduler.stop();
     std::cout << "  contiguous arena keeps the slot rule: PASS" << std::endl;
+}
+
+// ============================================================================
+// Capabilities are declared, not inferred.
+//
+// The scheduler used to read kv_total_blocks() == 0 as "contiguous arena",
+// which is an inference from an accounting field: an engine that supports
+// neither paging nor batching reports the same zero. These assertions pin what
+// QwenEngine declares for each configuration, so a scheduler reading caps()
+// gets the truth rather than a coincidence.
+// ============================================================================
+void test_caps_declare_the_configuration(const std::string& dir) {
+    {
+        pocket::QwenEngineOptions options = paged_options();
+        options.kv_cache_bytes = budget_for_blocks(2 * kBlocksPerSeq);
+        pocket::QwenEngine engine(dir, options, 2, kMaxContext);
+        const pocket::Capabilities caps = engine.caps();
+        require(caps.paged_kv, "paged engine should declare paged_kv");
+        require(caps.paged_kv == engine.kv_paged(),
+                "caps().paged_kv must agree with kv_paged()");
+        require(caps.continuous_batching,
+                "an 8-slot engine should declare continuous batching");
+        require(caps.chunked_prefill,
+                "batch_prefill honours its token budget on every configuration");
+        require(caps.max_slots == kSlots,
+                "max_slots should be the configured batch size, got " +
+                    std::to_string(caps.max_slots));
+    }
+    {
+        pocket::QwenEngineOptions options = paged_options();
+        options.kv_paged = false;
+        pocket::QwenEngine engine(dir, options, 2, kMaxContext);
+        const pocket::Capabilities caps = engine.caps();
+        require(!caps.paged_kv,
+                "contiguous engine should declare paged_kv false");
+        require(caps.max_slots == kSlots, "max_slots should still be the "
+                                          "configured batch size");
+    }
+    {
+        // One slot is the shape a non-batching engine reports, and it must be
+        // distinguishable from the contiguous 8-slot case above by caps() alone
+        // -- both report kv_total_blocks() == 0.
+        pocket::QwenEngineOptions options = paged_options();
+        options.kv_paged = false;
+        options.max_batch_size = 1;
+        pocket::QwenEngine engine(dir, options, 2, kMaxContext);
+        const pocket::Capabilities caps = engine.caps();
+        require(!caps.continuous_batching,
+                "a single-slot engine should not declare continuous batching");
+        require(caps.max_slots == 1, "single-slot engine should report 1 slot");
+        require(engine.kv_total_blocks() == 0,
+                "this is the case the old zero-blocks inference could not tell "
+                "apart from a wide contiguous engine");
+    }
+
+    std::cout << "  capabilities are declared, not inferred: PASS" << std::endl;
 }
 
 }  // namespace
@@ -413,6 +469,7 @@ int main() {
         test_cancellation_releases_blocks(dir);
         test_oversized_request_rejected(dir);
         test_contiguous_unaffected(dir);
+        test_caps_declare_the_configuration(dir);
 
         std::cout << "\nAll scheduler paged admission tests PASSED"
                   << std::endl;


### PR DESCRIPTION
## Summary

`BatchScheduler` took a `QwenEngine*`, so continuous batching, paged-KV admission, and chunked prefill were reachable only by that one model. The coupling was never the logic — `grep -oE "engine_->[a-z_]+"` over the scheduler reports exactly ten distinct methods, none of which mentions attention, weights, or quantization. It was the type.

## Implementation

New `include/inference_engine.hpp` holds that surface as an abstract class, plus the request and result types the scheduler has to name without naming a model:

- `ForwardResult`, `BatchSamplingParams`, `BatchedRequest`, `BatchPrefillResult`, `BatchDecodeResult`, `PartialPrefillResult` move out of `qwen_engine.hpp` and lose their `Qwen` prefix
- new `Capabilities` declares `paged_kv`, `continuous_batching`, `chunked_prefill`, `max_slots`
- `QwenEngine` now implements `InferenceEngine`; what stays in `qwen_engine.hpp` is what is genuinely Qwen3.5's — its options, weight map, prefix-cache and MTP accounting, TP worker protocol, speculative entry points
- `engine/qwen_batch_scheduler.*` → `engine/batch_scheduler.*`, `QwenBatchScheduler` → `BatchScheduler`, taking `InferenceEngine*`
- `tests/test_qwen_batch_scheduler.cpp` → `tests/test_batch_scheduler.cpp`

### Why `Capabilities`

The scheduler currently reads `kv_total_blocks() == 0` as "contiguous arena". That is an inference from an accounting field, not a statement of capability: an engine supporting neither paging nor batching reports the same zero, and the scheduler would go on treating it as a wide batched engine. A new case in `test_qwen_scheduler_paged_admission` pins what `QwenEngine` declares for paged, contiguous, and single-slot configurations — including the pair the old zero-blocks inference could not tell apart. The scheduler starts *reading* `caps()` in the next change, alongside the DeepSeek-V4 adapter that makes the distinction load-bearing.

### Why virtual is safe here

Every method on `InferenceEngine` is called once per scheduler iteration, never per token and never per layer, so an indirect call cannot show up against a batched forward pass. Layer components will be concrete types for the opposite reason.

### Incidental

`engine_->options().device` becomes `engine_->device()`. `batch_prefill` loses its defaulted `token_budget` argument, which no caller used and which would have been statically bound through a virtual.

### Python API is unchanged

pybind11 still exports `QwenForwardResult`, `QwenBatchSamplingParams`, `QwenBatchScheduler`, and `QwenBatchSchedulerStats` under those names, with every field name untouched. Only the C++ types behind them moved. No Python source file is touched by this change.

## Testing

Against the pre-change build, real checkpoint `/mnt/data2/Qwen3.8-27B-FP8`, TP4 on 4×2080 Ti, one configuration per process.

**Token parity — 4-layer TP4 digest** (`bench_qwen_paged_tp_parity`, contiguous and paged, batch 1/4/8): all six checksums byte-identical (`df92123420008a37`, `2c2fdc7199eb3f43`, `156efc37fb5e762a`).

**Token parity — full 64-layer TP4** at 8,192 and 65,536 prompt tokens: generated token sequences identical, peak GPU bytes identical, `rank_token_parity=PASS`.

**Throughput A/B** — serial, fresh process per length, TG=64:

| Prompt | Prefill before → after | Decode before → after (TG=64) |
|---|---|---|
| 8,192 | 1838.98 → 1835.39 tok/s | 45.249 → 45.526 tok/s |
| 65,536 | 1457.40 → 1473.45 tok/s | 40.106 → 40.733 tok/s |

**Existing suites:** all 81 C++ test binaries return exit codes identical to the baseline. The tracked Python suite has the same failure set as a detached-HEAD worktree, minus one case that only fails in a bare worktree because it needs build artifacts the worktree lacks. The native module builds and exports the same 21 names.

## Checklist

- [x] `InferenceEngine` derived from the scheduler's actual call set, not invented
- [x] `Capabilities` covered by a test over paged / contiguous / single-slot
- [x] Token-exact parity, 4-layer and full 64-layer
- [x] Serial short + long throughput A/B with TG length stated
- [x] C++ and Python suites diffed against baseline
- [x] Python API surface unchanged
- [ ] Follow-up: model registry, capability negotiation, DeepSeek adapter (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)