### PR TITLE
Add a model registry and a DeepSeek-V4 engine adapter

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -38,6 +38,7 @@ set(POCKET_CORE_SOURCES
     core/safetensors_model.cpp
     core/weight_source.cpp
     core/model_config.cpp
+    core/model_registry.cpp
     core/qwen_config.cpp
     core/block_pool.cpp
     core/block_table.cpp
@@ -60,6 +61,8 @@ set(POCKET_ENGINE_SOURCES
     engine/qwen_target_head.cpp
     engine/qwen_engine.cpp
     engine/batch_scheduler.cpp
+    engine/persistent_engine_adapter.cpp
+    engine/engine_registry_builtin.cpp
 )
 
 # Engines that still call CUDA kernels by name. A runtime guard cannot help here:
@@ -887,6 +890,10 @@ set_target_properties(test_persistent_engine PROPERTIES RUNTIME_OUTPUT_DIRECTORY
 add_executable(test_batch_scheduler tests/test_batch_scheduler.cpp)
 target_link_libraries(test_batch_scheduler PRIVATE pocket_cpp_core)
 set_target_properties(test_batch_scheduler PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_model_registry tests/test_model_registry.cpp)
+target_link_libraries(test_model_registry PRIVATE pocket_cpp_core)
+set_target_properties(test_model_registry PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(bench_qwen_fp8_batch_crossover tests/bench_qwen_fp8_batch_crossover.cpp)
 target_link_libraries(bench_qwen_fp8_batch_crossover PRIVATE pocket_cpp_core)

--- a/cpp_engine/core/model_registry.cpp
+++ b/cpp_engine/core/model_registry.cpp
@@ -1,0 +1,180 @@
+// Architecture detection and the engine registry.
+//
+// This is the model-selection seam: everything above it -- the CLI, the server,
+// the Python backend -- names a checkpoint, and this decides which runtime opens
+// it. Before this existed the answer was an `is_qwen3_5_checkpoint()` if/else in
+// main.cpp and an `engine_kind` string in the Python backend, so adding a model
+// meant editing every dispatch site.
+//
+// Deliberately free of engine dependencies: pocket_core links this, and a tool
+// that inspects a checkpoint without any accelerator toolkit present must keep
+// working. The engines register themselves from engine/engine_registry_builtin.cpp.
+
+#include "model_registry.hpp"
+
+#include "gguf_reader.hpp"
+#include "json_lite.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <map>
+#include <mutex>
+#include <sstream>
+#include <stdexcept>
+
+namespace pocket {
+namespace {
+
+std::mutex& registry_mutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
+std::map<std::string, EngineFactory>& registry() {
+    static std::map<std::string, EngineFactory> factories;
+    return factories;
+}
+
+bool try_read_file(const std::string& path, std::string* out) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) return false;
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    *out = buffer.str();
+    return true;
+}
+
+bool has_suffix(const std::string& value, const std::string& suffix) {
+    if (value.size() < suffix.size()) return false;
+    return std::equal(suffix.rbegin(), suffix.rend(), value.rbegin(),
+                      [](char a, char b) {
+                          return std::tolower(static_cast<unsigned char>(a)) ==
+                                 std::tolower(static_cast<unsigned char>(b));
+                      });
+}
+
+std::string lowered(const std::string& value) {
+    std::string out = value;
+    for (char& c : out) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    return out;
+}
+
+// Fold the spellings a checkpoint may use onto the key an engine registers.
+//
+// Qwen3.5 publishes `qwen3_5` at the config root and `qwen3_5_text` inside
+// text_config, and either can be the only one present depending on whether the
+// checkpoint is the multimodal wrapper or the text-only export. Both are the same
+// runtime, so both have to reach the same factory.
+std::string canonical_architecture(const std::string& raw) {
+    const std::string arch = lowered(raw);
+    if (arch == "qwen3_5_text") return "qwen3_5";
+    return arch;
+}
+
+std::string architecture_from_json_config(const std::string& ckpt_dir) {
+    std::string text;
+    if (!try_read_file(ckpt_dir + "/config.json", &text)) return {};
+    const JsonValue root_value = parse_json(text);
+    if (!root_value.is_object()) return {};
+    const JsonObject& root = root_value.object();
+
+    const JsonValue* model_type = object_get(root, "model_type");
+    if (model_type != nullptr && model_type->is_string() && !model_type->string().empty()) {
+        return model_type->string();
+    }
+    // A multimodal wrapper may declare only the nested text model's type.
+    const JsonValue* nested = object_get(root, "text_config");
+    if (nested == nullptr || !nested->is_object()) return {};
+    const JsonValue* nested_type = object_get(nested->object(), "model_type");
+    if (nested_type == nullptr || !nested_type->is_string()) return {};
+    return nested_type->string();
+}
+
+}  // namespace
+
+void register_engine(const std::string& architecture, EngineFactory factory) {
+    if (architecture.empty()) {
+        throw std::invalid_argument("register_engine: architecture must not be empty");
+    }
+    if (!factory) {
+        throw std::invalid_argument("register_engine: factory must not be empty for architecture '" +
+                                    architecture + "'");
+    }
+    const std::string key = canonical_architecture(architecture);
+    std::lock_guard<std::mutex> lock(registry_mutex());
+    if (registry().count(key) != 0) {
+        throw std::runtime_error("register_engine: architecture '" + key +
+                                 "' is already registered");
+    }
+    registry().emplace(key, std::move(factory));
+}
+
+bool engine_registered(const std::string& architecture) {
+    const std::string key = canonical_architecture(architecture);
+    std::lock_guard<std::mutex> lock(registry_mutex());
+    return registry().count(key) != 0;
+}
+
+std::vector<std::string> registered_architectures() {
+    std::lock_guard<std::mutex> lock(registry_mutex());
+    std::vector<std::string> names;
+    names.reserve(registry().size());
+    for (const auto& entry : registry()) names.push_back(entry.first);
+    return names;  // std::map already orders these.
+}
+
+std::string detect_architecture(const std::string& ckpt_path) {
+    if (ckpt_path.empty()) {
+        throw std::runtime_error("detect_architecture: empty checkpoint path");
+    }
+    if (has_suffix(ckpt_path, ".gguf")) {
+        const GGUFFile file(ckpt_path);
+        return canonical_architecture(
+            file.metadata_string("general.architecture").value_or(std::string()));
+    }
+    std::string probe;
+    if (!try_read_file(ckpt_path + "/config.json", &probe)) {
+        throw std::runtime_error(
+            "detect_architecture: no config.json under '" + ckpt_path +
+            "' and the path is not a .gguf file");
+    }
+    return canonical_architecture(architecture_from_json_config(ckpt_path));
+}
+
+std::unique_ptr<InferenceEngine> create_engine(const std::string& ckpt_path,
+                                               const EngineOptions& options) {
+    const std::string architecture = detect_architecture(ckpt_path);
+
+    EngineFactory factory;
+    std::vector<std::string> known;
+    {
+        std::lock_guard<std::mutex> lock(registry_mutex());
+        auto it = registry().find(architecture);
+        if (it != registry().end()) factory = it->second;
+        for (const auto& entry : registry()) known.push_back(entry.first);
+    }
+
+    if (!factory) {
+        std::ostringstream message;
+        message << "no engine registered for architecture '"
+                << (architecture.empty() ? std::string("<undeclared>") : architecture)
+                << "' declared by " << ckpt_path << "; registered: ";
+        if (known.empty()) {
+            // The usual cause is a caller that never called
+            // register_builtin_engines(), which is a much more useful thing to
+            // say than "unknown architecture".
+            message << "<none; call register_builtin_engines() first>";
+        } else {
+            for (size_t i = 0; i < known.size(); ++i) {
+                if (i != 0) message << ", ";
+                message << known[i];
+            }
+        }
+        throw std::runtime_error(message.str());
+    }
+
+    return factory(ckpt_path, options);
+}
+
+}  // namespace pocket

--- a/cpp_engine/engine/batch_scheduler.cpp
+++ b/cpp_engine/engine/batch_scheduler.cpp
@@ -15,6 +15,31 @@ BatchScheduler::BatchScheduler(InferenceEngine* engine, int max_batch_size)
         throw std::invalid_argument("BatchScheduler: max_batch_size must be > 0");
     }
 
+    caps_ = engine_->caps();
+
+    // Honour what the engine declared rather than what the caller asked for. An
+    // engine that runs one session at a time will reject a wider
+    // allocate_batch_slots outright, and an engine that supports slots but not
+    // concurrent execution would have its caches interleaved by two live
+    // requests. Clamping here means a caller can hand the same max_batch_size to
+    // any engine and get that engine's honest width.
+    int allowed = caps_.continuous_batching ? caps_.max_slots : 1;
+    if (allowed < 1) allowed = 1;
+    if (max_batch_size_ > allowed) {
+        std::cerr << "BatchScheduler: engine declares max_slots=" << caps_.max_slots
+                  << (caps_.continuous_batching ? "" : " and no continuous batching")
+                  << "; running at width " << allowed
+                  << " instead of the requested " << max_batch_size_ << std::endl;
+        max_batch_size_ = allowed;
+    }
+
+    // A budget only means something to an engine that can return an unfinished
+    // prompt. Sending one to an engine that cannot would have it silently run the
+    // whole prompt anyway, so the scheduler stops pretending it chunked.
+    if (!caps_.chunked_prefill) {
+        prefill_token_budget_ = 0;
+    }
+
     // Allocate batch slots in the engine
     engine_->allocate_batch_slots(max_batch_size_);
 
@@ -82,7 +107,7 @@ uint64_t BatchScheduler::submit_request(
     // blocking everything behind it forever. Safe outside queue_mutex_: this
     // reads only the pool geometry, fixed once the engine is constructed, and
     // the request's own fields, which no other thread can see yet.
-    if (engine_->kv_paged() &&
+    if (caps_.paged_kv &&
         worst_case_blocks(*req) > engine_->kv_total_blocks()) {
         return 0;
     }
@@ -210,7 +235,7 @@ void BatchScheduler::schedule_loop() {
 }
 
 int BatchScheduler::worst_case_blocks(const SchedulerRequest& req) const {
-    if (!engine_->kv_paged()) return 0;
+    if (!caps_.paged_kv) return 0;
     // Prompt plus every token the request is still allowed to generate. Charging
     // only the prompt would admit a request whose decode cannot be backed, and a
     // decode step must write its K/V somewhere. Requests therefore hold their
@@ -231,8 +256,11 @@ void BatchScheduler::admit_requests() {
         // blocks its context will span, so a queue of short prompts can run at
         // full width while long ones are held back. The contiguous arena gives
         // every slot max_context up front, so there is nothing to weigh and the
-        // slot bound above is the whole admission rule.
-        if (engine_->kv_paged()) {
+        // slot bound above is the whole admission rule. Which of the two applies
+        // is what the engine declared, not what its block counters happen to
+        // read: an engine with no paging at all reports the same zeros as a
+        // contiguous arena.
+        if (caps_.paged_kv) {
             const int needed =
                 worst_case_blocks(*waiting_queue_.front());
             // Checked against the pool total minus what admitted requests may

--- a/cpp_engine/engine/engine_registry_builtin.cpp
+++ b/cpp_engine/engine/engine_registry_builtin.cpp
@@ -1,0 +1,67 @@
+// The engines this build contains, bound to the architectures they serve.
+//
+// Kept apart from core/model_registry.cpp on purpose: the registry itself has no
+// engine dependency, so a checkpoint-inspection tool can link pocket_core alone.
+// This translation unit is where naming a concrete engine is allowed.
+//
+// Registration is explicit rather than static-initializer-driven. In a static
+// library a self-registering object is dropped by the linker unless something
+// already references it, which makes "which models does this binary support"
+// depend on link order; an explicit call cannot silently lose an engine.
+
+#include "model_registry.hpp"
+
+#include "persistent_engine_adapter.hpp"
+#include "qwen_engine.hpp"
+
+#include <memory>
+#include <mutex>
+
+namespace pocket {
+namespace {
+
+// DeepSeek-V4's full depth, and what the CLI's --serve path has always used when
+// no explicit layer count was given.
+constexpr int kDeepSeekV4Layers = 43;
+
+std::unique_ptr<InferenceEngine> make_qwen_engine(const std::string& ckpt_dir,
+                                                  const EngineOptions& options) {
+    QwenEngineOptions qwen;
+    qwen.tp_world = options.tp_world;
+    qwen.tp_rank = options.tp_rank;
+    qwen.device = options.device;
+    qwen.nccl_id_path = options.nccl_id_path;
+    qwen.max_batch_size = options.max_batch_size;
+    qwen.kv_paged = options.kv_paged;
+    qwen.kv_block_size = options.kv_block_size;
+    qwen.kv_cache_bytes = options.kv_cache_bytes;
+    // Everything else -- prefill chunk, KV dtype, prefix cache, snapshots, the
+    // drafters -- keeps its tuned default. A caller that needs to move one of
+    // those knows it is talking to Qwen and can construct QwenEngine directly.
+    return std::make_unique<QwenEngine>(ckpt_dir, qwen, options.layer_count,
+                                        options.max_context);
+}
+
+std::unique_ptr<InferenceEngine> make_deepseek_v4_engine(
+    const std::string& ckpt_dir, const EngineOptions& options) {
+    ForwardSmokeOptions opts;
+    opts.tp_world = options.tp_world;
+    opts.tp_rank = options.tp_rank;
+    opts.device = options.device;
+    opts.nccl_id_path = options.nccl_id_path;
+    const int layers = options.layer_count > 0 ? options.layer_count : kDeepSeekV4Layers;
+    return std::make_unique<PersistentEngineAdapter>(ckpt_dir, opts, layers,
+                                                     options.max_context);
+}
+
+}  // namespace
+
+void register_builtin_engines() {
+    static std::once_flag once;
+    std::call_once(once, [] {
+        register_engine("qwen3_5", make_qwen_engine);
+        register_engine("deepseek_v4", make_deepseek_v4_engine);
+    });
+}
+
+}  // namespace pocket

--- a/cpp_engine/engine/main.cpp
+++ b/cpp_engine/engine/main.cpp
@@ -3,8 +3,10 @@
 #include "device_runtime.hpp"
 #include "deepseek_v4_engine.hpp"
 #include "model_config.hpp"
+#include "model_registry.hpp"
 #include "openai_server.hpp"
 #include "persistent_engine.hpp"
+#include "persistent_engine_adapter.hpp"
 #include "qwen_config.hpp"
 #include "qwen_engine.hpp"
 #include "python_sidecar.hpp"
@@ -388,18 +390,38 @@ int main(int argc, char** argv) {
         }
         if (args.serve) {
             if (args.ckpt.empty()) throw std::runtime_error("--serve requires --ckpt");
-            if (pocket::is_qwen3_5_checkpoint(args.ckpt)) {
-                throw std::runtime_error("Qwen checkpoint is not supported by the DeepSeek-V4 OpenAI server yet; use --smoke-forward or --generate-token");
+            pocket::register_builtin_engines();
+            // The remaining restriction is the server's, not the checkpoint's:
+            // OpenAIServer still takes a PersistentEngine& and drives it through
+            // prefill/decode_step by hand, so only the engine behind that type
+            // can be served. Checked before construction, because otherwise a
+            // Qwen checkpoint would load 27B of weights only to be rejected.
+            // Giving the server an InferenceEngine& deletes this whole guard.
+            const std::string architecture = pocket::detect_architecture(args.ckpt);
+            if (architecture != "deepseek_v4") {
+                throw std::runtime_error(
+                    "the OpenAI server currently accepts only the DeepSeek-V4 persistent "
+                    "engine; '" + (architecture.empty() ? std::string("<undeclared>") : architecture) +
+                    "' checkpoints are served through the Python backend for now");
             }
-            const int layer_count = args.smoke_layers > 0 ? args.smoke_layers : 43;
             const int max_context = args.max_context > 0 ? args.max_context : 8192;
-            pocket::ForwardSmokeOptions opts;
-            opts.tp_world = args.tp_world;
-            opts.tp_rank = args.tp_rank;
-            opts.device = args.device >= 0 ? args.device : args.tp_rank;
-            opts.nccl_id_path = args.nccl_id_path;
+            pocket::EngineOptions engine_options;
+            engine_options.tp_world = args.tp_world;
+            engine_options.tp_rank = args.tp_rank;
+            engine_options.device = args.device >= 0 ? args.device : args.tp_rank;
+            engine_options.nccl_id_path = args.nccl_id_path;
+            engine_options.layer_count = args.smoke_layers;
+            engine_options.max_context = max_context;
             const pocket::ModelConfig model_cfg = pocket::ModelConfig::from_hf_config(args.ckpt);
-            pocket::PersistentEngine engine(args.ckpt, opts, layer_count, max_context);
+            std::unique_ptr<pocket::InferenceEngine> runtime =
+                pocket::create_engine(args.ckpt, engine_options);
+            auto* adapter = dynamic_cast<pocket::PersistentEngineAdapter*>(runtime.get());
+            if (adapter == nullptr) {
+                throw std::runtime_error(
+                    "the engine registered for '" + architecture +
+                    "' is not the persistent engine the OpenAI server drives");
+            }
+            pocket::PersistentEngine& engine = adapter->engine();
             std::cout << "server_max_context=" << max_context << "\n";
             std::cout << "model_context_length=" << model_cfg.context_length << "\n";
             engine.warmup_tp();
@@ -422,7 +444,8 @@ int main(int argc, char** argv) {
             return 0;
         }
         if (!args.ckpt.empty()) {
-            const bool qwen_checkpoint = pocket::is_qwen3_5_checkpoint(args.ckpt);
+            const bool qwen_checkpoint =
+                pocket::detect_architecture(args.ckpt) == "qwen3_5";
             pocket::SafeTensorsIndex index(args.ckpt);
             std::cout << "pocketllm_engine opened " << args.ckpt << "\n";
             std::cout << "format=safetensors tensors=" << index.tensor_count()

--- a/cpp_engine/engine/persistent_engine_adapter.cpp
+++ b/cpp_engine/engine/persistent_engine_adapter.cpp
@@ -1,0 +1,188 @@
+#include "persistent_engine_adapter.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <stdexcept>
+
+namespace pocket {
+namespace {
+
+// Matches the server's rule and PersistentEngine's own contract: a temperature
+// at or below this is greedy argmax, which is what keeps existing greedy runs
+// reproducible when a request leaves temperature unset.
+constexpr float kGreedyTemperatureEpsilon = 1.0e-5f;
+
+SamplingParams to_persistent_sampling(const BatchSamplingParams& sampling) {
+    SamplingParams sp;
+    sp.temperature = sampling.temperature;
+    sp.top_p = sampling.top_p;
+    sp.greedy = sampling.temperature <= kGreedyTemperatureEpsilon;
+    sp.seed = sampling.seed;
+    // PersistentEngine's sampler has no top-k stage, so BatchSamplingParams::top_k
+    // is dropped here rather than silently reinterpreted as something else.
+    return sp;
+}
+
+double elapsed_seconds(std::chrono::steady_clock::time_point start) {
+    const std::chrono::duration<double> delta =
+        std::chrono::steady_clock::now() - start;
+    return delta.count();
+}
+
+}  // namespace
+
+PersistentEngineAdapter::PersistentEngineAdapter(const std::string& ckpt_dir,
+                                                 const ForwardSmokeOptions& opts,
+                                                 int layer_count,
+                                                 int max_context)
+    : owned_(std::make_unique<PersistentEngine>(ckpt_dir, opts, layer_count, max_context)),
+      engine_(owned_.get()) {}
+
+PersistentEngineAdapter::PersistentEngineAdapter(PersistentEngine& engine)
+    : engine_(&engine) {}
+
+PersistentEngineAdapter::~PersistentEngineAdapter() = default;
+
+Capabilities PersistentEngineAdapter::caps() const {
+    Capabilities c;
+    c.paged_kv = false;
+    c.continuous_batching = false;
+    c.chunked_prefill = false;
+    c.max_slots = 1;
+    return c;
+}
+
+int PersistentEngineAdapter::max_context() const { return engine_->max_context(); }
+
+int PersistentEngineAdapter::device() const { return engine_->options().device; }
+
+void PersistentEngineAdapter::allocate_batch_slots(int max_batch_size) {
+    if (max_batch_size > 1) {
+        throw std::invalid_argument(
+            "PersistentEngineAdapter: DeepSeek-V4 runs one session at a time; "
+            "requested " + std::to_string(max_batch_size) +
+            " slots but caps().max_slots is 1");
+    }
+    // One slot always exists; there is nothing to allocate.
+}
+
+int PersistentEngineAdapter::allocate_slot(uint64_t request_id) {
+    if (slot_taken_) return -1;
+    slot_taken_ = true;
+    slot_request_id_ = request_id;
+    position_ = 0;
+    // The session carries the previous request's KV cache and position, so a new
+    // occupant has to start from a cleared one. Doing it here rather than inside
+    // batch_prefill keeps it to exactly one reset per request, which matters
+    // because reset is the only thing standing between two requests' caches.
+    engine_->worker_command_reset();
+    engine_->reset_session();
+    return 0;
+}
+
+void PersistentEngineAdapter::free_slot(uint64_t request_id) {
+    if (!slot_taken_ || slot_request_id_ != request_id) return;
+    slot_taken_ = false;
+    slot_request_id_ = 0;
+    position_ = 0;
+}
+
+bool PersistentEngineAdapter::kv_paged() const { return false; }
+int PersistentEngineAdapter::kv_free_blocks() const { return 0; }
+int PersistentEngineAdapter::kv_total_blocks() const { return 0; }
+int PersistentEngineAdapter::kv_blocks_for_tokens(int) const { return 0; }
+
+bool PersistentEngineAdapter::is_stop_token(const BatchSamplingParams& sampling,
+                                            int token) const {
+    if (sampling.ignore_eos) return false;
+    if (!sampling.stop_token_ids.empty()) {
+        return std::find(sampling.stop_token_ids.begin(),
+                         sampling.stop_token_ids.end(),
+                         token) != sampling.stop_token_ids.end();
+    }
+    return token == engine_->eos_id();
+}
+
+BatchPrefillResult PersistentEngineAdapter::batch_prefill(
+    const std::vector<BatchedRequest*>& requests, int /*token_budget*/) {
+    BatchPrefillResult out;
+    if (requests.empty()) return out;
+    if (requests.size() > 1) {
+        throw std::invalid_argument(
+            "PersistentEngineAdapter::batch_prefill: one request at a time "
+            "(caps().max_slots is 1), got " + std::to_string(requests.size()));
+    }
+
+    BatchedRequest* req = requests[0];
+    if (req == nullptr) throw std::invalid_argument(
+        "PersistentEngineAdapter::batch_prefill: null request");
+    if (req->seq_len != 0) {
+        // caps().chunked_prefill is false, so a prompt always completes in one
+        // call and the scheduler never resumes one. Arriving here means it did
+        // anyway, and replaying the prompt from token 0 into a cache that already
+        // holds part of it would duplicate positions.
+        throw std::invalid_argument(
+            "PersistentEngineAdapter::batch_prefill: cannot resume a partially "
+            "prefilled prompt; this engine does not declare chunked_prefill");
+    }
+
+    const auto started = std::chrono::steady_clock::now();
+    const SamplingParams sp = to_persistent_sampling(req->sampling);
+    engine_->worker_command_prefill(req->prompt_tokens);
+    const int token = engine_->prefill(req->prompt_tokens, sp);
+
+    const int prompt_tokens = static_cast<int>(req->prompt_tokens.size());
+    position_ = prompt_tokens;
+
+    ForwardResult result;
+    result.token = token;
+    result.top_token = token;
+    result.position = position_;
+
+    req->seq_len = prompt_tokens;
+    req->last_token = token;
+    req->last_result = result;
+    req->finished = is_stop_token(req->sampling, token);
+
+    out.results.push_back(result);
+    out.incomplete.push_back(false);
+    out.total_tokens = prompt_tokens;
+    out.seconds = elapsed_seconds(started);
+    return out;
+}
+
+BatchDecodeResult PersistentEngineAdapter::batch_decode_step(
+    const std::vector<BatchedRequest*>& requests) {
+    BatchDecodeResult out;
+    if (requests.empty()) return out;
+    if (requests.size() > 1) {
+        throw std::invalid_argument(
+            "PersistentEngineAdapter::batch_decode_step: one request at a time "
+            "(caps().max_slots is 1), got " + std::to_string(requests.size()));
+    }
+
+    BatchedRequest* req = requests[0];
+    if (req == nullptr) throw std::invalid_argument(
+        "PersistentEngineAdapter::batch_decode_step: null request");
+
+    const auto started = std::chrono::steady_clock::now();
+    const SamplingParams sp = to_persistent_sampling(req->sampling);
+    // position_ is where `last_token` itself sits, which is the position
+    // decode_step wants -- not the position being produced.
+    engine_->worker_command_decode(req->last_token, position_);
+    const int token = engine_->decode_step(req->last_token, position_, sp);
+    ++position_;
+
+    const bool stopped = is_stop_token(req->sampling, token);
+    req->last_token = token;
+    req->seq_len += 1;
+    req->finished = stopped;
+
+    out.next_tokens.push_back(token);
+    out.finished.push_back(stopped);
+    out.hit_stop_token.push_back(stopped);
+    out.seconds = elapsed_seconds(started);
+    return out;
+}
+
+}  // namespace pocket

--- a/cpp_engine/include/batch_scheduler.hpp
+++ b/cpp_engine/include/batch_scheduler.hpp
@@ -99,9 +99,12 @@ public:
     // (0.94x), while 512 drops to 1330 (0.71x). 4096 keeps full prefill
     // throughput while capping a 65K prompt's uninterrupted hold at about 2.2s
     // instead of 56s. 0 disables chunking and restores the previous behaviour of
-    // running each prompt to completion.
+    // running each prompt to completion. An engine that does not declare
+    // chunked_prefill pins this at 0: it would run the whole prompt regardless,
+    // and holding a budget it ignores would only misreport what is happening.
     void set_prefill_token_budget(int tokens) {
-        prefill_token_budget_ = tokens < 0 ? 0 : tokens;
+        prefill_token_budget_ =
+            (!caps_.chunked_prefill || tokens < 0) ? 0 : tokens;
     }
     int prefill_token_budget() const { return prefill_token_budget_; }
 
@@ -109,6 +112,12 @@ public:
     // Returns true if result was populated, false on timeout
     bool poll_result(uint64_t request_id, SchedulerGenerationResult* out,
                      int timeout_ms = 30000);
+
+    // What the engine behind this scheduler declared it can do, read once at
+    // construction. `max_batch_size` may have been clamped to caps().max_slots,
+    // so this is how a caller learns the width it actually got.
+    const Capabilities& engine_caps() const { return caps_; }
+    int max_batch_size() const { return max_batch_size_; }
 
     // Get scheduler statistics
     struct Stats {
@@ -155,6 +164,11 @@ private:
 
     // Internal state
     InferenceEngine* engine_;
+    // Read once in the constructor. Capabilities are fixed by how the engine was
+    // built, so re-reading them per admission would be a virtual call answering
+    // the same question. Every place the scheduler used to infer a capability --
+    // "kv_total_blocks() == 0 means contiguous arena" -- consults this instead.
+    Capabilities caps_;
     int max_batch_size_;
     // Default 4096: the largest chunk that still measured full prefill
     // throughput on TP4 27B, so interleaving costs nothing on the prefill side.

--- a/cpp_engine/include/model_registry.hpp
+++ b/cpp_engine/include/model_registry.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "inference_engine.hpp"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace pocket {
+
+// Construction parameters every registered engine understands.
+//
+// This is deliberately not the union of every engine's option struct. It carries
+// what a *caller who does not know the model* can meaningfully supply: topology,
+// device, depth, context, and the KV geometry admission reasons in. Model-specific
+// tuning -- KV cache dtype, prefill chunk size, drafter checkpoints, attention
+// windows -- stays on the concrete engine's own options struct, which a caller
+// that has chosen a model can name directly.
+//
+// A factory maps these onto its native options and leaves the rest at their
+// documented defaults, so going through the registry never silently changes a
+// tuned default.
+struct EngineOptions {
+    int tp_world = 1;
+    int tp_rank = 0;
+    int device = 0;
+    std::string nccl_id_path;
+    // Layers to run. 0 means the checkpoint's full depth; smaller values are the
+    // smoke-test path that loads a prefix of the network.
+    int layer_count = 0;
+    // Per-sequence context ceiling, prompt plus generation.
+    int max_context = 8192;
+    // Requested concurrent slots. An engine that declares max_slots == 1 may
+    // reject anything larger rather than pretend to batch.
+    int max_batch_size = 1;
+    // Paged KV cache instead of a per-slot contiguous arena. Engines that cannot
+    // page ignore this; ask caps() rather than assuming it took effect.
+    bool kv_paged = false;
+    int kv_block_size = 16;
+    // Paged pool budget in bytes on this rank; 0 derives it from what the
+    // contiguous arena would have reserved.
+    uint64_t kv_cache_bytes = 0;
+};
+
+// Builds one engine for one checkpoint. Registered per architecture.
+using EngineFactory = std::function<std::unique_ptr<InferenceEngine>(
+    const std::string& ckpt_path, const EngineOptions& options)>;
+
+// Bind an architecture string to its engine. Throws if the architecture is
+// already registered: silently replacing a builtin would make which engine runs
+// depend on link order.
+void register_engine(const std::string& architecture, EngineFactory factory);
+
+bool engine_registered(const std::string& architecture);
+
+// Registered architectures in sorted order. This is what a server reports as the
+// models it can serve, rather than a hand-maintained list that drifts.
+std::vector<std::string> registered_architectures();
+
+// Architecture a checkpoint declares about itself, normalized to a registry key.
+//
+// Reuses the readers that already exist rather than adding a parser: a path
+// ending in `.gguf` is read through GGUFFile for `general.architecture`, and
+// anything else is treated as a directory whose config.json declares
+// `model_type` (falling back to `text_config.model_type` for the multimodal
+// wrappers, which is where Qwen3.5 hides it).
+//
+// Throws when neither is readable, so a mistyped checkpoint path fails here with
+// the path in the message instead of deep inside a loader. Returns "" when the
+// checkpoint parses but declares no architecture at all.
+std::string detect_architecture(const std::string& ckpt_path);
+
+// Detect, look up, construct. Throws naming the registered architectures when
+// the checkpoint's architecture has no engine.
+std::unique_ptr<InferenceEngine> create_engine(const std::string& ckpt_path,
+                                               const EngineOptions& options);
+
+// Register the engines this build contains. Idempotent, so a process that links
+// both the CLI and the Python module can call it from either entry point.
+//
+// Defined alongside the engines in engine/engine_registry_builtin.cpp, not here:
+// the registry itself must stay free of engine dependencies so a tool that links
+// only pocket_core can still parse and inspect a checkpoint.
+void register_builtin_engines();
+
+}  // namespace pocket

--- a/cpp_engine/include/persistent_engine_adapter.hpp
+++ b/cpp_engine/include/persistent_engine_adapter.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "inference_engine.hpp"
+#include "persistent_engine.hpp"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace pocket {
+
+// Presents the DeepSeek-V4 PersistentEngine through the InferenceEngine surface.
+//
+// PersistentEngine is a single mutable session: one KV cache, one position
+// counter the caller maintains (see persistent_engine.hpp), no slots, no block
+// pool, no bounded prefill. None of that is a defect to be papered over here --
+// porting it onto paged KV and slots is a separate effort -- so this adapter does
+// not pretend. It declares `paged_kv = false`, `continuous_batching = false`,
+// `chunked_prefill = false`, `max_slots = 1`, and the scheduler reads that
+// declaration instead of inferring capability from an accounting field that
+// happens to read zero.
+//
+// What the adapter does supply is the position bookkeeping the batched API hides
+// and PersistentEngine requires: `decode_step` takes the absolute position of the
+// token it is fed, which every existing caller has had to track by hand.
+//
+// TP is handled the way QwenEngine's batched entry points handle it: each forward
+// announces itself on the worker command channel first, so a scheduler driving
+// this adapter is TP-safe without knowing the protocol exists. Rank 0 drives;
+// worker ranks stay in PersistentEngine::run_worker_loop(), which the owner
+// reaches through engine().
+class PersistentEngineAdapter : public InferenceEngine {
+public:
+    // Owning form: constructs the PersistentEngine. This is what the model
+    // registry's factory uses.
+    PersistentEngineAdapter(const std::string& ckpt_dir,
+                            const ForwardSmokeOptions& opts,
+                            int layer_count,
+                            int max_context);
+
+    // Borrowing form, for a caller that already owns a PersistentEngine and
+    // still needs its non-batched entry points (speculative decoding, the TP
+    // worker loop). The engine must outlive the adapter.
+    explicit PersistentEngineAdapter(PersistentEngine& engine);
+
+    ~PersistentEngineAdapter() override;
+
+    PersistentEngineAdapter(const PersistentEngineAdapter&) = delete;
+    PersistentEngineAdapter& operator=(const PersistentEngineAdapter&) = delete;
+
+    // The wrapped engine, for the model-specific surface the interface does not
+    // carry: warmup_tp(), run_worker_loop(), worker_command_shutdown(),
+    // speculative decoding, the tokenizer.
+    PersistentEngine& engine() { return *engine_; }
+    const PersistentEngine& engine() const { return *engine_; }
+
+    Capabilities caps() const override;
+    int max_context() const override;
+    int device() const override;
+
+    // Rejects anything above one slot rather than accepting it and overwriting
+    // one request's KV cache with another's.
+    void allocate_batch_slots(int max_batch_size) override;
+    int allocate_slot(uint64_t request_id) override;
+    void free_slot(uint64_t request_id) override;
+
+    // Not paged; all three report 0, which caps().paged_kv == false is what makes
+    // meaningful.
+    bool kv_paged() const override;
+    int kv_free_blocks() const override;
+    int kv_total_blocks() const override;
+    int kv_blocks_for_tokens(int tokens) const override;
+
+    // Single-request degradations. Both reject a batch wider than one row: the
+    // adapter declared max_slots == 1, so a wider call is a scheduler that
+    // ignored the declaration, and failing loudly beats silently interleaving two
+    // sequences through one KV cache.
+    //
+    // `token_budget` is ignored, as caps().chunked_prefill == false announces:
+    // the prompt runs to completion in one call.
+    BatchPrefillResult batch_prefill(const std::vector<BatchedRequest*>& requests,
+                                     int token_budget) override;
+    BatchDecodeResult batch_decode_step(
+        const std::vector<BatchedRequest*>& requests) override;
+
+private:
+    bool is_stop_token(const BatchSamplingParams& sampling, int token) const;
+
+    std::unique_ptr<PersistentEngine> owned_;
+    PersistentEngine* engine_ = nullptr;
+    // The one slot, and whose it is. -1 means free.
+    bool slot_taken_ = false;
+    uint64_t slot_request_id_ = 0;
+    // Absolute position of `last_token` for the request holding the slot. Prefill
+    // of n tokens leaves this at n, which is where the token it sampled sits.
+    int position_ = 0;
+};
+
+}  // namespace pocket

--- a/cpp_engine/python/bindings.cpp
+++ b/cpp_engine/python/bindings.cpp
@@ -10,6 +10,7 @@
 #include "qwen_weights.hpp"
 #include "batch_scheduler.hpp"
 #include "device_runtime.hpp"
+#include "model_registry.hpp"
 
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
@@ -184,6 +185,18 @@ std::vector<int> persistent_batch_verify(PersistentEngine& engine,
 
 PYBIND11_MODULE(pocketllm_cpp, module) {
     module.doc() = "Optional native PocketLLM C++ backend";
+
+    // Same registry the C++ CLI dispatches on, so a checkpoint reaches the same
+    // engine whichever side opens it. Registration is idempotent.
+    register_builtin_engines();
+
+    // Model selection. The Python backend constructs the concrete engine classes
+    // below directly, because it needs their full option surface, but it asks
+    // this which one a checkpoint wants rather than carrying its own rules.
+    module.def("detect_architecture", &detect_architecture,
+               "Architecture a checkpoint declares, normalized to a registry key");
+    module.def("registered_architectures", &registered_architectures,
+               "Architectures this build has an engine for, in sorted order");
 
     py::enum_<QwenKvCacheDType>(module, "QwenKvCacheDType")
         .value("Fp16", QwenKvCacheDType::Fp16)

--- a/cpp_engine/tests/test_model_registry.cpp
+++ b/cpp_engine/tests/test_model_registry.cpp
@@ -1,0 +1,341 @@
+// The model-selection seam: architecture detection and the engine registry.
+//
+// What this pins is that choosing an engine is driven by what a checkpoint
+// declares about itself, and that the scheduler is driven by what an engine
+// declares about itself. Both used to be inferred -- `is_qwen3_5_checkpoint()`
+// in main.cpp, an `engine_kind` string in the Python backend, and
+// `kv_total_blocks() == 0` in the scheduler -- and an inference that happens to
+// be right for the one model that exists is exactly what a second model breaks.
+//
+// No checkpoint and no device are needed here: the detection fixtures are a few
+// bytes of JSON and a header-only GGUF, and the engines are stubs. That is the
+// point -- the seam has to be testable without the 27B weights.
+
+#include "batch_scheduler.hpp"
+#include "model_registry.hpp"
+
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const std::string& message) {
+    if (condition) {
+        std::cout << "  " << message << ": PASS\n";
+    } else {
+        std::cout << "  " << message << ": FAIL\n";
+        ++failures;
+    }
+}
+
+void check_eq(const std::string& actual, const std::string& expected,
+              const std::string& message) {
+    check(actual == expected, message + " (got '" + actual + "', expected '" +
+                                  expected + "')");
+}
+
+std::string fixture_root() {
+    const char* base = std::getenv("CLAUDE_JOB_DIR");
+    const std::string root = base != nullptr ? std::string(base) + "/tmp"
+                                             : std::string("/tmp");
+    return root + "/model_registry_fixture";
+}
+
+void make_dir(const std::string& path) {
+    const std::string cmd = "mkdir -p '" + path + "'";
+    if (std::system(cmd.c_str()) != 0) {
+        throw std::runtime_error("could not create fixture dir " + path);
+    }
+}
+
+void write_file(const std::string& path, const std::string& contents) {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) throw std::runtime_error("could not write fixture " + path);
+    out << contents;
+    if (!out) throw std::runtime_error("short write to fixture " + path);
+}
+
+// A checkpoint directory whose config.json is exactly `body`.
+std::string config_dir(const std::string& name, const std::string& body) {
+    const std::string dir = fixture_root() + "/" + name;
+    make_dir(dir);
+    write_file(dir + "/config.json", body);
+    return dir;
+}
+
+// --- Minimal GGUF writer ----------------------------------------------------
+//
+// Header plus one metadata string, zero tensors. Enough for the architecture
+// probe, which is all detect_architecture reads out of a GGUF.
+
+void put_u32(std::string& out, uint32_t value) {
+    for (int i = 0; i < 4; ++i) out.push_back(static_cast<char>((value >> (8 * i)) & 0xFF));
+}
+
+void put_u64(std::string& out, uint64_t value) {
+    for (int i = 0; i < 8; ++i) out.push_back(static_cast<char>((value >> (8 * i)) & 0xFF));
+}
+
+void put_string(std::string& out, const std::string& value) {
+    put_u64(out, value.size());
+    out += value;
+}
+
+std::string gguf_with_architecture(const std::string& name,
+                                   const std::string& architecture) {
+    std::string bytes;
+    bytes += "GGUF";
+    put_u32(bytes, 3);   // version
+    put_u64(bytes, 0);   // tensor count
+    put_u64(bytes, 1);   // metadata count
+    put_string(bytes, "general.architecture");
+    put_u32(bytes, 8);   // GGUF string type
+    put_string(bytes, architecture);
+
+    const std::string path = fixture_root() + "/" + name + ".gguf";
+    write_file(path, bytes);
+    return path;
+}
+
+// --- Stub engines -----------------------------------------------------------
+
+// Declares whatever capabilities the test hands it and records what the
+// scheduler asked of it. Runs no forward pass; every assertion here is about
+// negotiation, which happens before the first token.
+class StubEngine : public pocket::InferenceEngine {
+public:
+    explicit StubEngine(pocket::Capabilities caps) : caps_(caps) {}
+
+    pocket::Capabilities caps() const override { return caps_; }
+    int max_context() const override { return 4096; }
+    int device() const override { return 0; }
+
+    void allocate_batch_slots(int max_batch_size) override {
+        requested_slots_ = max_batch_size;
+    }
+    int allocate_slot(uint64_t) override { return -1; }
+    void free_slot(uint64_t) override {}
+
+    bool kv_paged() const override { return caps_.paged_kv; }
+    // Zero even when paged, which is the shape the old inference could not tell
+    // apart from "this engine has no paged cache at all".
+    int kv_free_blocks() const override { return 0; }
+    int kv_total_blocks() const override { return 0; }
+    int kv_blocks_for_tokens(int) const override { return 0; }
+
+    pocket::BatchPrefillResult batch_prefill(
+        const std::vector<pocket::BatchedRequest*>&, int) override {
+        return {};
+    }
+    pocket::BatchDecodeResult batch_decode_step(
+        const std::vector<pocket::BatchedRequest*>&) override {
+        return {};
+    }
+
+    int requested_slots() const { return requested_slots_; }
+
+private:
+    pocket::Capabilities caps_;
+    int requested_slots_ = -1;
+};
+
+pocket::Capabilities single_session_caps() {
+    pocket::Capabilities caps;
+    caps.paged_kv = false;
+    caps.continuous_batching = false;
+    caps.chunked_prefill = false;
+    caps.max_slots = 1;
+    return caps;
+}
+
+pocket::Capabilities paged_batched_caps(int slots) {
+    pocket::Capabilities caps;
+    caps.paged_kv = true;
+    caps.continuous_batching = true;
+    caps.chunked_prefill = true;
+    caps.max_slots = slots;
+    return caps;
+}
+
+// ============================================================================
+
+void test_architecture_detection() {
+    std::cout << "detect_architecture reads what the checkpoint declares\n";
+
+    const std::string deepseek = config_dir(
+        "deepseek", R"({"model_type": "deepseek_v4", "num_hidden_layers": 43})");
+    check_eq(pocket::detect_architecture(deepseek), "deepseek_v4",
+             "root model_type is the architecture");
+
+    const std::string qwen = config_dir("qwen", R"({"model_type": "qwen3_5"})");
+    check_eq(pocket::detect_architecture(qwen), "qwen3_5",
+             "qwen3_5 is its own key");
+
+    // The multimodal wrapper hides the runtime's type one level down, and the
+    // text-only export spells it differently. Both are the same engine, so both
+    // have to fold onto one key or a checkpoint reaches no factory at all.
+    const std::string nested = config_dir(
+        "qwen_nested", R"({"text_config": {"model_type": "qwen3_5_text"}})");
+    check_eq(pocket::detect_architecture(nested), "qwen3_5",
+             "text_config.model_type is used when the root declares none");
+
+    const std::string cased = config_dir("cased", R"({"model_type": "Qwen3_5_Text"})");
+    check_eq(pocket::detect_architecture(cased), "qwen3_5",
+             "architecture keys are case-insensitive");
+
+    const std::string silent = config_dir("silent", R"({"hidden_size": 4096})");
+    check_eq(pocket::detect_architecture(silent), "",
+             "a config that declares no model_type detects as unknown");
+
+    const std::string gguf = gguf_with_architecture("minimax", "minimax-m2");
+    check_eq(pocket::detect_architecture(gguf), "minimax-m2",
+             "a .gguf path is read through general.architecture");
+
+    bool threw = false;
+    try {
+        pocket::detect_architecture(fixture_root() + "/does_not_exist");
+    } catch (const std::exception&) {
+        threw = true;
+    }
+    check(threw, "a path that is neither a config dir nor a .gguf is an error");
+}
+
+void test_registry_dispatch() {
+    std::cout << "the registry dispatches on the detected architecture\n";
+
+    const std::string dir = config_dir("stub_arch", R"({"model_type": "stub_arch"})");
+
+    std::string seen_ckpt;
+    int seen_slots = 0;
+    pocket::register_engine("stub_arch", [&](const std::string& ckpt,
+                                             const pocket::EngineOptions& options) {
+        seen_ckpt = ckpt;
+        seen_slots = options.max_batch_size;
+        return std::unique_ptr<pocket::InferenceEngine>(
+            new StubEngine(paged_batched_caps(options.max_batch_size)));
+    });
+
+    check(pocket::engine_registered("stub_arch"), "a registered engine is visible");
+
+    pocket::EngineOptions options;
+    options.max_batch_size = 3;
+    std::unique_ptr<pocket::InferenceEngine> engine =
+        pocket::create_engine(dir, options);
+    check(engine != nullptr, "create_engine builds the registered engine");
+    check_eq(seen_ckpt, dir, "the factory receives the checkpoint path");
+    check(seen_slots == 3, "the factory receives the caller's options");
+    check(engine->caps().max_slots == 3, "the built engine's caps reach the caller");
+
+    // Silently replacing a registration would make which engine runs depend on
+    // link order, which is exactly the failure a registry is supposed to remove.
+    bool duplicate_threw = false;
+    try {
+        pocket::register_engine("stub_arch", [](const std::string&,
+                                                const pocket::EngineOptions&) {
+            return std::unique_ptr<pocket::InferenceEngine>();
+        });
+    } catch (const std::exception&) {
+        duplicate_threw = true;
+    }
+    check(duplicate_threw, "re-registering an architecture is rejected");
+
+    const std::string unknown = config_dir("unknown", R"({"model_type": "not_a_model"})");
+    std::string message;
+    try {
+        pocket::create_engine(unknown, options);
+    } catch (const std::exception& e) {
+        message = e.what();
+    }
+    check(message.find("not_a_model") != std::string::npos &&
+              message.find("stub_arch") != std::string::npos,
+          "an unregistered architecture is reported with what is registered");
+}
+
+void test_builtin_registrations() {
+    std::cout << "the build's engines are registered by name\n";
+
+    pocket::register_builtin_engines();
+    // Idempotent: the CLI and the Python module are separate entry points into
+    // the same process image, and either may be first.
+    pocket::register_builtin_engines();
+
+    check(pocket::engine_registered("qwen3_5"), "qwen3_5 has an engine");
+    check(pocket::engine_registered("deepseek_v4"), "deepseek_v4 has an engine");
+
+    const std::vector<std::string> known = pocket::registered_architectures();
+    bool sorted = true;
+    for (size_t i = 1; i < known.size(); ++i) {
+        if (known[i - 1] > known[i]) sorted = false;
+    }
+    check(sorted, "registered_architectures is ordered, so a server's model list is stable");
+}
+
+void test_scheduler_honours_declared_capabilities() {
+    std::cout << "the scheduler runs at the width the engine declares\n";
+
+    // A single-session engine used to be indistinguishable from a wide one with
+    // an empty block pool: both answer kv_total_blocks() == 0. The scheduler
+    // would have opened 8 slots on it and fed it a chunked prefill budget.
+    StubEngine serial(single_session_caps());
+    {
+        pocket::BatchScheduler scheduler(&serial, 8);
+        check(serial.requested_slots() == 1,
+              "a max_slots=1 engine is never asked for more than one slot");
+        check(scheduler.max_batch_size() == 1,
+              "the scheduler's own width follows the declaration");
+        check(scheduler.prefill_token_budget() == 0,
+              "no chunked prefill means no token budget");
+        scheduler.set_prefill_token_budget(4096);
+        check(scheduler.prefill_token_budget() == 0,
+              "a budget cannot be set on an engine that ignores it");
+        scheduler.stop();
+    }
+
+    StubEngine wide(paged_batched_caps(4));
+    {
+        pocket::BatchScheduler scheduler(&wide, 8);
+        check(wide.requested_slots() == 4,
+              "a request wider than max_slots is clamped, not rejected");
+        check(scheduler.prefill_token_budget() > 0,
+              "an engine that declares chunked prefill keeps its budget");
+        scheduler.stop();
+    }
+
+    StubEngine exact(paged_batched_caps(8));
+    {
+        pocket::BatchScheduler scheduler(&exact, 4);
+        check(exact.requested_slots() == 4,
+              "a request inside max_slots is passed through unchanged");
+        scheduler.stop();
+    }
+}
+
+}  // namespace
+
+int main() {
+    try {
+        make_dir(fixture_root());
+        test_architecture_detection();
+        test_registry_dispatch();
+        test_builtin_registrations();
+        test_scheduler_honours_declared_capabilities();
+    } catch (const std::exception& e) {
+        std::cout << "[FAIL] " << e.what() << "\n";
+        return 1;
+    }
+
+    if (failures != 0) {
+        std::cout << "[FAIL] " << failures << " model registry checks failed\n";
+        return 1;
+    }
+    std::cout << "[PASS] model registry\n";
+    return 0;
+}

--- a/pocketllm/backends/cpp_backend.py
+++ b/pocketllm/backends/cpp_backend.py
@@ -283,6 +283,22 @@ class CppBackend(BackendBase):
         except BackendUnavailableError:
             return False
 
+    def _registered_architectures(self) -> tuple[str, ...]:
+        """Models this build can serve, read from the native engine registry.
+
+        This is the same list the C++ CLI dispatches on, so a build that links a
+        second engine reports it here without anyone editing a literal.  The
+        fallback covers a native module predating the registry, and a
+        capabilities report is not worth failing a backend over.
+        """
+        listed = getattr(self._native, "registered_architectures", None)
+        if listed is None:
+            return ("qwen3_5",)
+        try:
+            return tuple(str(name) for name in listed())
+        except Exception:
+            return ("qwen3_5",)
+
     @property
     def capabilities(self) -> BackendCapabilities:
         # The Ascend build rejects the external drafters, so report only what the
@@ -291,7 +307,7 @@ class CppBackend(BackendBase):
         speculative: tuple[str, ...] = ("mtp",) if native_backend == "ascend" else ("mtp", "dspark", "dflash2")
         return BackendCapabilities(
             name="cpp",
-            models=("qwen3.5",),
+            models=self._registered_architectures(),
             model_formats=("safetensors",),
             devices=(native_backend,) if native_backend else ("cuda", "ascend"),
             supports_batch=self._batching_enabled,  # Phase 3.4: dynamic based on scheduler
@@ -332,12 +348,14 @@ class CppBackend(BackendBase):
             return None
 
     def _construct_engine(self) -> Any:
-        # QwenEngine is the default at every world size.  It has its own worker
-        # loop, so TP no longer has to fall back to PersistentEngine — that
-        # fallback silently routed Qwen checkpoints into the DeepSeek-V4 loader,
-        # which fails on `embed.weight`.  PersistentEngine stays opt-in for
-        # DeepSeek-V4 checkpoints via backend_options["engine_kind"].
-        kind = str(self.args.backend_options.get("engine_kind", "qwen")).lower()
+        # Which engine opens a checkpoint is the checkpoint's own declaration,
+        # read through the same C++ model registry the native CLI dispatches on.
+        # `engine_kind` remains as an explicit override for the cases detection
+        # cannot cover -- a directory without a config.json, or forcing one
+        # runtime onto a checkpoint for a comparison.
+        kind = str(self.args.backend_options.get("engine_kind", "auto")).lower()
+        if kind == "auto":
+            kind = self._detect_engine_kind()
 
         if kind == "persistent":
             return self._construct_persistent_engine()
@@ -345,8 +363,45 @@ class CppBackend(BackendBase):
             return self._construct_qwen_engine()
         else:
             raise UnsupportedFeatureError(
-                f"unsupported engine_kind: {kind}; use 'persistent' or 'qwen'"
+                f"unsupported engine_kind: {kind}; use 'auto', 'persistent' or 'qwen'"
             )
+
+    # Architectures the registry knows, mapped to the native engine class this
+    # backend constructs for them.  The backend builds the concrete classes
+    # rather than going through create_engine() because it needs their full
+    # option surface (KV dtype, drafters, prefill chunk), which the registry's
+    # model-agnostic EngineOptions deliberately does not carry.
+    _ENGINE_KIND_BY_ARCHITECTURE = {
+        "qwen3_5": "qwen",
+        "deepseek_v4": "persistent",
+    }
+
+    def _detect_engine_kind(self) -> str:
+        """Ask the native registry which engine this checkpoint wants."""
+        detect = getattr(self._native, "detect_architecture", None)
+        checkpoint = self.args.checkpoint_dir
+        if detect is None or not checkpoint:
+            # An older native module, or a caller that passed no checkpoint at
+            # all (token-only tests).  Keep the previous default rather than
+            # failing on a path that never needed detecting.
+            return "qwen"
+        try:
+            architecture = str(detect(checkpoint))
+        except Exception as exc:
+            raise ConfigurationError(
+                f"could not detect the model architecture of {checkpoint}: {exc}; "
+                "pass --engine-kind qwen or --engine-kind persistent to choose one"
+            ) from exc
+
+        kind = self._ENGINE_KIND_BY_ARCHITECTURE.get(architecture)
+        if kind is None:
+            known = ", ".join(sorted(self._ENGINE_KIND_BY_ARCHITECTURE)) or "none"
+            raise UnsupportedFeatureError(
+                f"no cpp backend engine for architecture "
+                f"'{architecture or '<undeclared>'}' declared by {checkpoint}; "
+                f"known architectures: {known}"
+            )
+        return kind
 
     def _construct_persistent_engine(self) -> Any:
         """Construct PersistentEngine (supports TP worker loop)."""

--- a/pocketllm/cli.py
+++ b/pocketllm/cli.py
@@ -56,7 +56,11 @@ def build_parser() -> argparse.ArgumentParser:
     serve_parser.add_argument("--max-batch-size", type=int, default=1)
     serve_parser.add_argument("--host", default="0.0.0.0")
     serve_parser.add_argument("--port", type=int, default=8000)
-    serve_parser.add_argument("--engine-kind", default="qwen")
+    # "auto" asks the native model registry which engine the checkpoint wants.
+    # The explicit values stay for checkpoints that declare nothing, and for
+    # forcing one runtime onto a checkpoint to compare them.
+    serve_parser.add_argument("--engine-kind", default="auto",
+                              choices=["auto", "qwen", "persistent"])
     # Matches the legacy server default: routed experts live in host memory so
     # a 4x2080Ti box can hold the model. "gpu" needs far more device memory.
     serve_parser.add_argument("--routed-experts-device", choices=["gpu", "cpu"], default="cpu")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,7 +81,7 @@ def test_backend_option_values_are_json_typed() -> None:
     assert args.backend_options["max_state_snapshots"] == 16
     assert args.backend_options["mtp_adaptive"] is True
     assert args.backend_options["dspark_checkpoint"] == "/models/drafter"
-    assert args.backend_options["engine_kind"] == "qwen"
+    assert args.backend_options["engine_kind"] == "auto"
 
 
 def test_backend_option_requires_key_value_form() -> None:

--- a/tests/test_cpp_backend.py
+++ b/tests/test_cpp_backend.py
@@ -108,10 +108,19 @@ class FakeNativeModule:
 
     def __init__(self) -> None:
         self.constructed: tuple[str, FakeOptions, int, int] | None = None
+        self.detected: list[str] = []
 
     @staticmethod
     def parse_qwen_kv_cache_dtype(value: str) -> str:
         return f"native:{value}"
+
+    @staticmethod
+    def registered_architectures() -> list[str]:
+        return ["deepseek_v4", "qwen3_5"]
+
+    def detect_architecture(self, checkpoint: str) -> str:
+        self.detected.append(checkpoint)
+        return "qwen3_5"
 
     def QwenEngine(
         self,
@@ -360,10 +369,68 @@ def test_cpp_capabilities_match_phase_one_surface() -> None:
     backend, _ = make_backend()
 
     capabilities = backend.capabilities
-    assert capabilities.models == ("qwen3.5",)
+    # The served models come from the native engine registry rather than a
+    # literal here, so a build that links a second engine reports it.
+    assert capabilities.models == ("qwen3_5",)
     assert capabilities.model_formats == ("safetensors",)
     assert capabilities.supports_streaming is True
     assert capabilities.supports_batch is False
+
+
+def test_cpp_capabilities_list_the_registered_architectures() -> None:
+    native = FakeNativeModule()
+    backend = CppBackend(
+        EngineArgs(model="checkpoint", backend="cpp"),
+        native_module=native,
+        tokenizer=FakeTokenizer(),
+    )
+
+    assert backend.capabilities.models == ("deepseek_v4", "qwen3_5")
+    backend.close()
+
+
+def test_cpp_engine_kind_is_detected_from_the_checkpoint() -> None:
+    native = FakeNativeModule()
+    backend = CppBackend(
+        EngineArgs(model="checkpoint", backend="cpp"),
+        native_module=native,
+        tokenizer=FakeTokenizer(),
+    )
+
+    # Detection ran against the checkpoint and picked the Qwen runtime, without
+    # an engine_kind having been supplied.
+    assert native.detected == ["checkpoint"]
+    assert native.constructed is not None
+    backend.close()
+
+
+def test_cpp_unknown_architecture_is_reported_not_guessed() -> None:
+    class UnknownArchModule(FakeNativeModule):
+        def detect_architecture(self, checkpoint: str) -> str:
+            return "llama"
+
+    with pytest.raises(UnsupportedFeatureError, match="llama"):
+        CppBackend(
+            EngineArgs(model="checkpoint", backend="cpp"),
+            native_module=UnknownArchModule(),
+            tokenizer=FakeTokenizer(),
+        )
+
+
+def test_cpp_engine_kind_override_skips_detection() -> None:
+    native = FakeNativeModule()
+    backend = CppBackend(
+        EngineArgs(
+            model="checkpoint",
+            backend="cpp",
+            backend_options={"engine_kind": "qwen"},
+        ),
+        native_module=native,
+        tokenizer=FakeTokenizer(),
+    )
+
+    assert native.detected == []
+    backend.close()
 
 
 def test_cpp_capabilities_follow_the_linked_device_backend() -> None:


### PR DESCRIPTION
## Summary

Third of six PRs componentizing the C++ engine along the model axis (after #138 `core/` extraction and #139 `InferenceEngine` + generic scheduler).

Model selection was two hardcoded branches — `is_qwen3_5_checkpoint()` in `main.cpp` and an `engine_kind` string in the Python backend. Adding a third model meant editing both. This replaces them with architecture detection plus a factory registry, the same shape as vLLM's `ModelRegistry`, and wraps the DeepSeek-V4 `PersistentEngine` behind `InferenceEngine` so the scheduler reads what it can do instead of assuming.

## Implementation

**`core/model_registry.cpp` — detection and dispatch**

Reads the architecture from `config.json` (including a nested `text_config`) or from `general.architecture` in a GGUF header, folds `qwen3_5_text` onto `qwen3_5`, and maps the result to a factory.

Two placement decisions, both load-bearing:

- It lives in `pocket_core` with **no engine dependency**. `qwen_audit` and `test_qwen_bf16_checkpoint` link only `pocket_core`, so a checkpoint-inspection tool must be able to name an architecture without pulling in an engine. Engine names appear solely in `engine/engine_registry_builtin.cpp`, which is part of `pocket_cpp_core`.
- Registration is an explicit `register_builtin_engines()`, not static initializers. In a static library a self-registering object is dropped by the linker unless something references it, which would make "which models does this binary support" depend on link order.

**`PersistentEngineAdapter` — capability negotiation, not pretending**

Wraps `PersistentEngine` behind `InferenceEngine` and declares the truth: `paged_kv=false`, `continuous_batching=false`, `chunked_prefill=false`, `max_slots=1`. It tracks the absolute decode position that `PersistentEngine` requires its *caller* to maintain, and rejects a batch wider than one or a chunked resume rather than silently mis-serving it.

It links on Ascend without an `#ifdef`: `engine/backend_unimplemented_ascend.cpp` already supplies throwing `PersistentEngine` stubs, so the adapter compiles there and fails only at construction.

**`BatchScheduler` reads `caps()`**

Three sites that inferred paged KV from `kv_total_blocks() == 0` now read `caps_.paged_kv`, captured once in the constructor. An engine declaring fewer slots than the requested batch width is clamped with a diagnostic rather than driven past its declaration, and `set_prefill_token_budget()` is a no-op on an engine that declares no chunked prefill.

**`main.cpp --serve`**

Dispatches through `detect_architecture()`. The remaining restriction is the *server's*, not the checkpoint's: `OpenAIServer` still takes a `PersistentEngine&`. A non-DeepSeek architecture is therefore refused **before** engine construction — otherwise a Qwen checkpoint would load 27B of weights only to be rejected. PR 4 widens the server to `InferenceEngine&` and deletes that guard entirely.

**Python consumes the same registry**

`--engine-kind` now defaults to `auto` and asks `detect_architecture()` which runtime the checkpoint wants; `capabilities.models` reports `registered_architectures()` instead of a hardcoded `("qwen3_5",)`. An unrecognised architecture is reported, not guessed. The explicit `qwen` / `persistent` values stay, for checkpoints that declare nothing and for forcing one runtime onto a checkpoint to compare them.

## Testing

**`test_model_registry` — 24 checks, all PASS.** Detection (deepseek_v4, qwen3_5, nested `text_config`, mixed-case `Qwen3_5_Text`, undeclared → `""`, a hand-written GGUF header declaring `minimax-m2`, missing path throws), factory dispatch and option propagation, duplicate-registration rejection, builtin registration idempotence, and the scheduler honouring three different declared capability sets.

**Token-exact parity — PASS.** `bench_qwen_paged_tp_parity`, TP4, 4 layers, contiguous + paged × batch 1/4/8 on `/mnt/data2/Qwen3.8-27B-FP8`. All six checksums byte-identical to master:

| batch | checksum |
|---|---|
| 1 | `df92123420008a37` |
| 4 | `2c2fdc7199eb3f43` |
| 8 | `156efc37fb5e762a` |

**Performance A/B — no regression.** `/mnt/data2/Qwen3.8-27B-FP8`, TP4 on 4×2080 Ti, one configuration per process, first round discarded, NCCL linkage confirmed on both binaries (`ldd | grep nccl`).

| length | metric | master fb9ebe1 | this PR | Δ |
|---|---|---|---|---|
| 8192 | prefill tok/s | 1845.24 | 1845.62 | +0.02% |
| 8192 | decode tok/s (**TG64**) | 45.44 | 45.47 | +0.08% |
| 65536 | prefill tok/s | 1470.16 | 1473.88 | +0.25% |
| 65536 | decode tok/s (**TG64**) | 40.71 | 40.74 | +0.08% |

All within noise, as expected: no forward-path code is touched, and the only Qwen-path runtime change is a single `caps()` read in the `BatchScheduler` constructor.

**Existing suites.**
- C++: 103 test binaries vs the baseline's 102; all 102 shared binaries have byte-identical exit codes, the one new line being `test_model_registry rc=0`.
- `check_layering`: 64 files clean of vendor SDK includes and runtime calls.
- Python: 8 failed / 436 passed / 55 skipped / 4 errors, vs master's 9 failed / 431 passed. The +5 passes are the 4 tests added here plus `test_inspect_gguf_specs::test_inspect_minimax_cuda_smoke_routed_blocks`, a CUDA smoke test unrelated to this change whose outcome tracks GPU contention. The other 8 failures are identical name-for-name to master's; they stem from `pocketllm_cpp` being unimportable under the py3.11 env (the module is built for CPython 3.10).

**Python bindings against real checkpoints.** `registered_architectures() == ['deepseek_v4', 'qwen3_5']`; `/mnt/data2/Qwen3.8-27B-FP8 → qwen3_5`; `/mnt/data3/DeepSeek-V4-Flash-0731 → deepseek_v4`; a missing path raises. All 7 previously Python-visible names still present.

## Checklist

- [x] `core/model_registry.cpp` with config.json + GGUF detection, no engine dependency
- [x] `engine/engine_registry_builtin.cpp` registering `qwen3_5` and `deepseek_v4`
- [x] `PersistentEngineAdapter` declaring its capabilities honestly
- [x] `BatchScheduler` reading `caps()` instead of inferring
- [x] `main.cpp` dispatching through the registry
- [x] Python `--engine-kind auto` + registry-driven `capabilities.models`
- [x] Token-exact parity, perf A/B, both suites
- [ ] PR 4 — `OpenAIServer(InferenceEngine&)`, deleting the serve-path architecture guard
- [ ] PR 5 — layer components
- [ ] PR 6 — scheduler driven against both engines through the interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
