### PR TITLE
Make the C++ OpenAI server engine-agnostic

### DIFF
--- a/cpp_engine/CMakeLists.txt
+++ b/cpp_engine/CMakeLists.txt
@@ -48,7 +48,6 @@ set(POCKET_CORE_SOURCES
     core/sampler.cpp
     core/cmd_channel.cpp
     core/python_sidecar.cpp
-    core/openai_server.cpp
     third_party/httplib.cpp
 )
 
@@ -63,6 +62,10 @@ set(POCKET_ENGINE_SOURCES
     engine/batch_scheduler.cpp
     engine/persistent_engine_adapter.cpp
     engine/engine_registry_builtin.cpp
+    # Drives the engine through BatchScheduler, which reaches the device
+    # runtime, so it sits with the engine rather than in pocket_core -- which
+    # must stay linkable on its own by the checkpoint-inspection tools.
+    engine/openai_server.cpp
 )
 
 # Engines that still call CUDA kernels by name. A runtime guard cannot help here:
@@ -894,6 +897,10 @@ set_target_properties(test_batch_scheduler PROPERTIES RUNTIME_OUTPUT_DIRECTORY $
 add_executable(test_model_registry tests/test_model_registry.cpp)
 target_link_libraries(test_model_registry PRIVATE pocket_cpp_core)
 set_target_properties(test_model_registry PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+add_executable(test_scheduler_callbacks tests/test_scheduler_callbacks.cpp)
+target_link_libraries(test_scheduler_callbacks PRIVATE pocket_cpp_core)
+set_target_properties(test_scheduler_callbacks PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
 add_executable(bench_qwen_fp8_batch_crossover tests/bench_qwen_fp8_batch_crossover.cpp)
 target_link_libraries(bench_qwen_fp8_batch_crossover PRIVATE pocket_cpp_core)

--- a/cpp_engine/core/python_sidecar.cpp
+++ b/cpp_engine/core/python_sidecar.cpp
@@ -81,7 +81,8 @@ void write_all(int fd, const std::string& s) {
 
 PythonSidecar::PythonSidecar(const std::string& python_bin,
                              const std::string& script_path,
-                             const std::string& ckpt_dir) {
+                             const std::string& ckpt_dir,
+                             const std::string& architecture) {
     int parent_to_child[2] = {-1, -1};
     int child_to_parent[2] = {-1, -1};
     if (::pipe(parent_to_child) != 0) throw std::runtime_error("pipe1 failed");
@@ -108,6 +109,10 @@ PythonSidecar::PythonSidecar(const std::string& python_bin,
         argv.push_back(const_cast<char*>(script_path.c_str()));
         argv.push_back(const_cast<char*>("--ckpt"));
         argv.push_back(const_cast<char*>(ckpt_dir.c_str()));
+        if (!architecture.empty()) {
+            argv.push_back(const_cast<char*>("--architecture"));
+            argv.push_back(const_cast<char*>(architecture.c_str()));
+        }
         argv.push_back(nullptr);
         ::execvp(python_bin.c_str(), argv.data());
         std::cerr << "execvp python failed: " << std::strerror(errno) << "\n";

--- a/cpp_engine/engine/backend_unimplemented_ascend.cpp
+++ b/cpp_engine/engine/backend_unimplemented_ascend.cpp
@@ -11,8 +11,9 @@
 // in the link has to resolve even when its branch is unreachable. Excluding the
 // sources removes those references, and this translation unit supplies the
 // handful of definitions the surviving callers still need -- main.cpp and
-// core/openai_server.cpp for the DeepSeek-V4 entry points, and engine/qwen_engine.cpp
-// for the drafter runtime methods its shared bookkeeping calls.
+// engine/persistent_engine_adapter.cpp for the DeepSeek-V4 entry points, and
+// engine/qwen_engine.cpp for the drafter runtime methods its shared bookkeeping
+// calls.
 //
 // Every entry point throws. None of them is reachable from the Qwen FP16 path
 // that this backend does implement: QwenEngine's constructor rejects a drafter

--- a/cpp_engine/engine/batch_scheduler.cpp
+++ b/cpp_engine/engine/batch_scheduler.cpp
@@ -87,7 +87,8 @@ void BatchScheduler::stop() {
 uint64_t BatchScheduler::submit_request(
     const std::vector<int>& prompt_tokens,
     const BatchSamplingParams& sampling,
-    std::function<void(const SchedulerGenerationResult&)> callback) {
+    std::function<void(const SchedulerGenerationResult&)> callback,
+    TokenCallback on_token) {
 
     if (prompt_tokens.empty()) {
         return 0;  // Invalid request
@@ -100,6 +101,7 @@ uint64_t BatchScheduler::submit_request(
     req->prompt_tokens = prompt_tokens;
     req->sampling = sampling;
     req->callback = std::move(callback);
+    req->token_callback = std::move(on_token);
     req->submit_time = std::chrono::steady_clock::now();
 
     // A request whose worst case exceeds the entire pool can never be admitted,
@@ -195,9 +197,11 @@ void BatchScheduler::schedule_loop() {
     // The current device is per-thread, and the engine bound it on the thread
     // that constructed it.  This loop runs every forward pass from its own
     // thread, so it has to bind the same device before touching device memory.
-    if (!device_set(engine_->device())) {
+    // A host-only engine reports -1 and needs no device context.
+    const int engine_device = engine_->device();
+    if (engine_device >= 0 && !device_set(engine_device)) {
         std::cerr << "BatchScheduler: failed to select device "
-                  << engine_->device()
+                  << engine_device
                   << "; scheduler thread stopping" << std::endl;
         running_.store(false);
         return;
@@ -342,44 +346,82 @@ bool BatchScheduler::run_prefill_batch() {
     // Advance each prompt by at most prefill_token_budget_ tokens so a long
     // prompt cannot hold the device for its whole length while running decodes
     // stall behind it.
+    //
+    // Tokens are recorded here and delivered after the lock is released. A
+    // caller's token callback is arbitrary code; running it under queue_mutex_
+    // would let a slow consumer block admission and completion for every other
+    // request, and would deadlock outright if it called cancel_request().
+    std::vector<std::pair<SchedulerRequest*, int>> emitted;
     try {
         auto result = engine_->batch_prefill(prefill_batch, prefill_token_budget_);
+        if (result.results.size() != prefill_batch.size() ||
+            result.incomplete.size() != prefill_batch.size()) {
+            throw std::runtime_error(
+                "batch_prefill returned " + std::to_string(result.results.size()) +
+                " result rows and " + std::to_string(result.incomplete.size()) +
+                " completion flags for " + std::to_string(prefill_batch.size()) +
+                " requests");
+        }
 
         // Update request states
-        std::lock_guard<std::mutex> lock(queue_mutex_);
-        for (size_t i = 0; i < prefill_batch.size(); ++i) {
-            auto* req = prefill_requests[i];
-            if (i >= result.results.size()) continue;
+        {
+            std::lock_guard<std::mutex> lock(queue_mutex_);
+            for (size_t i = 0; i < prefill_batch.size(); ++i) {
+                auto* req = prefill_requests[i];
+                if (i >= result.results.size()) continue;
 
-            req->prefilled_tokens = prefill_batch[i]->seq_len;
-            const bool complete =
-                i < result.incomplete.size() && !result.incomplete[i];
-            if (!complete) {
-                // Interior logits predict the next prompt token, which the prompt
-                // already supplies. Emitting it would inject a token the caller
-                // never asked for, so this row just waits for its next chunk.
-                continue;
-            }
+                req->prefilled_tokens = prefill_batch[i]->seq_len;
+                const bool complete =
+                    i < result.incomplete.size() && !result.incomplete[i];
+                if (!complete) {
+                    // Interior logits predict the next prompt token, which the
+                    // prompt already supplies. Emitting it would inject a token
+                    // the caller never asked for, so this row just waits for its
+                    // next chunk.
+                    continue;
+                }
 
-            req->prefill_complete = true;
-            req->last_token = result.results[i].top_token;
-            req->generated_tokens.push_back(req->last_token);
-            req->seq_len = req->prefilled_tokens;
-            // batch_prefill flags a prompt whose very first predicted token is a
-            // stop token; such a request must never reach the decode batch.
-            if (prefill_batch[i]->finished) {
-                req->finished = true;
-                req->stopped_on_token = true;
-            }
+                req->prefill_complete = true;
+                req->last_token = result.results[i].top_token;
+                req->generated_tokens.push_back(req->last_token);
+                req->seq_len = req->prefilled_tokens;
+                // batch_prefill flags a prompt whose very first predicted token
+                // is a stop token; such a request must never reach the decode
+                // batch or be exposed to a streaming caller.
+                const bool stopped = prefill_batch[i]->finished;
+                if (stopped) {
+                    req->finished = true;
+                    req->stopped_on_token = true;
+                }
+                // The token sampled from prefill is generation token number one.
+                // Without this check max_new_tokens=1 ran one decode step and
+                // returned two tokens because the length cap existed only in the
+                // decode path.
+                if (req->generated_tokens.size() >=
+                    static_cast<size_t>(req->sampling.max_new_tokens)) {
+                    req->finished = true;
+                }
+                if (req->token_callback && !stopped) {
+                    emitted.emplace_back(req, req->last_token);
+                }
 
-            // Record TTFT
-            if (req->first_token_time == std::chrono::steady_clock::time_point{}) {
-                req->first_token_time = std::chrono::steady_clock::now();
+                // Record TTFT
+                if (req->first_token_time == std::chrono::steady_clock::time_point{}) {
+                    req->first_token_time = std::chrono::steady_clock::now();
+                }
             }
         }
     } catch (const std::exception& e) {
-        std::cerr << "BatchScheduler: prefill failed: " << e.what() << std::endl;
+        const std::string message = std::string("prefill failed: ") + e.what();
+        std::cerr << "BatchScheduler: " << message << std::endl;
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        for (SchedulerRequest* req : prefill_requests) {
+            req->error = message;
+            req->finished = true;
+        }
     }
+
+    deliver_tokens(emitted);
 
     // Clean up temporary batch requests
     for (auto* batch_req : prefill_batch) {
@@ -426,42 +468,71 @@ bool BatchScheduler::run_decode_batch() {
     }
 
     // Call engine batch_decode_step
+    std::vector<std::pair<SchedulerRequest*, int>> emitted;
     try {
         auto result = engine_->batch_decode_step(decode_batch);
+        if (result.next_tokens.size() != decode_batch.size() ||
+            result.finished.size() != decode_batch.size() ||
+            result.hit_stop_token.size() != decode_batch.size()) {
+            throw std::runtime_error(
+                "batch_decode_step returned " +
+                std::to_string(result.next_tokens.size()) + " tokens, " +
+                std::to_string(result.finished.size()) + " finished flags and " +
+                std::to_string(result.hit_stop_token.size()) +
+                " stop flags for " + std::to_string(decode_batch.size()) +
+                " requests");
+        }
 
         // Update request states
-        std::lock_guard<std::mutex> lock(queue_mutex_);
-        for (size_t i = 0; i < decode_batch.size(); ++i) {
-            auto* req = decode_requests[i];
-            if (i < result.next_tokens.size()) {
-                req->last_token = result.next_tokens[i];
-                req->generated_tokens.push_back(req->last_token);
-                req->seq_len++;
+        {
+            std::lock_guard<std::mutex> lock(queue_mutex_);
+            for (size_t i = 0; i < decode_batch.size(); ++i) {
+                auto* req = decode_requests[i];
+                if (i < result.next_tokens.size()) {
+                    req->last_token = result.next_tokens[i];
+                    req->generated_tokens.push_back(req->last_token);
+                    req->seq_len++;
 
-                // Record TTFT for first decode token (if prefill didn't set it)
-                if (req->first_token_time == std::chrono::steady_clock::time_point{} &&
-                    req->generated_tokens.size() == 1) {
-                    req->first_token_time = std::chrono::steady_clock::now();
-                }
+                    // Record TTFT for first decode token (if prefill didn't set it)
+                    if (req->first_token_time == std::chrono::steady_clock::time_point{} &&
+                        req->generated_tokens.size() == 1) {
+                        req->first_token_time = std::chrono::steady_clock::now();
+                    }
 
-                // Check if finished
-                if (i < result.finished.size() && result.finished[i]) {
-                    req->finished = true;
-                }
-                if (i < result.hit_stop_token.size() && result.hit_stop_token[i]) {
-                    req->stopped_on_token = true;
-                }
+                    // Check if finished. A stop token remains in the scheduler's
+                    // sequence so it agrees with the engine's KV state, but it is
+                    // not delivered to a streaming caller.
+                    const bool stopped =
+                        i < result.hit_stop_token.size() && result.hit_stop_token[i];
+                    if (i < result.finished.size() && result.finished[i]) {
+                        req->finished = true;
+                    }
+                    if (stopped) {
+                        req->stopped_on_token = true;
+                    }
+                    if (req->token_callback && !stopped) {
+                        emitted.emplace_back(req, req->last_token);
+                    }
 
-                // Check max_new_tokens
-                if (req->generated_tokens.size() >=
-                    static_cast<size_t>(req->sampling.max_new_tokens)) {
-                    req->finished = true;
+                    // Check max_new_tokens
+                    if (req->generated_tokens.size() >=
+                        static_cast<size_t>(req->sampling.max_new_tokens)) {
+                        req->finished = true;
+                    }
                 }
             }
         }
     } catch (const std::exception& e) {
-        std::cerr << "BatchScheduler: decode failed: " << e.what() << std::endl;
+        const std::string message = std::string("decode failed: ") + e.what();
+        std::cerr << "BatchScheduler: " << message << std::endl;
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        for (SchedulerRequest* req : decode_requests) {
+            req->error = message;
+            req->finished = true;
+        }
     }
+
+    deliver_tokens(emitted);
 
     // Clean up temporary batch requests
     for (auto* batch_req : decode_batch) {
@@ -469,6 +540,22 @@ bool BatchScheduler::run_decode_batch() {
     }
 
     return true;
+}
+
+void BatchScheduler::deliver_tokens(
+    const std::vector<std::pair<SchedulerRequest*, int>>& emitted) {
+    // Called from the schedule loop with no lock held, and before
+    // handle_completions(), which is the only place a SchedulerRequest is
+    // destroyed and which runs on this same thread -- so every pointer here is
+    // still alive.
+    for (const auto& [req, token] : emitted) {
+        try {
+            req->token_callback(req->request_id, token);
+        } catch (const std::exception& e) {
+            std::cerr << "BatchScheduler: token callback exception: " << e.what()
+                      << std::endl;
+        }
+    }
 }
 
 void BatchScheduler::handle_completions() {
@@ -556,7 +643,10 @@ void BatchScheduler::notify_result(SchedulerRequest* req) {
     // Previously `finished ? "length" : "stop"`, which was backwards: `finished`
     // was only ever set by the length cap, so a normal completion reported
     // "length" and "stop" was reachable only via cancellation.
-    if (req->cancelled) {
+    if (!req->error.empty()) {
+        result.finish_reason = "error";
+        result.error = req->error;
+    } else if (req->cancelled) {
         result.finish_reason = "cancelled";
     } else {
         result.finish_reason = req->stopped_on_token ? "stop" : "length";
@@ -578,16 +668,19 @@ void BatchScheduler::notify_result(SchedulerRequest* req) {
 
     req->callback_invoked = true;
 
-    // Invoke callback if provided
+    // A request chooses one completion channel. Storing every callback result as
+    // well made a streaming server leak one completed result per request, because
+    // it consumes the callback and never polls the duplicate map entry.
     if (req->callback) {
         try {
             req->callback(result);
         } catch (const std::exception& e) {
             std::cerr << "BatchScheduler: callback exception: " << e.what() << std::endl;
         }
+        return;
     }
 
-    // Store result for polling
+    // No callback: store for the blocking poll API.
     {
         std::lock_guard<std::mutex> lock(results_mutex_);
         completed_results_[req->request_id] = result;

--- a/cpp_engine/engine/engine_registry_builtin.cpp
+++ b/cpp_engine/engine/engine_registry_builtin.cpp
@@ -35,6 +35,13 @@ std::unique_ptr<InferenceEngine> make_qwen_engine(const std::string& ckpt_dir,
     qwen.kv_paged = options.kv_paged;
     qwen.kv_block_size = options.kv_block_size;
     qwen.kv_cache_bytes = options.kv_cache_bytes;
+    // Fixed at construction here, which is why EngineOptions carries it:
+    // QwenEngine reports caps().per_request_sampling == false, so this is the
+    // only place its temperature can be set.
+    qwen.temperature = options.temperature;
+    qwen.top_p = options.top_p;
+    qwen.top_k = options.top_k;
+    qwen.sampling_seed = options.seed;
     // Everything else -- prefill chunk, KV dtype, prefix cache, snapshots, the
     // drafters -- keeps its tuned default. A caller that needs to move one of
     // those knows it is talking to Qwen and can construct QwenEngine directly.

--- a/cpp_engine/engine/main.cpp
+++ b/cpp_engine/engine/main.cpp
@@ -6,7 +6,6 @@
 #include "model_registry.hpp"
 #include "openai_server.hpp"
 #include "persistent_engine.hpp"
-#include "persistent_engine_adapter.hpp"
 #include "qwen_config.hpp"
 #include "qwen_engine.hpp"
 #include "python_sidecar.hpp"
@@ -35,6 +34,10 @@ struct Args {
     std::string token_ids_csv;
     std::string token_ids_file;
     int smoke_layers = 1;
+    // Lets serving default to the checkpoint's full depth while preserving the
+    // one-layer default of the standalone smoke commands. The same option is an
+    // explicit reduced-depth server request only when it appeared on the CLI.
+    bool smoke_layers_explicit = false;
     int forward_token = -1;
     int position = 0;
     int max_new_tokens = 1;
@@ -75,6 +78,15 @@ struct Args {
     bool serve = false;
     int port = 8000;
     std::string host = "0.0.0.0";
+    // Completions the server may run at once. Clamped down to whatever the
+    // engine declares, so leaving this at 8 costs nothing on an engine that
+    // serves one session at a time.
+    int max_batch_size = 8;
+    // Paged KV is what lets several requests share one pool instead of each
+    // reserving max_context. Off by default so the serve path keeps the
+    // contiguous arena's behaviour unless asked.
+    bool kv_paged = false;
+    int kv_block_size = 16;
     std::string python_bin = "python";
     std::string sidecar_script;
 };
@@ -125,6 +137,7 @@ Args parse_args(int argc, char** argv) {
             args.qwen_persistent_stdin = true;
         } else if (arg == "--smoke-layers" && i + 1 < argc) {
             args.smoke_forward = true;
+            args.smoke_layers_explicit = true;
             args.smoke_layers = std::stoi(argv[++i]);
         } else if (arg == "--forward-token" && i + 1 < argc) {
             args.smoke_forward = true;
@@ -209,6 +222,12 @@ Args parse_args(int argc, char** argv) {
             args.port = std::stoi(argv[++i]);
         } else if (arg == "--host" && i + 1 < argc) {
             args.host = argv[++i];
+        } else if (arg == "--max-batch-size" && i + 1 < argc) {
+            args.max_batch_size = std::stoi(argv[++i]);
+        } else if (arg == "--kv-paged") {
+            args.kv_paged = true;
+        } else if (arg == "--kv-block-size" && i + 1 < argc) {
+            args.kv_block_size = std::stoi(argv[++i]);
         } else if (arg == "--python" && i + 1 < argc) {
             args.python_bin = argv[++i];
         } else if (arg == "--sidecar" && i + 1 < argc) {
@@ -229,6 +248,15 @@ Args parse_args(int argc, char** argv) {
     }
     if (args.qwen_mtp_tokens <= 0) {
         throw std::runtime_error("--qwen-mtp-tokens must be positive");
+    }
+    if (args.smoke_layers < 0) {
+        throw std::runtime_error("--smoke-layers must not be negative");
+    }
+    if (args.max_batch_size <= 0) {
+        throw std::runtime_error("--max-batch-size must be positive");
+    }
+    if (args.kv_block_size <= 0) {
+        throw std::runtime_error("--kv-block-size must be positive");
     }
     const int external_drafter_count =
         (!args.qwen_dspark_checkpoint.empty() ? 1 : 0) +
@@ -391,56 +419,58 @@ int main(int argc, char** argv) {
         if (args.serve) {
             if (args.ckpt.empty()) throw std::runtime_error("--serve requires --ckpt");
             pocket::register_builtin_engines();
-            // The remaining restriction is the server's, not the checkpoint's:
-            // OpenAIServer still takes a PersistentEngine& and drives it through
-            // prefill/decode_step by hand, so only the engine behind that type
-            // can be served. Checked before construction, because otherwise a
-            // Qwen checkpoint would load 27B of weights only to be rejected.
-            // Giving the server an InferenceEngine& deletes this whole guard.
+            // Whatever the registry has a factory for can be served. The server
+            // takes an InferenceEngine& and drives it through BatchScheduler, so
+            // nothing here needs to know which model it got -- an engine that
+            // declares paged KV and continuous batching gets both, and one that
+            // declares a single session is serialised for free.
             const std::string architecture = pocket::detect_architecture(args.ckpt);
-            if (architecture != "deepseek_v4") {
-                throw std::runtime_error(
-                    "the OpenAI server currently accepts only the DeepSeek-V4 persistent "
-                    "engine; '" + (architecture.empty() ? std::string("<undeclared>") : architecture) +
-                    "' checkpoints are served through the Python backend for now");
-            }
             const int max_context = args.max_context > 0 ? args.max_context : 8192;
             pocket::EngineOptions engine_options;
             engine_options.tp_world = args.tp_world;
             engine_options.tp_rank = args.tp_rank;
             engine_options.device = args.device >= 0 ? args.device : args.tp_rank;
             engine_options.nccl_id_path = args.nccl_id_path;
-            engine_options.layer_count = args.smoke_layers;
+            // A production server loads the checkpoint's full depth unless the
+            // operator explicitly asks for a reduced-depth smoke server.
+            engine_options.layer_count =
+                args.smoke_layers_explicit ? args.smoke_layers : 0;
             engine_options.max_context = max_context;
-            const pocket::ModelConfig model_cfg = pocket::ModelConfig::from_hf_config(args.ckpt);
-            std::unique_ptr<pocket::InferenceEngine> runtime =
+            engine_options.max_batch_size = args.max_batch_size;
+            engine_options.kv_paged = args.kv_paged;
+            engine_options.kv_block_size = args.kv_block_size;
+            engine_options.temperature = args.qwen_temperature;
+            engine_options.top_p = args.qwen_top_p;
+            engine_options.top_k = args.qwen_top_k;
+            engine_options.seed = args.qwen_seed;
+            std::unique_ptr<pocket::InferenceEngine> engine =
                 pocket::create_engine(args.ckpt, engine_options);
-            auto* adapter = dynamic_cast<pocket::PersistentEngineAdapter*>(runtime.get());
-            if (adapter == nullptr) {
-                throw std::runtime_error(
-                    "the engine registered for '" + architecture +
-                    "' is not the persistent engine the OpenAI server drives");
-            }
-            pocket::PersistentEngine& engine = adapter->engine();
-            std::cout << "server_max_context=" << max_context << "\n";
-            std::cout << "model_context_length=" << model_cfg.context_length << "\n";
-            engine.warmup_tp();
+            std::cout << "server_architecture=" << architecture << "\n";
+            std::cout << "server_max_context=" << engine->max_context() << "\n";
+            engine->warmup_tp();
             if (args.tp_rank > 0) {
                 // Worker rank: park on the NCCL command channel until rank 0
                 // sends SHUTDOWN.
-                engine.run_worker_loop();
+                engine->run_worker_loop();
                 return 0;
             }
             const std::string sidecar_script = args.sidecar_script.empty()
                 ? std::string("src/server/cpp_sidecar.py")
                 : args.sidecar_script;
-            pocket::PythonSidecar sidecar(args.python_bin, sidecar_script, args.ckpt);
+            pocket::PythonSidecar sidecar(args.python_bin, sidecar_script, args.ckpt,
+                                           architecture);
+            // The server's own tokenizer, not the engine's: detokenizing a
+            // response is a serving concern, and QwenEngine carries no Tokenizer
+            // at all.
+            const pocket::Tokenizer tokenizer(args.ckpt);
             pocket::OpenAIServerConfig cfg;
             cfg.port = args.port;
             cfg.host = args.host;
-            pocket::OpenAIServer server(engine, sidecar, cfg);
+            cfg.model_name = architecture.empty() ? std::string("pocketllm") : architecture;
+            cfg.max_batch_size = args.max_batch_size;
+            pocket::OpenAIServer server(*engine, tokenizer, sidecar, cfg);
             server.run();
-            engine.worker_command_shutdown();
+            engine->shutdown_tp_workers();
             return 0;
         }
         if (!args.ckpt.empty()) {

--- a/cpp_engine/engine/openai_server.cpp
+++ b/cpp_engine/engine/openai_server.cpp
@@ -1,5 +1,6 @@
 #include "openai_server.hpp"
 
+#include "batch_scheduler.hpp"
 #include "json_lite.hpp"
 
 #define CPPHTTPLIB_OPENSSL_SUPPORT 0
@@ -7,11 +8,17 @@
 
 #include <atomic>
 #include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <cstdio>
+#include <deque>
 #include <iostream>
 #include <memory>
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace pocket {
 
@@ -169,17 +176,86 @@ std::string render_choice_message(const std::string& content, const std::string&
     return os.str();
 }
 
+// Hand-off between the scheduler thread, which produces tokens, and the HTTP
+// thread, which writes them to the socket.
+//
+// The scheduler's callbacks run inline in its schedule loop, so writing to a
+// socket from them would let one slow client stall every other request in the
+// batch. They only append here and signal; all socket I/O happens on the HTTP
+// thread draining this. Held by shared_ptr because the callbacks outlive the
+// handler's stack frame if the client disconnects early.
+struct TokenStream {
+    std::mutex m;
+    std::condition_variable cv;
+    std::deque<int> tokens;
+    bool done = false;
+    SchedulerGenerationResult result;
+
+    enum class Next { Token, Done, Timeout };
+
+    void push(int token) {
+        {
+            std::lock_guard<std::mutex> lk(m);
+            tokens.push_back(token);
+        }
+        cv.notify_one();
+    }
+
+    void finish(const SchedulerGenerationResult& r) {
+        {
+            std::lock_guard<std::mutex> lk(m);
+            result = r;
+            done = true;
+        }
+        cv.notify_one();
+    }
+
+    // Queued tokens are drained before Done is reported: the completion
+    // callback can land while tokens are still buffered, and dropping them
+    // would truncate the answer.
+    Next next(int* token, std::chrono::steady_clock::time_point deadline) {
+        std::unique_lock<std::mutex> lk(m);
+        while (tokens.empty() && !done) {
+            if (cv.wait_until(lk, deadline) == std::cv_status::timeout &&
+                tokens.empty() && !done) {
+                return Next::Timeout;
+            }
+        }
+        if (tokens.empty()) return Next::Done;
+        *token = tokens.front();
+        tokens.pop_front();
+        return Next::Token;
+    }
+};
+
 }  // namespace
 
 struct OpenAIServer::Impl {
-    PersistentEngine& engine;
+    InferenceEngine& engine;
+    const Tokenizer& tok;
     PythonSidecar& sidecar;
     OpenAIServerConfig cfg;
+    // Constructed here rather than handed in: how many completions run at once
+    // is a serving decision, and the scheduler clamps it to what the engine
+    // declared anyway.
+    BatchScheduler sched;
     httplib::Server svr;
-    std::mutex inflight;
     std::atomic<bool> running{false};
+    // Token id for "</think>", or -1 when the vocabulary has none. Looked up
+    // once; the streaming path needs it per token.
+    const int think_end_id;
 
-    Impl(PersistentEngine& e, PythonSidecar& s, const OpenAIServerConfig& c) : engine(e), sidecar(s), cfg(c) {}
+    Impl(InferenceEngine& e, const Tokenizer& t, PythonSidecar& s, const OpenAIServerConfig& c)
+        : engine(e), tok(t), sidecar(s), cfg(c),
+          sched(&e, c.max_batch_size > 0 ? c.max_batch_size : 1),
+          think_end_id(t.token_id("</think>")) {
+        sched.set_prefill_token_budget(cfg.prefill_token_budget);
+        std::cerr << "[server] batch width " << sched.max_batch_size()
+                  << " (engine declares max_slots=" << sched.engine_caps().max_slots
+                  << ", continuous_batching="
+                  << (sched.engine_caps().continuous_batching ? "yes" : "no")
+                  << "), prefill budget " << sched.prefill_token_budget() << "\n";
+    }
 
     void handle_health(httplib::Response& res) {
         res.set_content("{\"status\":\"ok\"}", "application/json");
@@ -187,14 +263,71 @@ struct OpenAIServer::Impl {
 
     void handle_models(httplib::Response& res) {
         std::ostringstream os;
-        os << "{\"object\":\"list\",\"data\":[{\"id\":\"deepseek-v4-flash\",\"object\":\"model\",\"owned_by\":\"local\"}]}";
+        os << "{\"object\":\"list\",\"data\":[{\"id\":\"" << json_escape(cfg.model_name)
+           << "\",\"object\":\"model\",\"owned_by\":\"local\"}]}";
         res.set_content(os.str(), "application/json");
+    }
+
+    // Rejects a request that names sampling this engine cannot vary per row
+    // unless it happens to name exactly what the engine will do anyway. The
+    // alternative -- accepting the field and sampling with something else --
+    // returns output the caller has no way to know is not what it asked for.
+    bool check_sampling_supported(const JsonObject& obj, std::string& err_out) const {
+        const Capabilities& caps = sched.engine_caps();
+
+        auto mismatch = [&](const char* key, double requested, double configured) {
+            std::ostringstream os;
+            os << "this engine's effective " << key << " is " << configured
+               << " and it cannot apply " << key << "=" << requested
+               << " to this request. Omit the field to accept the effective value, "
+               << "or run an engine configuration that supports it.";
+            err_out = os.str();
+        };
+
+        const JsonValue* v = object_get(obj, "temperature");
+        if (!caps.per_request_sampling && v != nullptr && v->is_number() &&
+            std::fabs(v->number() - caps.fixed_temperature) > 1.0e-5) {
+            mismatch("temperature", v->number(), caps.fixed_temperature);
+            return false;
+        }
+        const double effective_temperature = caps.per_request_sampling
+            ? get_number(obj, "temperature", 1.0)
+            : caps.fixed_temperature;
+        const bool stochastic = effective_temperature > 1.0e-5;
+
+        v = object_get(obj, "top_p");
+        if (!caps.per_request_sampling && stochastic &&
+            v != nullptr && v->is_number() &&
+            std::fabs(v->number() - caps.fixed_top_p) > 1.0e-5) {
+            mismatch("top_p", v->number(), caps.fixed_top_p);
+            return false;
+        }
+        v = object_get(obj, "top_k");
+        if (!caps.per_request_top_k && stochastic &&
+            v != nullptr && v->is_number() &&
+            static_cast<int>(v->number()) != caps.fixed_top_k) {
+            mismatch("top_k", v->number(), caps.fixed_top_k);
+            return false;
+        }
+        // Seed only changes anything once sampling is stochastic; under greedy
+        // decoding every seed produces the same tokens, so naming one is not a
+        // disagreement.
+        v = object_get(obj, "seed");
+        if (!caps.per_request_sampling && stochastic &&
+            v != nullptr && v->is_number() &&
+            static_cast<unsigned long long>(v->number()) != caps.fixed_seed) {
+            mismatch("seed", v->number(), static_cast<double>(caps.fixed_seed));
+            return false;
+        }
+        return true;
     }
 
     bool encode_request(const std::string& body, const JsonObject& obj,
                         EncodeReply& out, std::string& thinking_mode_out,
                         int& max_tokens_out, bool& stream_out,
-                        SamplingParams& sp_out, std::string& err_out) {
+                        BatchSamplingParams& sp_out, std::string& err_out) {
+        if (!check_sampling_supported(obj, err_out)) return false;
+
         EncodeRequest enc;
         enc.messages_json = extract_messages_json(body);
         enc.tools_json = extract_tools_json(body);
@@ -207,11 +340,16 @@ struct OpenAIServer::Impl {
         max_tokens_out = static_cast<int>(get_number(obj, "max_tokens", cfg.default_max_tokens));
         if (max_tokens_out <= 0) max_tokens_out = cfg.default_max_tokens;
         stream_out = get_bool(obj, "stream", false);
+
+        // An engine that fixes its own sampling ignores these; check_sampling_
+        // supported has already established the request agrees with them, so
+        // filling them in either way keeps one code path.
         sp_out.temperature = static_cast<float>(get_number(obj, "temperature", 1.0));
         sp_out.top_p = static_cast<float>(get_number(obj, "top_p", 1.0));
-        sp_out.seed = static_cast<uint64_t>(get_number(obj, "seed", 0));
-        // Treat near-zero temperature as greedy.
-        sp_out.greedy = sp_out.temperature <= 1.0e-5f;
+        sp_out.top_k = static_cast<int>(get_number(obj, "top_k", 20));
+        sp_out.seed = static_cast<unsigned long long>(get_number(obj, "seed", 0));
+        sp_out.max_new_tokens = max_tokens_out;
+
         out = sidecar.encode(enc);
         if (!out.ok) {
             err_out = out.err;
@@ -248,7 +386,7 @@ struct OpenAIServer::Impl {
         std::string thinking_mode;
         int max_tokens = 0;
         bool stream = false;
-        SamplingParams sp;
+        BatchSamplingParams sp;
         std::string err;
         if (!encode_request(body, obj, enc_reply, thinking_mode, max_tokens, stream, sp, err)) {
             emit_error(res, 400, err);
@@ -261,40 +399,70 @@ struct OpenAIServer::Impl {
                       << " thinking_mode=" << thinking_mode << "\n";
         }
 
-        std::lock_guard<std::mutex> inflight_lk(inflight);
+        // No inflight mutex: concurrency is the scheduler's to decide, bounded
+        // by what the engine declared. Serialising here would give a paged
+        // batched engine the throughput of a single-session one.
         if (static_cast<int>(enc_reply.token_ids.size()) + max_tokens > engine.max_context()) {
             emit_error(res, 400, "prompt + max_tokens exceeds max_context");
             return;
         }
 
         if (stream) {
-            handle_stream(req, res, enc_reply, max_tokens, sp, thinking_mode);
+            handle_stream(req, res, enc_reply, sp, thinking_mode);
         } else {
-            handle_nonstream(res, enc_reply, max_tokens, sp, thinking_mode);
+            handle_nonstream(res, enc_reply, sp, thinking_mode);
         }
     }
 
-    void handle_nonstream(httplib::Response& res, const EncodeReply& enc, int max_tokens,
-                          const SamplingParams& sp, const std::string& thinking_mode) {
-        engine.worker_command_reset();
-        engine.reset_session();
-        engine.worker_command_prefill(enc.token_ids);
-        int token = engine.prefill(enc.token_ids, sp);
+    // A stop token is the last token of a sequence and is still counted and
+    // stored by the engine, which needs it to keep the KV cache consistent with
+    // what it returns. It is not part of the answer, so drop it before
+    // detokenizing and before reporting completion_tokens.
+    static std::vector<int> strip_stop_token(const std::vector<int>& tokens,
+                                             const std::string& finish_reason) {
+        if (finish_reason != "stop" || tokens.empty()) return tokens;
+        return std::vector<int>(tokens.begin(), tokens.end() - 1);
+    }
 
-        std::vector<int> generated;
-        generated.reserve(static_cast<size_t>(max_tokens));
-        const int eos_id = engine.eos_id();
-        bool hit_eos = (token == eos_id);
-        if (!hit_eos) generated.push_back(token);
-        int position = static_cast<int>(enc.token_ids.size());
-        for (int step = 1; step < max_tokens && !hit_eos; ++step) {
-            engine.worker_command_decode(token, position + step - 1);
-            token = engine.decode_step(token, position + step - 1, sp);
-            if (token == eos_id) { hit_eos = true; break; }
-            generated.push_back(token);
+    void handle_nonstream(httplib::Response& res, const EncodeReply& enc,
+                          const BatchSamplingParams& sp, const std::string& thinking_mode) {
+        auto completion = std::make_shared<TokenStream>();
+        const uint64_t request_id = sched.submit_request(
+            enc.token_ids, sp,
+            [completion](const SchedulerGenerationResult& r) { completion->finish(r); });
+        if (request_id == 0) {
+            emit_error(res, 503,
+                       "request rejected: its worst-case KV footprint exceeds the "
+                       "whole block pool, so it could never be admitted");
+            return;
         }
 
-        const std::string text = engine.tokenizer().decode_tokens(generated);
+        int unused_token = 0;
+        const auto deadline = std::chrono::steady_clock::now() +
+                              std::chrono::seconds(cfg.request_timeout_seconds);
+        if (completion->next(&unused_token, deadline) == TokenStream::Next::Timeout) {
+            // The callback owns `completion`, so it remains valid until the
+            // scheduler observes the cancellation. Because callback-mode
+            // requests are not duplicated into poll_result(), abandoning this
+            // HTTP response leaves no completed-result map entry behind.
+            sched.cancel_request(request_id);
+            emit_error(res, 504, "generation timed out");
+            return;
+        }
+
+        SchedulerGenerationResult out;
+        {
+            std::lock_guard<std::mutex> lk(completion->m);
+            out = completion->result;
+        }
+
+        if (!out.error.empty()) {
+            emit_error(res, 500, out.error);
+            return;
+        }
+
+        const std::vector<int> generated = strip_stop_token(out.generated_tokens, out.finish_reason);
+        const std::string text = tok.decode_tokens(generated);
         const ParsedMessage parsed = sidecar.parse(text, thinking_mode);
         std::string content = parsed.ok ? parsed.content : text;
         std::string reasoning = parsed.ok ? parsed.reasoning : std::string();
@@ -304,8 +472,8 @@ struct OpenAIServer::Impl {
         os << "{\"id\":\"" << make_request_id() << "\""
            << ",\"object\":\"chat.completion\""
            << ",\"created\":" << std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count()
-           << ",\"model\":\"deepseek-v4-flash\""
-           << ",\"choices\":[{\"index\":0,\"finish_reason\":\"" << (hit_eos ? "stop" : "length") << "\""
+           << ",\"model\":\"" << json_escape(cfg.model_name) << "\""
+           << ",\"choices\":[{\"index\":0,\"finish_reason\":\"" << out.finish_reason << "\""
            << ",\"message\":" << render_choice_message(content, reasoning, tool_calls_json) << "}]"
            << ",\"usage\":{\"prompt_tokens\":" << enc.token_ids.size()
            << ",\"completion_tokens\":" << generated.size()
@@ -314,40 +482,21 @@ struct OpenAIServer::Impl {
     }
 
     void handle_stream(const httplib::Request& /*req*/, httplib::Response& res,
-                       const EncodeReply& enc, int max_tokens,
-                       const SamplingParams& sp, const std::string& thinking_mode) {
+                       const EncodeReply& enc, const BatchSamplingParams& sp,
+                       const std::string& thinking_mode) {
         const std::string id = make_request_id();
         const long long created = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-        const std::string model = "deepseek-v4-flash";
-        const int eos_id = engine.eos_id();
-
-        // Sliding-window prefix used to compute deltas + UTF-8 boundary buffer.
-        std::vector<int> generated;
-        generated.reserve(static_cast<size_t>(max_tokens));
-        size_t sent_offset = 0;  // bytes of decode_tokens(generated) already sent
-
-        // In thinking mode the prompt ends with <think>, so the completion starts
-        // inside the reasoning block and switches to the answer at the first
-        // </think>. Splitting on the token id rather than the decoded text keeps
-        // each stream's UTF-8 decoding self-contained and cannot be fooled by a
-        // model that writes the literal characters.
-        const int think_end_id = engine.tokenizer().token_id("</think>");
-        bool in_reasoning = (thinking_mode == "thinking");
 
         res.set_header("Cache-Control", "no-cache");
         res.set_chunked_content_provider("text/event-stream",
-            [this, enc, max_tokens, sp, id, created, model, eos_id, think_end_id,
-             generated, sent_offset, in_reasoning]
+            [this, enc, sp, id, created, thinking_mode]
             (size_t /*offset*/, httplib::DataSink& sink) mutable -> bool {
-
-            engine.worker_command_reset();
-            engine.reset_session();
 
             auto send_chunk = [&](const std::string& delta, const char* field,
                                   const char* finish_reason = nullptr) {
                 std::ostringstream os;
                 os << "{\"id\":\"" << id << "\",\"object\":\"chat.completion.chunk\""
-                   << ",\"created\":" << created << ",\"model\":\"" << model << "\""
+                   << ",\"created\":" << created << ",\"model\":\"" << json_escape(cfg.model_name) << "\""
                    << ",\"choices\":[{\"index\":0,\"delta\":{";
                 if (!delta.empty()) {
                     os << "\"" << field << "\":\"" << json_escape(delta) << "\"";
@@ -363,24 +512,51 @@ struct OpenAIServer::Impl {
                 sink.write(line.data(), line.size());
             };
 
+            auto send_error = [&](const std::string& message) {
+                std::ostringstream os;
+                os << "{\"error\":{\"message\":\"" << json_escape(message)
+                   << "\",\"type\":\"server_error\"}}";
+                std::string line = "data: " + os.str() + "\n\n";
+                sink.write(line.data(), line.size());
+            };
+
             // First chunk: role marker.
             {
                 std::ostringstream os;
                 os << "{\"id\":\"" << id << "\",\"object\":\"chat.completion.chunk\""
-                   << ",\"created\":" << created << ",\"model\":\"" << model << "\""
+                   << ",\"created\":" << created << ",\"model\":\"" << json_escape(cfg.model_name) << "\""
                    << ",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}";
                 std::string line = "data: " + os.str() + "\n\n";
                 sink.write(line.data(), line.size());
             }
 
-            engine.worker_command_prefill(enc.token_ids);
-            int token = engine.prefill(enc.token_ids, sp);
-            bool hit_eos = (token == eos_id);
-            int position = static_cast<int>(enc.token_ids.size());
-            int decoded_count = 0;
+            auto stream = std::make_shared<TokenStream>();
+            const uint64_t request_id = sched.submit_request(
+                enc.token_ids, sp,
+                [stream](const SchedulerGenerationResult& r) { stream->finish(r); },
+                [stream](uint64_t, int token) { stream->push(token); });
+            if (request_id == 0) {
+                send_error("request rejected: its worst-case KV footprint exceeds "
+                           "the whole block pool, so it could never be admitted");
+                const std::string done = "data: [DONE]\n\n";
+                sink.write(done.data(), done.size());
+                sink.done();
+                return true;
+            }
+
+            // Sliding-window prefix used to compute deltas + UTF-8 boundary buffer.
+            std::vector<int> generated;
+            size_t sent_offset = 0;  // bytes of decode_tokens(generated) already sent
+
+            // In thinking mode the prompt ends with <think>, so the completion
+            // starts inside the reasoning block and switches to the answer at the
+            // first </think>. Splitting on the token id rather than the decoded
+            // text keeps each stream's UTF-8 decoding self-contained and cannot be
+            // fooled by a model that writes the literal characters.
+            bool in_reasoning = (thinking_mode == "thinking");
 
             auto emit_delta = [&]() {
-                const std::string full = engine.tokenizer().decode_tokens(generated);
+                const std::string full = tok.decode_tokens(generated);
                 if (full.size() <= sent_offset) return;
                 std::string candidate = full.substr(sent_offset);
                 auto [complete, leftover] = split_utf8_complete(candidate);
@@ -393,36 +569,53 @@ struct OpenAIServer::Impl {
             // Closing the reasoning block restarts the delta window: the marker
             // itself belongs to neither stream, and dropping the tokens before it
             // keeps decode_tokens() cheap on long generations.
-            auto accept = [&](int tok) {
-                if (in_reasoning && tok == think_end_id) {
+            auto accept = [&](int tok_id) {
+                if (in_reasoning && tok_id == think_end_id) {
                     emit_delta();
                     generated.clear();
                     sent_offset = 0;
                     in_reasoning = false;
                     return;
                 }
-                generated.push_back(tok);
+                generated.push_back(tok_id);
                 emit_delta();
             };
 
-            if (!hit_eos) {
-                accept(token);
-                ++decoded_count;
+            const auto deadline = std::chrono::steady_clock::now() +
+                                  std::chrono::seconds(cfg.request_timeout_seconds);
+            bool timed_out = false;
+            while (true) {
+                int token = 0;
+                const TokenStream::Next next = stream->next(&token, deadline);
+                if (next == TokenStream::Next::Token) {
+                    accept(token);
+                    continue;
+                }
+                if (next == TokenStream::Next::Timeout) {
+                    timed_out = true;
+                    sched.cancel_request(request_id);
+                }
+                break;
             }
 
-            for (int step = 1; step < max_tokens && !hit_eos; ++step) {
-                engine.worker_command_decode(token, position + step - 1);
-                token = engine.decode_step(token, position + step - 1, sp);
-                if (token == eos_id) { hit_eos = true; break; }
-                accept(token);
-                ++decoded_count;
+            std::string finish_reason = "length";
+            std::string generation_error;
+            if (timed_out) {
+                finish_reason = "timeout";
+            } else {
+                std::lock_guard<std::mutex> lk(stream->m);
+                finish_reason = stream->result.finish_reason;
+                generation_error = stream->result.error;
+                // Stop tokens are not queued by the scheduler, so they can never
+                // contribute bytes to the stream even when a caller supplies a
+                // custom, non-special stop id.
             }
 
             // Flush any remaining tail bytes (e.g. an isolated partial sequence
             // at EOS). In practice decode_tokens at terminal state produces
             // valid UTF-8, so this is usually empty.
             {
-                const std::string full = engine.tokenizer().decode_tokens(generated);
+                const std::string full = tok.decode_tokens(generated);
                 if (full.size() > sent_offset) {
                     std::string tail = full.substr(sent_offset);
                     sent_offset += tail.size();
@@ -430,8 +623,17 @@ struct OpenAIServer::Impl {
                 }
             }
 
+            if (timed_out) send_error("generation timed out");
+            if (!generation_error.empty()) {
+                send_error(generation_error);
+                const std::string done = "data: [DONE]\n\n";
+                sink.write(done.data(), done.size());
+                sink.done();
+                return true;
+            }
+
             // Final chunk with finish_reason.
-            send_chunk("", "content", hit_eos ? "stop" : "length");
+            send_chunk("", "content", finish_reason.c_str());
             const std::string done = "data: [DONE]\n\n";
             sink.write(done.data(), done.size());
             sink.done();
@@ -457,8 +659,9 @@ struct OpenAIServer::Impl {
     }
 };
 
-OpenAIServer::OpenAIServer(PersistentEngine& engine, PythonSidecar& sidecar, const OpenAIServerConfig& cfg)
-    : impl_(std::make_unique<Impl>(engine, sidecar, cfg)) {}
+OpenAIServer::OpenAIServer(InferenceEngine& engine, const Tokenizer& tokenizer,
+                           PythonSidecar& sidecar, const OpenAIServerConfig& cfg)
+    : impl_(std::make_unique<Impl>(engine, tokenizer, sidecar, cfg)) {}
 OpenAIServer::~OpenAIServer() = default;
 void OpenAIServer::run() { impl_->run(); }
 void OpenAIServer::stop() { impl_->stop(); }

--- a/cpp_engine/engine/persistent_engine_adapter.cpp
+++ b/cpp_engine/engine/persistent_engine_adapter.cpp
@@ -49,6 +49,12 @@ Capabilities PersistentEngineAdapter::caps() const {
     c.continuous_batching = false;
     c.chunked_prefill = false;
     c.max_slots = 1;
+    // One request at a time, so "per row" is trivially satisfiable: each
+    // request's temperature/top_p/seed go straight onto the SamplingParams for
+    // its own forward.
+    c.per_request_sampling = true;
+    c.per_request_top_k = false;
+    c.fixed_top_k = 0;
     return c;
 }
 

--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -4634,6 +4634,17 @@ Capabilities QwenEngine::caps() const {
     // batch_prefill honours its token budget on every configuration.
     c.chunked_prefill = true;
     c.max_slots = options_.max_batch_size;
+    // Sampling is an engine option here, not a per-row one: one temperature,
+    // top_p, top_k and seed are baked into the batch sampler at construction.
+    // Varying them per request would take a kernel change, not a plumbing one.
+    // Reporting the configured values lets a server accept a request that asks
+    // for exactly this and reject one that asks for anything else.
+    c.per_request_sampling = false;
+    c.per_request_top_k = false;
+    c.fixed_temperature = options_.temperature;
+    c.fixed_top_p = options_.top_p;
+    c.fixed_top_k = options_.top_k;
+    c.fixed_seed = options_.sampling_seed;
     return c;
 }
 

--- a/cpp_engine/include/batch_scheduler.hpp
+++ b/cpp_engine/include/batch_scheduler.hpp
@@ -14,6 +14,7 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace pocket {
@@ -27,7 +28,24 @@ struct SchedulerGenerationResult {
     int completion_tokens = 0;
     double total_seconds = 0.0;
     double ttft_seconds = 0.0;  // Time to first token
+    // Non-empty when the engine rejected or failed a forward. The old direct
+    // server path surfaced that exception as HTTP 500; routing through a
+    // background scheduler must preserve it rather than retrying forever until
+    // the HTTP request times out.
+    std::string error;
 };
+
+// Invoked once per generated token, from the scheduler thread, as soon as the
+// token is produced rather than when the request completes. This is what a
+// streaming server needs: waiting for the completion callback would buffer the
+// whole answer and defeat the point.
+//
+// It runs inline in the schedule loop, so it MUST NOT BLOCK. Time spent here
+// delays every other running request, and writing to a socket from it would let
+// one slow client stall the batch. Push the token onto a queue and return.
+// Re-entering the scheduler from it (submit_request, cancel_request) is safe --
+// it is called with no scheduler lock held -- but still counts as time spent.
+using TokenCallback = std::function<void(uint64_t request_id, int token)>;
 
 // Internal request wrapper with scheduling metadata
 struct SchedulerRequest {
@@ -49,6 +67,9 @@ struct SchedulerRequest {
     // Cancelled before finishing. Recorded here because the cancelled set is
     // erased before results are reported.
     bool cancelled = false;
+    // Terminal engine failure. Kept separate from cancellation because callers
+    // report it as an error, not as a finish_reason.
+    std::string error;
     int last_token = 0;
     std::vector<int> generated_tokens;
 
@@ -60,6 +81,8 @@ struct SchedulerRequest {
     // Result notification
     std::function<void(const SchedulerGenerationResult&)> callback;
     bool callback_invoked = false;
+    // Fired per token; see TokenCallback.
+    TokenCallback token_callback;
 };
 
 // Continuous batching scheduler over any InferenceEngine.
@@ -82,12 +105,16 @@ public:
     BatchScheduler& operator=(const BatchScheduler&) = delete;
 
     // Submit a new generation request
-    // Returns request_id (> 0) on success, 0 on failure
-    // The callback will be invoked from the scheduler thread when generation completes
+    // Returns request_id (> 0) on success, 0 on failure.
+    // With `callback`, completion is delivered from the scheduler thread and is
+    // not duplicated into poll_result(); without one, poll_result is the result
+    // channel. `on_token`, when supplied, additionally fires per token as it is
+    // produced.
     uint64_t submit_request(
         const std::vector<int>& prompt_tokens,
         const BatchSamplingParams& sampling,
-        std::function<void(const SchedulerGenerationResult&)> callback = nullptr);
+        std::function<void(const SchedulerGenerationResult&)> callback = nullptr,
+        TokenCallback on_token = nullptr);
 
     // Cancel a pending or running request
     // Returns true if the request was found and marked for cancellation
@@ -154,6 +181,10 @@ private:
 
     // Handle completed requests
     void handle_completions();
+
+    // Fire the per-token callbacks recorded during a prefill or decode pass.
+    // Separate from those passes because it must run with queue_mutex_ released.
+    void deliver_tokens(const std::vector<std::pair<SchedulerRequest*, int>>& emitted);
 
     // Blocks a request may end up holding: prompt plus its full generation
     // allowance. 0 under the contiguous arena, where slots are the only budget.

--- a/cpp_engine/include/inference_engine.hpp
+++ b/cpp_engine/include/inference_engine.hpp
@@ -29,6 +29,25 @@ struct Capabilities {
     bool chunked_prefill = false;
     // Concurrent request slots. 1 means one mutable session at a time.
     int max_slots = 1;
+    // BatchSamplingParams' temperature / top_p / seed are applied per row. When
+    // false the engine samples every row with whatever it was constructed with
+    // and reads only max_new_tokens, stop_token_ids and ignore_eos off the
+    // request -- so a server must refuse a request that asks for different
+    // sampling rather than quietly returning something else.
+    bool per_request_sampling = false;
+    // Top-k is separate because the DeepSeek-V4 sampler varies temperature,
+    // top_p and seed per request but has no top-k stage at all.
+    bool per_request_top_k = false;
+    // What every row gets when the corresponding per-request flag is false.
+    // Without these a server can only choose between rejecting every request
+    // that names a temperature -- which is most OpenAI clients, since they send
+    // the default explicitly -- and silently substituting its own. With them it
+    // can tell "asked for exactly what it will get" from "asked for something
+    // else". fixed_top_k == 0 means no top-k cap.
+    float fixed_temperature = 0.0f;
+    float fixed_top_p = 1.0f;
+    int fixed_top_k = 0;
+    unsigned long long fixed_seed = 0;
 };
 
 // One forward pass over one sequence.
@@ -134,7 +153,9 @@ public:
 
     // Device this engine bound at construction. The current device is
     // per-thread, so a scheduler thread has to re-select it before touching
-    // device memory.
+    // device memory. -1 means the engine has no accelerator context (used by
+    // host-only engines and scheduler conformance stubs), in which case there
+    // is nothing to select.
     virtual int device() const = 0;
 
     // ---- Slot lifecycle ----
@@ -178,6 +199,32 @@ public:
     // but must occupy distinct slots.
     virtual BatchDecodeResult batch_decode_step(
         const std::vector<BatchedRequest*>& requests) = 0;
+
+    // ---- Tensor-parallel process lifecycle ----
+    //
+    // Only these three, not the whole worker protocol. The per-forward
+    // worker_command_* announcements stay on the concrete engine, where the
+    // batched entry points above already issue them; a caller driving the
+    // engine through batch_prefill/batch_decode_step never sends one by hand.
+    // What a caller *cannot* do without knowing the model is bring the group up
+    // and take it down, and a process that serves whichever engine the registry
+    // handed it has to do exactly that. Called at most twice per process, so
+    // dispatching them virtually costs nothing.
+    //
+    // Default no-ops: an engine with no tensor parallelism needs no boilerplate
+    // to be driven by the same main().
+
+    // Establish the TP command channel and collectives. Must precede any
+    // batched call at world size > 1. No-op at world size 1.
+    virtual void warmup_tp() {}
+
+    // Entry point for ranks other than 0: block on the command channel and
+    // serve whatever rank 0 announces until it sends shutdown. Returns only
+    // once the group is torn down.
+    virtual void run_worker_loop() {}
+
+    // Rank 0 only: tell every worker rank to leave run_worker_loop().
+    virtual void shutdown_tp_workers() {}
 };
 
 }  // namespace pocket

--- a/cpp_engine/include/model_registry.hpp
+++ b/cpp_engine/include/model_registry.hpp
@@ -42,6 +42,16 @@ struct EngineOptions {
     // Paged pool budget in bytes on this rank; 0 derives it from what the
     // contiguous arena would have reserved.
     uint64_t kv_cache_bytes = 0;
+    // Sampling, for engines that fix it at construction rather than reading it
+    // off each request. Nothing about a temperature is model-specific, and an
+    // engine reporting caps().per_request_sampling == false has no other way to
+    // be told: a caller that could not set these here would be stuck with
+    // greedy decoding for the life of the process. Engines that sample per
+    // request ignore them.
+    float temperature = 0.0f;
+    float top_p = 1.0f;
+    int top_k = 20;
+    unsigned long long seed = 0;
 };
 
 // Builds one engine for one checkpoint. Registered per architecture.

--- a/cpp_engine/include/openai_server.hpp
+++ b/cpp_engine/include/openai_server.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "persistent_engine.hpp"
+#include "inference_engine.hpp"
 #include "python_sidecar.hpp"
+#include "tokenizer.hpp"
 
-#include <atomic>
-#include <mutex>
+#include <memory>
 #include <string>
 
 namespace pocket {
@@ -15,17 +15,40 @@ struct OpenAIServerConfig {
     std::string default_thinking_mode = "chat";
     int default_max_tokens = 256;
     bool log_requests = true;
+    // Reported by /v1/models and echoed in every completion.
+    std::string model_name = "pocketllm";
+    // Requests the scheduler may run concurrently. Clamped down to whatever the
+    // engine declares in caps().max_slots, so the DeepSeek-V4 adapter still
+    // serialises at 1 while a multi-slot engine runs the full width.
+    int max_batch_size = 8;
+    // Prompt tokens a request may advance per schedule iteration; 0 disables
+    // chunking. Ignored by an engine that does not declare chunked prefill.
+    int prefill_token_budget = 4096;
+    // How long a single completion may take before the connection is failed.
+    // Generous by default: a 65K prompt at TP4 spends seconds in prefill alone,
+    // and a queued request also waits behind everything admitted before it.
+    int request_timeout_seconds = 900;
 };
 
-// Single-tenant OpenAI-compatible HTTP server backed by PersistentEngine.
-// Requests are serialised: while one chat completion is generating, others
-// queue on the inflight mutex. Stream and non-stream paths are both supported.
+// OpenAI-compatible HTTP server over any InferenceEngine.
+//
+// Requests are driven through BatchScheduler rather than by calling the engine
+// directly, which is what makes concurrency the engine's decision instead of the
+// server's: an engine declaring continuous batching runs several completions at
+// once, and one declaring a single session has the scheduler serialise them.
+// Either way the server issues no worker_command_* itself -- the scheduler's
+// batched entry points announce each forward to the TP group.
+//
+// The tokenizer is the server's, not the engine's. Detokenizing a response is a
+// serving concern, and requiring every model runtime to carry a Tokenizer would
+// put one on engines that have no use for it.
 class OpenAIServer {
 public:
-    OpenAIServer(PersistentEngine& engine, PythonSidecar& sidecar, const OpenAIServerConfig& cfg);
+    OpenAIServer(InferenceEngine& engine, const Tokenizer& tokenizer,
+                 PythonSidecar& sidecar, const OpenAIServerConfig& cfg);
     ~OpenAIServer();
 
-    // Blocks until stop() is called or SIGINT/SIGTERM arrives.
+    // Blocks until stop() is called or the listener fails.
     void run();
     void stop();
 

--- a/cpp_engine/include/persistent_engine_adapter.hpp
+++ b/cpp_engine/include/persistent_engine_adapter.hpp
@@ -27,8 +27,7 @@ namespace pocket {
 // TP is handled the way QwenEngine's batched entry points handle it: each forward
 // announces itself on the worker command channel first, so a scheduler driving
 // this adapter is TP-safe without knowing the protocol exists. Rank 0 drives;
-// worker ranks stay in PersistentEngine::run_worker_loop(), which the owner
-// reaches through engine().
+// worker ranks stay in run_worker_loop(), which the interface exposes.
 class PersistentEngineAdapter : public InferenceEngine {
 public:
     // Owning form: constructs the PersistentEngine. This is what the model
@@ -49,8 +48,8 @@ public:
     PersistentEngineAdapter& operator=(const PersistentEngineAdapter&) = delete;
 
     // The wrapped engine, for the model-specific surface the interface does not
-    // carry: warmup_tp(), run_worker_loop(), worker_command_shutdown(),
-    // speculative decoding, the tokenizer.
+    // carry: speculative decoding, the tokenizer, the per-forward worker
+    // commands. TP bring-up and teardown are on the interface itself.
     PersistentEngine& engine() { return *engine_; }
     const PersistentEngine& engine() const { return *engine_; }
 
@@ -82,6 +81,13 @@ public:
                                      int token_budget) override;
     BatchDecodeResult batch_decode_step(
         const std::vector<BatchedRequest*>& requests) override;
+
+    // Straight forwards. PersistentEngine spells the last one
+    // worker_command_shutdown(); the interface asks for the intent, not the
+    // wire op.
+    void warmup_tp() override { engine_->warmup_tp(); }
+    void run_worker_loop() override { engine_->run_worker_loop(); }
+    void shutdown_tp_workers() override { engine_->worker_command_shutdown(); }
 
 private:
     bool is_stop_token(const BatchSamplingParams& sampling, int token) const;

--- a/cpp_engine/include/python_sidecar.hpp
+++ b/cpp_engine/include/python_sidecar.hpp
@@ -31,15 +31,16 @@ struct ParsedMessage {
     std::string tool_calls_json;      // raw JSON array string, may be "[]"
 };
 
-// Thin C++ wrapper around a long-running python helper. The helper renders
-// DeepSeek-V4 chat templates and parses generated text into structured fields.
-// One sidecar instance per server process; calls are serialised via the
-// internal mutex.
+// Thin C++ wrapper around a long-running Python helper. The helper selects the
+// checkpoint's chat template, tokenizes requests, and parses generated text into
+// structured fields. One sidecar instance per server process; calls are
+// serialised via the internal mutex.
 class PythonSidecar {
 public:
     PythonSidecar(const std::string& python_bin,
                   const std::string& script_path,
-                  const std::string& ckpt_dir);
+                  const std::string& ckpt_dir,
+                  const std::string& architecture = "");
     ~PythonSidecar();
 
     PythonSidecar(const PythonSidecar&) = delete;

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -253,7 +253,7 @@ public:
     void reset();
     // Drops every cached prefix so the next prefill recomputes from zero.
     void clear_prefix_cache();
-    void warmup_tp();
+    void warmup_tp() override;
     ForwardResult prefill(const std::vector<int>& token_ids, int slot_id = 0);
     // Prefill that consumes at most `max_tokens` prompt tokens and returns,
     // leaving the rest for a later call. This is what lets a scheduler keep a
@@ -340,7 +340,11 @@ public:
 
     // TP rank > 0 entry point. Blocks on a small NCCL int32 broadcast channel
     // driven by rank 0; runs the requested op until SHUTDOWN.
-    void run_worker_loop();
+    void run_worker_loop() override;
+
+    // InferenceEngine's name for worker_command_shutdown(), so a caller holding
+    // only the interface can tear the group down.
+    void shutdown_tp_workers() override { worker_command_shutdown(); }
 
     // Rank 0 utilities to drive the worker loop. No-op for tp_world == 1.
     enum class WorkerCommand : int32_t {

--- a/cpp_engine/python/bindings.cpp
+++ b/cpp_engine/python/bindings.cpp
@@ -443,7 +443,8 @@ PYBIND11_MODULE(pocketllm_cpp, module) {
         .def_readwrite("prompt_tokens", &SchedulerGenerationResult::prompt_tokens)
         .def_readwrite("completion_tokens", &SchedulerGenerationResult::completion_tokens)
         .def_readwrite("total_seconds", &SchedulerGenerationResult::total_seconds)
-        .def_readwrite("ttft_seconds", &SchedulerGenerationResult::ttft_seconds);
+        .def_readwrite("ttft_seconds", &SchedulerGenerationResult::ttft_seconds)
+        .def_readwrite("error", &SchedulerGenerationResult::error);
 
     py::class_<BatchScheduler::Stats>(module, "QwenBatchSchedulerStats")
         .def(py::init<>())

--- a/cpp_engine/tests/test_model_registry.cpp
+++ b/cpp_engine/tests/test_model_registry.cpp
@@ -215,10 +215,14 @@ void test_registry_dispatch() {
 
     std::string seen_ckpt;
     int seen_slots = 0;
+    float seen_temperature = 0.0f;
+    int seen_top_k = 0;
     pocket::register_engine("stub_arch", [&](const std::string& ckpt,
                                              const pocket::EngineOptions& options) {
         seen_ckpt = ckpt;
         seen_slots = options.max_batch_size;
+        seen_temperature = options.temperature;
+        seen_top_k = options.top_k;
         return std::unique_ptr<pocket::InferenceEngine>(
             new StubEngine(paged_batched_caps(options.max_batch_size)));
     });
@@ -227,11 +231,15 @@ void test_registry_dispatch() {
 
     pocket::EngineOptions options;
     options.max_batch_size = 3;
+    options.temperature = 0.75f;
+    options.top_k = 17;
     std::unique_ptr<pocket::InferenceEngine> engine =
         pocket::create_engine(dir, options);
     check(engine != nullptr, "create_engine builds the registered engine");
     check_eq(seen_ckpt, dir, "the factory receives the checkpoint path");
-    check(seen_slots == 3, "the factory receives the caller's options");
+    check(seen_slots == 3, "the factory receives the caller's topology options");
+    check(seen_temperature == 0.75f && seen_top_k == 17,
+          "the factory receives the caller's sampling options");
     check(engine->caps().max_slots == 3, "the built engine's caps reach the caller");
 
     // Silently replacing a registration would make which engine runs depend on

--- a/cpp_engine/tests/test_scheduler_callbacks.cpp
+++ b/cpp_engine/tests/test_scheduler_callbacks.cpp
@@ -1,0 +1,266 @@
+// Scheduler result delivery, streaming token callbacks, and generation bounds.
+//
+// This is a host-only conformance test: the fake engine reports device == -1,
+// so it needs no checkpoint and no accelerator. That is deliberate -- the
+// callback contract belongs to the scheduler, not to any one model runtime.
+
+#include "batch_scheduler.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <iostream>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const std::string& message) {
+    std::cout << "  " << message << ": " << (condition ? "PASS" : "FAIL") << "\n";
+    if (!condition) ++failures;
+}
+
+bool is_stop(const pocket::BatchSamplingParams& sampling, int token) {
+    if (sampling.ignore_eos) return false;
+    return std::find(sampling.stop_token_ids.begin(),
+                     sampling.stop_token_ids.end(), token) !=
+           sampling.stop_token_ids.end();
+}
+
+// Predicts token 10 from every prompt, then 11, 12, ... on decode. This makes
+// the exact callback sequence readable in the assertions below.
+class CountingEngine final : public pocket::InferenceEngine {
+public:
+    pocket::Capabilities caps() const override {
+        pocket::Capabilities c;
+        c.continuous_batching = true;
+        c.chunked_prefill = true;
+        c.max_slots = 4;
+        c.per_request_sampling = true;
+        c.per_request_top_k = true;
+        return c;
+    }
+
+    int max_context() const override { return 4096; }
+    int device() const override { return -1; }
+
+    void allocate_batch_slots(int max_batch_size) override {
+        slots_.assign(static_cast<size_t>(max_batch_size), 0);
+    }
+
+    int allocate_slot(uint64_t request_id) override {
+        for (size_t i = 0; i < slots_.size(); ++i) {
+            if (slots_[i] == 0) {
+                slots_[i] = request_id;
+                return static_cast<int>(i);
+            }
+        }
+        return -1;
+    }
+
+    void free_slot(uint64_t request_id) override {
+        for (uint64_t& owner : slots_) {
+            if (owner == request_id) owner = 0;
+        }
+    }
+
+    bool kv_paged() const override { return false; }
+    int kv_free_blocks() const override { return 0; }
+    int kv_total_blocks() const override { return 0; }
+    int kv_blocks_for_tokens(int) const override { return 0; }
+
+    pocket::BatchPrefillResult batch_prefill(
+        const std::vector<pocket::BatchedRequest*>& requests,
+        int /*token_budget*/) override {
+        ++prefill_calls;
+        if (fail_prefill) throw std::runtime_error("synthetic prefill failure");
+        pocket::BatchPrefillResult out;
+        for (pocket::BatchedRequest* req : requests) {
+            pocket::ForwardResult result;
+            result.top_token = 10;
+            req->seq_len = static_cast<int>(req->prompt_tokens.size());
+            req->finished = is_stop(req->sampling, result.top_token);
+            out.results.push_back(result);
+            out.incomplete.push_back(false);
+            out.total_tokens += req->seq_len;
+        }
+        return out;
+    }
+
+    pocket::BatchDecodeResult batch_decode_step(
+        const std::vector<pocket::BatchedRequest*>& requests) override {
+        ++decode_calls;
+        if (fail_decode) throw std::runtime_error("synthetic decode failure");
+        pocket::BatchDecodeResult out;
+        for (pocket::BatchedRequest* req : requests) {
+            const int token = req->last_token + 1;
+            const bool stopped = is_stop(req->sampling, token);
+            out.next_tokens.push_back(token);
+            out.finished.push_back(stopped);
+            out.hit_stop_token.push_back(stopped);
+        }
+        return out;
+    }
+
+    std::atomic<int> prefill_calls{0};
+    std::atomic<int> decode_calls{0};
+    bool fail_prefill = false;
+    bool fail_decode = false;
+
+private:
+    std::vector<uint64_t> slots_;
+};
+
+struct CallbackState {
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool done = false;
+    std::vector<int> tokens;
+    std::vector<std::string> events;
+    pocket::SchedulerGenerationResult result;
+};
+
+bool wait_done(CallbackState& state) {
+    std::unique_lock<std::mutex> lock(state.mutex);
+    return state.cv.wait_for(lock, std::chrono::seconds(2), [&] { return state.done; });
+}
+
+uint64_t submit_with_callbacks(pocket::BatchScheduler& scheduler,
+                               const pocket::BatchSamplingParams& sampling,
+                               CallbackState& state) {
+    return scheduler.submit_request(
+        {1, 2, 3}, sampling,
+        [&](const pocket::SchedulerGenerationResult& result) {
+            {
+                std::lock_guard<std::mutex> lock(state.mutex);
+                state.result = result;
+                state.events.push_back("complete");
+                state.done = true;
+            }
+            state.cv.notify_one();
+        },
+        [&](uint64_t, int token) {
+            std::lock_guard<std::mutex> lock(state.mutex);
+            state.tokens.push_back(token);
+            state.events.push_back("token:" + std::to_string(token));
+        });
+}
+
+void test_prefill_token_counts_toward_limit() {
+    std::cout << "prefill's sampled token counts as generation token one\n";
+    CountingEngine engine;
+    pocket::BatchScheduler scheduler(&engine, 1);
+
+    pocket::BatchSamplingParams sampling;
+    sampling.max_new_tokens = 1;
+    CallbackState state;
+    const uint64_t id = submit_with_callbacks(scheduler, sampling, state);
+
+    check(id != 0, "request is accepted");
+    check(wait_done(state), "completion callback arrives");
+    check(state.result.generated_tokens == std::vector<int>{10},
+          "max_new_tokens=1 returns exactly the prefill token");
+    check(state.tokens == std::vector<int>{10},
+          "the streaming callback sees exactly one token");
+    check(state.events == std::vector<std::string>{"token:10", "complete"},
+          "the token callback precedes completion");
+    check(engine.decode_calls.load() == 0,
+          "no decode forward runs past the one-token limit");
+
+    pocket::SchedulerGenerationResult duplicate;
+    check(!scheduler.poll_result(id, &duplicate, 0),
+          "a callback result is not duplicated into the poll map");
+    scheduler.stop();
+}
+
+void test_stop_token_is_not_streamed() {
+    std::cout << "stop tokens stay in engine state but not in the stream\n";
+    CountingEngine engine;
+    pocket::BatchScheduler scheduler(&engine, 1);
+
+    pocket::BatchSamplingParams sampling;
+    sampling.max_new_tokens = 8;
+    sampling.stop_token_ids = {12};
+    CallbackState state;
+    submit_with_callbacks(scheduler, sampling, state);
+
+    check(wait_done(state), "stop-token request completes");
+    check(state.tokens == std::vector<int>({10, 11}),
+          "the per-token callback excludes the stop token");
+    check(state.result.generated_tokens == std::vector<int>({10, 11, 12}),
+          "the scheduler result retains the stop token for KV consistency");
+    check(state.result.finish_reason == "stop",
+          "the completion reports stop rather than length");
+    check(state.events ==
+              std::vector<std::string>({"token:10", "token:11", "complete"}),
+          "completion follows the last visible token");
+    scheduler.stop();
+}
+
+void test_poll_result_without_callback() {
+    std::cout << "poll_result remains the completion channel without a callback\n";
+    CountingEngine engine;
+    pocket::BatchScheduler scheduler(&engine, 1);
+
+    pocket::BatchSamplingParams sampling;
+    sampling.max_new_tokens = 2;
+    const uint64_t id = scheduler.submit_request({4, 5}, sampling);
+    pocket::SchedulerGenerationResult result;
+
+    check(id != 0, "poll-mode request is accepted");
+    check(scheduler.poll_result(id, &result, 2000),
+          "poll_result receives completion");
+    check(result.generated_tokens == std::vector<int>({10, 11}),
+          "poll mode observes the exact generation bound");
+    check(result.finish_reason == "length", "the length cap is reported");
+    check(!scheduler.poll_result(id, &result, 0),
+          "poll_result consumes its map entry");
+    scheduler.stop();
+}
+
+void test_engine_failure_is_terminal() {
+    std::cout << "engine failures complete the request instead of retrying forever\n";
+    CountingEngine engine;
+    engine.fail_decode = true;
+    pocket::BatchScheduler scheduler(&engine, 1);
+
+    pocket::BatchSamplingParams sampling;
+    sampling.max_new_tokens = 4;
+    CallbackState state;
+    const uint64_t id = submit_with_callbacks(scheduler, sampling, state);
+
+    check(id != 0, "failing request is initially accepted");
+    check(wait_done(state), "the failure reaches the completion callback");
+    check(state.tokens == std::vector<int>{10},
+          "tokens produced before the failure are still delivered");
+    check(state.result.finish_reason == "error",
+          "the terminal reason is error");
+    check(state.result.error.find("synthetic decode failure") != std::string::npos,
+          "the engine exception reaches the caller");
+    check(engine.decode_calls.load() == 1,
+          "the failed forward is not retried in a loop");
+    scheduler.stop();
+}
+
+}  // namespace
+
+int main() {
+    test_prefill_token_counts_toward_limit();
+    test_stop_token_is_not_streamed();
+    test_poll_result_without_callback();
+    test_engine_failure_is_terminal();
+
+    if (failures != 0) {
+        std::cout << "[FAIL] " << failures << " scheduler callback checks failed\n";
+        return 1;
+    }
+    std::cout << "[PASS] scheduler callbacks\n";
+    return 0;
+}

--- a/pocketllm/backends/cpp_backend.py
+++ b/pocketllm/backends/cpp_backend.py
@@ -145,11 +145,12 @@ def _native_device_index(value: str | int | None) -> int:
 
 
 class CppBackend(BackendBase):
-    """Serialized compatibility adapter for the stateful native engines.
+    """Native C++ engine adapter with optional scheduler-backed batching.
 
-    The initial bridge intentionally supports Qwen's token-oriented API.  The
-    native engine still owns its optimized KV layout and TP protocol; this
-    adapter does not turn it into a Torch module or copy its buffers.
+    The native runtime keeps ownership of its optimized KV layout and tensor-
+    parallel protocol. This adapter handles model selection, request conversion,
+    lifecycle, and the serial or scheduler result path without turning an engine
+    into a Torch module or copying its buffers.
     """
 
     def __init__(
@@ -741,6 +742,7 @@ class CppBackend(BackendBase):
 
         # Poll for results
         outputs: list[GenerationResult] = []
+        native_errors: list[str] = []
         timeout_ms = 60000  # 60 seconds per request
 
         for native_req_id in native_request_ids:
@@ -751,6 +753,17 @@ class CppBackend(BackendBase):
                 # Timeout
                 self._clear_request(request.request_id)
                 raise TimeoutError(f"Request {request.request_id} timed out after {timeout_ms}ms")
+
+            native_error = str(getattr(result, "error", "") or "")
+            if native_error:
+                # Poll the rest of this submitted batch before raising. A failed
+                # native forward normally completes every participating row with
+                # an error; abandoning their poll results here would retain one
+                # native completed-result entry and one public active request per
+                # row after the first.
+                native_errors.append(native_error)
+                self._clear_request(request.request_id)
+                continue
 
             # Convert native result to GenerationResult
             token_ids = result.generated_tokens
@@ -771,6 +784,10 @@ class CppBackend(BackendBase):
             )
 
             self._clear_request(request.request_id)
+
+        if native_errors:
+            joined = "; ".join(dict.fromkeys(native_errors))
+            raise RuntimeError(f"native C++ generation failed: {joined}")
 
         return outputs
 

--- a/scripts/run_cpp_serve_tp4.sh
+++ b/scripts/run_cpp_serve_tp4.sh
@@ -1,28 +1,47 @@
 #!/bin/bash
-# Launch the cpp_engine OpenAI-compatible server on 4×GPU TP=4.
-# Rank 0 listens on $PORT (default 8000); ranks 1-3 are NCCL workers.
+# Launch the engine-agnostic C++ OpenAI-compatible server on four TP ranks.
+# Rank 0 listens on $PORT (default 8000); ranks 1-3 are collective workers.
+# The checkpoint's config.json selects the registered engine.
 set -e
 
 CKPT="${CKPT:-/mnt/data1/modelscope/deepseek-ai/DeepSeek-V4-Flash}"
 PORT="${PORT:-8000}"
 NCCL_ID="${NCCL_ID:-/tmp/pocketllm_cpp_serve_nccl.id}"
 MAX_CONTEXT="${MAX_CONTEXT:-8192}"
+MAX_BATCH_SIZE="${MAX_BATCH_SIZE:-8}"
+# 0 means the checkpoint's full depth for every registered architecture.
+SMOKE_LAYERS="${SMOKE_LAYERS:-0}"
+# Paging is ignored by an engine that does not support it. It is on here so a
+# Qwen server shares one block pool across the requested batch width instead of
+# reserving max_context separately for every slot.
+KV_PAGED="${KV_PAGED:-1}"
+KV_BLOCK_SIZE="${KV_BLOCK_SIZE:-16}"
 PYTHON="${PYTHON:-python}"
 SIDECAR="${SIDECAR:-/mnt/data1/dsv4_inference/src/server/cpp_sidecar.py}"
 BIN="${BIN:-/mnt/data1/dsv4_inference/build/cpp_engine/pocketllm_engine}"
 LOG_DIR="${LOG_DIR:-/tmp}"
 EXTRA_ENV="${EXTRA_ENV:-}"
+EXTRA_ARGS="${EXTRA_ARGS:-}"
 
 rm -f "$NCCL_ID"
 
-COMMON="--serve --ckpt $CKPT --tp-world 4 --nccl-id-path $NCCL_ID --smoke-layers 43 --max-context $MAX_CONTEXT --python $PYTHON --sidecar $SIDECAR --port $PORT"
+COMMON="--serve --ckpt $CKPT --tp-world 4 --nccl-id-path $NCCL_ID --smoke-layers $SMOKE_LAYERS --max-context $MAX_CONTEXT --max-batch-size $MAX_BATCH_SIZE --kv-block-size $KV_BLOCK_SIZE --python $PYTHON --sidecar $SIDECAR --port $PORT $EXTRA_ARGS"
+if [ "$KV_PAGED" != "0" ]; then
+    COMMON="$COMMON --kv-paged"
+fi
+
+pids=""
+cleanup() {
+    kill $pids 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
 
 for rank in 0 1 2 3; do
-  eval "$EXTRA_ENV CUDA_VISIBLE_DEVICES=$rank $BIN $COMMON --tp-rank $rank --device 0 > $LOG_DIR/pocketllm_cpp_serve_rank${rank}.log 2>&1 &"
+    eval "$EXTRA_ENV CUDA_VISIBLE_DEVICES=$rank $BIN $COMMON --tp-rank $rank --device 0 > $LOG_DIR/pocketllm_cpp_serve_rank${rank}.log 2>&1 &"
+    pids="$pids $!"
 done
 
-echo "started 4 ranks; rank 0 PID list:" >&2
-jobs -p
+echo "started 4 ranks; PIDs:$pids" >&2
 echo "log dir: $LOG_DIR/pocketllm_cpp_serve_rank{0,1,2,3}.log" >&2
 echo "tail logs with: tail -F $LOG_DIR/pocketllm_cpp_serve_rank0.log" >&2
 wait

--- a/src/server/cpp_sidecar.py
+++ b/src/server/cpp_sidecar.py
@@ -1,9 +1,13 @@
 """Long-lived Python helper for the cpp_engine OpenAI server.
 
 Reads JSON-line requests on stdin, writes JSON-line responses on stdout.
-Reuses src.encoding.deepseek_v4 to render DeepSeek-V4 chat templates (with DSML
-tool-call syntax, thinking_mode, reasoning_effort) and to parse generated
-text back into {content, reasoning, tool_calls}.
+
+Chat templating is per-architecture, mirroring the C++ model registry: the
+checkpoint declares a ``model_type`` and that selects a templater.  DeepSeek-V4
+keeps ``src.encoding.deepseek_v4``, which renders DSML tool-call syntax,
+thinking_mode and reasoning_effort.  Everything else goes through the
+checkpoint's own HF chat template, which is what makes the C++ server able to
+serve a model this repo has no bespoke encoder for.
 
 Protocol (one JSON object per stdin/stdout line):
 
@@ -32,18 +36,20 @@ from typing import Any
 
 from transformers import AutoTokenizer
 
-# stdin/stdout must be UTF-8 regardless of locale — the C++ parent emits raw
-# multi-byte JSON for non-ASCII content (Chinese prompts, tool-call XML, etc.).
-sys.stdin.reconfigure(encoding="utf-8", errors="replace")
-sys.stdout.reconfigure(encoding="utf-8")
-
 # Make sure src/ is importable when invoked from arbitrary CWDs.
 import os
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-from src.encoding.deepseek_v4 import encode_messages, eos_token, parse_message_from_completion_text  # noqa: E402
+
+def _configure_stdio() -> None:
+    """Use UTF-8 for the JSON-line protocol regardless of the parent locale."""
+    # The C++ parent emits raw multi-byte JSON for non-ASCII content (Chinese
+    # prompts, tool-call XML, etc.). Kept out of module import so the templaters
+    # remain unit-testable under pytest's captured stdin/stdout wrappers.
+    sys.stdin.reconfigure(encoding="utf-8", errors="replace")
+    sys.stdout.reconfigure(encoding="utf-8")
 
 
 def _emit(obj: dict[str, Any]) -> None:
@@ -56,58 +62,185 @@ def _err(msg: str) -> None:
     _emit({"ok": False, "err": msg})
 
 
-def _handle_encode(tokenizer, req: dict[str, Any]) -> None:
-    messages = list(req.get("messages") or [])
-    thinking_mode = req.get("thinking_mode", "chat")
-    reasoning_effort = req.get("reasoning_effort")
-    context = req.get("context")
-    drop_thinking = bool(req.get("drop_thinking", True))
-    add_bos = bool(req.get("add_generation_prompt", True))
-    tools = req.get("tools")
-    if isinstance(tools, list) and tools:
-        # Splice tools onto an existing system/developer message, or prepend one.
-        attach_idx = None
-        for idx, msg in enumerate(messages):
-            if msg.get("role") in {"system", "developer"}:
-                attach_idx = idx
-                break
-        if attach_idx is None:
-            messages.insert(0, {"role": "system", "content": ""})
-            attach_idx = 0
-        messages[attach_idx] = {**messages[attach_idx], "tools": tools}
-    prompt_text = encode_messages(
-        messages,
-        thinking_mode=thinking_mode,
-        context=context,
-        drop_thinking=drop_thinking,
-        add_default_bos_token=add_bos,
-        reasoning_effort=reasoning_effort,
-    )
-    token_ids = tokenizer.encode(prompt_text)
-    _emit({"ok": True, "prompt_text": prompt_text, "token_ids": list(token_ids)})
+def detect_architecture(ckpt: str) -> str:
+    """The checkpoint's architecture, normalized the way the C++ registry does.
+
+    Same rule as ``pocket::detect_architecture`` in core/model_registry.cpp,
+    including folding ``qwen3_5_text`` (where the multimodal wrapper hides the
+    text model's type) onto ``qwen3_5``.  Returns "" when nothing is declared,
+    which selects the generic templater.
+    """
+    try:
+        with open(os.path.join(ckpt, "config.json"), encoding="utf-8") as handle:
+            config = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return ""
+    model_type = config.get("model_type")
+    if not model_type:
+        text_config = config.get("text_config")
+        if isinstance(text_config, dict):
+            model_type = text_config.get("model_type")
+    model_type = str(model_type or "").lower()
+    return "qwen3_5" if model_type == "qwen3_5_text" else model_type
 
 
-def _handle_parse(req: dict[str, Any]) -> None:
-    text = req.get("text", "")
-    thinking_mode = req.get("thinking_mode", "chat")
-    # parse_message_from_completion_text requires the EOS token to be present.
-    # The C++ engine emits raw decoded text without re-inserting the EOS string
-    # (it stops on the EOS token id), so we append it here if missing.
-    if not text.endswith(eos_token):
-        text = text + eos_token
-    parsed = parse_message_from_completion_text(text, thinking_mode)
+def _splice_tools(messages: list[dict[str, Any]], tools: Any) -> list[dict[str, Any]]:
+    """Attach `tools` to the system/developer message, adding one if absent."""
+    messages = list(messages)
+    attach_idx = None
+    for idx, msg in enumerate(messages):
+        if msg.get("role") in {"system", "developer"}:
+            attach_idx = idx
+            break
+    if attach_idx is None:
+        messages.insert(0, {"role": "system", "content": ""})
+        attach_idx = 0
+    messages[attach_idx] = {**messages[attach_idx], "tools": tools}
+    return messages
+
+
+class DeepSeekV4Templater:
+    """DSML chat template, thinking modes and tool-call parsing for DeepSeek-V4."""
+
+    def __init__(self, tokenizer) -> None:
+        from src.encoding.deepseek_v4 import (
+            encode_messages,
+            eos_token,
+            parse_message_from_completion_text,
+        )
+
+        self._tokenizer = tokenizer
+        self._encode_messages = encode_messages
+        self._eos_token = eos_token
+        self._parse = parse_message_from_completion_text
+
+    def encode(self, req: dict[str, Any]) -> tuple[str, list[int]]:
+        messages = list(req.get("messages") or [])
+        tools = req.get("tools")
+        if isinstance(tools, list) and tools:
+            messages = _splice_tools(messages, tools)
+        prompt_text = self._encode_messages(
+            messages,
+            thinking_mode=req.get("thinking_mode", "chat"),
+            context=req.get("context"),
+            drop_thinking=bool(req.get("drop_thinking", True)),
+            add_default_bos_token=bool(req.get("add_generation_prompt", True)),
+            reasoning_effort=req.get("reasoning_effort"),
+        )
+        return prompt_text, list(self._tokenizer.encode(prompt_text))
+
+    def parse(self, text: str, thinking_mode: str) -> dict[str, Any]:
+        # parse_message_from_completion_text requires the EOS token to be
+        # present.  The C++ engine emits raw decoded text without re-inserting
+        # the EOS string (it stops on the EOS token id), so append it if missing.
+        if not text.endswith(self._eos_token):
+            text = text + self._eos_token
+        return self._parse(text, thinking_mode)
+
+
+class ChatTemplateTemplater:
+    """The checkpoint's own HF chat template, for models with no bespoke encoder.
+
+    Deliberately narrower than the DeepSeek path.  ``reasoning_effort``,
+    ``context`` and ``drop_thinking`` have no equivalent in a stock chat
+    template and are ignored, and tool *calls* in the completion are left in the
+    content rather than parsed: their syntax is per-model, and returning an empty
+    tool_calls list keeps them visible instead of inventing a parse that would
+    silently drop them.
+    """
+
+    def __init__(self, tokenizer) -> None:
+        self._tokenizer = tokenizer
+
+    def _apply(self, messages, tools, add_generation_prompt, thinking_mode, tokenize):
+        kwargs: dict[str, Any] = {
+            "add_generation_prompt": add_generation_prompt,
+            "tokenize": tokenize,
+        }
+        if tools:
+            kwargs["tools"] = tools
+        # Qwen and several other templates gate the reasoning block on
+        # `enable_thinking`; templates that do not take it raise TypeError, so
+        # fall back rather than refusing the request.
+        try:
+            return self._tokenizer.apply_chat_template(
+                messages, enable_thinking=(thinking_mode == "thinking"), **kwargs
+            )
+        except TypeError:
+            return self._tokenizer.apply_chat_template(messages, **kwargs)
+
+    def encode(self, req: dict[str, Any]) -> tuple[str, list[int]]:
+        messages = list(req.get("messages") or [])
+        tools = req.get("tools")
+        tools = tools if isinstance(tools, list) and tools else None
+        add_generation_prompt = bool(req.get("add_generation_prompt", True))
+        thinking_mode = req.get("thinking_mode", "chat")
+        # Tokenize through the template rather than re-encoding the rendered
+        # text: a template that emits a BOS would otherwise get a second one
+        # from encode().
+        token_ids = self._apply(messages, tools, add_generation_prompt, thinking_mode, True)
+        prompt_text = self._apply(messages, tools, add_generation_prompt, thinking_mode, False)
+        return str(prompt_text), [int(t) for t in token_ids]
+
+    def parse(self, text: str, thinking_mode: str) -> dict[str, Any]:
+        reasoning = ""
+        content = text
+        marker = "</think>"
+        if marker in text:
+            head, _, tail = text.partition(marker)
+            # A prompt built with enable_thinking ends inside the block, so the
+            # opening tag is usually part of the prompt rather than the answer.
+            reasoning = head.removeprefix("<think>")
+            content = tail
+        elif thinking_mode == "thinking":
+            # Generation stopped before closing the block; all of it is reasoning.
+            reasoning = text.removeprefix("<think>")
+            content = ""
+        return {"content": content, "reasoning_content": reasoning, "tool_calls": []}
+
+
+def build_templater(architecture: str, tokenizer):
+    if architecture == "deepseek_v4":
+        return DeepSeekV4Templater(tokenizer)
+    return ChatTemplateTemplater(tokenizer)
+
+
+def _handle_encode(templater, req: dict[str, Any]) -> None:
+    prompt_text, token_ids = templater.encode(req)
+    _emit({"ok": True, "prompt_text": prompt_text, "token_ids": token_ids})
+
+
+def _handle_parse(templater, req: dict[str, Any]) -> None:
+    parsed = templater.parse(req.get("text", ""), req.get("thinking_mode", "chat"))
     _emit({"ok": True, **parsed})
 
 
 def main() -> int:
+    _configure_stdio()
     parser = argparse.ArgumentParser()
     parser.add_argument("--ckpt", required=True, help="Path to the model checkpoint (used to load the HF tokenizer)")
     parser.add_argument("--tokenizer-path", default=None, help="Optional override for tokenizer directory")
+    parser.add_argument(
+        "--architecture",
+        default=None,
+        help="Architecture already detected by the native model registry",
+    )
     args = parser.parse_args()
 
     tokenizer_path = args.tokenizer_path or args.ckpt
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_path)
-    _emit({"ok": True, "ready": True, "eos_token_id": int(tokenizer.eos_token_id) if tokenizer.eos_token_id is not None else 1})
+    # The C++ server passes the answer from pocket::detect_architecture so the
+    # two halves cannot select different models. Detection here is only the
+    # standalone-script fallback used by tests and manual protocol probes.
+    architecture = args.architecture or detect_architecture(args.ckpt)
+    templater = build_templater(architecture, tokenizer)
+    _emit({
+        "ok": True,
+        "ready": True,
+        "architecture": architecture,
+        "templater": type(templater).__name__,
+        "eos_token_id": int(tokenizer.eos_token_id) if tokenizer.eos_token_id is not None else 1,
+    })
 
     for line in sys.stdin:
         line = line.strip()
@@ -121,9 +254,9 @@ def main() -> int:
         op = req.get("op")
         try:
             if op == "encode":
-                _handle_encode(tokenizer, req)
+                _handle_encode(templater, req)
             elif op == "parse":
-                _handle_parse(req)
+                _handle_parse(templater, req)
             elif op == "ping":
                 _emit({"ok": True, "pong": True})
             elif op == "shutdown":

--- a/tests/test_cpp_backend.py
+++ b/tests/test_cpp_backend.py
@@ -217,6 +217,51 @@ def test_generate_converts_native_results_and_usage() -> None:
     }
 
 
+def test_batched_native_error_is_raised_and_clears_request() -> None:
+    class NativeSamplingParams:
+        pass
+
+    class NativeModule:
+        QwenBatchSamplingParams = NativeSamplingParams
+
+    class NativeResult:
+        error = "synthetic failure"
+
+    class Scheduler:
+        def __init__(self) -> None:
+            self.next_id = 16
+            self.polled = []
+
+        def submit_request(self, prompt_ids, sampling, callback):
+            self.next_id += 1
+            return self.next_id
+
+        def poll_result(self, request_id, timeout_ms):
+            self.polled.append(request_id)
+            return NativeResult()
+
+    backend, _ = make_backend()
+    backend._native = NativeModule()
+    scheduler = Scheduler()
+    backend._scheduler = scheduler
+    backend._batching_enabled = True
+    requests = [
+        GenerationRequest(
+            prompt_tokens=[4, 5],
+            request_id=f"req-native-error-{index}",
+            sampling_params=SamplingParams(max_tokens=1),
+        )
+        for index in range(2)
+    ]
+
+    with pytest.raises(RuntimeError, match="native C\\+\\+ generation failed: synthetic failure"):
+        backend.generate(requests)
+
+    assert scheduler.polled == [17, 18]
+    assert backend.active_request_count() == 0
+    backend.close()
+
+
 def test_stream_matches_native_prefill_decode_order() -> None:
     backend, engine = make_backend()
     request = GenerationRequest(

--- a/tests/test_cpp_sidecar.py
+++ b/tests/test_cpp_sidecar.py
@@ -1,0 +1,118 @@
+import json
+
+from src.server.cpp_sidecar import ChatTemplateTemplater, detect_architecture
+
+
+class RecordingTokenizer:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.calls.append((messages, kwargs))
+        return [7, 8, 9] if kwargs["tokenize"] else "rendered prompt"
+
+
+class NoThinkingArgumentTokenizer:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def apply_chat_template(
+        self,
+        messages,
+        *,
+        add_generation_prompt,
+        tokenize,
+    ):
+        self.calls.append((messages, add_generation_prompt, tokenize))
+        return [4, 5] if tokenize else "fallback prompt"
+
+
+def test_cpp_sidecar_detects_root_and_nested_architectures(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "config.json").write_text(
+        json.dumps({"model_type": "DeepSeek_V4"}), encoding="utf-8"
+    )
+    assert detect_architecture(str(root)) == "deepseek_v4"
+
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "config.json").write_text(
+        json.dumps({"text_config": {"model_type": "Qwen3_5_Text"}}),
+        encoding="utf-8",
+    )
+    assert detect_architecture(str(nested)) == "qwen3_5"
+
+    undeclared = tmp_path / "undeclared"
+    undeclared.mkdir()
+    (undeclared / "config.json").write_text("{}", encoding="utf-8")
+    assert detect_architecture(str(undeclared)) == ""
+
+
+def test_generic_sidecar_uses_checkpoint_chat_template_for_ids_and_text():
+    tokenizer = RecordingTokenizer()
+    templater = ChatTemplateTemplater(tokenizer)
+    messages = [{"role": "user", "content": "hello"}]
+    tools = [{"type": "function", "function": {"name": "weather"}}]
+
+    prompt, token_ids = templater.encode(
+        {
+            "messages": messages,
+            "tools": tools,
+            "thinking_mode": "thinking",
+            "add_generation_prompt": True,
+        }
+    )
+
+    assert prompt == "rendered prompt"
+    assert token_ids == [7, 8, 9]
+    assert len(tokenizer.calls) == 2
+    for seen_messages, kwargs in tokenizer.calls:
+        assert seen_messages == messages
+        assert kwargs["tools"] == tools
+        assert kwargs["add_generation_prompt"] is True
+        assert kwargs["enable_thinking"] is True
+    assert tokenizer.calls[0][1]["tokenize"] is True
+    assert tokenizer.calls[1][1]["tokenize"] is False
+
+
+def test_generic_sidecar_falls_back_when_template_has_no_thinking_argument():
+    tokenizer = NoThinkingArgumentTokenizer()
+    prompt, token_ids = ChatTemplateTemplater(tokenizer).encode(
+        {
+            "messages": [{"role": "user", "content": "hello"}],
+            "thinking_mode": "chat",
+        }
+    )
+
+    assert prompt == "fallback prompt"
+    assert token_ids == [4, 5]
+    # Each render first tries enable_thinking, then retries without it.
+    assert len(tokenizer.calls) == 2
+    assert tokenizer.calls[0][2] is True
+    assert tokenizer.calls[1][2] is False
+
+
+def test_generic_sidecar_splits_reasoning_into_protocol_field():
+    templater = ChatTemplateTemplater(RecordingTokenizer())
+
+    parsed = templater.parse("work it out</think>final answer", "thinking")
+    assert parsed == {
+        "content": "final answer",
+        "reasoning_content": "work it out",
+        "tool_calls": [],
+    }
+
+    unfinished = templater.parse("still reasoning", "thinking")
+    assert unfinished == {
+        "content": "",
+        "reasoning_content": "still reasoning",
+        "tool_calls": [],
+    }
+
+    chat = templater.parse(" plain answer ", "chat")
+    assert chat == {
+        "content": " plain answer ",
+        "reasoning_content": "",
+        "tool_calls": [],
+    }


### PR DESCRIPTION
## Summary

- Route the native OpenAI-compatible server through `InferenceEngine` and `BatchScheduler` instead of the DeepSeek-V4-only `PersistentEngine` surface.
- Serve any architecture registered in the native model registry; Qwen now reaches the C++ server with paged KV and continuous batching, while DeepSeek-V4 remains truthfully clamped to one slot.
- Keep model-specific chat protocol handling behind the Python sidecar while using each other checkpoint's own Hugging Face chat template.

## Implementation notes

- Added tensor-parallel lifecycle hooks to `InferenceEngine` and implemented them for Qwen and the persistent-engine adapter.
- Added explicit sampling capabilities so the server rejects unsupported per-request settings instead of silently substituting process-wide values.
- Added nonblocking per-token scheduler callbacks. Scheduler callbacks enqueue tokens; HTTP threads own all socket writes, so a slow client cannot block the scheduler loop.
- Made engine forward failures terminal scheduler results and surfaced them through HTTP, SSE, and the Python backend.
- Fixed scheduler result delivery and generation semantics:
  - the prefill prediction counts as generation token one;
  - stop tokens remain in engine/scheduler state but are not emitted as visible output;
  - callback-mode results are not duplicated into the polling map;
  - engine errors are not retried until request timeout.
- Moved `openai_server.cpp` from `core/` to `engine/` because the server now depends on the scheduler and device runtime; `pocket_core` remains independently linkable.
- Generalized the TP4 launcher with registry selection, full-depth defaults, configurable batch width, paged KV, block size, extra arguments, and process cleanup.
- The direct `--serve` CLI now loads the checkpoint's full depth unless `--smoke-layers` is explicitly supplied.

## Testing

- CUDA Release C++ build: pass.
- Python extension build: pass.
- NCCL linkage verified with `ldd`.
- `check_layering`: pass, 64 files clean.
- `test_model_registry`: pass.
- New host-only `test_scheduler_callbacks`: pass.
- Focused Python backend and sidecar tests: **35 passed**.
- Python binding smoke for `SchedulerGenerationResult.error` and registry listing: pass.
- Single-rank Qwen server smoke: health, model listing, non-stream, SSE, exact `max_tokens`, and unsupported-sampling rejection all pass.
- Single-rank DeepSeek-V4 server smoke: pass; scheduler reports and enforces width 1 / prefill budget 0.
- TP4 Qwen server smoke: health, non-stream, SSE, and two simultaneous 8-token requests pass with no NCCL warnings.
- Existing C++ test-binary exit-code comparison against `master`: no differences except the new passing scheduler callback test. The TP-context-only smoke aborts identically on both when launched standalone.
- Final TP4 token-exact digests match `master` in all six configurations:

| KV mode | Batch | Digest |
|---|---:|---|
| contiguous | 1 | `df92123420008a37` |
| paged | 1 | `df92123420008a37` |
| contiguous | 4 | `2c2fdc7199eb3f43` |
| paged | 4 | `2c2fdc7199eb3f43` |
| contiguous | 8 | `156efc37fb5e762a` |
| paged | 8 | `156efc37fb5e762a` |

The latest tracked Python-suite run reports **387 passed, 82 skipped, 12 failed, 4 errors**. Eight failures and all four errors are the existing baseline set. The four additional failures are unrelated CUDA-extension tests after the checked-in `cuda_kernel.so` failed to import with an unresolved PyTorch CUDA symbol; all 35 tests directly covering this change pass.

## Performance impact

Real `/mnt/data2/Qwen3.8-27B-FP8`, TP4, one configuration per process, TG64:

| Context | Metric | `master` | This PR | Delta |
|---:|---|---:|---:|---:|
| 8K | Prefill | 1845.62 tok/s | 1844.82 tok/s | -0.04% |
| 8K | Decode TG64 | 45.4711 tok/s | 45.4321 tok/s | -0.09% |
| 65K | Prefill | 1473.88 tok/s | 1471.16 tok/s | -0.18% |
| 65K | Decode TG64 | 40.7442 tok/s | 40.6398 tok/s | -0.26% |

All changes are within measurement noise; rank token parity and GPU memory usage are unchanged.

## Checklist

- [x] Registered Qwen and DeepSeek-V4 engines share one native server path
- [x] Engine capabilities govern scheduling and sampling behavior
- [x] Streaming does not perform socket I/O on the scheduler thread
- [x] TP4 launch and concurrent-request smoke validated
- [x] Token-exact parity validated against `master`
- [x] Short and long real-checkpoint performance A/B completed
- [x] Focused C++ and Python tests added
- [x] Unrelated working-tree files excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
