### PR TITLE
Extract Qwen layer execution components

### DIFF
--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -1,4 +1,5 @@
 #include "qwen_engine.hpp"
+#include "qwen_layer_components.hpp"
 
 #include <chrono>
 #include <unordered_map>
@@ -79,71 +80,68 @@ int qwen_env_int(const char* name, int fallback) {
     return static_cast<int>(parsed);
 }
 
-// The wide 128x64 tile only pays off once the batch fills its row span; below
-// that the WMMA path stays cheaper. Enabled by default above the row threshold.
-bool qwen_nvfp4_wide_n64_enabled(int rows) {
-    return rows >= qwen_env_int("POCKETLLM_QWEN_NVFP4_WIDE_N64_MIN_ROWS", 128) &&
-           qwen_env_enabled_default("POCKETLLM_QWEN_NVFP4_WIDE_N64");
+using qwen_components::DeviceLayer;
+using qwen_components::DeviceLinear;
+using qwen_components::LayerExecutionConfig;
+using qwen_components::NvFp4Mode;
+using qwen_components::OptionalSwitch;
+
+NvFp4Mode qwen_nvfp4_mode() {
+    const char* value = std::getenv("POCKETLLM_QWEN_NVFP4");
+    if (value == nullptr || *value == '\0' || std::strcmp(value, "auto") == 0) {
+        return NvFp4Mode::Auto;
+    }
+    if (std::strcmp(value, "dp4a") == 0) return NvFp4Mode::Dp4a;
+    if (std::strcmp(value, "wmma") == 0) return NvFp4Mode::Wmma;
+    if (std::strcmp(value, "reference") == 0) return NvFp4Mode::Reference;
+    return NvFp4Mode::Invalid;
 }
 
-struct DeviceLinear {
-    QwenLinearKind kind = QwenLinearKind::DenseF16;
-    std::vector<uint64_t> logical_shape;
-    QwenDeviceTensor weight;
-    QwenDeviceTensor scale;
-    // Optional dense FP16 expansion used only by batched target verification.
-    // The raw FP8 matrix remains canonical and serves decode/prefill.
-    QwenDeviceTensor verify_weight;
-    // NVFP4 tensor-level scaling. The factor is reciprocal(weight_global_scale);
-    // input_global_scale is calibration metadata the SM75 path does not apply.
-    float weight_global_factor = 1.0f;
-    float input_global_scale = 1.0f;
-};
+OptionalSwitch qwen_optional_switch(const char* name) {
+    if (std::getenv(name) == nullptr) return OptionalSwitch::Auto;
+    return qwen_env_enabled(name) ? OptionalSwitch::Enabled
+                                  : OptionalSwitch::Disabled;
+}
 
-struct DeviceLinearAttention {
-    DeviceLinear qkv;
-    DeviceLinear z;
-    DeviceLinear out;
-    DeviceLinear a;
-    DeviceLinear b;
-    // Row-concat of a and b; empty when the two cannot be fused.
-    DeviceLinear ab;
-    QwenDeviceTensor conv;
-    QwenDeviceTensor a_log;
-    QwenDeviceTensor dt_bias;
-    QwenDeviceTensor norm;
-    QwenDeviceTensor state;
-    QwenDeviceTensor conv_tail;
-};
-
-struct DeviceFullAttention {
-    DeviceLinear q;
-    DeviceLinear k;
-    DeviceLinear v;
-    // Row-concat of K and V for batched verify/prefill. Decode keeps the
-    // individual projections so its established one-row path is unchanged.
-    DeviceLinear kv;
-    DeviceLinear out;
-    QwenDeviceTensor q_norm;
-    QwenDeviceTensor k_norm;
-    QwenDeviceTensor k_cache;
-    QwenDeviceTensor v_cache;
-    QwenDeviceTensor k_scale;
-    QwenDeviceTensor v_scale;
-    // TurboQuant K8V4 combined cache: 196-byte slots with FP8 E5M2 key + 4-bit
-    // value + FP16 metadata. Only allocated when kv_cache_dtype is TurboQuantK8V4.
-    QwenDeviceTensor turboquant_cache;
-};
-
-struct DeviceLayer {
-    QwenDeviceTensor input_norm;
-    QwenDeviceTensor post_norm;
-    DeviceLinearAttention linear;
-    DeviceFullAttention full;
-    DeviceLinear gate;
-    DeviceLinear up;
-    DeviceLinear down;
-};
+LayerExecutionConfig read_layer_execution_config() {
+    LayerExecutionConfig config;
+    config.nvfp4_mode = qwen_nvfp4_mode();
+    config.nvfp4_wide_n64 =
+        qwen_env_enabled_default("POCKETLLM_QWEN_NVFP4_WIDE_N64");
+    config.nvfp4_wide_n64_min_rows = qwen_env_int(
+        "POCKETLLM_QWEN_NVFP4_WIDE_N64_MIN_ROWS", 128);
+    const char* fused_nvfp4 =
+        std::getenv("POCKETLLM_QWEN_NVFP4_FUSED_SWIGLU");
+    config.nvfp4_fused_swiglu = fused_nvfp4 != nullptr &&
+        std::strcmp(fused_nvfp4, "1") == 0;
+    const char* shared_nvfp4 =
+        std::getenv("POCKETLLM_QWEN_NVFP4_SHARED_Q8_SWIGLU");
+    config.nvfp4_shared_q8_swiglu = shared_nvfp4 == nullptr ||
+        std::strcmp(shared_nvfp4, "0") != 0;
+    config.verify_small_fp16_cublas =
+        qwen_env_enabled_default("QWEN_VERIFY_SMALL_FP16_CUBLAS");
+    config.gated_delta_flashqla =
+        qwen_env_enabled_default("QWEN_GATED_DELTA_FLASHQLA_SM75");
+    config.fuse_qkvz_decode = qwen_env_enabled("QWEN_FUSE_QKVZ_DECODE");
+    config.fuse_ab_projection =
+        qwen_env_enabled_default("QWEN_FUSE_AB_PROJECTION");
+    config.gated_delta_prenormalize =
+        qwen_env_enabled_default("QWEN_GATED_DELTA_PRENORMALIZE");
+    config.gated_delta_shared_state =
+        qwen_env_enabled("QWEN_GATED_DELTA_SHARED_STATE");
+    config.fuse_full_qkv_decode =
+        qwen_env_enabled("QWEN_FUSE_FULL_QKV_DECODE");
+    config.gqa_optimized =
+        qwen_env_enabled_default("POCKETLLM_QWEN_GQA_OPTIMIZED");
+    config.gqa_verify_cublas_qk =
+        qwen_env_enabled("QWEN_GQA_VERIFY_CUBLAS_QK");
+    config.gqa_verify_split = qwen_optional_switch("QWEN_GQA_VERIFY_SPLIT");
+    config.gqa_verify_splits = qwen_env_int("QWEN_GQA_VERIFY_SPLITS", 0);
+    config.fuse_attention_residual_norm =
+        qwen_env_enabled_default("QWEN_FUSE_ATTN_RESID_NORM");
+    config.comm_overlap_slices = qwen_env_int("QWEN_COMM_OVERLAP_SLICES", 4);
+    return config;
+}
 
 QwenDeviceTensor upload(const SafeTensorsIndex& index, const QwenTensorRef& ref) {
     return qwen_upload_tensor(index, ref);
@@ -375,6 +373,8 @@ struct QwenWorkspace {
 
 }  // namespace
 
+#include "qwen_layer_components.inl"
+
 const char* qwen_kv_cache_dtype_name(QwenKvCacheDType dtype) {
     switch (dtype) {
         case QwenKvCacheDType::Fp16: return "fp16";
@@ -397,6 +397,13 @@ struct QwenEngine::Impl {
     SafeTensorsIndex& index;
     QwenConfig& config;
     QwenEngineOptions options;
+    LayerExecutionConfig layer_config;
+    qwen_components::Linear linear_component;
+    qwen_components::RMSNorm rms_norm_component;
+    qwen_components::GatedDeltaNetAttention gated_delta_attention_component;
+    qwen_components::GqaAttention gqa_attention_component;
+    qwen_components::FusedGateUpSwiGLU swiglu_component;
+    qwen_components::DecoderLayer decoder_layer_component;
     int max_context = 0;
     std::vector<DeviceLayer> layers;
     QwenDeviceTensor transaction_packed;
@@ -788,6 +795,7 @@ struct QwenEngine::Impl {
          const QwenWeightMap& map, const QwenEngineOptions& options_,
          int max_context_, int active_layers)
         : index(index_), config(config_), options(options_),
+          layer_config(read_layer_execution_config()),
           max_context(max_context_) {
         // Phase 3.2: Initialize max_batch_size from options
         max_batch_size = options_.max_batch_size;
@@ -810,19 +818,14 @@ struct QwenEngine::Impl {
             map.checkpoint_linear_kind_counts();
         telemetry.host_global_metadata_bytes = map.host_global_metadata_bytes();
         if (telemetry.checkpoint_linear_kinds.nvfp4_group16 != 0) {
-            const char* requested = std::getenv("POCKETLLM_QWEN_NVFP4");
-            const bool reference = requested != nullptr &&
-                std::strcmp(requested, "reference") == 0;
-            const bool dp4a = requested != nullptr &&
-                std::strcmp(requested, "dp4a") == 0;
-            const bool wmma = requested != nullptr &&
-                std::strcmp(requested, "wmma") == 0;
-            const bool automatic = requested == nullptr || *requested == '\0' ||
-                std::strcmp(requested, "auto") == 0;
-            if (!reference && !dp4a && !wmma && !automatic) {
+            const NvFp4Mode mode = layer_config.nvfp4_mode;
+            if (mode == NvFp4Mode::Invalid) {
                 throw std::runtime_error(
                     "POCKETLLM_QWEN_NVFP4 must be auto, dp4a, wmma, or reference");
             }
+            const bool reference = mode == NvFp4Mode::Reference;
+            const bool dp4a = mode == NvFp4Mode::Dp4a;
+            const bool wmma = mode == NvFp4Mode::Wmma;
             telemetry.nvfp4_decode_path = reference
                 ? "packed_reference" : wmma ? "q8_group32_wmma" :
                     "q8_group32_dp4a";
@@ -831,20 +834,16 @@ struct QwenEngine::Impl {
             } else if (dp4a) {
                 telemetry.nvfp4_prefill_path = "q8_group32_dp4a";
             } else {
-                const char* fused =
-                    std::getenv("POCKETLLM_QWEN_NVFP4_FUSED_SWIGLU");
-                const char* shared =
-                    std::getenv("POCKETLLM_QWEN_NVFP4_SHARED_Q8_SWIGLU");
-                // Report the path the configured chunk size will actually
-                // take, since the wide tile only engages above a row count.
-                const bool wide = qwen_nvfp4_wide_n64_enabled(
+                // Report the path the configured chunk size will actually take,
+                // since the wide tile only engages above a row count.
+                const bool wide = layer_config.use_nvfp4_wide_n64(
                     std::max(1, options_.prefill_chunk_tokens));
                 telemetry.nvfp4_prefill_path =
-                    fused != nullptr && std::strcmp(fused, "1") == 0
+                    layer_config.nvfp4_fused_swiglu
                         ? "q8_group32_wmma_fused_gate_up_swiglu_experimental"
                         : wide
                               ? "q8_group32_wide_n64_shared_gate_up_q8"
-                        : shared == nullptr || std::strcmp(shared, "0") != 0
+                        : layer_config.nvfp4_shared_q8_swiglu
                               ? "q8_group32_wmma_shared_gate_up_q8"
                               : "q8_group32_wmma";
             }
@@ -1912,9 +1911,7 @@ struct QwenEngine::Impl {
     // The collective is bytes-bound at ~8.8 GB/s of ring bandwidth per rank, so
     // it cannot be made faster, only hidden. Set 0 or 1 to disable.
     int comm_overlap_slices() const {
-        static const int slices =
-            qwen_env_int("QWEN_COMM_OVERLAP_SLICES", 4);
-        return slices;
+        return layer_config.comm_overlap_slices;
     }
 
     // Pipelined projection and all-reduce.
@@ -1965,8 +1962,10 @@ struct QwenEngine::Impl {
         for (int start = 0; start < rows; start += per, ++index) {
             const int count = std::min(per, rows - start);
             const size_t offset = static_cast<size_t>(start) * hidden;
-            projection(linear, input + static_cast<size_t>(start) * linear_columns(linear),
-                       output + offset, count, proj_site);
+            linear_component.forward(
+                *this, linear,
+                input + static_cast<size_t>(start) * linear_columns(linear),
+                output + offset, count, proj_site);
             // Wait for the previous slice's collective only now, so it had the
             // whole of this slice's GEMM to run underneath.
             if (pending) {
@@ -2079,7 +2078,7 @@ struct QwenEngine::Impl {
                 nvfp4_q8_scale.f32_data(), rows, columns, columns)) {
             return false;
         }
-        if (wmma && qwen_nvfp4_wide_n64_enabled(rows)) {
+        if (wmma && layer_config.use_nvfp4_wide_n64(rows)) {
             return qwen_nvfp4_group16_matmul_q8_wide_n64_f16_cuda(
                 static_cast<const int8_t*>(nvfp4_q8.data),
                 nvfp4_q8_scale.f32_data(), linear.weight.u8_data(), output,
@@ -2113,7 +2112,7 @@ struct QwenEngine::Impl {
         }
         const int8_t* q8 = static_cast<const int8_t*>(nvfp4_q8.data);
         const float* q8_scale = nvfp4_q8_scale.f32_data();
-        if (qwen_nvfp4_wide_n64_enabled(rows)) {
+        if (layer_config.use_nvfp4_wide_n64(rows)) {
             return qwen_nvfp4_group16_matmul_q8_wide_n64_f16_cuda(
                        q8, q8_scale, gate.weight.u8_data(), gate_output,
                        rows, output_rows, columns, columns, output_rows,
@@ -2153,129 +2152,6 @@ struct QwenEngine::Impl {
     }
 #endif
 
-    void projection(const DeviceLinear& linear, const uint16_t* input,
-                    uint16_t* output, int rows, const char* site = "other") {
-        PhaseScope scope(this, std::string(rows == 1 ? "pd." : "pr.") + site);
-        if (linear.logical_shape.size() != 2) {
-            throw std::runtime_error("Qwen linear has invalid logical shape");
-        }
-        const int output_rows = static_cast<int>(linear.logical_shape[0]);
-        const int columns = static_cast<int>(linear.logical_shape[1]);
-#ifdef POCKET_BACKEND_ASCEND
-        // Only the dense FP16 kind has an Ascend implementation. The quantized
-        // kinds are rejected here rather than left to a runtime branch: a
-        // reference to their CUDA kernels in this object would make the whole
-        // executable require the CUDA toolchain to link.
-        if (linear.kind != QwenLinearKind::DenseF16) {
-            throw std::runtime_error(
-                std::string("Qwen Ascend path is not implemented for ") +
-                qwen_linear_kind_name(linear.kind));
-        }
-        require_launch(qwen_fp16_matmul_rows_f16(
-            input, linear.weight.f16_data(), output, rows, output_rows,
-            columns, columns, output_rows, columns),
-            "FP16 activation/weight projection");
-        return;
-#else
-        if (linear.kind == QwenLinearKind::Fp8Block128) {
-            if (rows == 1) {
-                require_launch(qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
-                    input, linear.weight.fp8_data(), linear.scale.f16_data(),
-                    output, output_rows, columns, columns,
-                    static_cast<int>(linear.scale.shape[1])),
-                    "FP8 FP16-activation decode projection");
-            } else if (rows <= 8 && linear.verify_weight.data != nullptr) {
-                require_launch(qwen_fp16_matmul_rows_f16_cublas_cuda(
-                    input, linear.verify_weight.f16_data(), output, rows,
-                    output_rows, columns, columns, output_rows, columns),
-                    "resident FP16 verify projection");
-            } else {
-                require_launch(qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
-                    input, linear.weight.fp8_data(), linear.scale.f16_data(),
-                    output, rows, output_rows, columns, columns, output_rows,
-                    columns, static_cast<int>(linear.scale.shape[1])),
-                    "FP8 FP16-activation projection");
-            }
-        } else if (linear.kind == QwenLinearKind::Fp8Channel) {
-            require_launch(rows == 1
-                ? qwen_fp8_e4m3_channel_matvec_f16_cuda(
-                      input, linear.weight.fp8_data(), linear.scale.f16_data(),
-                      output, output_rows, columns, columns)
-                : qwen_fp8_e4m3_channel_matmul_rows_f16_cuda(
-                      input, linear.weight.fp8_data(), linear.scale.f16_data(),
-                      output, rows, output_rows, columns, columns, output_rows,
-                      columns),
-                "channel FP8 FP16-activation projection");
-        } else if (linear.kind == QwenLinearKind::NvFp4Group16) {
-            const char* requested = std::getenv("POCKETLLM_QWEN_NVFP4");
-            const bool reference = requested != nullptr &&
-                std::strcmp(requested, "reference") == 0;
-            const bool explicit_dp4a = requested != nullptr &&
-                std::strcmp(requested, "dp4a") == 0;
-            const bool explicit_wmma = requested != nullptr &&
-                std::strcmp(requested, "wmma") == 0;
-            const bool automatic = requested == nullptr || *requested == '\0' ||
-                std::strcmp(requested, "auto") == 0;
-            if (!reference && !explicit_dp4a && !explicit_wmma && !automatic) {
-                throw std::runtime_error(
-                    "POCKETLLM_QWEN_NVFP4 must be auto, dp4a, wmma, or reference");
-            }
-            const int blocks_per_row = columns / 64;
-            if (!reference) {
-                const bool use_wmma = explicit_wmma || (automatic && rows >= 8);
-                const bool use_wide =
-                    use_wmma && qwen_nvfp4_wide_n64_enabled(rows);
-                require_launch(nvfp4_integer_projection(
-                    linear, input, output, rows, use_wmma),
-                    use_wide ? "NVFP4 group-16 Q8 wide-N64 projection" :
-                    use_wmma ? "NVFP4 group-16 Q8 WMMA projection" :
-                               "NVFP4 group-16 Q8 DP4A projection");
-            } else {
-                require_launch(rows == 1
-                    ? qwen_nvfp4_group16_matvec_f16_cuda(
-                          input, linear.weight.u8_data(), output, output_rows,
-                          columns, blocks_per_row, linear.weight_global_factor)
-                    : qwen_nvfp4_group16_matmul_rows_f16_cuda(
-                          input, linear.weight.u8_data(), output, rows,
-                          output_rows, columns, columns, output_rows,
-                          blocks_per_row, linear.weight_global_factor),
-                    "NVFP4 group-16 reference projection");
-            }
-        } else if (linear.kind == QwenLinearKind::DenseF16) {
-            // The fused DeltaNet a/b matrix is only 24 rows per TP4 rank. At
-            // verify width 8, tensor cores are ~5x faster than the generic
-            // warp-per-output-row reduction. Decode keeps its established
-            // reduction order, and wider prefill remains on the existing path.
-            const bool verify_cublas = rows >= 4 && rows <= 8 &&
-                output_rows <= 32 && columns % 8 == 0 &&
-                qwen_env_enabled_default("QWEN_VERIFY_SMALL_FP16_CUBLAS");
-            if (verify_cublas) {
-                require_launch(qwen_fp16_matmul_rows_f16_cublas_cuda(
-                    input, linear.weight.f16_data(), output, rows, output_rows,
-                    columns, columns, output_rows, columns),
-                    "small FP16 verify cuBLAS projection");
-            } else {
-                require_launch(qwen_fp16_matmul_rows_f16(
-                    input, linear.weight.f16_data(), output, rows, output_rows,
-                    columns, columns, output_rows, columns),
-                    "FP16 activation/weight projection");
-            }
-        } else {
-            throw std::runtime_error(
-                std::string("Qwen linear CUDA path is not implemented for ") +
-                qwen_linear_kind_name(linear.kind));
-        }
-#endif
-    }
-
-    void norm(const QwenDeviceTensor& gamma, const uint16_t* input,
-              uint16_t* output, int rows, int columns) {
-        PhaseScope scope(this, "norm");
-        require_launch(qwen_rmsnorm_fp16_gamma_rows_f16(
-            input, gamma.f16_data(), output, rows, columns,
-            static_cast<float>(config.rms_norm_eps)), "Qwen FP16 RMSNorm");
-    }
-
     void add(uint16_t* output, const uint16_t* input, int count) {
         PhaseScope scope(this, "add");
         require_launch(qwen_add_inplace_f16(output, input, count),
@@ -2292,1024 +2168,6 @@ struct QwenEngine::Impl {
     QwenDeviceTensor& workspace_float(size_t elements,
                                       const std::vector<uint64_t>& shape) {
         return workspace.float_tensor(elements, shape);
-    }
-
-    void linear_attention(DeviceLayer& layer, const uint16_t* hidden,
-                          uint16_t* output, int rows, int position_offset,
-                          int slot_id) {
-        // Phase 3.4: Every kernel below advances this slot's own recurrent
-        // state. Resolved once here so the many call sites cannot disagree.
-        const size_t state_offset = recurrent_slot_offset(slot_id, layer.linear.state);
-        const size_t tail_offset = recurrent_slot_offset(slot_id, layer.linear.conv_tail);
-        float* const state = layer.linear.state.f32_data() + state_offset;
-        uint16_t* const conv_tail = layer.linear.conv_tail.f16_data() + tail_offset;
-        const int key_heads = static_cast<int>(
-            config.linear_attention.key_heads / options.tp_world);
-        const int value_heads = static_cast<int>(
-            config.linear_attention.value_heads / options.tp_world);
-        const int key_dim = key_heads *
-            static_cast<int>(config.linear_attention.key_head_dim);
-        const int value_dim = value_heads *
-            static_cast<int>(config.linear_attention.value_head_dim);
-        const int packed_dim = 2 * key_dim + value_dim;
-        const int kernel = static_cast<int>(config.linear_attention.conv_kernel_dim);
-        const int hidden_size = static_cast<int>(config.hidden_size);
-        const size_t packed_elements = static_cast<size_t>(rows) * packed_dim;
-        const size_t key_elements = static_cast<size_t>(rows) * key_dim;
-        const size_t value_elements = static_cast<size_t>(rows) * value_dim;
-        const size_t gate_elements = static_cast<size_t>(rows) * value_heads;
-        QwenDeviceTensor& packed = workspace_half(
-            packed_elements, {static_cast<uint64_t>(rows),
-                              static_cast<uint64_t>(packed_dim)});
-        QwenDeviceTensor& convolved = workspace_half(packed_elements, packed.shape);
-        QwenDeviceTensor& q = workspace_half(
-            key_elements, {static_cast<uint64_t>(rows),
-                           static_cast<uint64_t>(key_dim)});
-        QwenDeviceTensor& k = workspace_half(key_elements, q.shape);
-        QwenDeviceTensor& v = workspace_half(
-            value_elements, {static_cast<uint64_t>(rows),
-                             static_cast<uint64_t>(value_dim)});
-        QwenDeviceTensor& a = workspace_half(
-            gate_elements, {static_cast<uint64_t>(rows),
-                            static_cast<uint64_t>(value_heads)});
-        QwenDeviceTensor& b = workspace_half(gate_elements, a.shape);
-        QwenDeviceTensor& gates = workspace_half(gate_elements, a.shape);
-        QwenDeviceTensor& beta = workspace_half(gate_elements, a.shape);
-        QwenDeviceTensor& core = workspace_half(value_elements, v.shape);
-        QwenDeviceTensor& z = workspace_half(value_elements, v.shape);
-        QwenDeviceTensor& normalized = workspace_half(value_elements, v.shape);
-        // FlashQLA is an SM75 register/subgroup layout of the same recurrence,
-        // not a distinct operation, so the Ascend build simply does not have the
-        // selector: the normalized sequence kernel below produces the same
-        // result from the same FP32 normalized Q/K.
-#ifndef POCKET_BACKEND_ASCEND
-        QwenDeviceTensor* q_normalized = nullptr;
-        QwenDeviceTensor* k_normalized = nullptr;
-        // Every sequence-recurrence kernel below reads `rows` as consecutive
-        // tokens of one stream. A batched decode step is the opposite: `rows`
-        // independent sequences each advancing one token, so none of them apply
-        // and the batched step kernel handles it instead.
-        const bool flashqla = batch_rows == nullptr && rows >= 8 &&
-            qwen_env_enabled_default("QWEN_GATED_DELTA_FLASHQLA_SM75");
-        if (flashqla) {
-            q_normalized = &workspace_float(
-                key_elements,
-                {static_cast<uint64_t>(rows), static_cast<uint64_t>(key_dim)});
-            k_normalized = &workspace_float(key_elements, q_normalized->shape);
-        }
-#endif
-
-#ifndef POCKET_BACKEND_ASCEND
-        bool dual_qkvz = rows == 1 &&
-            layer.linear.qkv.kind == QwenLinearKind::Fp8Block128 &&
-            layer.linear.z.kind == QwenLinearKind::Fp8Block128 &&
-            qwen_env_enabled("QWEN_FUSE_QKVZ_DECODE");
-#else
-        const bool dual_qkvz = false;
-#endif
-#ifndef POCKET_BACKEND_ASCEND
-        if (dual_qkvz) {
-            PhaseScope dual_scope(this, "pd.lin.qkvz");
-            require_launch(qwen_fp8_e4m3_fp16scale_matvec_dual_f16_cuda(
-                hidden,
-                layer.linear.qkv.weight.fp8_data(),
-                layer.linear.qkv.scale.f16_data(), packed.f16_data(), packed_dim,
-                hidden_size, static_cast<int>(layer.linear.qkv.scale.shape[1]),
-                layer.linear.z.weight.fp8_data(),
-                layer.linear.z.scale.f16_data(), z.f16_data(), value_dim,
-                hidden_size, static_cast<int>(layer.linear.z.scale.shape[1]),
-                hidden_size), "dual FP8 QKV/Z decode projection");
-        } else
-#endif
-        {
-            projection(layer.linear.qkv, hidden, packed.f16_data(), rows,
-                       "lin.qkv");
-        }
-#ifndef POCKET_BACKEND_ASCEND
-        if (batch_rows != nullptr) {
-            // One token per sequence against that sequence's own tail. The
-            // pointer is the arena base here, not this slot's rows, because the
-            // kernel resolves the slot per row.
-            require_launch(qwen_causal_depthwise_conv_silu_f16_batched_cuda(
-                packed.f16_data(), layer.linear.conv.f16_data(),
-                layer.linear.conv_tail.f16_data(), convolved.f16_data(),
-                batch_rows->slot_ids, rows, packed_dim, kernel,
-                slot_stride_elements(layer.linear.conv_tail)),
-                "FP16 batched linear causal convolution");
-        } else
-#endif
-        require_launch(qwen_causal_depthwise_conv_silu_f16(
-            packed.f16_data(), layer.linear.conv.f16_data(),
-            conv_tail, convolved.f16_data(), rows,
-            packed_dim, kernel, true), "FP16 linear causal convolution");
-        require_launch(qwen_split_packed_qkv_f16(
-            convolved.f16_data(), q.f16_data(), k.f16_data(), v.f16_data(),
-            rows, key_dim, value_dim), "FP16 linear QKV split");
-        if (layer.linear.ab.weight.data != nullptr &&
-            qwen_env_enabled_default("QWEN_FUSE_AB_PROJECTION")) {
-            // One GEMM over the row-concatenated [2*gate, hidden] weight. The
-            // output is [rows, 2*gate] interleaved per row, so a and b are
-            // strided slices of it rather than contiguous halves.
-            QwenDeviceTensor& ab = workspace_half(
-                gate_elements * 2,
-                {static_cast<uint64_t>(rows),
-                 static_cast<uint64_t>(value_heads * 2)});
-            projection(layer.linear.ab, hidden, ab.f16_data(), rows, "lin.ab");
-            require_launch(qwen_split_rows_pair_f16(
-                ab.f16_data(), a.f16_data(), b.f16_data(), rows, value_heads),
-                "FP16 fused a/b split");
-        } else {
-            projection(layer.linear.a, hidden, a.f16_data(), rows, "lin.a");
-            projection(layer.linear.b, hidden, b.f16_data(), rows, "lin.b");
-        }
-        require_launch(qwen_linear_attn_gates_f16(
-            a.f16_data(), b.f16_data(), layer.linear.a_log.f16_data(),
-            layer.linear.dt_bias.f16_data(), gates.f16_data(), beta.f16_data(),
-            rows, value_heads), "FP16 linear attention gates");
-        const float q_scale = 1.0f / std::sqrt(
-            static_cast<float>(config.linear_attention.key_head_dim));
-        std::optional<PhaseScope> delta_scope;
-        delta_scope.emplace(this, "gated_delta");
-        bool sequenced = false;
-#ifndef POCKET_BACKEND_ASCEND
-        if (batch_rows != nullptr) {
-            sequenced = qwen_gated_delta_step_batched_f16_cuda(
-                layer.linear.state.f32_data(), q.f16_data(), k.f16_data(),
-                v.f16_data(), gates.f16_data(), beta.f16_data(),
-                core.f16_data(), batch_rows->slot_ids, rows, value_heads,
-                key_heads,
-                static_cast<int>(config.linear_attention.key_head_dim),
-                static_cast<int>(config.linear_attention.value_head_dim),
-                q_scale, slot_stride_elements(layer.linear.state));
-            require_launch(sequenced, "FP16 batched linear recurrent state");
-        } else if (flashqla) {
-            // FlashQLA SM75 subgroup-sharded kernel. Still a serial recurrence,
-            // but sharding the [128, 128] state over 16-lane subgroups replaces
-            // the baseline's 128-element per-thread register vector: 1.85x on the
-            // primitive and +5-7% real TP4 prefill at token-exact parity.
-            // Consume the established FP32 normalized Q/K tensors so the norm
-            // reduction order remains identical to the reference path.
-            sequenced = qwen_normalize_gated_delta_qk_f16(
-                q.f16_data(), k.f16_data(), q_normalized->f32_data(),
-                k_normalized->f32_data(), rows, key_heads,
-                static_cast<int>(config.linear_attention.key_head_dim)) &&
-                qwen_gated_delta_flashqla_sm75_f16_cuda(
-                    state, q_normalized->f32_data(),
-                    k_normalized->f32_data(), v.f16_data(), gates.f16_data(),
-                    beta.f16_data(), core.f16_data(), rows, value_heads,
-                    key_heads,
-                    static_cast<int>(config.linear_attention.key_head_dim),
-                    static_cast<int>(config.linear_attention.value_head_dim),
-                    q_scale);
-        } else
-#endif
-        if (rows >= 5 && key_heads < value_heads &&
-            qwen_env_enabled_default("QWEN_GATED_DELTA_PRENORMALIZE")) {
-            QwenDeviceTensor& q_normalized = workspace_float(
-                key_elements, {static_cast<uint64_t>(rows),
-                               static_cast<uint64_t>(key_dim)});
-            QwenDeviceTensor& k_normalized = workspace_float(
-                key_elements, q_normalized.shape);
-            sequenced = qwen_normalize_gated_delta_qk_f16(
-                q.f16_data(), k.f16_data(), q_normalized.f32_data(),
-                k_normalized.f32_data(), rows, key_heads,
-                static_cast<int>(config.linear_attention.key_head_dim)) &&
-                (qwen_env_enabled("QWEN_GATED_DELTA_SHARED_STATE")
-                 ? qwen_gated_delta_sequence_normalized_shared_f16(
-                        state, q_normalized.f32_data(),
-                        k_normalized.f32_data(), v.f16_data(), gates.f16_data(),
-                        beta.f16_data(), core.f16_data(), rows, value_heads,
-                        key_heads,
-                        static_cast<int>(config.linear_attention.key_head_dim),
-                        static_cast<int>(config.linear_attention.value_head_dim),
-                        q_scale)
-                    : qwen_gated_delta_sequence_normalized_f16(
-                        state, q_normalized.f32_data(),
-                        k_normalized.f32_data(), v.f16_data(), gates.f16_data(),
-                        beta.f16_data(), core.f16_data(), rows, value_heads,
-                        key_heads,
-                        static_cast<int>(config.linear_attention.key_head_dim),
-                        static_cast<int>(config.linear_attention.value_head_dim),
-                        q_scale));
-        } else {
-            // Also covers rows == 1. Decode used to fall through to the step
-            // loop below, which round-trips the [128, 128] state through global
-            // memory twice per token; the sequence kernel holds it in registers
-            // and is bit-exact against the step kernel, so there is no reason to
-            // reserve it for multi-token chunks. See the step-vs-sequence parity
-            // check in test_qwen_half_ops.
-            sequenced = qwen_gated_delta_sequence_f16(
-                state, q.f16_data(), k.f16_data(),
-                v.f16_data(), gates.f16_data(), beta.f16_data(),
-                core.f16_data(), rows, value_heads, key_heads,
-                static_cast<int>(config.linear_attention.key_head_dim),
-                static_cast<int>(config.linear_attention.value_head_dim), q_scale);
-        }
-        for (int token = 0; !sequenced && token < rows; ++token) {
-            require_launch(qwen_gated_delta_step_f16(
-                state,
-                q.f16_data() + static_cast<size_t>(token) * key_dim,
-                k.f16_data() + static_cast<size_t>(token) * key_dim,
-                v.f16_data() + static_cast<size_t>(token) * value_dim,
-                gates.f16_data() + static_cast<size_t>(token) * value_heads,
-                beta.f16_data() + static_cast<size_t>(token) * value_heads,
-                core.f16_data() + static_cast<size_t>(token) * value_dim,
-                value_heads, key_heads,
-                static_cast<int>(config.linear_attention.key_head_dim),
-                static_cast<int>(config.linear_attention.value_head_dim), q_scale),
-                "FP16 linear recurrent state");
-        }
-        delta_scope.reset();
-        if (!dual_qkvz) {
-            projection(layer.linear.z, hidden, z.f16_data(), rows, "lin.z");
-        }
-        require_launch(qwen_gated_rmsnorm_fp16_gamma_rows_f16(
-            core.f16_data(), layer.linear.norm.f16_data(), z.f16_data(),
-            normalized.f16_data(), rows * value_heads,
-            static_cast<int>(config.linear_attention.value_head_dim),
-            static_cast<float>(config.rms_norm_eps)),
-            "FP16 linear gated RMSNorm");
-        // ar.lin.out is the second-largest collective (2.69 s at 32K) and runs on
-        // the 48 DeltaNet layers, so it is the other worthwhile overlap site.
-        if (!projection_all_reduce_overlapped(
-                layer.linear.out, normalized.f16_data(), output, rows,
-                hidden_size, "lin.out", "lin.out")) {
-            projection(layer.linear.out, normalized.f16_data(), output, rows,
-                       "lin.out");
-            all_reduce_half(output, rows * hidden_size, "lin.out");
-        }
-        (void)position_offset;
-    }
-
-    void full_attention(DeviceLayer& layer, const uint16_t* hidden,
-                        uint16_t* output, int rows, int position_offset,
-                        int slot_id) {
-        PhaseScope scope(this, "full_attention");
-        const int q_heads = static_cast<int>(
-            config.full_attention.num_heads / options.tp_world);
-        const int kv_heads = static_cast<int>(
-            config.full_attention.num_key_value_heads / options.tp_world);
-        const int head_dim = static_cast<int>(config.full_attention.head_dim);
-        const int attention_dim = q_heads * head_dim;
-        const int q_projection_dim = attention_dim * 2;
-        const size_t q_projection_elements =
-            static_cast<size_t>(rows) * q_projection_dim;
-        const size_t attention_elements =
-            static_cast<size_t>(rows) * attention_dim;
-        const size_t kv_elements =
-            static_cast<size_t>(rows) * kv_heads * head_dim;
-        QwenDeviceTensor& q_projection = workspace_half(
-            q_projection_elements, {static_cast<uint64_t>(rows),
-                                    static_cast<uint64_t>(q_projection_dim)});
-        QwenDeviceTensor& q = workspace_half(
-            attention_elements, {static_cast<uint64_t>(rows),
-                                 static_cast<uint64_t>(attention_dim)});
-        QwenDeviceTensor& gate = workspace_half(attention_elements, q.shape);
-        QwenDeviceTensor& k = workspace_half(
-            kv_elements, {static_cast<uint64_t>(rows),
-                          static_cast<uint64_t>(kv_heads),
-                          static_cast<uint64_t>(head_dim)});
-        QwenDeviceTensor& v = workspace_half(kv_elements, k.shape);
-        QwenDeviceTensor* kv_projection = nullptr;
-        // Keep the candidate isolated to the fixed-width target verify batch;
-        // prefill and one-row decode retain their established K/V projections.
-        const bool fused_kv = rows > 1 && rows <= 8 &&
-            layer.full.kv.weight.data != nullptr;
-        if (fused_kv) {
-            kv_projection = &workspace_half(
-                static_cast<size_t>(rows) * 2 * kv_heads * head_dim,
-                {static_cast<uint64_t>(rows),
-                 static_cast<uint64_t>(2 * kv_heads * head_dim)});
-        }
-        QwenDeviceTensor& q_norm = workspace_half(attention_elements, q.shape);
-        QwenDeviceTensor& k_norm = workspace_half(kv_elements, k.shape);
-        QwenDeviceTensor& attention = workspace_half(attention_elements, q.shape);
-        QwenDeviceTensor& merged = workspace_half(attention_elements, q.shape);
-
-        const int hidden_size = static_cast<int>(config.hidden_size);
-#ifndef POCKET_BACKEND_ASCEND
-        const bool grouped_qkv = rows == 1 && !fused_kv &&
-            layer.full.q.kind == QwenLinearKind::Fp8Block128 &&
-            layer.full.k.kind == QwenLinearKind::Fp8Block128 &&
-            layer.full.v.kind == QwenLinearKind::Fp8Block128 &&
-            qwen_env_enabled("QWEN_FUSE_FULL_QKV_DECODE");
-        if (grouped_qkv) {
-            PhaseScope sub(this, "pd.full.qkv");
-            require_launch(qwen_fp8_e4m3_fp16scale_matvec_triple_f16_cuda(
-                hidden, layer.full.q.weight.fp8_data(),
-                layer.full.q.scale.f16_data(), q_projection.f16_data(),
-                q_projection_dim, hidden_size,
-                static_cast<int>(layer.full.q.scale.shape[1]),
-                layer.full.k.weight.fp8_data(), layer.full.k.scale.f16_data(),
-                k.f16_data(), kv_heads * head_dim, hidden_size,
-                static_cast<int>(layer.full.k.scale.shape[1]),
-                layer.full.v.weight.fp8_data(), layer.full.v.scale.f16_data(),
-                v.f16_data(), kv_heads * head_dim, hidden_size,
-                static_cast<int>(layer.full.v.scale.shape[1]), hidden_size),
-                "triple FP8 full Q/K/V decode projection");
-        } else
-#endif
-        {
-            { PhaseScope sub(this, "full.q_proj"); projection(layer.full.q, hidden, q_projection.f16_data(), rows, "full.q"); }
-            if (fused_kv) {
-                { PhaseScope sub(this, "full.kv_proj"); projection(
-                    layer.full.kv, hidden, kv_projection->f16_data(), rows,
-                    "full.kv"); }
-                require_launch(qwen_split_rows_pair_f16(
-                    kv_projection->f16_data(), k.f16_data(), v.f16_data(), rows,
-                    kv_heads * head_dim), "FP16 fused full K/V split");
-            } else {
-                { PhaseScope sub(this, "full.k_proj"); projection(layer.full.k, hidden, k.f16_data(), rows, "full.k"); }
-                { PhaseScope sub(this, "full.v_proj"); projection(layer.full.v, hidden, v.f16_data(), rows, "full.v"); }
-            }
-        }
-        require_launch(qwen_split_q_gate_f16(
-            q_projection.f16_data(), q.f16_data(), gate.f16_data(), rows,
-            q_heads, head_dim), "FP16 full Q/gate split");
-        norm(layer.full.q_norm, q.f16_data(), q_norm.f16_data(),
-             rows * q_heads, head_dim);
-        norm(layer.full.k_norm, k.f16_data(), k_norm.f16_data(),
-             rows * kv_heads, head_dim);
-#ifndef POCKET_BACKEND_ASCEND
-        if (batch_rows != nullptr) {
-            // Each row is a different sequence at its own position, so the
-            // rotation angle is per row rather than position_offset + row.
-            require_launch(qwen_partial_rope_rows_f16_batched_cuda(
-                q_norm.f16_data(), k_norm.f16_data(), batch_rows->positions,
-                rows, static_cast<int>(config.partial_rotary_dim()),
-                static_cast<float>(config.rope_theta), q_heads, kv_heads,
-                head_dim), "FP16 batched partial RoPE");
-        } else
-#endif
-        require_launch(qwen_partial_rope_rows_f16(
-            q_norm.f16_data(), k_norm.f16_data(), position_offset, rows,
-            static_cast<int>(config.partial_rotary_dim()),
-            static_cast<float>(config.rope_theta), q_heads, kv_heads, head_dim),
-            "FP16 partial RoPE");
-
-        const QwenKvCacheDType cache_dtype = options.kv_cache_dtype;
-        const int attention_window = options.attention_window;
-        const int sink_tokens = options.attention_sink_tokens;
-#ifdef POCKET_BACKEND_ASCEND
-        // The engine constructor rejects every non-FP16 cache dtype on this
-        // backend, so only the FP16 append and the three neutral attention
-        // launchers are compiled. The quantized caches are not merely disabled:
-        // naming their kernels here would put a CUDA dependency in this object.
-
-        // Phase 3.3: Use slot_id parameter instead of global current_slot_id
-        const size_t slot_offset = kv_slot_offset_elements(slot_id, kv_heads, head_dim);
-
-        require_launch(qwen_append_kv_cache_f16(
-            k_norm.f16_data(), v.f16_data(),
-            layer.full.k_cache.f16_data() + slot_offset,
-            layer.full.v_cache.f16_data() + slot_offset,
-            rows, kv_heads, head_dim,
-            position_offset, max_context), "append FP16 full KV cache");
-
-        if (rows == 1) {
-            const int context_length = position_offset + 1;
-            QwenDeviceTensor& scores = workspace_float(
-                static_cast<size_t>(q_heads) * context_length,
-                {static_cast<uint64_t>(q_heads),
-                 static_cast<uint64_t>(context_length)});
-            require_launch(qwen_gqa_decode_attention_f16(
-                q_norm.f16_data(),
-                layer.full.k_cache.f16_data() + slot_offset,
-                layer.full.v_cache.f16_data() + slot_offset,
-                attention.f16_data(),
-                scores.f32_data(), q_heads, kv_heads, head_dim,
-                context_length, max_context), "decode FP16-cache GQA");
-        } else if (rows <= 8) {
-            const int context_length = position_offset + rows;
-            // Same split geometry the CUDA verify path uses, so a verify block
-            // reduces its partials in the same order on both backends.
-            const int default_splits = context_length >= 1024 ? 64 : 32;
-            int target_splits = qwen_env_int(
-                "QWEN_GQA_VERIFY_SPLITS", default_splits);
-            if (target_splits <= 0) target_splits = default_splits;
-            const int verify_splits = std::max(
-                1, std::min(target_splits, context_length));
-            QwenDeviceTensor& partials = workspace_float(
-                static_cast<size_t>(rows) * q_heads * verify_splits *
-                    static_cast<size_t>(head_dim + 2),
-                {static_cast<uint64_t>(rows), static_cast<uint64_t>(q_heads),
-                 static_cast<uint64_t>(verify_splits),
-                 static_cast<uint64_t>(head_dim + 2)});
-            PhaseScope sub(this, "full.attn_kernel");
-            require_launch(qwen_gqa_verify_attention_f16(
-                q_norm.f16_data(),
-                layer.full.k_cache.f16_data() + slot_offset,
-                layer.full.v_cache.f16_data() + slot_offset,
-                attention.f16_data(),
-                partials.f32_data(), rows, q_heads, kv_heads, head_dim,
-                position_offset, max_context, verify_splits),
-                "verify split FP16-cache GQA");
-        } else {
-            require_launch(qwen_gqa_prefill_attention_f16(
-                q_norm.f16_data(),
-                layer.full.k_cache.f16_data() + slot_offset,
-                layer.full.v_cache.f16_data() + slot_offset,
-                attention.f16_data(), rows,
-                q_heads, kv_heads, head_dim, position_offset, max_context),
-                "prefill FP16-cache GQA");
-        }
-        (void)sink_tokens;
-#else
-        // Phase 3.3: Use slot_id parameter instead of global current_slot_id
-        const size_t slot_offset = kv_slot_offset_elements(slot_id, kv_heads, head_dim);
-        // Distance between slots in the KV arena. kv_slot_offset_elements folds
-        // this to zero for a single session, so the stride is recomputed rather
-        // than divided out of it.
-        const size_t kv_slot_stride = static_cast<size_t>(max_context) *
-            kv_heads * head_dim;
-
-        if (batch_rows != nullptr) {
-            // Each row appends its new K/V at its own position in its own slot.
-            // Under paging the slot stride is replaced by the block table, which
-            // the caller has already grown and uploaded for these positions.
-            require_launch(qwen_append_kv_cache_f16_batched_cuda(
-                k_norm.f16_data(), v.f16_data(),
-                layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
-                rows, kv_heads, head_dim, batch_rows->positions,
-                batch_rows->slot_ids, max_context, kv_slot_stride,
-                block_table_data(), paged_block_size(),
-                paged_blocks_per_seq()),
-                "append batched FP16 full KV cache");
-        } else if (kv_paged()) {
-            // Single-sequence paged append: consecutive positions of one
-            // sequence, scattered across the blocks its row names.
-            require_launch(qwen_append_kv_cache_f16_paged_cuda(
-                k_norm.f16_data(), v.f16_data(),
-                layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
-                rows, kv_heads, head_dim, position_offset,
-                block_table_row(slot_id), paged_block_size()),
-                "append paged FP16 full KV cache");
-        } else if (cache_dtype == QwenKvCacheDType::Fp8) {
-            require_launch(qwen_append_kv_cache_fp8_cuda(
-                k_norm.f16_data(), v.f16_data(),
-                layer.full.k_cache.fp8_data() + slot_offset,
-                layer.full.v_cache.fp8_data() + slot_offset,
-                layer.full.k_scale.f16_data() + slot_offset / kKvScaleBlock,
-                layer.full.v_scale.f16_data() + slot_offset / kKvScaleBlock,
-                rows, kv_heads, head_dim,
-                kKvScaleBlock, position_offset, max_context),
-                "append FP8 full KV cache");
-        } else if (cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
-            const int slot_bytes = qwen_turboquant_k8v4_slot_bytes(head_dim);
-            const size_t turboquant_slot_offset = static_cast<size_t>(slot_id) *
-                max_context * kv_heads * slot_bytes;
-            require_launch(qwen_append_kv_cache_turboquant_k8v4_cuda(
-                k_norm.f16_data(), v.f16_data(),
-                layer.full.turboquant_cache.byte_data() + turboquant_slot_offset,
-                rows, kv_heads, head_dim, position_offset, max_context),
-                "append TurboQuant K8V4 full KV cache");
-        } else if (cache_dtype == QwenKvCacheDType::Int8PerTokenHead) {
-            const size_t scale_offset = static_cast<size_t>(slot_id) * max_context * kv_heads;
-            require_launch(qwen_append_kv_cache_int8_per_token_head_cuda(
-                k_norm.f16_data(), v.f16_data(),
-                layer.full.k_cache.int8_data() + slot_offset,
-                layer.full.v_cache.int8_data() + slot_offset,
-                layer.full.k_scale.f16_data() + scale_offset,
-                layer.full.v_scale.f16_data() + scale_offset,
-                rows, kv_heads, head_dim,
-                position_offset, max_context),
-                "append INT8 per-token-head full KV cache");
-        } else {
-            require_launch(qwen_append_kv_cache_f16(
-                k_norm.f16_data(), v.f16_data(),
-                layer.full.k_cache.f16_data() + slot_offset,
-                layer.full.v_cache.f16_data() + slot_offset,
-                rows, kv_heads, head_dim,
-                position_offset, max_context), "append FP16 full KV cache");
-        }
-
-        // Where the read kernels find this sequence's history. Contiguous, that
-        // is the slot's own span of the arena. Paged and single-sequence, the
-        // blocks are gathered once per layer into the dense
-        // `[context, kv_heads, head_dim]` layout every read kernel already
-        // indexes, so the five tuned prefill and decode variants stay untouched.
-        // This is the same dequant-once trade the FP8 and TurboQuant paths make:
-        // one O(context) pass instead of translating inside O(rows * context)
-        // inner loops. Batched decode does not come through here; it reads the
-        // blocks natively, which is the path that has to scale with batch size.
-        // Only the FP16 cache stores halves here; the quantized caches keep
-        // their own packed buffers and reach for them inside their own branches
-        // below, so binding these eagerly would trip f16_data()'s dtype check.
-        const bool fp16_cache = cache_dtype == QwenKvCacheDType::Fp16;
-        const uint16_t* k_read = fp16_cache
-            ? layer.full.k_cache.f16_data() + slot_offset : nullptr;
-        const uint16_t* v_read = fp16_cache
-            ? layer.full.v_cache.f16_data() + slot_offset : nullptr;
-        if (kv_paged() && batch_rows == nullptr) {
-            const int context_length = position_offset + rows;
-            const std::vector<uint64_t> dense_shape = {
-                static_cast<uint64_t>(context_length),
-                static_cast<uint64_t>(kv_heads),
-                static_cast<uint64_t>(head_dim)};
-            const size_t dense_elements =
-                static_cast<size_t>(context_length) * kv_heads * head_dim;
-            QwenDeviceTensor& k_dense =
-                workspace_half(dense_elements, dense_shape);
-            QwenDeviceTensor& v_dense =
-                workspace_half(dense_elements, dense_shape);
-            PhaseScope sub(this, "full.kv_gather");
-            require_launch(qwen_gather_kv_cache_f16_paged_cuda(
-                layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
-                k_dense.f16_data(), v_dense.f16_data(), context_length,
-                kv_heads, head_dim, block_table_row(slot_id),
-                paged_block_size()), "gather paged FP16 KV cache");
-            k_read = k_dense.f16_data();
-            v_read = v_dense.f16_data();
-        }
-
-        if (batch_rows != nullptr) {
-            // One launch for the whole batch. The split geometry comes from the
-            // longest row, so the scratch is sized from that same query the
-            // launcher uses; shorter rows leave their trailing splits empty.
-            const int splits = qwen_gqa_decode_batched_split_count(
-                batch_rows->max_context_len, kv_heads, attention_window,
-                sink_tokens);
-            require_launch(splits > 0, "batched decode split geometry");
-            QwenDeviceTensor& partials = workspace_float(
-                static_cast<size_t>(rows) * q_heads * splits *
-                    static_cast<size_t>(head_dim + 2),
-                {static_cast<uint64_t>(rows), static_cast<uint64_t>(q_heads),
-                 static_cast<uint64_t>(splits),
-                 static_cast<uint64_t>(head_dim + 2)});
-            PhaseScope sub(this, "full.attn_kernel");
-            require_launch(qwen_gqa_decode_attention_f16_batched_cuda(
-                q_norm.f16_data(), layer.full.k_cache.f16_data(),
-                layer.full.v_cache.f16_data(), attention.f16_data(),
-                partials.f32_data(), batch_rows->context_lens,
-                batch_rows->slot_ids, rows, batch_rows->max_context_len,
-                kv_slot_stride, q_heads, kv_heads, head_dim, max_context,
-                attention_window, sink_tokens, block_table_data(),
-                paged_block_size(), paged_blocks_per_seq()),
-                "batched decode FP16-cache GQA");
-        } else if (rows == 1) {
-            const int context_length = position_offset + 1;
-            const bool optimized_attention =
-                qwen_env_enabled_default("POCKETLLM_QWEN_GQA_OPTIMIZED") ||
-                attention_window > 0;
-            // The split/merge decode path used to lose below 16384 context
-            // because it walked 2048 positions per split serially, leaving the
-            // device idle. At 128 positions per split it wins everywhere it is
-            // allowed to run: 3.6x the reference kernels at 4096 context and
-            // 16.1x at 65536. Its own guard still declines contexts under 4096.
-            const bool optimized_decode = cache_dtype == QwenKvCacheDType::Fp16 &&
-                optimized_attention &&
-                (context_length >= 4096 || attention_window > 0);
-            int attended_positions = context_length;
-            if (attention_window > 0) {
-                const int sink_count = std::min(sink_tokens, context_length);
-                const int window_start = std::max(
-                    context_length - attention_window, sink_count);
-                attended_positions = sink_count + (context_length - window_start);
-            }
-            // Must match the launch exactly; it sizes the partial scratch.
-            const bool tensor_core_decode_shape = attention_window <= 0 &&
-                sink_tokens == 0 && q_heads == kv_heads * 6 && head_dim == 256;
-            const int optimized_splits = qwen_gqa_decode_split_count(
-                attended_positions, kv_heads, tensor_core_decode_shape);
-            const size_t score_elements = optimized_decode
-                ? static_cast<size_t>(q_heads) * optimized_splits *
-                      static_cast<size_t>(head_dim + 2)
-                : static_cast<size_t>(q_heads) * context_length;
-            QwenDeviceTensor& scores = workspace_float(
-                score_elements,
-                optimized_decode
-                    ? std::vector<uint64_t>{static_cast<uint64_t>(q_heads),
-                                            static_cast<uint64_t>(optimized_splits),
-                                            static_cast<uint64_t>(head_dim + 2)}
-                    : std::vector<uint64_t>{static_cast<uint64_t>(q_heads),
-                                             static_cast<uint64_t>(context_length)});
-            if (cache_dtype == QwenKvCacheDType::Fp8) {
-                require_launch(qwen_gqa_decode_attention_fp8_cuda(
-                    q_norm.f16_data(),
-                    layer.full.k_cache.fp8_data() + slot_offset,
-                    layer.full.v_cache.fp8_data() + slot_offset,
-                    layer.full.k_scale.f16_data() + slot_offset / kKvScaleBlock,
-                    layer.full.v_scale.f16_data() + slot_offset / kKvScaleBlock,
-                    attention.f16_data(),
-                    scores.f32_data(), q_heads, kv_heads, head_dim,
-                    kKvScaleBlock, context_length, max_context),
-                    "decode FP8-cache GQA");
-            } else if (cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
-                const int slot_bytes = qwen_turboquant_k8v4_slot_bytes(head_dim);
-                const size_t turboquant_slot_offset = static_cast<size_t>(slot_id) *
-                    max_context * kv_heads * slot_bytes;
-                require_launch(qwen_gqa_decode_attention_turboquant_k8v4_cuda(
-                    q_norm.f16_data(),
-                    layer.full.turboquant_cache.byte_data() + turboquant_slot_offset,
-                    attention.f16_data(), scores.f32_data(), q_heads, kv_heads,
-                    head_dim, context_length, max_context, attention_window,
-                    sink_tokens), "decode TurboQuant K8V4 GQA");
-            } else if (cache_dtype == QwenKvCacheDType::Int8PerTokenHead) {
-                const size_t scale_offset = static_cast<size_t>(slot_id) * max_context * kv_heads;
-                require_launch(qwen_gqa_decode_attention_int8_per_token_head_cuda(
-                    q_norm.f16_data(),
-                    layer.full.k_cache.int8_data() + slot_offset,
-                    layer.full.v_cache.int8_data() + slot_offset,
-                    layer.full.k_scale.f16_data() + scale_offset,
-                    layer.full.v_scale.f16_data() + scale_offset,
-                    attention.f16_data(),
-                    scores.f32_data(), q_heads, kv_heads, head_dim,
-                    context_length, max_context, attention_window, sink_tokens),
-                    "decode INT8 per-token-head GQA");
-            } else if (optimized_decode) {
-                require_launch(qwen_gqa_decode_attention_f16_fused_cuda(
-                    q_norm.f16_data(),
-                    k_read,
-                    v_read,
-                    attention.f16_data(),
-                    scores.f32_data(), q_heads, kv_heads, head_dim,
-                    context_length, max_context, attention_window, sink_tokens),
-                    "decode optimized FP16-cache GQA");
-            } else {
-                require_launch(qwen_gqa_decode_attention_f16(
-                    q_norm.f16_data(),
-                    k_read,
-                    v_read,
-                    attention.f16_data(),
-                    scores.f32_data(), q_heads, kv_heads, head_dim,
-                    context_length, max_context), "decode FP16-cache GQA");
-            }
-        } else if (cache_dtype == QwenKvCacheDType::Fp8) {
-            const int context_length = position_offset + rows;
-            // Dequantize the [0, context_length) range once into dense FP16
-            // buffers, then call the tensor-core prefill kernel. O(ctx) dequant
-            // + tensor core beats O(rows*ctx) inline dequant by the same factor
-            // as TurboQuant (6-13×).
-            QwenDeviceTensor& k_dense = workspace_half(
-                static_cast<size_t>(context_length) * kv_heads * head_dim,
-                {static_cast<uint64_t>(context_length),
-                 static_cast<uint64_t>(kv_heads),
-                 static_cast<uint64_t>(head_dim)});
-            QwenDeviceTensor& v_dense = workspace_half(
-                static_cast<size_t>(context_length) * kv_heads * head_dim,
-                {static_cast<uint64_t>(context_length),
-                 static_cast<uint64_t>(kv_heads),
-                 static_cast<uint64_t>(head_dim)});
-            require_launch(qwen_fp8_dequant_kv_cache_cuda(
-                layer.full.k_cache.fp8_data() + slot_offset,
-                layer.full.v_cache.fp8_data() + slot_offset,
-                layer.full.k_scale.f16_data() + slot_offset / kKvScaleBlock,
-                layer.full.v_scale.f16_data() + slot_offset / kKvScaleBlock,
-                k_dense.f16_data(), v_dense.f16_data(), context_length,
-                kv_heads, head_dim, kKvScaleBlock, max_context),
-                "dequant FP8 cache to dense FP16");
-            if (qwen_env_enabled_default("POCKETLLM_QWEN_GQA_OPTIMIZED") ||
-                attention_window > 0) {
-                require_launch(qwen_gqa_prefill_attention_f16_tiled_cuda(
-                    q_norm.f16_data(), k_dense.f16_data(), v_dense.f16_data(),
-                    attention.f16_data(), rows, q_heads, kv_heads, head_dim,
-                    position_offset, max_context, attention_window, sink_tokens),
-                    "prefill FP8 via tensor-core tiled");
-            } else {
-                require_launch(qwen_gqa_prefill_attention_f16(
-                    q_norm.f16_data(), k_dense.f16_data(), v_dense.f16_data(),
-                    attention.f16_data(), rows, q_heads, kv_heads, head_dim,
-                    position_offset, max_context),
-                    "prefill FP8 via tensor-core exact");
-            }
-        } else if (cache_dtype == QwenKvCacheDType::Int8PerTokenHead) {
-            const int context_length = position_offset + rows;
-            // INT8 per-token-head uses the same dequant-once architecture as FP8
-            QwenDeviceTensor& k_dense = workspace_half(
-                static_cast<size_t>(context_length) * kv_heads * head_dim,
-                {static_cast<uint64_t>(context_length),
-                 static_cast<uint64_t>(kv_heads),
-                 static_cast<uint64_t>(head_dim)});
-            QwenDeviceTensor& v_dense = workspace_half(
-                static_cast<size_t>(context_length) * kv_heads * head_dim,
-                {static_cast<uint64_t>(context_length),
-                 static_cast<uint64_t>(kv_heads),
-                 static_cast<uint64_t>(head_dim)});
-            const size_t scale_offset = static_cast<size_t>(slot_id) * max_context * kv_heads;
-            require_launch(qwen_int8_dequant_kv_cache_cuda(
-                layer.full.k_cache.int8_data() + slot_offset,
-                layer.full.v_cache.int8_data() + slot_offset,
-                layer.full.k_scale.f16_data() + scale_offset,
-                layer.full.v_scale.f16_data() + scale_offset,
-                k_dense.f16_data(), v_dense.f16_data(), context_length,
-                kv_heads, head_dim, max_context),
-                "dequant INT8 cache to dense FP16");
-            if (qwen_env_enabled_default("POCKETLLM_QWEN_GQA_OPTIMIZED") ||
-                attention_window > 0) {
-                require_launch(qwen_gqa_prefill_attention_f16_tiled_cuda(
-                    q_norm.f16_data(), k_dense.f16_data(), v_dense.f16_data(),
-                    attention.f16_data(), rows, q_heads, kv_heads, head_dim,
-                    position_offset, max_context, attention_window, sink_tokens),
-                    "prefill INT8 via tensor-core tiled");
-            } else {
-                require_launch(qwen_gqa_prefill_attention_f16(
-                    q_norm.f16_data(), k_dense.f16_data(), v_dense.f16_data(),
-                    attention.f16_data(), rows, q_heads, kv_heads, head_dim,
-                    position_offset, max_context),
-                    "prefill INT8 via tensor-core exact");
-            }
-        } else if (cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
-            const int context_length = position_offset + rows;
-            // Dequantize the [0, context_length) range once into dense FP16
-            // buffers laid out like the FP16 cache, then call the tensor-core
-            // prefill kernel on them. O(ctx) dequant + tensor core beats
-            // O(rows*ctx) inline dequant by 6-13× and keeps prefill fast.
-            QwenDeviceTensor& k_dense = workspace_half(
-                static_cast<size_t>(context_length) * kv_heads * head_dim,
-                {static_cast<uint64_t>(context_length),
-                 static_cast<uint64_t>(kv_heads),
-                 static_cast<uint64_t>(head_dim)});
-            QwenDeviceTensor& v_dense = workspace_half(
-                static_cast<size_t>(context_length) * kv_heads * head_dim,
-                {static_cast<uint64_t>(context_length),
-                 static_cast<uint64_t>(kv_heads),
-                 static_cast<uint64_t>(head_dim)});
-            const int slot_bytes = qwen_turboquant_k8v4_slot_bytes(head_dim);
-            const size_t turboquant_slot_offset = static_cast<size_t>(slot_id) *
-                max_context * kv_heads * slot_bytes;
-            require_launch(qwen_turboquant_k8v4_dequant_kv_cuda(
-                layer.full.turboquant_cache.byte_data() + turboquant_slot_offset, k_dense.f16_data(),
-                v_dense.f16_data(), context_length, kv_heads, head_dim,
-                max_context), "dequant TurboQuant cache to dense FP16");
-            if (qwen_env_enabled_default("POCKETLLM_QWEN_GQA_OPTIMIZED") ||
-                attention_window > 0) {
-                require_launch(qwen_gqa_prefill_attention_f16_tiled_cuda(
-                    q_norm.f16_data(), k_dense.f16_data(), v_dense.f16_data(),
-                    attention.f16_data(), rows, q_heads, kv_heads, head_dim,
-                    position_offset, max_context, attention_window, sink_tokens),
-                    "prefill TurboQuant via tensor-core tiled");
-            } else {
-                require_launch(qwen_gqa_prefill_attention_f16(
-                    q_norm.f16_data(), k_dense.f16_data(), v_dense.f16_data(),
-                    attention.f16_data(), rows, q_heads, kv_heads, head_dim,
-                    position_offset, max_context),
-                    "prefill TurboQuant via tensor-core exact");
-            }
-        } else if (cache_dtype == QwenKvCacheDType::Fp16 && rows <= 8 && attention_window == 0) {
-            const int context_length = position_offset + rows;
-            // Tensor-core QK experiment for the real TP4 shape (one KV head per
-            // rank). Keeps the existing FP32 softmax/PV order; opt-in until real
-            // parity and latency are validated.
-            if (qwen_env_enabled("QWEN_GQA_VERIFY_CUBLAS_QK") &&
-                kv_heads == 1) {
-                const size_t score_elements =
-                    static_cast<size_t>(rows) * q_heads * context_length;
-                QwenDeviceTensor& scores = workspace_float(
-                    score_elements,
-                    {static_cast<uint64_t>(rows),
-                     static_cast<uint64_t>(q_heads),
-                     static_cast<uint64_t>(context_length)});
-                PhaseScope sub(this, "full.attn_kernel");
-                require_launch(qwen_gqa_verify_attention_f16_cublas_qk_cuda(
-                    q_norm.f16_data(),
-                    k_read,
-                    v_read,
-                    attention.f16_data(),
-                    scores.f32_data(), rows, q_heads, kv_heads, head_dim,
-                    position_offset, max_context),
-                    "verify cuBLAS-QK FP16-cache GQA");
-            // The exact three-kernel path avoids split partials below 1K context;
-            // the split-K path crosses over above that and remains faster at long
-            // context. QWEN_GQA_VERIFY_SPLIT explicitly overrides the crossover.
-            } else if ((std::getenv("QWEN_GQA_VERIFY_SPLIT") != nullptr
-                            ? qwen_env_enabled("QWEN_GQA_VERIFY_SPLIT")
-                            : context_length > 1024)) {
-                // 32 splits stay slightly faster end-to-end at short context;
-                // 64 cross over at 1K and remain best through 32K.
-                const int default_splits = context_length >= 1024 ? 64 : 32;
-                int target_splits = qwen_env_int(
-                    "QWEN_GQA_VERIFY_SPLITS", default_splits);
-                if (target_splits <= 0) target_splits = default_splits;
-                const int verify_splits = std::max(
-                    1, std::min(target_splits, context_length));
-                const size_t partial_elements =
-                    static_cast<size_t>(rows) * q_heads * verify_splits *
-                    static_cast<size_t>(head_dim + 2);
-                QwenDeviceTensor& partials = workspace_float(
-                    partial_elements,
-                    {static_cast<uint64_t>(rows),
-                     static_cast<uint64_t>(q_heads),
-                     static_cast<uint64_t>(verify_splits),
-                     static_cast<uint64_t>(head_dim + 2)});
-                PhaseScope sub(this, "full.attn_kernel");
-                require_launch(qwen_gqa_verify_attention_f16(
-                    q_norm.f16_data(),
-                    k_read,
-                    v_read,
-                    attention.f16_data(),
-                    partials.f32_data(), rows, q_heads, kv_heads, head_dim,
-                    position_offset, max_context, verify_splits),
-                    "verify split FP16-cache GQA");
-            } else {
-                const size_t score_elements =
-                    static_cast<size_t>(rows) * q_heads * context_length;
-                QwenDeviceTensor& scores = workspace_float(
-                    score_elements,
-                    {static_cast<uint64_t>(rows),
-                     static_cast<uint64_t>(q_heads),
-                     static_cast<uint64_t>(context_length)});
-                { PhaseScope sub(this, "full.attn_kernel"); require_launch(qwen_gqa_verify_attention_f16_exact_cuda(
-                    q_norm.f16_data(),
-                    k_read,
-                    v_read,
-                    attention.f16_data(),
-                    scores.f32_data(), rows, q_heads, kv_heads, head_dim,
-                    position_offset, max_context),
-                    "verify exact FP16-cache GQA"); }
-            }
-        // The tiled kernel shares each K/V element across a head group and a
-        // pair of query rows, so it is the default for multi-row prefill. The
-        // wider TP4 candidate is selected separately through LONG_TILE.
-        } else if (qwen_env_enabled_default("POCKETLLM_QWEN_GQA_OPTIMIZED") ||
-                   attention_window > 0) {
-            require_launch(qwen_gqa_prefill_attention_f16_tiled_cuda(
-                q_norm.f16_data(),
-                k_read,
-                v_read,
-                attention.f16_data(), rows,
-                q_heads, kv_heads, head_dim, position_offset, max_context,
-                attention_window, sink_tokens),
-                "prefill optimized FP16-cache GQA");
-        } else {
-            require_launch(qwen_gqa_prefill_attention_f16(
-                q_norm.f16_data(),
-                k_read,
-                v_read,
-                attention.f16_data(), rows,
-                q_heads, kv_heads, head_dim, position_offset, max_context),
-                "prefill FP16-cache GQA");
-        }
-#endif
-        require_launch(qwen_sigmoid_mul_f16(
-            attention.f16_data(), gate.f16_data(), merged.f16_data(),
-            rows * attention_dim), "FP16 full attention output gate");
-        // Row-parallel output projection: each slice's rows are complete once its
-        // GEMM lands, so the collective for slice i can run under slice i+1's GEMM.
-        // This site was left serial when mlp.down and lin.out were pipelined, and
-        // at 65K it was the single largest exposed collective in the profile
-        // (ar.full.out 2.12 s against tp_all_reduce's 3.16 s total).
-        if (!projection_all_reduce_overlapped(
-                layer.full.out, merged.f16_data(), output, rows,
-                static_cast<int>(config.hidden_size), "full.out", "full.out")) {
-            { PhaseScope sub(this, "full.out_proj"); projection(layer.full.out, merged.f16_data(), output, rows, "full.out"); }
-            all_reduce_half(output, rows * static_cast<int>(config.hidden_size), "full.out");
-        }
-    }
-
-    void layer_forward(DeviceLayer& layer, const uint16_t* hidden,
-                       uint16_t* output, int rows, int position_offset, int slot_id) {
-        const int hidden_size = static_cast<int>(config.hidden_size);
-        begin_workspace();
-        const size_t hidden_elements = static_cast<size_t>(rows) * hidden_size;
-        const size_t intermediate_elements = static_cast<size_t>(rows) *
-            layer.gate.logical_shape[0];
-        QwenDeviceTensor& normalized = workspace_half(
-            hidden_elements, {static_cast<uint64_t>(rows),
-                              static_cast<uint64_t>(hidden_size)});
-        QwenDeviceTensor& attention = workspace_half(hidden_elements, normalized.shape);
-        QwenDeviceTensor& post = workspace_half(hidden_elements, normalized.shape);
-#ifdef POCKET_BACKEND_ASCEND
-        // Every fused SwiGLU variant below is a quantized-weight kernel, and no
-        // quantized kind loads on this backend. Keeping the flags as constants
-        // lets the shared control flow read identically on both backends while
-        // the dead arms are removed before codegen.
-        constexpr bool fused_decode_swiglu = false;
-        constexpr bool fused_small_batch_swiglu = false;
-        constexpr bool fused_nvfp4_swiglu = false;
-#else
-        const bool compatible_fp8_swiglu =
-            layer.gate.kind == QwenLinearKind::Fp8Block128 &&
-            layer.up.kind == QwenLinearKind::Fp8Block128 &&
-            layer.gate.logical_shape == layer.up.logical_shape &&
-            layer.gate.scale.shape == layer.up.scale.shape;
-        const bool fused_decode_swiglu = rows == 1 && compatible_fp8_swiglu;
-        const bool fused_small_batch_swiglu = rows > 1 && rows <= 8 &&
-            compatible_fp8_swiglu && hidden_size % 4 == 0;
-        const char* nvfp4_mode = std::getenv("POCKETLLM_QWEN_NVFP4");
-        const bool nvfp4_wmma = nvfp4_mode == nullptr || *nvfp4_mode == '\0' ||
-            std::strcmp(nvfp4_mode, "auto") == 0 ||
-            std::strcmp(nvfp4_mode, "wmma") == 0;
-        const char* fused_nvfp4 =
-            std::getenv("POCKETLLM_QWEN_NVFP4_FUSED_SWIGLU");
-        const bool fused_nvfp4_swiglu = rows >= 8 && nvfp4_wmma &&
-            fused_nvfp4 != nullptr && std::strcmp(fused_nvfp4, "1") == 0 &&
-            layer.gate.kind == QwenLinearKind::NvFp4Group16 &&
-            layer.up.kind == QwenLinearKind::NvFp4Group16 &&
-            layer.gate.logical_shape == layer.up.logical_shape;
-        const char* shared_nvfp4 =
-            std::getenv("POCKETLLM_QWEN_NVFP4_SHARED_Q8_SWIGLU");
-        const bool shared_nvfp4_enabled = shared_nvfp4 == nullptr ||
-            std::strcmp(shared_nvfp4, "0") != 0;
-        const bool shared_nvfp4_swiglu = rows >= 8 && nvfp4_wmma &&
-            shared_nvfp4_enabled && !fused_nvfp4_swiglu &&
-            layer.gate.kind == QwenLinearKind::NvFp4Group16 &&
-            layer.up.kind == QwenLinearKind::NvFp4Group16 &&
-            layer.gate.logical_shape == layer.up.logical_shape;
-#endif
-        QwenDeviceTensor* gate = nullptr;
-        QwenDeviceTensor* up = nullptr;
-        if (!fused_decode_swiglu && !fused_small_batch_swiglu &&
-            !fused_nvfp4_swiglu) {
-            gate = &workspace_half(intermediate_elements,
-                {static_cast<uint64_t>(rows), layer.gate.logical_shape[0]});
-            up = &workspace_half(intermediate_elements, gate->shape);
-        }
-        QwenDeviceTensor& intermediate = workspace_half(
-            intermediate_elements,
-            {static_cast<uint64_t>(rows), layer.gate.logical_shape[0]});
-        QwenDeviceTensor& mlp = workspace_half(hidden_elements, normalized.shape);
-
-        norm(layer.input_norm, hidden, normalized.f16_data(), rows, hidden_size);
-        if (layer.linear.qkv.weight.data != nullptr) {
-            linear_attention(layer, normalized.f16_data(), attention.f16_data(),
-                             rows, position_offset, slot_id);
-        } else {
-            full_attention(layer, normalized.f16_data(), attention.f16_data(),
-                           rows, position_offset, slot_id);
-        }
-        // One fused pass replaces the residual copy, the add, and the norm. It is
-        // the default: measured on the real 65K TP4 prefill it saves 1.51 s
-        // (55.80 -> 54.28 s) with identical generated tokens. `=0` restores the
-        // three separate passes for A/B.
-        if (qwen_env_enabled_default("QWEN_FUSE_ATTN_RESID_NORM")) {
-            PhaseScope scope(this, "attn_resid_norm");
-            require_launch(
-                qwen_residual_add_rmsnorm_fp16_gamma_rows_f16(
-                    hidden, attention.f16_data(), layer.post_norm.f16_data(),
-                    output, post.f16_data(), rows, hidden_size,
-                    static_cast<float>(config.rms_norm_eps)),
-                "Qwen fused attention residual RMSNorm");
-        } else {
-            {
-                PhaseScope scope(this, "resid_copy");
-                check_device(memcpy_d2d(output, hidden, hidden_elements * sizeof(uint16_t)),
-                      "Qwen FP16 residual copy");
-            }
-            add(output, attention.f16_data(), rows * hidden_size);
-            norm(layer.post_norm, output, post.f16_data(), rows, hidden_size);
-        }
-#ifdef POCKET_BACKEND_ASCEND
-        {
-            projection(layer.gate, post.f16_data(), gate->f16_data(), rows, "mlp.gate");
-            projection(layer.up, post.f16_data(), up->f16_data(), rows, "mlp.up");
-            require_launch(qwen_silu_mul_rows_f16(
-                gate->f16_data(), up->f16_data(), intermediate.f16_data(), rows,
-                static_cast<int>(layer.gate.logical_shape[0])), "FP16 SwiGLU");
-        }
-#else
-        if (fused_decode_swiglu) {
-            PhaseScope scope(this, "swiglu.d");
-            require_launch(qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
-                post.f16_data(), layer.gate.weight.fp8_data(),
-                layer.gate.scale.f16_data(), layer.up.weight.fp8_data(),
-                layer.up.scale.f16_data(), intermediate.f16_data(),
-                static_cast<int>(layer.gate.logical_shape[0]), hidden_size,
-                hidden_size, static_cast<int>(layer.gate.scale.shape[1])),
-                "FP16 fused decode SwiGLU");
-        } else if (fused_small_batch_swiglu) {
-            PhaseScope scope(this, "swiglu.r");
-            require_launch(
-                qwen_fp8_e4m3_fp16scale_swiglu_small_batch_f16_cuda(
-                    post.f16_data(), layer.gate.weight.fp8_data(),
-                    layer.gate.scale.f16_data(), layer.up.weight.fp8_data(),
-                    layer.up.scale.f16_data(), intermediate.f16_data(), rows,
-                    static_cast<int>(layer.gate.logical_shape[0]), hidden_size,
-                    hidden_size, static_cast<int>(layer.gate.logical_shape[0]),
-                    hidden_size, static_cast<int>(layer.gate.scale.shape[1])),
-                "FP16 fused small-batch SwiGLU");
-        } else if (fused_nvfp4_swiglu) {
-            PhaseScope scope(this, "projection_rows_nvfp4");
-            require_launch(nvfp4_fused_swiglu_projection(
-                layer.gate, layer.up, post.f16_data(),
-                intermediate.f16_data(), rows),
-                "NVFP4 fused Q8 WMMA SwiGLU projection");
-        } else {
-            if (shared_nvfp4_swiglu) {
-                PhaseScope scope(this, "projection_rows_nvfp4");
-                require_launch(nvfp4_shared_q8_swiglu_projection(
-                    layer.gate, layer.up, post.f16_data(), gate->f16_data(),
-                    up->f16_data(), rows),
-                    "NVFP4 shared-Q8 WMMA gate/up projection");
-            } else {
-                projection(layer.gate, post.f16_data(), gate->f16_data(), rows, "mlp.gate");
-                projection(layer.up, post.f16_data(), up->f16_data(), rows, "mlp.up");
-            }
-            require_launch(qwen_silu_mul_rows_f16(
-                gate->f16_data(), up->f16_data(), intermediate.f16_data(), rows,
-                static_cast<int>(layer.gate.logical_shape[0])), "FP16 SwiGLU");
-        }
-#endif
-        // ar.mlp is the largest single collective (3.58 s of the 7.24 s
-        // tp_all_reduce leaf at 32K), and down is a large GEMM, so this is the
-        // best overlap candidate in the layer.
-        if (!projection_all_reduce_overlapped(
-                layer.down, intermediate.f16_data(), mlp.f16_data(), rows,
-                hidden_size, "mlp.down", "mlp")) {
-            projection(layer.down, intermediate.f16_data(), mlp.f16_data(), rows,
-                       "mlp.down");
-            all_reduce_half(mlp.f16_data(), rows * hidden_size, "mlp");
-        }
-        add(output, mlp.f16_data(), rows * hidden_size);
     }
 
     bool sampling_enabled() const { return options.temperature > 1.0e-5f; }
@@ -3453,7 +2311,9 @@ struct QwenEngine::Impl {
             static_cast<size_t>(rows) * hidden_size,
             {static_cast<uint64_t>(rows), static_cast<uint64_t>(hidden_size)});
         if (output_norm != nullptr) {
-            norm(*output_norm, hidden, normalized.f16_data(), rows, hidden_size);
+            rms_norm_component.forward(
+                *this, *output_norm, hidden, normalized.f16_data(), rows,
+                hidden_size);
         } else {
             check_device(memcpy_d2d(normalized.data, hidden,
                                     static_cast<size_t>(rows) * hidden_size * sizeof(uint16_t)),
@@ -3466,7 +2326,8 @@ struct QwenEngine::Impl {
 #ifdef POCKET_BACKEND_ASCEND
         // The cuBLAS row variant is an alternative implementation of the same
         // GEMM, so the Ascend build has only the neutral launcher. Fp8Channel is
-        // rejected for the same reason projection() rejects the quantized kinds.
+        // rejected for the same reason the Linear component rejects quantized
+        // kinds.
         if (lm_head.kind != QwenLinearKind::DenseF16) {
             throw std::runtime_error(
                 std::string("Qwen Ascend target head is not implemented for ") +
@@ -3691,10 +2552,12 @@ struct QwenEngine::Impl {
 
         allocate_half(mtp_normalized_embedding, hidden_elements, hidden_shape);
         allocate_half(mtp_normalized_hidden, hidden_elements, hidden_shape);
-        norm(mtp_pre_fc_norm_embedding, mtp_embedding.f16_data(),
-             mtp_normalized_embedding.f16_data(), rows, hidden_size);
-        norm(mtp_pre_fc_norm_hidden, hidden,
-             mtp_normalized_hidden.f16_data(), rows, hidden_size);
+        rms_norm_component.forward(
+            *this, mtp_pre_fc_norm_embedding, mtp_embedding.f16_data(),
+            mtp_normalized_embedding.f16_data(), rows, hidden_size);
+        rms_norm_component.forward(
+            *this, mtp_pre_fc_norm_hidden, hidden,
+            mtp_normalized_hidden.f16_data(), rows, hidden_size);
         allocate_half(mtp_concat, hidden_elements * 2,
                       {static_cast<uint64_t>(rows),
                        static_cast<uint64_t>(2 * hidden_size)});
@@ -3703,13 +2566,17 @@ struct QwenEngine::Impl {
             mtp_normalized_hidden.f16_data(), mtp_concat.f16_data(), rows,
             hidden_size), "Qwen MTP fusion concat");
         allocate_half(mtp_fused, hidden_elements, hidden_shape);
-        projection(mtp_fc, mtp_concat.f16_data(), mtp_fused.f16_data(), rows, "mtp.fc");
+        linear_component.forward(
+            *this, mtp_fc, mtp_concat.f16_data(), mtp_fused.f16_data(), rows,
+            "mtp.fc");
         allocate_half(mtp_next_hidden, hidden_elements, hidden_shape);
-        layer_forward(mtp_layer, mtp_fused.f16_data(),
-                      mtp_next_hidden.f16_data(), rows, position, 0);  // slot_id=0 for MTP
+        decoder_layer_component.forward(
+            *this, mtp_layer, mtp_fused.f16_data(),
+            mtp_next_hidden.f16_data(), rows, position, 0);  // slot_id=0 for MTP
         allocate_half(mtp_normalized_output, hidden_elements, hidden_shape);
-        norm(mtp_norm, mtp_next_hidden.f16_data(),
-             mtp_normalized_output.f16_data(), rows, hidden_size);
+        rms_norm_component.forward(
+            *this, mtp_norm, mtp_next_hidden.f16_data(),
+            mtp_normalized_output.f16_data(), rows, hidden_size);
         const uint16_t* last_hidden = mtp_normalized_output.f16_data() +
             static_cast<size_t>(rows - 1) * hidden_size;
         ForwardResult result = mtp_logits_for(last_hidden, position + rows);
@@ -4145,8 +3012,9 @@ struct QwenEngine::Impl {
         for (int layer_index = 0; layer_index < active_layers; ++layer_index) {
             {
                 PhaseScope scope(this, rows == 1 ? "STACK.d" : "STACK.r");
-                layer_forward(layers[static_cast<size_t>(layer_index)], hidden,
-                              output, rows, position_offset, slot_id);
+                decoder_layer_component.forward(
+                    *this, layers[static_cast<size_t>(layer_index)], hidden,
+                    output, rows, position_offset, slot_id);
             }
             std::swap(hidden, output);
             if (dspark_enabled && dspark_tap_index < dspark_tap_count &&
@@ -4222,8 +3090,9 @@ struct QwenEngine::Impl {
             allocate_half(target_hidden_rows, hidden_elements, hidden_shape);
             // Qwen3.5 MTP consumes the target model's returned hidden states,
             // which are after the target final RMSNorm (matching vLLM/SGLang).
-            norm(final_norm, hidden, target_hidden_rows.f16_data(), rows,
-                 hidden_size);
+            rms_norm_component.forward(
+                *this, final_norm, hidden, target_hidden_rows.f16_data(), rows,
+                hidden_size);
             allocate_half(target_last_hidden, hidden_size,
                           {config.hidden_size});
             check_device(memcpy_d2d(target_last_hidden.data,
@@ -4387,8 +3256,9 @@ struct QwenEngine::Impl {
                 PhaseScope phase(this, "STACK.b");
                 // position_offset and slot_id are unused on the batched path:
                 // both are per row and come from the uploaded metadata.
-                layer_forward(layers[static_cast<size_t>(layer_index)], hidden,
-                              output, rows, 0, 0);
+                decoder_layer_component.forward(
+                    *this, layers[static_cast<size_t>(layer_index)], hidden,
+                    output, rows, 0, 0);
             }
             std::swap(hidden, output);
         }

--- a/cpp_engine/engine/qwen_layer_components.hpp
+++ b/cpp_engine/engine/qwen_layer_components.hpp
@@ -1,0 +1,174 @@
+#pragma once
+
+#include "qwen_engine.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace pocket::qwen_components {
+
+// Device-resident weights grouped by the operation that consumes them. These
+// are runtime layer objects, not checkpoint schema: loading stays in
+// qwen_engine.cpp, while the forward components below own execution.
+struct DeviceLinear {
+    QwenLinearKind kind = QwenLinearKind::DenseF16;
+    std::vector<uint64_t> logical_shape;
+    QwenDeviceTensor weight;
+    QwenDeviceTensor scale;
+    // Optional dense FP16 expansion used only by batched target verification.
+    // The raw FP8 matrix remains canonical and serves decode/prefill.
+    QwenDeviceTensor verify_weight;
+    // NVFP4 tensor-level scaling. The factor is reciprocal(weight_global_scale);
+    // input_global_scale is calibration metadata the SM75 path does not apply.
+    float weight_global_factor = 1.0f;
+    float input_global_scale = 1.0f;
+};
+
+struct DeviceLinearAttention {
+    DeviceLinear qkv;
+    DeviceLinear z;
+    DeviceLinear out;
+    DeviceLinear a;
+    DeviceLinear b;
+    // Row-concat of a and b; empty when the two cannot be fused.
+    DeviceLinear ab;
+    QwenDeviceTensor conv;
+    QwenDeviceTensor a_log;
+    QwenDeviceTensor dt_bias;
+    QwenDeviceTensor norm;
+    QwenDeviceTensor state;
+    QwenDeviceTensor conv_tail;
+};
+
+struct DeviceFullAttention {
+    DeviceLinear q;
+    DeviceLinear k;
+    DeviceLinear v;
+    // Row-concat of K and V for batched verify/prefill. Decode keeps the
+    // individual projections so its established one-row path is unchanged.
+    DeviceLinear kv;
+    DeviceLinear out;
+    QwenDeviceTensor q_norm;
+    QwenDeviceTensor k_norm;
+    QwenDeviceTensor k_cache;
+    QwenDeviceTensor v_cache;
+    QwenDeviceTensor k_scale;
+    QwenDeviceTensor v_scale;
+    // TurboQuant K8V4 combined cache: 196-byte slots with FP8 E5M2 key + 4-bit
+    // value + FP16 metadata. Only allocated for TurboQuantK8V4.
+    QwenDeviceTensor turboquant_cache;
+};
+
+struct DeviceLayer {
+    QwenDeviceTensor input_norm;
+    QwenDeviceTensor post_norm;
+    DeviceLinearAttention linear;
+    DeviceFullAttention full;
+    DeviceLinear gate;
+    DeviceLinear up;
+    DeviceLinear down;
+};
+
+enum class NvFp4Mode {
+    Auto,
+    Dp4a,
+    Wmma,
+    Reference,
+    Invalid,
+};
+
+enum class OptionalSwitch {
+    Auto,
+    Disabled,
+    Enabled,
+};
+
+// Environment-selected layer policy, captured once when the engine is built.
+// Forward used to call getenv() in every layer; besides the avoidable host work,
+// that let one process mutate the kernel sequence midway through a request.
+struct LayerExecutionConfig {
+    NvFp4Mode nvfp4_mode = NvFp4Mode::Auto;
+    bool nvfp4_wide_n64 = true;
+    int nvfp4_wide_n64_min_rows = 128;
+    bool nvfp4_fused_swiglu = false;
+    bool nvfp4_shared_q8_swiglu = true;
+    bool verify_small_fp16_cublas = true;
+    bool gated_delta_flashqla = true;
+    bool fuse_qkvz_decode = false;
+    bool fuse_ab_projection = true;
+    bool gated_delta_prenormalize = true;
+    bool gated_delta_shared_state = false;
+    bool fuse_full_qkv_decode = false;
+    bool gqa_optimized = true;
+    bool gqa_verify_cublas_qk = false;
+    OptionalSwitch gqa_verify_split = OptionalSwitch::Auto;
+    int gqa_verify_splits = 0;
+    bool fuse_attention_residual_norm = true;
+    int comm_overlap_slices = 4;
+
+    bool use_nvfp4_wide_n64(int rows) const {
+        return nvfp4_wide_n64 && rows >= nvfp4_wide_n64_min_rows;
+    }
+};
+
+// Concrete components rather than a layer-level vtable. Their templated runtime
+// parameter keeps the engine's workspace/communication services inlineable in
+// the 64-layer loop while giving each model operation an explicit owner.
+struct Linear {
+    template <typename Runtime>
+    void forward(Runtime& runtime, const DeviceLinear& linear,
+                 const uint16_t* input, uint16_t* output, int rows,
+                 const char* site = "other") const;
+};
+
+struct RMSNorm {
+    template <typename Runtime>
+    void forward(Runtime& runtime, const QwenDeviceTensor& gamma,
+                 const uint16_t* input, uint16_t* output, int rows,
+                 int columns) const;
+};
+
+struct GatedDeltaNetAttention {
+    template <typename Runtime>
+    void forward(Runtime& runtime, DeviceLayer& layer, const uint16_t* hidden,
+                 uint16_t* output, int rows, int position_offset,
+                 int slot_id) const;
+};
+
+struct GqaAttention {
+    template <typename Runtime>
+    void forward(Runtime& runtime, DeviceLayer& layer, const uint16_t* hidden,
+                 uint16_t* output, int rows, int position_offset,
+                 int slot_id) const;
+};
+
+struct FusedGateUpSwiGLU {
+    struct Workspace {
+        QwenDeviceTensor* gate = nullptr;
+        QwenDeviceTensor* up = nullptr;
+        QwenDeviceTensor* output = nullptr;
+        bool fused_decode = false;
+        bool fused_small_batch = false;
+        bool fused_nvfp4 = false;
+        bool shared_nvfp4 = false;
+    };
+
+    // Reserve before attention runs so workspace slot order stays identical to
+    // the monolithic layer implementation. Forward then owns kernel selection.
+    template <typename Runtime>
+    Workspace reserve(Runtime& runtime, DeviceLayer& layer, int rows,
+                      int hidden_size) const;
+
+    template <typename Runtime>
+    void forward(Runtime& runtime, DeviceLayer& layer, const uint16_t* input,
+                 Workspace& workspace, int rows, int hidden_size) const;
+};
+
+struct DecoderLayer {
+    template <typename Runtime>
+    void forward(Runtime& runtime, DeviceLayer& layer, const uint16_t* hidden,
+                 uint16_t* output, int rows, int position_offset,
+                 int slot_id) const;
+};
+
+}  // namespace pocket::qwen_components

--- a/cpp_engine/engine/qwen_layer_components.inl
+++ b/cpp_engine/engine/qwen_layer_components.inl
@@ -1,0 +1,1209 @@
+#pragma once
+
+namespace qwen_components {
+
+template <typename Runtime>
+void Linear::forward(
+    Runtime& runtime, const DeviceLinear& linear, const uint16_t* input,
+    uint16_t* output, int rows, const char* site) const {
+    typename Runtime::PhaseScope scope(&runtime, std::string(rows == 1 ? "pd." : "pr.") + site);
+    if (linear.logical_shape.size() != 2) {
+        throw std::runtime_error("Qwen linear has invalid logical shape");
+    }
+    const int output_rows = static_cast<int>(linear.logical_shape[0]);
+    const int columns = static_cast<int>(linear.logical_shape[1]);
+#ifdef POCKET_BACKEND_ASCEND
+    // Only the dense FP16 kind has an Ascend implementation. The quantized
+    // kinds are rejected here rather than left to a runtime branch: a
+    // reference to their CUDA kernels in this object would make the whole
+    // executable require the CUDA toolchain to link.
+    if (linear.kind != QwenLinearKind::DenseF16) {
+        throw std::runtime_error(
+            std::string("Qwen Ascend path is not implemented for ") +
+            qwen_linear_kind_name(linear.kind));
+    }
+    require_launch(qwen_fp16_matmul_rows_f16(
+        input, linear.weight.f16_data(), output, rows, output_rows,
+        columns, columns, output_rows, columns),
+        "FP16 activation/weight projection");
+    return;
+#else
+    if (linear.kind == QwenLinearKind::Fp8Block128) {
+        if (rows == 1) {
+            require_launch(qwen_fp8_e4m3_fp16scale_matvec_f16_cuda(
+                input, linear.weight.fp8_data(), linear.scale.f16_data(),
+                output, output_rows, columns, columns,
+                static_cast<int>(linear.scale.shape[1])),
+                "FP8 FP16-activation decode projection");
+        } else if (rows <= 8 && linear.verify_weight.data != nullptr) {
+            require_launch(qwen_fp16_matmul_rows_f16_cublas_cuda(
+                input, linear.verify_weight.f16_data(), output, rows,
+                output_rows, columns, columns, output_rows, columns),
+                "resident FP16 verify projection");
+        } else {
+            require_launch(qwen_fp8_e4m3_fp16scale_matmul_rows_f16_cuda(
+                input, linear.weight.fp8_data(), linear.scale.f16_data(),
+                output, rows, output_rows, columns, columns, output_rows,
+                columns, static_cast<int>(linear.scale.shape[1])),
+                "FP8 FP16-activation projection");
+        }
+    } else if (linear.kind == QwenLinearKind::Fp8Channel) {
+        require_launch(rows == 1
+            ? qwen_fp8_e4m3_channel_matvec_f16_cuda(
+                  input, linear.weight.fp8_data(), linear.scale.f16_data(),
+                  output, output_rows, columns, columns)
+            : qwen_fp8_e4m3_channel_matmul_rows_f16_cuda(
+                  input, linear.weight.fp8_data(), linear.scale.f16_data(),
+                  output, rows, output_rows, columns, columns, output_rows,
+                  columns),
+            "channel FP8 FP16-activation projection");
+    } else if (linear.kind == QwenLinearKind::NvFp4Group16) {
+        const NvFp4Mode mode = runtime.layer_config.nvfp4_mode;
+        if (mode == NvFp4Mode::Invalid) {
+            throw std::runtime_error(
+                "POCKETLLM_QWEN_NVFP4 must be auto, dp4a, wmma, or reference");
+        }
+        const bool reference = mode == NvFp4Mode::Reference;
+        const int blocks_per_row = columns / 64;
+        if (!reference) {
+            const bool use_wmma = mode == NvFp4Mode::Wmma ||
+                (mode == NvFp4Mode::Auto && rows >= 8);
+            const bool use_wide = use_wmma &&
+                runtime.layer_config.use_nvfp4_wide_n64(rows);
+            require_launch(runtime.nvfp4_integer_projection(
+                linear, input, output, rows, use_wmma),
+                use_wide ? "NVFP4 group-16 Q8 wide-N64 projection" :
+                use_wmma ? "NVFP4 group-16 Q8 WMMA projection" :
+                           "NVFP4 group-16 Q8 DP4A projection");
+        } else {
+            require_launch(rows == 1
+                ? qwen_nvfp4_group16_matvec_f16_cuda(
+                      input, linear.weight.u8_data(), output, output_rows,
+                      columns, blocks_per_row, linear.weight_global_factor)
+                : qwen_nvfp4_group16_matmul_rows_f16_cuda(
+                      input, linear.weight.u8_data(), output, rows,
+                      output_rows, columns, columns, output_rows,
+                      blocks_per_row, linear.weight_global_factor),
+                "NVFP4 group-16 reference projection");
+        }
+    } else if (linear.kind == QwenLinearKind::DenseF16) {
+        // The fused DeltaNet a/b matrix is only 24 rows per TP4 rank. At
+        // verify width 8, tensor cores are ~5x faster than the generic
+        // warp-per-output-row reduction. Decode keeps its established
+        // reduction order, and wider prefill remains on the existing path.
+        const bool verify_cublas = rows >= 4 && rows <= 8 &&
+            output_rows <= 32 && columns % 8 == 0 &&
+            runtime.layer_config.verify_small_fp16_cublas;
+        if (verify_cublas) {
+            require_launch(qwen_fp16_matmul_rows_f16_cublas_cuda(
+                input, linear.weight.f16_data(), output, rows, output_rows,
+                columns, columns, output_rows, columns),
+                "small FP16 verify cuBLAS projection");
+        } else {
+            require_launch(qwen_fp16_matmul_rows_f16(
+                input, linear.weight.f16_data(), output, rows, output_rows,
+                columns, columns, output_rows, columns),
+                "FP16 activation/weight projection");
+        }
+    } else {
+        throw std::runtime_error(
+            std::string("Qwen linear CUDA path is not implemented for ") +
+            qwen_linear_kind_name(linear.kind));
+    }
+#endif
+}
+
+template <typename Runtime>
+void RMSNorm::forward(
+    Runtime& runtime, const QwenDeviceTensor& gamma, const uint16_t* input,
+    uint16_t* output, int rows, int columns) const {
+    typename Runtime::PhaseScope scope(&runtime, "norm");
+    require_launch(qwen_rmsnorm_fp16_gamma_rows_f16(
+        input, gamma.f16_data(), output, rows, columns,
+        static_cast<float>(runtime.config.rms_norm_eps)), "Qwen FP16 RMSNorm");
+}
+
+template <typename Runtime>
+void GatedDeltaNetAttention::forward(
+    Runtime& runtime, DeviceLayer& layer, const uint16_t* hidden,
+    uint16_t* output, int rows, int position_offset, int slot_id) const {
+    // Phase 3.4: Every kernel below advances this slot's own recurrent
+    // state. Resolved once here so the many call sites cannot disagree.
+    const size_t state_offset = runtime.recurrent_slot_offset(slot_id, layer.linear.state);
+    const size_t tail_offset = runtime.recurrent_slot_offset(slot_id, layer.linear.conv_tail);
+    float* const state = layer.linear.state.f32_data() + state_offset;
+    uint16_t* const conv_tail = layer.linear.conv_tail.f16_data() + tail_offset;
+    const int key_heads = static_cast<int>(
+        runtime.config.linear_attention.key_heads / runtime.options.tp_world);
+    const int value_heads = static_cast<int>(
+        runtime.config.linear_attention.value_heads / runtime.options.tp_world);
+    const int key_dim = key_heads *
+        static_cast<int>(runtime.config.linear_attention.key_head_dim);
+    const int value_dim = value_heads *
+        static_cast<int>(runtime.config.linear_attention.value_head_dim);
+    const int packed_dim = 2 * key_dim + value_dim;
+    const int kernel = static_cast<int>(runtime.config.linear_attention.conv_kernel_dim);
+    const int hidden_size = static_cast<int>(runtime.config.hidden_size);
+    const size_t packed_elements = static_cast<size_t>(rows) * packed_dim;
+    const size_t key_elements = static_cast<size_t>(rows) * key_dim;
+    const size_t value_elements = static_cast<size_t>(rows) * value_dim;
+    const size_t gate_elements = static_cast<size_t>(rows) * value_heads;
+    QwenDeviceTensor& packed = runtime.workspace_half(
+        packed_elements, {static_cast<uint64_t>(rows),
+                          static_cast<uint64_t>(packed_dim)});
+    QwenDeviceTensor& convolved = runtime.workspace_half(packed_elements, packed.shape);
+    QwenDeviceTensor& q = runtime.workspace_half(
+        key_elements, {static_cast<uint64_t>(rows),
+                       static_cast<uint64_t>(key_dim)});
+    QwenDeviceTensor& k = runtime.workspace_half(key_elements, q.shape);
+    QwenDeviceTensor& v = runtime.workspace_half(
+        value_elements, {static_cast<uint64_t>(rows),
+                         static_cast<uint64_t>(value_dim)});
+    QwenDeviceTensor& a = runtime.workspace_half(
+        gate_elements, {static_cast<uint64_t>(rows),
+                        static_cast<uint64_t>(value_heads)});
+    QwenDeviceTensor& b = runtime.workspace_half(gate_elements, a.shape);
+    QwenDeviceTensor& gates = runtime.workspace_half(gate_elements, a.shape);
+    QwenDeviceTensor& beta = runtime.workspace_half(gate_elements, a.shape);
+    QwenDeviceTensor& core = runtime.workspace_half(value_elements, v.shape);
+    QwenDeviceTensor& z = runtime.workspace_half(value_elements, v.shape);
+    QwenDeviceTensor& normalized = runtime.workspace_half(value_elements, v.shape);
+    // FlashQLA is an SM75 register/subgroup layout of the same recurrence,
+    // not a distinct operation, so the Ascend build simply does not have the
+    // selector: the normalized sequence kernel below produces the same
+    // result from the same FP32 normalized Q/K.
+#ifndef POCKET_BACKEND_ASCEND
+    QwenDeviceTensor* q_normalized = nullptr;
+    QwenDeviceTensor* k_normalized = nullptr;
+    // Every sequence-recurrence kernel below reads `rows` as consecutive
+    // tokens of one stream. A batched decode step is the opposite: `rows`
+    // independent sequences each advancing one token, so none of them apply
+    // and the batched step kernel handles it instead.
+    const bool flashqla = runtime.batch_rows == nullptr && rows >= 8 &&
+        runtime.layer_config.gated_delta_flashqla;
+    if (flashqla) {
+        q_normalized = &runtime.workspace_float(
+            key_elements,
+            {static_cast<uint64_t>(rows), static_cast<uint64_t>(key_dim)});
+        k_normalized = &runtime.workspace_float(key_elements, q_normalized->shape);
+    }
+#endif
+
+#ifndef POCKET_BACKEND_ASCEND
+    bool dual_qkvz = rows == 1 &&
+        layer.linear.qkv.kind == QwenLinearKind::Fp8Block128 &&
+        layer.linear.z.kind == QwenLinearKind::Fp8Block128 &&
+        runtime.layer_config.fuse_qkvz_decode;
+#else
+    const bool dual_qkvz = false;
+#endif
+#ifndef POCKET_BACKEND_ASCEND
+    if (dual_qkvz) {
+        typename Runtime::PhaseScope dual_scope(&runtime, "pd.lin.qkvz");
+        require_launch(qwen_fp8_e4m3_fp16scale_matvec_dual_f16_cuda(
+            hidden,
+            layer.linear.qkv.weight.fp8_data(),
+            layer.linear.qkv.scale.f16_data(), packed.f16_data(), packed_dim,
+            hidden_size, static_cast<int>(layer.linear.qkv.scale.shape[1]),
+            layer.linear.z.weight.fp8_data(),
+            layer.linear.z.scale.f16_data(), z.f16_data(), value_dim,
+            hidden_size, static_cast<int>(layer.linear.z.scale.shape[1]),
+            hidden_size), "dual FP8 QKV/Z decode projection");
+    } else
+#endif
+    {
+        runtime.linear_component.forward(
+            runtime, layer.linear.qkv, hidden, packed.f16_data(), rows,
+            "lin.qkv");
+    }
+#ifndef POCKET_BACKEND_ASCEND
+    if (runtime.batch_rows != nullptr) {
+        // One token per sequence against that sequence's own tail. The
+        // pointer is the arena base here, not this slot's rows, because the
+        // kernel resolves the slot per row.
+        require_launch(qwen_causal_depthwise_conv_silu_f16_batched_cuda(
+            packed.f16_data(), layer.linear.conv.f16_data(),
+            layer.linear.conv_tail.f16_data(), convolved.f16_data(),
+            runtime.batch_rows->slot_ids, rows, packed_dim, kernel,
+            runtime.slot_stride_elements(layer.linear.conv_tail)),
+            "FP16 batched linear causal convolution");
+    } else
+#endif
+    require_launch(qwen_causal_depthwise_conv_silu_f16(
+        packed.f16_data(), layer.linear.conv.f16_data(),
+        conv_tail, convolved.f16_data(), rows,
+        packed_dim, kernel, true), "FP16 linear causal convolution");
+    require_launch(qwen_split_packed_qkv_f16(
+        convolved.f16_data(), q.f16_data(), k.f16_data(), v.f16_data(),
+        rows, key_dim, value_dim), "FP16 linear QKV split");
+    if (layer.linear.ab.weight.data != nullptr &&
+        runtime.layer_config.fuse_ab_projection) {
+        // One GEMM over the row-concatenated [2*gate, hidden] weight. The
+        // output is [rows, 2*gate] interleaved per row, so a and b are
+        // strided slices of it rather than contiguous halves.
+        QwenDeviceTensor& ab = runtime.workspace_half(
+            gate_elements * 2,
+            {static_cast<uint64_t>(rows),
+             static_cast<uint64_t>(value_heads * 2)});
+        runtime.linear_component.forward(
+            runtime, layer.linear.ab, hidden, ab.f16_data(), rows, "lin.ab");
+        require_launch(qwen_split_rows_pair_f16(
+            ab.f16_data(), a.f16_data(), b.f16_data(), rows, value_heads),
+            "FP16 fused a/b split");
+    } else {
+        runtime.linear_component.forward(
+            runtime, layer.linear.a, hidden, a.f16_data(), rows, "lin.a");
+        runtime.linear_component.forward(
+            runtime, layer.linear.b, hidden, b.f16_data(), rows, "lin.b");
+    }
+    require_launch(qwen_linear_attn_gates_f16(
+        a.f16_data(), b.f16_data(), layer.linear.a_log.f16_data(),
+        layer.linear.dt_bias.f16_data(), gates.f16_data(), beta.f16_data(),
+        rows, value_heads), "FP16 linear attention gates");
+    const float q_scale = 1.0f / std::sqrt(
+        static_cast<float>(runtime.config.linear_attention.key_head_dim));
+    std::optional<typename Runtime::PhaseScope> delta_scope;
+    delta_scope.emplace(&runtime, "gated_delta");
+    bool sequenced = false;
+#ifndef POCKET_BACKEND_ASCEND
+    if (runtime.batch_rows != nullptr) {
+        sequenced = qwen_gated_delta_step_batched_f16_cuda(
+            layer.linear.state.f32_data(), q.f16_data(), k.f16_data(),
+            v.f16_data(), gates.f16_data(), beta.f16_data(),
+            core.f16_data(), runtime.batch_rows->slot_ids, rows, value_heads,
+            key_heads,
+            static_cast<int>(runtime.config.linear_attention.key_head_dim),
+            static_cast<int>(runtime.config.linear_attention.value_head_dim),
+            q_scale, runtime.slot_stride_elements(layer.linear.state));
+        require_launch(sequenced, "FP16 batched linear recurrent state");
+    } else if (flashqla) {
+        // FlashQLA SM75 subgroup-sharded kernel. Still a serial recurrence,
+        // but sharding the [128, 128] state over 16-lane subgroups replaces
+        // the baseline's 128-element per-thread register vector: 1.85x on the
+        // primitive and +5-7% real TP4 prefill at token-exact parity.
+        // Consume the established FP32 normalized Q/K tensors so the norm
+        // reduction order remains identical to the reference path.
+        sequenced = qwen_normalize_gated_delta_qk_f16(
+            q.f16_data(), k.f16_data(), q_normalized->f32_data(),
+            k_normalized->f32_data(), rows, key_heads,
+            static_cast<int>(runtime.config.linear_attention.key_head_dim)) &&
+            qwen_gated_delta_flashqla_sm75_f16_cuda(
+                state, q_normalized->f32_data(),
+                k_normalized->f32_data(), v.f16_data(), gates.f16_data(),
+                beta.f16_data(), core.f16_data(), rows, value_heads,
+                key_heads,
+                static_cast<int>(runtime.config.linear_attention.key_head_dim),
+                static_cast<int>(runtime.config.linear_attention.value_head_dim),
+                q_scale);
+    } else
+#endif
+    if (rows >= 5 && key_heads < value_heads &&
+        runtime.layer_config.gated_delta_prenormalize) {
+        QwenDeviceTensor& q_normalized = runtime.workspace_float(
+            key_elements, {static_cast<uint64_t>(rows),
+                           static_cast<uint64_t>(key_dim)});
+        QwenDeviceTensor& k_normalized = runtime.workspace_float(
+            key_elements, q_normalized.shape);
+        sequenced = qwen_normalize_gated_delta_qk_f16(
+            q.f16_data(), k.f16_data(), q_normalized.f32_data(),
+            k_normalized.f32_data(), rows, key_heads,
+            static_cast<int>(runtime.config.linear_attention.key_head_dim)) &&
+            (runtime.layer_config.gated_delta_shared_state
+             ? qwen_gated_delta_sequence_normalized_shared_f16(
+                    state, q_normalized.f32_data(),
+                    k_normalized.f32_data(), v.f16_data(), gates.f16_data(),
+                    beta.f16_data(), core.f16_data(), rows, value_heads,
+                    key_heads,
+                    static_cast<int>(runtime.config.linear_attention.key_head_dim),
+                    static_cast<int>(runtime.config.linear_attention.value_head_dim),
+                    q_scale)
+                : qwen_gated_delta_sequence_normalized_f16(
+                    state, q_normalized.f32_data(),
+                    k_normalized.f32_data(), v.f16_data(), gates.f16_data(),
+                    beta.f16_data(), core.f16_data(), rows, value_heads,
+                    key_heads,
+                    static_cast<int>(runtime.config.linear_attention.key_head_dim),
+                    static_cast<int>(runtime.config.linear_attention.value_head_dim),
+                    q_scale));
+    } else {
+        // Also covers rows == 1. Decode used to fall through to the step
+        // loop below, which round-trips the [128, 128] state through global
+        // memory twice per token; the sequence kernel holds it in registers
+        // and is bit-exact against the step kernel, so there is no reason to
+        // reserve it for multi-token chunks. See the step-vs-sequence parity
+        // check in test_qwen_half_ops.
+        sequenced = qwen_gated_delta_sequence_f16(
+            state, q.f16_data(), k.f16_data(),
+            v.f16_data(), gates.f16_data(), beta.f16_data(),
+            core.f16_data(), rows, value_heads, key_heads,
+            static_cast<int>(runtime.config.linear_attention.key_head_dim),
+            static_cast<int>(runtime.config.linear_attention.value_head_dim), q_scale);
+    }
+    for (int token = 0; !sequenced && token < rows; ++token) {
+        require_launch(qwen_gated_delta_step_f16(
+            state,
+            q.f16_data() + static_cast<size_t>(token) * key_dim,
+            k.f16_data() + static_cast<size_t>(token) * key_dim,
+            v.f16_data() + static_cast<size_t>(token) * value_dim,
+            gates.f16_data() + static_cast<size_t>(token) * value_heads,
+            beta.f16_data() + static_cast<size_t>(token) * value_heads,
+            core.f16_data() + static_cast<size_t>(token) * value_dim,
+            value_heads, key_heads,
+            static_cast<int>(runtime.config.linear_attention.key_head_dim),
+            static_cast<int>(runtime.config.linear_attention.value_head_dim), q_scale),
+            "FP16 linear recurrent state");
+    }
+    delta_scope.reset();
+    if (!dual_qkvz) {
+        runtime.linear_component.forward(
+            runtime, layer.linear.z, hidden, z.f16_data(), rows, "lin.z");
+    }
+    require_launch(qwen_gated_rmsnorm_fp16_gamma_rows_f16(
+        core.f16_data(), layer.linear.norm.f16_data(), z.f16_data(),
+        normalized.f16_data(), rows * value_heads,
+        static_cast<int>(runtime.config.linear_attention.value_head_dim),
+        static_cast<float>(runtime.config.rms_norm_eps)),
+        "FP16 linear gated RMSNorm");
+    // ar.lin.out is the second-largest collective (2.69 s at 32K) and runs on
+    // the 48 DeltaNet layers, so it is the other worthwhile overlap site.
+    if (!runtime.projection_all_reduce_overlapped(
+            layer.linear.out, normalized.f16_data(), output, rows,
+            hidden_size, "lin.out", "lin.out")) {
+        runtime.linear_component.forward(
+            runtime, layer.linear.out, normalized.f16_data(), output, rows,
+            "lin.out");
+        runtime.all_reduce_half(output, rows * hidden_size, "lin.out");
+    }
+    (void)position_offset;
+}
+
+template <typename Runtime>
+void GqaAttention::forward(
+    Runtime& runtime, DeviceLayer& layer, const uint16_t* hidden,
+    uint16_t* output, int rows, int position_offset, int slot_id) const {
+    typename Runtime::PhaseScope scope(&runtime, "full_attention");
+    const int q_heads = static_cast<int>(
+        runtime.config.full_attention.num_heads / runtime.options.tp_world);
+    const int kv_heads = static_cast<int>(
+        runtime.config.full_attention.num_key_value_heads / runtime.options.tp_world);
+    const int head_dim = static_cast<int>(runtime.config.full_attention.head_dim);
+    const int attention_dim = q_heads * head_dim;
+    const int q_projection_dim = attention_dim * 2;
+    const size_t q_projection_elements =
+        static_cast<size_t>(rows) * q_projection_dim;
+    const size_t attention_elements =
+        static_cast<size_t>(rows) * attention_dim;
+    const size_t kv_elements =
+        static_cast<size_t>(rows) * kv_heads * head_dim;
+    QwenDeviceTensor& q_projection = runtime.workspace_half(
+        q_projection_elements, {static_cast<uint64_t>(rows),
+                                static_cast<uint64_t>(q_projection_dim)});
+    QwenDeviceTensor& q = runtime.workspace_half(
+        attention_elements, {static_cast<uint64_t>(rows),
+                             static_cast<uint64_t>(attention_dim)});
+    QwenDeviceTensor& gate = runtime.workspace_half(attention_elements, q.shape);
+    QwenDeviceTensor& k = runtime.workspace_half(
+        kv_elements, {static_cast<uint64_t>(rows),
+                      static_cast<uint64_t>(kv_heads),
+                      static_cast<uint64_t>(head_dim)});
+    QwenDeviceTensor& v = runtime.workspace_half(kv_elements, k.shape);
+    QwenDeviceTensor* kv_projection = nullptr;
+    // Keep the candidate isolated to the fixed-width target verify batch;
+    // prefill and one-row decode retain their established K/V projections.
+    const bool fused_kv = rows > 1 && rows <= 8 &&
+        layer.full.kv.weight.data != nullptr;
+    if (fused_kv) {
+        kv_projection = &runtime.workspace_half(
+            static_cast<size_t>(rows) * 2 * kv_heads * head_dim,
+            {static_cast<uint64_t>(rows),
+             static_cast<uint64_t>(2 * kv_heads * head_dim)});
+    }
+    QwenDeviceTensor& q_norm = runtime.workspace_half(attention_elements, q.shape);
+    QwenDeviceTensor& k_norm = runtime.workspace_half(kv_elements, k.shape);
+    QwenDeviceTensor& attention = runtime.workspace_half(attention_elements, q.shape);
+    QwenDeviceTensor& merged = runtime.workspace_half(attention_elements, q.shape);
+
+    const int hidden_size = static_cast<int>(runtime.config.hidden_size);
+#ifndef POCKET_BACKEND_ASCEND
+    const bool grouped_qkv = rows == 1 && !fused_kv &&
+        layer.full.q.kind == QwenLinearKind::Fp8Block128 &&
+        layer.full.k.kind == QwenLinearKind::Fp8Block128 &&
+        layer.full.v.kind == QwenLinearKind::Fp8Block128 &&
+        runtime.layer_config.fuse_full_qkv_decode;
+    if (grouped_qkv) {
+        typename Runtime::PhaseScope sub(&runtime, "pd.full.qkv");
+        require_launch(qwen_fp8_e4m3_fp16scale_matvec_triple_f16_cuda(
+            hidden, layer.full.q.weight.fp8_data(),
+            layer.full.q.scale.f16_data(), q_projection.f16_data(),
+            q_projection_dim, hidden_size,
+            static_cast<int>(layer.full.q.scale.shape[1]),
+            layer.full.k.weight.fp8_data(), layer.full.k.scale.f16_data(),
+            k.f16_data(), kv_heads * head_dim, hidden_size,
+            static_cast<int>(layer.full.k.scale.shape[1]),
+            layer.full.v.weight.fp8_data(), layer.full.v.scale.f16_data(),
+            v.f16_data(), kv_heads * head_dim, hidden_size,
+            static_cast<int>(layer.full.v.scale.shape[1]), hidden_size),
+            "triple FP8 full Q/K/V decode projection");
+    } else
+#endif
+    {
+        {
+            typename Runtime::PhaseScope sub(&runtime, "full.q_proj");
+            runtime.linear_component.forward(
+                runtime, layer.full.q, hidden, q_projection.f16_data(), rows,
+                "full.q");
+        }
+        if (fused_kv) {
+            {
+                typename Runtime::PhaseScope sub(&runtime, "full.kv_proj");
+                runtime.linear_component.forward(
+                    runtime, layer.full.kv, hidden, kv_projection->f16_data(),
+                    rows, "full.kv");
+            }
+            require_launch(qwen_split_rows_pair_f16(
+                kv_projection->f16_data(), k.f16_data(), v.f16_data(), rows,
+                kv_heads * head_dim), "FP16 fused full K/V split");
+        } else {
+            {
+                typename Runtime::PhaseScope sub(&runtime, "full.k_proj");
+                runtime.linear_component.forward(
+                    runtime, layer.full.k, hidden, k.f16_data(), rows,
+                    "full.k");
+            }
+            {
+                typename Runtime::PhaseScope sub(&runtime, "full.v_proj");
+                runtime.linear_component.forward(
+                    runtime, layer.full.v, hidden, v.f16_data(), rows,
+                    "full.v");
+            }
+        }
+    }
+    require_launch(qwen_split_q_gate_f16(
+        q_projection.f16_data(), q.f16_data(), gate.f16_data(), rows,
+        q_heads, head_dim), "FP16 full Q/gate split");
+    runtime.rms_norm_component.forward(
+        runtime, layer.full.q_norm, q.f16_data(), q_norm.f16_data(),
+        rows * q_heads, head_dim);
+    runtime.rms_norm_component.forward(
+        runtime, layer.full.k_norm, k.f16_data(), k_norm.f16_data(),
+        rows * kv_heads, head_dim);
+#ifndef POCKET_BACKEND_ASCEND
+    if (runtime.batch_rows != nullptr) {
+        // Each row is a different sequence at its own position, so the
+        // rotation angle is per row rather than position_offset + row.
+        require_launch(qwen_partial_rope_rows_f16_batched_cuda(
+            q_norm.f16_data(), k_norm.f16_data(), runtime.batch_rows->positions,
+            rows, static_cast<int>(runtime.config.partial_rotary_dim()),
+            static_cast<float>(runtime.config.rope_theta), q_heads, kv_heads,
+            head_dim), "FP16 batched partial RoPE");
+    } else
+#endif
+    require_launch(qwen_partial_rope_rows_f16(
+        q_norm.f16_data(), k_norm.f16_data(), position_offset, rows,
+        static_cast<int>(runtime.config.partial_rotary_dim()),
+        static_cast<float>(runtime.config.rope_theta), q_heads, kv_heads, head_dim),
+        "FP16 partial RoPE");
+
+    const QwenKvCacheDType cache_dtype = runtime.options.kv_cache_dtype;
+    const int attention_window = runtime.options.attention_window;
+    const int sink_tokens = runtime.options.attention_sink_tokens;
+#ifdef POCKET_BACKEND_ASCEND
+    // The engine constructor rejects every non-FP16 cache dtype on this
+    // backend, so only the FP16 append and the three neutral attention
+    // launchers are compiled. The quantized caches are not merely disabled:
+    // naming their kernels here would put a CUDA dependency in this object.
+
+    // Phase 3.3: Use slot_id parameter instead of global current_slot_id
+    const size_t slot_offset = runtime.kv_slot_offset_elements(slot_id, kv_heads, head_dim);
+
+    require_launch(qwen_append_kv_cache_f16(
+        k_norm.f16_data(), v.f16_data(),
+        layer.full.k_cache.f16_data() + slot_offset,
+        layer.full.v_cache.f16_data() + slot_offset,
+        rows, kv_heads, head_dim,
+        position_offset, runtime.max_context), "append FP16 full KV cache");
+
+    if (rows == 1) {
+        const int context_length = position_offset + 1;
+        QwenDeviceTensor& scores = runtime.workspace_float(
+            static_cast<size_t>(q_heads) * context_length,
+            {static_cast<uint64_t>(q_heads),
+             static_cast<uint64_t>(context_length)});
+        require_launch(qwen_gqa_decode_attention_f16(
+            q_norm.f16_data(),
+            layer.full.k_cache.f16_data() + slot_offset,
+            layer.full.v_cache.f16_data() + slot_offset,
+            attention.f16_data(),
+            scores.f32_data(), q_heads, kv_heads, head_dim,
+            context_length, runtime.max_context), "decode FP16-cache GQA");
+    } else if (rows <= 8) {
+        const int context_length = position_offset + rows;
+        // Same split geometry the CUDA verify path uses, so a verify block
+        // reduces its partials in the same order on both backends.
+        const int default_splits = context_length >= 1024 ? 64 : 32;
+        int target_splits = runtime.layer_config.gqa_verify_splits > 0
+                ? runtime.layer_config.gqa_verify_splits : default_splits;
+        if (target_splits <= 0) target_splits = default_splits;
+        const int verify_splits = std::max(
+            1, std::min(target_splits, context_length));
+        QwenDeviceTensor& partials = runtime.workspace_float(
+            static_cast<size_t>(rows) * q_heads * verify_splits *
+                static_cast<size_t>(head_dim + 2),
+            {static_cast<uint64_t>(rows), static_cast<uint64_t>(q_heads),
+             static_cast<uint64_t>(verify_splits),
+             static_cast<uint64_t>(head_dim + 2)});
+        typename Runtime::PhaseScope sub(&runtime, "full.attn_kernel");
+        require_launch(qwen_gqa_verify_attention_f16(
+            q_norm.f16_data(),
+            layer.full.k_cache.f16_data() + slot_offset,
+            layer.full.v_cache.f16_data() + slot_offset,
+            attention.f16_data(),
+            partials.f32_data(), rows, q_heads, kv_heads, head_dim,
+            position_offset, runtime.max_context, verify_splits),
+            "verify split FP16-cache GQA");
+    } else {
+        require_launch(qwen_gqa_prefill_attention_f16(
+            q_norm.f16_data(),
+            layer.full.k_cache.f16_data() + slot_offset,
+            layer.full.v_cache.f16_data() + slot_offset,
+            attention.f16_data(), rows,
+            q_heads, kv_heads, head_dim, position_offset, runtime.max_context),
+            "prefill FP16-cache GQA");
+    }
+    (void)sink_tokens;
+#else
+    // Phase 3.3: Use slot_id parameter instead of global current_slot_id
+    const size_t slot_offset = runtime.kv_slot_offset_elements(slot_id, kv_heads, head_dim);
+    // Distance between slots in the KV arena. kv_slot_offset_elements folds
+    // this to zero for a single session, so the stride is recomputed rather
+    // than divided out of it.
+    const size_t kv_slot_stride = static_cast<size_t>(runtime.max_context) *
+        kv_heads * head_dim;
+
+    if (runtime.batch_rows != nullptr) {
+        // Each row appends its new K/V at its own position in its own slot.
+        // Under paging the slot stride is replaced by the block table, which
+        // the caller has already grown and uploaded for these positions.
+        require_launch(qwen_append_kv_cache_f16_batched_cuda(
+            k_norm.f16_data(), v.f16_data(),
+            layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
+            rows, kv_heads, head_dim, runtime.batch_rows->positions,
+            runtime.batch_rows->slot_ids, runtime.max_context, kv_slot_stride,
+            runtime.block_table_data(), runtime.paged_block_size(),
+            runtime.paged_blocks_per_seq()),
+            "append batched FP16 full KV cache");
+    } else if (runtime.kv_paged()) {
+        // Single-sequence paged append: consecutive positions of one
+        // sequence, scattered across the blocks its row names.
+        require_launch(qwen_append_kv_cache_f16_paged_cuda(
+            k_norm.f16_data(), v.f16_data(),
+            layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
+            rows, kv_heads, head_dim, position_offset,
+            runtime.block_table_row(slot_id), runtime.paged_block_size()),
+            "append paged FP16 full KV cache");
+    } else if (cache_dtype == QwenKvCacheDType::Fp8) {
+        require_launch(qwen_append_kv_cache_fp8_cuda(
+            k_norm.f16_data(), v.f16_data(),
+            layer.full.k_cache.fp8_data() + slot_offset,
+            layer.full.v_cache.fp8_data() + slot_offset,
+            layer.full.k_scale.f16_data() + slot_offset / kKvScaleBlock,
+            layer.full.v_scale.f16_data() + slot_offset / kKvScaleBlock,
+            rows, kv_heads, head_dim,
+            kKvScaleBlock, position_offset, runtime.max_context),
+            "append FP8 full KV cache");
+    } else if (cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
+        const int slot_bytes = qwen_turboquant_k8v4_slot_bytes(head_dim);
+        const size_t turboquant_slot_offset = static_cast<size_t>(slot_id) *
+            runtime.max_context * kv_heads * slot_bytes;
+        require_launch(qwen_append_kv_cache_turboquant_k8v4_cuda(
+            k_norm.f16_data(), v.f16_data(),
+            layer.full.turboquant_cache.byte_data() + turboquant_slot_offset,
+            rows, kv_heads, head_dim, position_offset, runtime.max_context),
+            "append TurboQuant K8V4 full KV cache");
+    } else if (cache_dtype == QwenKvCacheDType::Int8PerTokenHead) {
+        const size_t scale_offset = static_cast<size_t>(slot_id) * runtime.max_context * kv_heads;
+        require_launch(qwen_append_kv_cache_int8_per_token_head_cuda(
+            k_norm.f16_data(), v.f16_data(),
+            layer.full.k_cache.int8_data() + slot_offset,
+            layer.full.v_cache.int8_data() + slot_offset,
+            layer.full.k_scale.f16_data() + scale_offset,
+            layer.full.v_scale.f16_data() + scale_offset,
+            rows, kv_heads, head_dim,
+            position_offset, runtime.max_context),
+            "append INT8 per-token-head full KV cache");
+    } else {
+        require_launch(qwen_append_kv_cache_f16(
+            k_norm.f16_data(), v.f16_data(),
+            layer.full.k_cache.f16_data() + slot_offset,
+            layer.full.v_cache.f16_data() + slot_offset,
+            rows, kv_heads, head_dim,
+            position_offset, runtime.max_context), "append FP16 full KV cache");
+    }
+
+    // Where the read kernels find this sequence's history. Contiguous, that
+    // is the slot's own span of the arena. Paged and single-sequence, the
+    // blocks are gathered once per layer into the dense
+    // `[context, kv_heads, head_dim]` layout every read kernel already
+    // indexes, so the five tuned prefill and decode variants stay untouched.
+    // This is the same dequant-once trade the FP8 and TurboQuant paths make:
+    // one O(context) pass instead of translating inside O(rows * context)
+    // inner loops. Batched decode does not come through here; it reads the
+    // blocks natively, which is the path that has to scale with batch size.
+    // Only the FP16 cache stores halves here; the quantized caches keep
+    // their own packed buffers and reach for them inside their own branches
+    // below, so binding these eagerly would trip f16_data()'s dtype check.
+    const bool fp16_cache = cache_dtype == QwenKvCacheDType::Fp16;
+    const uint16_t* k_read = fp16_cache
+        ? layer.full.k_cache.f16_data() + slot_offset : nullptr;
+    const uint16_t* v_read = fp16_cache
+        ? layer.full.v_cache.f16_data() + slot_offset : nullptr;
+    if (runtime.kv_paged() && runtime.batch_rows == nullptr) {
+        const int context_length = position_offset + rows;
+        const std::vector<uint64_t> dense_shape = {
+            static_cast<uint64_t>(context_length),
+            static_cast<uint64_t>(kv_heads),
+            static_cast<uint64_t>(head_dim)};
+        const size_t dense_elements =
+            static_cast<size_t>(context_length) * kv_heads * head_dim;
+        QwenDeviceTensor& k_dense =
+            runtime.workspace_half(dense_elements, dense_shape);
+        QwenDeviceTensor& v_dense =
+            runtime.workspace_half(dense_elements, dense_shape);
+        typename Runtime::PhaseScope sub(&runtime, "full.kv_gather");
+        require_launch(qwen_gather_kv_cache_f16_paged_cuda(
+            layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
+            k_dense.f16_data(), v_dense.f16_data(), context_length,
+            kv_heads, head_dim, runtime.block_table_row(slot_id),
+            runtime.paged_block_size()), "gather paged FP16 KV cache");
+        k_read = k_dense.f16_data();
+        v_read = v_dense.f16_data();
+    }
+
+    if (runtime.batch_rows != nullptr) {
+        // One launch for the whole batch. The split geometry comes from the
+        // longest row, so the scratch is sized from that same query the
+        // launcher uses; shorter rows leave their trailing splits empty.
+        const int splits = qwen_gqa_decode_batched_split_count(
+            runtime.batch_rows->max_context_len, kv_heads, attention_window,
+            sink_tokens);
+        require_launch(splits > 0, "batched decode split geometry");
+        QwenDeviceTensor& partials = runtime.workspace_float(
+            static_cast<size_t>(rows) * q_heads * splits *
+                static_cast<size_t>(head_dim + 2),
+            {static_cast<uint64_t>(rows), static_cast<uint64_t>(q_heads),
+             static_cast<uint64_t>(splits),
+             static_cast<uint64_t>(head_dim + 2)});
+        typename Runtime::PhaseScope sub(&runtime, "full.attn_kernel");
+        require_launch(qwen_gqa_decode_attention_f16_batched_cuda(
+            q_norm.f16_data(), layer.full.k_cache.f16_data(),
+            layer.full.v_cache.f16_data(), attention.f16_data(),
+            partials.f32_data(), runtime.batch_rows->context_lens,
+            runtime.batch_rows->slot_ids, rows, runtime.batch_rows->max_context_len,
+            kv_slot_stride, q_heads, kv_heads, head_dim, runtime.max_context,
+            attention_window, sink_tokens, runtime.block_table_data(),
+            runtime.paged_block_size(), runtime.paged_blocks_per_seq()),
+            "batched decode FP16-cache GQA");
+    } else if (rows == 1) {
+        const int context_length = position_offset + 1;
+        const bool optimized_attention =
+            runtime.layer_config.gqa_optimized ||
+            attention_window > 0;
+        // The split/merge decode path used to lose below 16384 context
+        // because it walked 2048 positions per split serially, leaving the
+        // device idle. At 128 positions per split it wins everywhere it is
+        // allowed to run: 3.6x the reference kernels at 4096 context and
+        // 16.1x at 65536. Its own guard still declines contexts under 4096.
+        const bool optimized_decode = cache_dtype == QwenKvCacheDType::Fp16 &&
+            optimized_attention &&
+            (context_length >= 4096 || attention_window > 0);
+        int attended_positions = context_length;
+        if (attention_window > 0) {
+            const int sink_count = std::min(sink_tokens, context_length);
+            const int window_start = std::max(
+                context_length - attention_window, sink_count);
+            attended_positions = sink_count + (context_length - window_start);
+        }
+        // Must match the launch exactly; it sizes the partial scratch.
+        const bool tensor_core_decode_shape = attention_window <= 0 &&
+            sink_tokens == 0 && q_heads == kv_heads * 6 && head_dim == 256;
+        const int optimized_splits = qwen_gqa_decode_split_count(
+            attended_positions, kv_heads, tensor_core_decode_shape);
+        const size_t score_elements = optimized_decode
+            ? static_cast<size_t>(q_heads) * optimized_splits *
+                  static_cast<size_t>(head_dim + 2)
+            : static_cast<size_t>(q_heads) * context_length;
+        QwenDeviceTensor& scores = runtime.workspace_float(
+            score_elements,
+            optimized_decode
+                ? std::vector<uint64_t>{static_cast<uint64_t>(q_heads),
+                                        static_cast<uint64_t>(optimized_splits),
+                                        static_cast<uint64_t>(head_dim + 2)}
+                : std::vector<uint64_t>{static_cast<uint64_t>(q_heads),
+                                         static_cast<uint64_t>(context_length)});
+        if (cache_dtype == QwenKvCacheDType::Fp8) {
+            require_launch(qwen_gqa_decode_attention_fp8_cuda(
+                q_norm.f16_data(),
+                layer.full.k_cache.fp8_data() + slot_offset,
+                layer.full.v_cache.fp8_data() + slot_offset,
+                layer.full.k_scale.f16_data() + slot_offset / kKvScaleBlock,
+                layer.full.v_scale.f16_data() + slot_offset / kKvScaleBlock,
+                attention.f16_data(),
+                scores.f32_data(), q_heads, kv_heads, head_dim,
+                kKvScaleBlock, context_length, runtime.max_context),
+                "decode FP8-cache GQA");
+        } else if (cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
+            const int slot_bytes = qwen_turboquant_k8v4_slot_bytes(head_dim);
+            const size_t turboquant_slot_offset = static_cast<size_t>(slot_id) *
+                runtime.max_context * kv_heads * slot_bytes;
+            require_launch(qwen_gqa_decode_attention_turboquant_k8v4_cuda(
+                q_norm.f16_data(),
+                layer.full.turboquant_cache.byte_data() + turboquant_slot_offset,
+                attention.f16_data(), scores.f32_data(), q_heads, kv_heads,
+                head_dim, context_length, runtime.max_context, attention_window,
+                sink_tokens), "decode TurboQuant K8V4 GQA");
+        } else if (cache_dtype == QwenKvCacheDType::Int8PerTokenHead) {
+            const size_t scale_offset = static_cast<size_t>(slot_id) *
+                runtime.max_context * kv_heads;
+            require_launch(qwen_gqa_decode_attention_int8_per_token_head_cuda(
+                q_norm.f16_data(),
+                layer.full.k_cache.int8_data() + slot_offset,
+                layer.full.v_cache.int8_data() + slot_offset,
+                layer.full.k_scale.f16_data() + scale_offset,
+                layer.full.v_scale.f16_data() + scale_offset,
+                attention.f16_data(),
+                scores.f32_data(), q_heads, kv_heads, head_dim,
+                context_length, runtime.max_context, attention_window, sink_tokens),
+                "decode INT8 per-token-head GQA");
+        } else if (optimized_decode) {
+            require_launch(qwen_gqa_decode_attention_f16_fused_cuda(
+                q_norm.f16_data(),
+                k_read,
+                v_read,
+                attention.f16_data(),
+                scores.f32_data(), q_heads, kv_heads, head_dim,
+                context_length, runtime.max_context, attention_window, sink_tokens),
+                "decode optimized FP16-cache GQA");
+        } else {
+            require_launch(qwen_gqa_decode_attention_f16(
+                q_norm.f16_data(),
+                k_read,
+                v_read,
+                attention.f16_data(),
+                scores.f32_data(), q_heads, kv_heads, head_dim,
+                context_length, runtime.max_context), "decode FP16-cache GQA");
+        }
+    } else if (cache_dtype == QwenKvCacheDType::Fp8) {
+        const int context_length = position_offset + rows;
+        // Dequantize the [0, context_length) range once into dense FP16
+        // buffers, then call the tensor-core prefill kernel. O(ctx) dequant
+        // + tensor core beats O(rows*ctx) inline dequant by the same factor
+        // as TurboQuant (6-13×).
+        QwenDeviceTensor& k_dense = runtime.workspace_half(
+            static_cast<size_t>(context_length) * kv_heads * head_dim,
+            {static_cast<uint64_t>(context_length),
+             static_cast<uint64_t>(kv_heads),
+             static_cast<uint64_t>(head_dim)});
+        QwenDeviceTensor& v_dense = runtime.workspace_half(
+            static_cast<size_t>(context_length) * kv_heads * head_dim,
+            {static_cast<uint64_t>(context_length),
+             static_cast<uint64_t>(kv_heads),
+             static_cast<uint64_t>(head_dim)});
+        require_launch(qwen_fp8_dequant_kv_cache_cuda(
+            layer.full.k_cache.fp8_data() + slot_offset,
+            layer.full.v_cache.fp8_data() + slot_offset,
+            layer.full.k_scale.f16_data() + slot_offset / kKvScaleBlock,
+            layer.full.v_scale.f16_data() + slot_offset / kKvScaleBlock,
+            k_dense.f16_data(), v_dense.f16_data(), context_length,
+            kv_heads, head_dim, kKvScaleBlock, runtime.max_context),
+            "dequant FP8 cache to dense FP16");
+        if (runtime.layer_config.gqa_optimized ||
+            attention_window > 0) {
+            require_launch(qwen_gqa_prefill_attention_f16_tiled_cuda(
+                q_norm.f16_data(), k_dense.f16_data(), v_dense.f16_data(),
+                attention.f16_data(), rows, q_heads, kv_heads, head_dim,
+                position_offset, runtime.max_context, attention_window, sink_tokens),
+                "prefill FP8 via tensor-core tiled");
+        } else {
+            require_launch(qwen_gqa_prefill_attention_f16(
+                q_norm.f16_data(), k_dense.f16_data(), v_dense.f16_data(),
+                attention.f16_data(), rows, q_heads, kv_heads, head_dim,
+                position_offset, runtime.max_context),
+                "prefill FP8 via tensor-core exact");
+        }
+    } else if (cache_dtype == QwenKvCacheDType::Int8PerTokenHead) {
+        const int context_length = position_offset + rows;
+        // INT8 per-token-head uses the same dequant-once architecture as FP8
+        QwenDeviceTensor& k_dense = runtime.workspace_half(
+            static_cast<size_t>(context_length) * kv_heads * head_dim,
+            {static_cast<uint64_t>(context_length),
+             static_cast<uint64_t>(kv_heads),
+             static_cast<uint64_t>(head_dim)});
+        QwenDeviceTensor& v_dense = runtime.workspace_half(
+            static_cast<size_t>(context_length) * kv_heads * head_dim,
+            {static_cast<uint64_t>(context_length),
+             static_cast<uint64_t>(kv_heads),
+             static_cast<uint64_t>(head_dim)});
+        const size_t scale_offset = static_cast<size_t>(slot_id) * runtime.max_context * kv_heads;
+        require_launch(qwen_int8_dequant_kv_cache_cuda(
+            layer.full.k_cache.int8_data() + slot_offset,
+            layer.full.v_cache.int8_data() + slot_offset,
+            layer.full.k_scale.f16_data() + scale_offset,
+            layer.full.v_scale.f16_data() + scale_offset,
+            k_dense.f16_data(), v_dense.f16_data(), context_length,
+            kv_heads, head_dim, runtime.max_context),
+            "dequant INT8 cache to dense FP16");
+        if (runtime.layer_config.gqa_optimized ||
+            attention_window > 0) {
+            require_launch(qwen_gqa_prefill_attention_f16_tiled_cuda(
+                q_norm.f16_data(), k_dense.f16_data(), v_dense.f16_data(),
+                attention.f16_data(), rows, q_heads, kv_heads, head_dim,
+                position_offset, runtime.max_context, attention_window, sink_tokens),
+                "prefill INT8 via tensor-core tiled");
+        } else {
+            require_launch(qwen_gqa_prefill_attention_f16(
+                q_norm.f16_data(), k_dense.f16_data(), v_dense.f16_data(),
+                attention.f16_data(), rows, q_heads, kv_heads, head_dim,
+                position_offset, runtime.max_context),
+                "prefill INT8 via tensor-core exact");
+        }
+    } else if (cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
+        const int context_length = position_offset + rows;
+        // Dequantize the [0, context_length) range once into dense FP16
+        // buffers laid out like the FP16 cache, then call the tensor-core
+        // prefill kernel on them. O(ctx) dequant + tensor core beats
+        // O(rows*ctx) inline dequant by 6-13× and keeps prefill fast.
+        QwenDeviceTensor& k_dense = runtime.workspace_half(
+            static_cast<size_t>(context_length) * kv_heads * head_dim,
+            {static_cast<uint64_t>(context_length),
+             static_cast<uint64_t>(kv_heads),
+             static_cast<uint64_t>(head_dim)});
+        QwenDeviceTensor& v_dense = runtime.workspace_half(
+            static_cast<size_t>(context_length) * kv_heads * head_dim,
+            {static_cast<uint64_t>(context_length),
+             static_cast<uint64_t>(kv_heads),
+             static_cast<uint64_t>(head_dim)});
+        const int slot_bytes = qwen_turboquant_k8v4_slot_bytes(head_dim);
+        const size_t turboquant_slot_offset = static_cast<size_t>(slot_id) *
+            runtime.max_context * kv_heads * slot_bytes;
+        require_launch(qwen_turboquant_k8v4_dequant_kv_cuda(
+            layer.full.turboquant_cache.byte_data() + turboquant_slot_offset, k_dense.f16_data(),
+            v_dense.f16_data(), context_length, kv_heads, head_dim,
+            runtime.max_context), "dequant TurboQuant cache to dense FP16");
+        if (runtime.layer_config.gqa_optimized ||
+            attention_window > 0) {
+            require_launch(qwen_gqa_prefill_attention_f16_tiled_cuda(
+                q_norm.f16_data(), k_dense.f16_data(), v_dense.f16_data(),
+                attention.f16_data(), rows, q_heads, kv_heads, head_dim,
+                position_offset, runtime.max_context, attention_window, sink_tokens),
+                "prefill TurboQuant via tensor-core tiled");
+        } else {
+            require_launch(qwen_gqa_prefill_attention_f16(
+                q_norm.f16_data(), k_dense.f16_data(), v_dense.f16_data(),
+                attention.f16_data(), rows, q_heads, kv_heads, head_dim,
+                position_offset, runtime.max_context),
+                "prefill TurboQuant via tensor-core exact");
+        }
+    } else if (cache_dtype == QwenKvCacheDType::Fp16 && rows <= 8 && attention_window == 0) {
+        const int context_length = position_offset + rows;
+        // Tensor-core QK experiment for the real TP4 shape (one KV head per
+        // rank). Keeps the existing FP32 softmax/PV order; opt-in until real
+        // parity and latency are validated.
+        if (runtime.layer_config.gqa_verify_cublas_qk &&
+            kv_heads == 1) {
+            const size_t score_elements =
+                static_cast<size_t>(rows) * q_heads * context_length;
+            QwenDeviceTensor& scores = runtime.workspace_float(
+                score_elements,
+                {static_cast<uint64_t>(rows),
+                 static_cast<uint64_t>(q_heads),
+                 static_cast<uint64_t>(context_length)});
+            typename Runtime::PhaseScope sub(&runtime, "full.attn_kernel");
+            require_launch(qwen_gqa_verify_attention_f16_cublas_qk_cuda(
+                q_norm.f16_data(),
+                k_read,
+                v_read,
+                attention.f16_data(),
+                scores.f32_data(), rows, q_heads, kv_heads, head_dim,
+                position_offset, runtime.max_context),
+                "verify cuBLAS-QK FP16-cache GQA");
+        // The exact three-kernel path avoids split partials below 1K context;
+        // the split-K path crosses over above that and remains faster at long
+        // context. QWEN_GQA_VERIFY_SPLIT explicitly overrides the crossover.
+        } else if (runtime.layer_config.gqa_verify_split ==
+                       OptionalSwitch::Enabled ||
+                   (runtime.layer_config.gqa_verify_split ==
+                        OptionalSwitch::Auto && context_length > 1024)) {
+            // 32 splits stay slightly faster end-to-end at short context;
+            // 64 cross over at 1K and remain best through 32K.
+            const int default_splits = context_length >= 1024 ? 64 : 32;
+            int target_splits = runtime.layer_config.gqa_verify_splits > 0
+                ? runtime.layer_config.gqa_verify_splits : default_splits;
+            if (target_splits <= 0) target_splits = default_splits;
+            const int verify_splits = std::max(
+                1, std::min(target_splits, context_length));
+            const size_t partial_elements =
+                static_cast<size_t>(rows) * q_heads * verify_splits *
+                static_cast<size_t>(head_dim + 2);
+            QwenDeviceTensor& partials = runtime.workspace_float(
+                partial_elements,
+                {static_cast<uint64_t>(rows),
+                 static_cast<uint64_t>(q_heads),
+                 static_cast<uint64_t>(verify_splits),
+                 static_cast<uint64_t>(head_dim + 2)});
+            typename Runtime::PhaseScope sub(&runtime, "full.attn_kernel");
+            require_launch(qwen_gqa_verify_attention_f16(
+                q_norm.f16_data(),
+                k_read,
+                v_read,
+                attention.f16_data(),
+                partials.f32_data(), rows, q_heads, kv_heads, head_dim,
+                position_offset, runtime.max_context, verify_splits),
+                "verify split FP16-cache GQA");
+        } else {
+            const size_t score_elements =
+                static_cast<size_t>(rows) * q_heads * context_length;
+            QwenDeviceTensor& scores = runtime.workspace_float(
+                score_elements,
+                {static_cast<uint64_t>(rows),
+                 static_cast<uint64_t>(q_heads),
+                 static_cast<uint64_t>(context_length)});
+            {
+                typename Runtime::PhaseScope sub(
+                    &runtime, "full.attn_kernel");
+                require_launch(qwen_gqa_verify_attention_f16_exact_cuda(
+                    q_norm.f16_data(),
+                    k_read,
+                    v_read,
+                    attention.f16_data(),
+                    scores.f32_data(), rows, q_heads, kv_heads, head_dim,
+                    position_offset, runtime.max_context),
+                    "verify exact FP16-cache GQA");
+            }
+        }
+    // The tiled kernel shares each K/V element across a head group and a
+    // pair of query rows, so it is the default for multi-row prefill. The
+    // wider TP4 candidate is selected separately through LONG_TILE.
+    } else if (runtime.layer_config.gqa_optimized ||
+               attention_window > 0) {
+        require_launch(qwen_gqa_prefill_attention_f16_tiled_cuda(
+            q_norm.f16_data(),
+            k_read,
+            v_read,
+            attention.f16_data(), rows,
+            q_heads, kv_heads, head_dim, position_offset, runtime.max_context,
+            attention_window, sink_tokens),
+            "prefill optimized FP16-cache GQA");
+    } else {
+        require_launch(qwen_gqa_prefill_attention_f16(
+            q_norm.f16_data(),
+            k_read,
+            v_read,
+            attention.f16_data(), rows,
+            q_heads, kv_heads, head_dim, position_offset, runtime.max_context),
+            "prefill FP16-cache GQA");
+    }
+#endif
+    require_launch(qwen_sigmoid_mul_f16(
+        attention.f16_data(), gate.f16_data(), merged.f16_data(),
+        rows * attention_dim), "FP16 full attention output gate");
+    // Row-parallel output projection: each slice's rows are complete once its
+    // GEMM lands, so the collective for slice i can run under slice i+1's GEMM.
+    // This site was left serial when mlp.down and lin.out were pipelined, and
+    // at 65K it was the single largest exposed collective in the profile
+    // (ar.full.out 2.12 s against tp_all_reduce's 3.16 s total).
+    if (!runtime.projection_all_reduce_overlapped(
+            layer.full.out, merged.f16_data(), output, rows,
+            static_cast<int>(runtime.config.hidden_size), "full.out", "full.out")) {
+        {
+            typename Runtime::PhaseScope sub(&runtime, "full.out_proj");
+            runtime.linear_component.forward(
+                runtime, layer.full.out, merged.f16_data(), output, rows,
+                "full.out");
+        }
+        runtime.all_reduce_half(
+            output, rows * static_cast<int>(runtime.config.hidden_size),
+            "full.out");
+    }
+}
+
+
+template <typename Runtime>
+typename FusedGateUpSwiGLU::Workspace FusedGateUpSwiGLU::reserve(
+    Runtime& runtime, DeviceLayer& layer, int rows, int hidden_size) const {
+    Workspace workspace;
+#ifdef POCKET_BACKEND_ASCEND
+    // Quantized fused kernels are unavailable on this backend. Constants keep
+    // the shared workspace and composition path identical after dead-code removal.
+    workspace.fused_decode = false;
+    workspace.fused_small_batch = false;
+    workspace.fused_nvfp4 = false;
+    workspace.shared_nvfp4 = false;
+#else
+    const bool compatible_fp8 =
+        layer.gate.kind == QwenLinearKind::Fp8Block128 &&
+        layer.up.kind == QwenLinearKind::Fp8Block128 &&
+        layer.gate.logical_shape == layer.up.logical_shape &&
+        layer.gate.scale.shape == layer.up.scale.shape;
+    workspace.fused_decode = rows == 1 && compatible_fp8;
+    workspace.fused_small_batch = rows > 1 && rows <= 8 &&
+        compatible_fp8 && hidden_size % 4 == 0;
+    const bool nvfp4_wmma =
+        runtime.layer_config.nvfp4_mode == NvFp4Mode::Auto ||
+        runtime.layer_config.nvfp4_mode == NvFp4Mode::Wmma;
+    const bool compatible_nvfp4 = rows >= 8 && nvfp4_wmma &&
+        layer.gate.kind == QwenLinearKind::NvFp4Group16 &&
+        layer.up.kind == QwenLinearKind::NvFp4Group16 &&
+        layer.gate.logical_shape == layer.up.logical_shape;
+    workspace.fused_nvfp4 = compatible_nvfp4 &&
+        runtime.layer_config.nvfp4_fused_swiglu;
+    workspace.shared_nvfp4 = compatible_nvfp4 &&
+        runtime.layer_config.nvfp4_shared_q8_swiglu &&
+        !workspace.fused_nvfp4;
+#endif
+    const size_t intermediate_elements = static_cast<size_t>(rows) *
+        layer.gate.logical_shape[0];
+    if (!workspace.fused_decode && !workspace.fused_small_batch &&
+        !workspace.fused_nvfp4) {
+        workspace.gate = &runtime.workspace_half(
+            intermediate_elements,
+            {static_cast<uint64_t>(rows), layer.gate.logical_shape[0]});
+        workspace.up = &runtime.workspace_half(
+            intermediate_elements, workspace.gate->shape);
+    }
+    workspace.output = &runtime.workspace_half(
+        intermediate_elements,
+        {static_cast<uint64_t>(rows), layer.gate.logical_shape[0]});
+    return workspace;
+}
+
+template <typename Runtime>
+void FusedGateUpSwiGLU::forward(
+    Runtime& runtime, DeviceLayer& layer, const uint16_t* input,
+    Workspace& workspace, int rows, int hidden_size) const {
+#ifdef POCKET_BACKEND_ASCEND
+    runtime.linear_component.forward(
+        runtime, layer.gate, input, workspace.gate->f16_data(), rows,
+        "mlp.gate");
+    runtime.linear_component.forward(
+        runtime, layer.up, input, workspace.up->f16_data(), rows, "mlp.up");
+    require_launch(qwen_silu_mul_rows_f16(
+        workspace.gate->f16_data(), workspace.up->f16_data(),
+        workspace.output->f16_data(), rows,
+        static_cast<int>(layer.gate.logical_shape[0])), "FP16 SwiGLU");
+#else
+    if (workspace.fused_decode) {
+        typename Runtime::PhaseScope scope(&runtime, "swiglu.d");
+        require_launch(qwen_fp8_e4m3_fp16scale_swiglu_matvec_f16_cuda(
+            input, layer.gate.weight.fp8_data(),
+            layer.gate.scale.f16_data(), layer.up.weight.fp8_data(),
+            layer.up.scale.f16_data(), workspace.output->f16_data(),
+            static_cast<int>(layer.gate.logical_shape[0]), hidden_size,
+            hidden_size, static_cast<int>(layer.gate.scale.shape[1])),
+            "FP16 fused decode SwiGLU");
+    } else if (workspace.fused_small_batch) {
+        typename Runtime::PhaseScope scope(&runtime, "swiglu.r");
+        require_launch(
+            qwen_fp8_e4m3_fp16scale_swiglu_small_batch_f16_cuda(
+                input, layer.gate.weight.fp8_data(),
+                layer.gate.scale.f16_data(), layer.up.weight.fp8_data(),
+                layer.up.scale.f16_data(), workspace.output->f16_data(), rows,
+                static_cast<int>(layer.gate.logical_shape[0]), hidden_size,
+                hidden_size, static_cast<int>(layer.gate.logical_shape[0]),
+                hidden_size, static_cast<int>(layer.gate.scale.shape[1])),
+            "FP16 fused small-batch SwiGLU");
+    } else if (workspace.fused_nvfp4) {
+        typename Runtime::PhaseScope scope(&runtime, "projection_rows_nvfp4");
+        require_launch(runtime.nvfp4_fused_swiglu_projection(
+            layer.gate, layer.up, input, workspace.output->f16_data(), rows),
+            "NVFP4 fused Q8 WMMA SwiGLU projection");
+    } else {
+        if (workspace.shared_nvfp4) {
+            typename Runtime::PhaseScope scope(
+                &runtime, "projection_rows_nvfp4");
+            require_launch(runtime.nvfp4_shared_q8_swiglu_projection(
+                layer.gate, layer.up, input, workspace.gate->f16_data(),
+                workspace.up->f16_data(), rows),
+                "NVFP4 shared-Q8 WMMA gate/up projection");
+        } else {
+            runtime.linear_component.forward(
+                runtime, layer.gate, input, workspace.gate->f16_data(), rows,
+                "mlp.gate");
+            runtime.linear_component.forward(
+                runtime, layer.up, input, workspace.up->f16_data(), rows,
+                "mlp.up");
+        }
+        require_launch(qwen_silu_mul_rows_f16(
+            workspace.gate->f16_data(), workspace.up->f16_data(),
+            workspace.output->f16_data(), rows,
+            static_cast<int>(layer.gate.logical_shape[0])), "FP16 SwiGLU");
+    }
+#endif
+}
+
+template <typename Runtime>
+void DecoderLayer::forward(Runtime& runtime, DeviceLayer& layer,
+                           const uint16_t* hidden, uint16_t* output, int rows,
+                           int position_offset, int slot_id) const {
+    const int hidden_size = static_cast<int>(runtime.config.hidden_size);
+    runtime.begin_workspace();
+    const size_t hidden_elements = static_cast<size_t>(rows) * hidden_size;
+    QwenDeviceTensor& normalized = runtime.workspace_half(
+        hidden_elements, {static_cast<uint64_t>(rows),
+                          static_cast<uint64_t>(hidden_size)});
+    QwenDeviceTensor& attention = runtime.workspace_half(
+        hidden_elements, normalized.shape);
+    QwenDeviceTensor& post = runtime.workspace_half(
+        hidden_elements, normalized.shape);
+    typename FusedGateUpSwiGLU::Workspace swiglu =
+        runtime.swiglu_component.reserve(runtime, layer, rows, hidden_size);
+    QwenDeviceTensor& mlp = runtime.workspace_half(
+        hidden_elements, normalized.shape);
+
+    runtime.rms_norm_component.forward(
+        runtime, layer.input_norm, hidden, normalized.f16_data(), rows,
+        hidden_size);
+    if (layer.linear.qkv.weight.data != nullptr) {
+        runtime.gated_delta_attention_component.forward(
+            runtime, layer, normalized.f16_data(), attention.f16_data(), rows,
+            position_offset, slot_id);
+    } else {
+        runtime.gqa_attention_component.forward(
+            runtime, layer, normalized.f16_data(), attention.f16_data(), rows,
+            position_offset, slot_id);
+    }
+    // One fused pass replaces residual copy, add, and norm. The opt-out remains
+    // available for A/B while construction-time policy keeps requests immutable.
+    if (runtime.layer_config.fuse_attention_residual_norm) {
+        typename Runtime::PhaseScope scope(&runtime, "attn_resid_norm");
+        require_launch(qwen_residual_add_rmsnorm_fp16_gamma_rows_f16(
+            hidden, attention.f16_data(), layer.post_norm.f16_data(), output,
+            post.f16_data(), rows, hidden_size,
+            static_cast<float>(runtime.config.rms_norm_eps)),
+            "Qwen fused attention residual RMSNorm");
+    } else {
+        {
+            typename Runtime::PhaseScope scope(&runtime, "resid_copy");
+            check_device(memcpy_d2d(
+                output, hidden, hidden_elements * sizeof(uint16_t)),
+                "Qwen FP16 residual copy");
+        }
+        runtime.add(output, attention.f16_data(), rows * hidden_size);
+        runtime.rms_norm_component.forward(
+            runtime, layer.post_norm, output, post.f16_data(), rows,
+            hidden_size);
+    }
+    runtime.swiglu_component.forward(
+        runtime, layer, post.f16_data(), swiglu, rows, hidden_size);
+    // The down projection and all-reduce are the largest overlap opportunity.
+    if (!runtime.projection_all_reduce_overlapped(
+            layer.down, swiglu.output->f16_data(), mlp.f16_data(), rows,
+            hidden_size, "mlp.down", "mlp")) {
+        runtime.linear_component.forward(
+            runtime, layer.down, swiglu.output->f16_data(), mlp.f16_data(),
+            rows, "mlp.down");
+        runtime.all_reduce_half(mlp.f16_data(), rows * hidden_size, "mlp");
+    }
+    runtime.add(output, mlp.f16_data(), rows * hidden_size);
+}
+
+}  // namespace qwen_components


### PR DESCRIPTION
## Summary

- Extract Qwen projection, normalization, attention, SwiGLU, and decoder-layer execution from the monolithic engine implementation.
- Keep layer components concrete and template-dispatched so the 64-layer hot loop does not gain virtual calls.
- Capture layer execution policy once when the engine is constructed instead of reading environment variables in every layer.

## Implementation notes

- Added explicit `Linear`, `RMSNorm`, `GatedDeltaNetAttention`, `GqaAttention`, `FusedGateUpSwiGLU`, and `DecoderLayer` components.
- Moved device-resident layer structures next to the operations that consume them while leaving checkpoint loading in `qwen_engine.cpp`.
- Kept runtime services in `QwenEngine::Impl`: workspace allocation, paged-KV addressing, profiling, NVFP4 scratch, collectives, and projection/all-reduce overlap.
- Split SwiGLU workspace reservation from execution so the original workspace slot order and peak allocation remain unchanged.
- Preserved every existing FP8, NVFP4, Gated DeltaNet, GQA, paged-KV, fused residual, and communication-overlap path.
- Preserved malformed/absent environment-variable semantics, including deferred NVFP4 mode validation for non-NVFP4 checkpoints.

## Testing

- CUDA Release build: PASS.
- Optional Python extension build and import: PASS; NCCL linkage confirmed.
- Layering check: PASS (`64 files clean`).
- Ascend-neutral preprocessor syntax check of `qwen_engine.cpp`: PASS.
- Kernel-call sequence comparison against the pre-extraction source: PASS for Linear (12), RMSNorm (1), GDN (15), GQA (42), and decoder/SwiGLU composition (5).
- No component vtables found in the linked static library.
- Focused C++ tests: PASS, including Qwen engine, half ops, GQA, FlashQLA GDN, and NVFP4.
- Full 83-binary no-argument C++ suite: status-for-status identical to PR #141 baseline, including the same pre-existing usage-only and hardware-dependent failures.
- Focused Python backend/sidecar tests: `35 passed`.
- Tracked Python suite: `12 failed, 387 passed, 82 skipped, 4 errors`, identical to the PR #141 baseline failure/error set.

### Token-exact parity

FP8 TP4, four active layers, context 1024, 16 decode steps:

| KV layout | Batch | Baseline digest | Extracted digest |
|---|---:|---|---|
| contiguous | 1 | `df92123420008a37` | `df92123420008a37` |
| paged | 1 | `df92123420008a37` | `df92123420008a37` |
| contiguous | 4 | `2c2fdc7199eb3f43` | `2c2fdc7199eb3f43` |
| paged | 4 | `2c2fdc7199eb3f43` | `2c2fdc7199eb3f43` |
| contiguous | 8 | `156efc37fb5e762a` | `156efc37fb5e762a` |
| paged | 8 | `156efc37fb5e762a` | `156efc37fb5e762a` |

NVFP4 TP4, four active layers:

- `auto`: `df92123420008a37` before and after.
- `reference`: `df92123420008a37` before and after.

## Performance impact

Measured with `/mnt/data2/Qwen3.8-27B-FP8`, full 64 layers, TP4 on four RTX 2080 Ti GPUs, FP16 KV, prefill chunk 4096, and one configuration per fresh process. Both orders were run serially; repetition 0 was discarded. Decode requested TG64 and timed 63 decode transitions.

Order-balanced geometric extracted/baseline ratios:

| Context | Prefill | Decode TG64 |
|---:|---:|---:|
| 8K | `+0.45%` | `-0.23%` |
| 65K | `-0.50%` | `-0.19%` |

The deltas are within observed run-order and thermal noise. A synchronization-heavy 8K component profile also kept the extracted compute components flat or slightly faster; the whole stack changed by `+0.08%`.

## Checklist

- [x] No virtual dispatch in the layer loop
- [x] Kernel launch order preserved
- [x] Workspace allocation order preserved
- [x] Token-exact FP8 and NVFP4 parity
- [x] Serial short/long real-checkpoint performance A/B
- [x] Existing C++ and Python suites compared with baseline
- [x] No unrelated files included

🤖 Generated with [Claude Code](https://claude.com/claude-code)