### PR TITLE
Validate Qwen native OpenAI serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The project started with DeepSeek-V4 on 4×RTX 2080 Ti and now includes validate
 - **Low-bit execution without unnecessary expansion:** FP4, FP8 E4M3, GGUF Q4/Q5/Q8, IQ1/IQ2/IQ3, and Q2 paths consume quantized blocks directly in the hot path where supported.
 - **Consumer-GPU parallelism:** TP4/NCCL execution on PCIe-connected GPUs, with CPU/NUMA expert placement for checkpoints that do not fit in device memory.
 - **Separate prefill and decode dispatch:** large-row kernels are optimized independently from single-token latency paths.
-- **Native C++/CUDA runtime:** the `cpp_engine/` path supports DeepSeek-V4 GGUF/Safetensors flows and Qwen3.8 FP8 Safetensors text generation.
+- **Native C++/CUDA runtime:** the `cpp_engine/` path supports DeepSeek-V4 GGUF/Safetensors flows, Qwen3.8 FP8 Safetensors text generation, and the validated Qwen OpenAI-compatible text server.
 - **Inspection and validation tools:** GGUF architecture/spec reports, Safetensors audits, tensor-shape checks, numerical parity tests, and real-checkpoint benchmarks.
 
 ## Supported models at a glance
@@ -24,7 +24,7 @@ The project started with DeepSeek-V4 on 4×RTX 2080 Ti and now includes validate
 | [DeepSeek-V4-Flash](docs/models/deepseek-v4.md) | Safetensors FP4/FP8; GGUF Q2/IQ2/IQ1 | **Validated generation** | PyTorch heterogeneous, C++/CUDA, GGUF TP4 | C++ FP4: ~401 tok/s prefill at 32K–64K; ~3.7 tok/s decode |
 | [MiniMax-M2.7](docs/models/minimax-m2.7.md) | GGUF `UD-IQ1_M` | **Validated TP4 generation** | Raw-block CUDA, GGUF TP4 | Full-model 256-token prefill: ~104.9–107 tok/s; 43-layer decode benchmark: 10.32 tok/s |
 | [GLM-5.2](docs/models/glm-5.2.md) | GGUF `UD-Q2_K_XL` | **Validated text generation** | Raw-block CUDA, GGUF TP4 | ~0.79 tok/s prefill; ~0.66 tok/s decode |
-| [Qwen3.8-27B-FP8](docs/models/qwen3.8-27b-fp8.md) | Safetensors FP8 E4M3 | **Validated C++ text runtime** | C++/CUDA TP4, GPU-resident FP8 | 416.48 tok/s prefill; 35.87 tok/s decode on a 512-token prompt |
+| [Qwen3.8-27B-FP8](docs/models/qwen3.8-27b-fp8.md) | Safetensors FP8 E4M3 | **Validated C++ text runtime and server** | C++/CUDA TP4, GPU-resident FP8 | 416.48 tok/s prefill; 35.87 tok/s decode on a 512-token prompt |
 
 The model pages separate architecture specifications from what PocketLLM currently implements. `inspect`, `smoke`, and a benchmark are not automatically equivalent to a production serving guarantee.
 
@@ -37,7 +37,7 @@ All figures in this section use real checkpoints on the same baseline system unl
 - 64-token prompt: 138.61–138.69 tok/s prefill, 36.82 tok/s decode.
 - 512-token prompt: 416.48 tok/s prefill, 35.87 tok/s decode.
 - Approximately 8.0–8.6 GiB used per rank in the measured runs; local FP8 weights and scales remain GPU-resident.
-- Token sequences were identical across all four TP ranks. The current path is text-only and is not wired to the OpenAI server.
+- Token sequences were identical across all four TP ranks. The native OpenAI-compatible server is validated for text requests; image and video inputs remain unsupported.
 
 ### DeepSeek-V4 C++ FP4 runtime
 
@@ -186,7 +186,18 @@ done
 wait
 ```
 
-For a normal run, use the same command-line options as the Qwen smoke entrypoint and let rank 0 report `prefill_tokens_per_s`, `decode_tokens_per_s`, resident weight bytes, and GPU memory. The Qwen OpenAI server adapter is not implemented yet.
+For a normal run, use the same command-line options as the Qwen smoke entrypoint and let rank 0 report `prefill_tokens_per_s`, `decode_tokens_per_s`, resident weight bytes, and GPU memory. The native Qwen text server can be verified against a real checkpoint with:
+
+```bash
+python scripts/verify_cpp_qwen_openai.py \\
+  --ckpt /path/to/Qwen3.8-27B-FP8 \\
+  --binary build/cpp_engine/pocketllm_engine \\
+  --python /path/to/python-with-transformers \\
+  --sidecar src/server/cpp_sidecar.py \\
+  --devices 0,1,2,3
+```
+
+The harness checks health, model discovery, non-streaming and streaming chat completions, fixed-sampling validation, and concurrent scheduler admission.
 
 External Qwen DSpark is available as an opt-in with `--qwen-dspark /path/to/Qwen3.8-27B-DSpark`; it cannot be combined with native MTP. The real five-layer drafter proposes seven tokens and verifies eight target rows at once. It remains default-off because measured gains are acceptance-dependent. See the [Qwen model page](docs/models/qwen3.8-27b-fp8.md#external-dspark-speculative-decoding) for real 512/8K/32K results and the prefix/cold-parity command.
 
@@ -225,7 +236,7 @@ The benchmark starts ranks 1–3 as command workers and keeps rank 0 alive for a
 - [x] MiniMax-M2.7 and GLM-5.2 GGUF raw-block generation paths.
 - [x] Qwen3.8-27B-FP8 C++ TP4 text runtime.
 - [ ] Generalize the C++ model dispatch and binary naming without breaking existing scripts.
-- [ ] Qwen OpenAI-compatible serving adapter.
+- [x] Qwen OpenAI-compatible text serving adapter.
 - [ ] CUDA Graph and persistent decode dispatch where measured beneficial.
 - [ ] More model-specific benchmark fixtures and automated regression dashboards.
 
@@ -235,7 +246,7 @@ The benchmark starts ranks 1–3 as command workers and keeps rank 0 alive for a
 - GGUF expert staging can dominate decode on PCIe-only systems; a high prefill number does not imply high decode TPS.
 - DeepSeek-V4 DSpark's current C++ verify path is sequential and should not be presented as a speedup claim. Qwen DSpark is a separate external drafter with one eight-row target verification and model-specific parity/performance data.
 - Qwen DFlash2 wall-clock speedup is acceptance-dependent and prefill-capped: the synthetic fixtures accept the full eight-row block while GSM8K accepts 2.9–4.4, and shared prefill limits the 8,192-token case to 1.95x even with zero decode time. Upstream's 2.67–3.43x is a decode-latency ratio, not a full-request wall ratio.
-- The Qwen runtime currently supports the text checkpoint path only. Vision inputs and OpenAI-compatible Qwen serving are not wired in.
+- The Qwen runtime currently supports the text checkpoint path only. Vision inputs and multimodal serving are not implemented.
 - Some experimental optimizations are intentionally opt-in or disabled after real end-to-end regressions. See the model pages and historical notes for details.
 
 ## License

--- a/README_CN.md
+++ b/README_CN.md
@@ -14,7 +14,7 @@ PocketLLM 是一个面向消费级多卡系统的大模型推理工程栈，包�
 - **避免不必要的低 bit 展开：** 在支持的热路径中直接消费 FP4、FP8 E4M3、GGUF Q4/Q5/Q8、IQ1/IQ2/IQ3、Q2 等量化 block。
 - **消费级 GPU 并行：** 支持 PCIe 多卡上的 TP4/NCCL；对放不进显存的 checkpoint，支持 CPU/NUMA expert placement。
 - **Prefill/decode 分离：** 大 batch kernel 与单 token latency 路径独立调度、独立优化。
-- **原生 C++/CUDA runtime：** `cpp_engine/` 当前支持 DeepSeek-V4 GGUF/Safetensors 路径，以及 Qwen3.8 FP8 Safetensors 文本生成。
+- **原生 C++/CUDA runtime：** `cpp_engine/` 当前支持 DeepSeek-V4 GGUF/Safetensors 路径、Qwen3.8 FP8 Safetensors 文本生成，以及已验证的 Qwen OpenAI 兼容文本 server。
 - **检查和验证工具：** GGUF 架构/spec 报告、Safetensors audit、tensor shape 检查、数值 parity 测试和真实 checkpoint benchmark。
 
 ## 支持模型一览
@@ -37,7 +37,7 @@ PocketLLM 是一个面向消费级多卡系统的大模型推理工程栈，包�
 - 64-token prompt：prefill 138.61–138.69 tok/s，decode 36.82 tok/s。
 - 512-token prompt：prefill 416.48 tok/s，decode 35.87 tok/s。
 - 实测每 rank 约使用 8.0–8.6 GiB；本地 FP8 权重和 scale 常驻 GPU。
-- 四个 TP rank 的生成 token 序列一致。当前路径是 text-only，尚未接入 OpenAI server。
+- 四个 TP rank 的生成 token 序列一致。原生 OpenAI 兼容 server 已验证 text 请求；图像和视频输入仍不支持。
 
 ### DeepSeek-V4 C++ FP4 runtime
 
@@ -154,7 +154,18 @@ done
 wait
 ```
 
-正常运行时使用相同的 Qwen smoke 参数；rank 0 会输出 `prefill_tokens_per_s`、`decode_tokens_per_s`、resident weight bytes 和 GPU memory。Qwen OpenAI server adapter 尚未实现。
+正常运行时使用相同的 Qwen smoke 参数；rank 0 会输出 `prefill_tokens_per_s`、`decode_tokens_per_s`、resident weight bytes 和 GPU memory。可以使用真实 checkpoint 验证原生 Qwen 文本 server：
+
+```bash
+python scripts/verify_cpp_qwen_openai.py \\
+  --ckpt /path/to/Qwen3.8-27B-FP8 \\
+  --binary build/cpp_engine/pocketllm_engine \\
+  --python /path/to/python-with-transformers \\
+  --sidecar src/server/cpp_sidecar.py \\
+  --devices 0,1,2,3
+```
+
+该 harness 会检查 health、model discovery、非流式和流式 chat completion、固定 sampling 校验，以及并发 scheduler admission。
 
 对于单并发客户端，如果后续请求会追加或压缩上一次请求，使用长期存活的 TP4 token-ID worker。rank 0 读取 `<max_new_tokens> token0 token1 ...`，并输出 exact prefix 统计；追加请求复用 live state，分叉请求从 GPU snapshot 恢复：
 
@@ -189,7 +200,7 @@ benchmark 会启动 rank 1–3 command worker，让 rank 0 在多轮请求间保
 - [x] MiniMax-M2.7 与 GLM-5.2 GGUF raw-block generation 路径。
 - [x] Qwen3.8-27B-FP8 C++ TP4 文本 runtime。
 - [ ] 在不破坏现有脚本的前提下，统一 C++ model dispatch 和 binary 命名。
-- [ ] Qwen OpenAI 兼容 serving adapter。
+- [x] Qwen OpenAI 兼容文本 serving adapter。
 - [ ] 在实测有收益时接入 CUDA Graph 和 persistent decode dispatch。
 - [ ] 增加更多模型 benchmark fixture 和自动化 regression dashboard。
 
@@ -198,7 +209,7 @@ benchmark 会启动 rank 1–3 command worker，让 rank 0 在多轮请求间保
 - 性能高度依赖 GPU 型号、PCIe 拓扑、NUMA placement、驱动/runtime 版本和 checkpoint 变体。
 - PCIe 系统上的 GGUF expert staging 可能主导 decode；prefill TPS 高不代表 decode TPS 高。
 - DSpark 当前 C++ verify path 是 sequential，不应宣称为加速路径；multi-token verify 有独立的数值漂移策略。
-- Qwen runtime 当前只支持 text checkpoint 路径，视觉输入和 OpenAI 兼容 Qwen serving 尚未接入。
+- Qwen runtime 当前只支持 text checkpoint 路径，视觉输入和多模态 serving 尚未实现。
 - 部分实验优化在真实端到端测试出现回归后被保留为 opt-in 或关闭；具体见模型页和历史分析文档。
 
 ## License

--- a/cpp_engine/README.md
+++ b/cpp_engine/README.md
@@ -12,10 +12,10 @@ The executable is still named `pocketllm_engine` for compatibility with existing
 | --- | --- |
 | DeepSeek-V4 Safetensors FP4/FP8 | Persistent generation and OpenAI-compatible TP4 server |
 | DeepSeek-V4 GGUF Q2/IQ2/IQ1 | Inspect, low-bit kernels, TP4 generation/smoke paths |
-| Qwen3.8-27B-FP8 Safetensors | Config/tensor audit, GPU-resident TP4 text prefill/decode, timed greedy CLI |
+| Qwen3.8-27B-FP8 Safetensors | GPU-resident TP4 text runtime and native OpenAI-compatible text server |
 | Other GGUF architectures | Generic reader/inspection tools; generation may live in the Python raw-block runtime |
 
-Qwen vision execution and Qwen OpenAI serving are not implemented. Model metadata support should not be interpreted as full generation support.
+Qwen vision execution and multimodal serving are not implemented. The text-only Qwen path, including the native OpenAI-compatible server, is validated separately from vision support.
 
 ## Build
 

--- a/cpp_engine/engine/engine_registry_builtin.cpp
+++ b/cpp_engine/engine/engine_registry_builtin.cpp
@@ -32,6 +32,9 @@ std::unique_ptr<InferenceEngine> make_qwen_engine(const std::string& ckpt_dir,
     qwen.device = options.device;
     qwen.nccl_id_path = options.nccl_id_path;
     qwen.max_batch_size = options.max_batch_size;
+    if (options.prefill_chunk_tokens > 0) {
+        qwen.prefill_chunk_tokens = options.prefill_chunk_tokens;
+    }
     qwen.kv_paged = options.kv_paged;
     qwen.kv_block_size = options.kv_block_size;
     qwen.kv_cache_bytes = options.kv_cache_bytes;

--- a/cpp_engine/engine/main.cpp
+++ b/cpp_engine/engine/main.cpp
@@ -82,6 +82,10 @@ struct Args {
     // engine declares, so leaving this at 8 costs nothing on an engine that
     // serves one session at a time.
     int max_batch_size = 8;
+    // Prompt tokens advanced per scheduler prefill iteration. 0 preserves the
+    // server default; the engine may clamp or ignore this according to caps().
+    int prefill_token_budget = 4096;
+    int request_timeout_seconds = 900;
     // Paged KV is what lets several requests share one pool instead of each
     // reserving max_context. Off by default so the serve path keeps the
     // contiguous arena's behaviour unless asked.
@@ -224,6 +228,10 @@ Args parse_args(int argc, char** argv) {
             args.host = argv[++i];
         } else if (arg == "--max-batch-size" && i + 1 < argc) {
             args.max_batch_size = std::stoi(argv[++i]);
+        } else if (arg == "--prefill-token-budget" && i + 1 < argc) {
+            args.prefill_token_budget = std::stoi(argv[++i]);
+        } else if (arg == "--request-timeout-seconds" && i + 1 < argc) {
+            args.request_timeout_seconds = std::stoi(argv[++i]);
         } else if (arg == "--kv-paged") {
             args.kv_paged = true;
         } else if (arg == "--kv-block-size" && i + 1 < argc) {
@@ -254,6 +262,12 @@ Args parse_args(int argc, char** argv) {
     }
     if (args.max_batch_size <= 0) {
         throw std::runtime_error("--max-batch-size must be positive");
+    }
+    if (args.prefill_token_budget < 0) {
+        throw std::runtime_error("--prefill-token-budget must not be negative");
+    }
+    if (args.request_timeout_seconds <= 0) {
+        throw std::runtime_error("--request-timeout-seconds must be positive");
     }
     if (args.kv_block_size <= 0) {
         throw std::runtime_error("--kv-block-size must be positive");
@@ -437,6 +451,7 @@ int main(int argc, char** argv) {
                 args.smoke_layers_explicit ? args.smoke_layers : 0;
             engine_options.max_context = max_context;
             engine_options.max_batch_size = args.max_batch_size;
+            engine_options.prefill_chunk_tokens = args.prefill_chunk_tokens;
             engine_options.kv_paged = args.kv_paged;
             engine_options.kv_block_size = args.kv_block_size;
             engine_options.temperature = args.qwen_temperature;
@@ -468,6 +483,8 @@ int main(int argc, char** argv) {
             cfg.host = args.host;
             cfg.model_name = architecture.empty() ? std::string("pocketllm") : architecture;
             cfg.max_batch_size = args.max_batch_size;
+            cfg.prefill_token_budget = args.prefill_token_budget;
+            cfg.request_timeout_seconds = args.request_timeout_seconds;
             pocket::OpenAIServer server(*engine, tokenizer, sidecar, cfg);
             server.run();
             engine->shutdown_tp_workers();

--- a/cpp_engine/include/model_registry.hpp
+++ b/cpp_engine/include/model_registry.hpp
@@ -35,6 +35,9 @@ struct EngineOptions {
     // Requested concurrent slots. An engine that declares max_slots == 1 may
     // reject anything larger rather than pretend to batch.
     int max_batch_size = 1;
+    // Prompt tokens processed by one prefill call. 0 leaves each engine's
+    // documented default unchanged; engines without chunked prefill ignore it.
+    int prefill_chunk_tokens = 0;
     // Paged KV cache instead of a per-slot contiguous arena. Engines that cannot
     // page ignore this; ask caps() rather than assuming it took effect.
     bool kv_paged = false;

--- a/cpp_engine/tests/test_model_registry.cpp
+++ b/cpp_engine/tests/test_model_registry.cpp
@@ -215,12 +215,14 @@ void test_registry_dispatch() {
 
     std::string seen_ckpt;
     int seen_slots = 0;
+    int seen_prefill_chunk_tokens = 0;
     float seen_temperature = 0.0f;
     int seen_top_k = 0;
     pocket::register_engine("stub_arch", [&](const std::string& ckpt,
                                              const pocket::EngineOptions& options) {
         seen_ckpt = ckpt;
         seen_slots = options.max_batch_size;
+        seen_prefill_chunk_tokens = options.prefill_chunk_tokens;
         seen_temperature = options.temperature;
         seen_top_k = options.top_k;
         return std::unique_ptr<pocket::InferenceEngine>(
@@ -231,6 +233,7 @@ void test_registry_dispatch() {
 
     pocket::EngineOptions options;
     options.max_batch_size = 3;
+    options.prefill_chunk_tokens = 256;
     options.temperature = 0.75f;
     options.top_k = 17;
     std::unique_ptr<pocket::InferenceEngine> engine =
@@ -238,6 +241,8 @@ void test_registry_dispatch() {
     check(engine != nullptr, "create_engine builds the registered engine");
     check_eq(seen_ckpt, dir, "the factory receives the checkpoint path");
     check(seen_slots == 3, "the factory receives the caller's topology options");
+    check(seen_prefill_chunk_tokens == 256,
+          "the factory receives the prefill chunk option");
     check(seen_temperature == 0.75f && seen_top_k == 17,
           "the factory receives the caller's sampling options");
     check(engine->caps().max_slots == 3, "the built engine's caps reach the caller");

--- a/docs/models/README.md
+++ b/docs/models/README.md
@@ -17,9 +17,9 @@ PocketLLM uses model-specific runtimes rather than treating every checkpoint as 
 | DeepSeek-V4-Flash | MLA + sparse/indexed attention + MoE | Safetensors FP4/FP8; GGUF Q2/IQ2/IQ1 | PyTorch and C++/CUDA | Validated | Safetensors C++ and PyTorch paths | [DeepSeek-V4](deepseek-v4.md) |
 | MiniMax-M2.7 | GQA + 256-expert MoE | GGUF `UD-IQ1_M` | PyTorch orchestration + raw-block CUDA | Validated TP4 | No dedicated adapter | [MiniMax-M2.7](minimax-m2.7.md) |
 | GLM-5.2 | DSA/MLA-indexed attention + dense prefix + MoE | GGUF `UD-Q2_K_XL` | PyTorch orchestration + raw-block CUDA | Validated text generation | No dedicated adapter | [GLM-5.2](glm-5.2.md) |
-| Qwen3.8-27B-FP8 | 48 Gated DeltaNet + 16 GQA layers, dense MLP | Safetensors FP8 E4M3 | Native C++/CUDA | Validated TP4 text CLI | Not implemented | [Qwen3.8-27B-FP8](qwen3.8-27b-fp8.md) |
-| Qwen3.8-27B-NVFP4 | Same text architecture as the FP8 checkpoint | Safetensors mixed NVFP4 group-16 + FP8 per-channel | Native C++/CUDA | Validated TP2 text CLI | Not implemented | [Qwen3.8-27B-NVFP4](qwen3.8-27b-nvfp4.md) |
-| Qwen3.8-27B (official BF16) | Same text architecture as the FP8 checkpoint | Safetensors BF16, vision tower bundled | Native C++/CUDA | Inspect only: TP audit validated, generation unvalidated | Not implemented | [Qwen3.8-27B BF16](qwen3.8-27b-bf16.md) |
+| Qwen3.8-27B-FP8 | 48 Gated DeltaNet + 16 GQA layers, dense MLP | Safetensors FP8 E4M3 | Native C++/CUDA | Validated TP4 text runtime and server | Validated native C++ text server | [Qwen3.8-27B-FP8](qwen3.8-27b-fp8.md) |
+| Qwen3.8-27B-NVFP4 | Same text architecture as the FP8 checkpoint | Safetensors mixed NVFP4 group-16 + FP8 per-channel | Native C++/CUDA | Validated TP2 text CLI | Shared native text path; no dedicated serving benchmark | [Qwen3.8-27B-NVFP4](qwen3.8-27b-nvfp4.md) |
+| Qwen3.8-27B (official BF16) | Same text architecture as the FP8 checkpoint | Safetensors BF16, vision tower bundled | Native C++/CUDA | Inspect only: TP audit validated, generation unvalidated | Not validated: generation is unvalidated | [Qwen3.8-27B BF16](qwen3.8-27b-bf16.md) |
 
 ## Shared baseline
 

--- a/docs/models/qwen3.8-27b-bf16.md
+++ b/docs/models/qwen3.8-27b-bf16.md
@@ -125,7 +125,7 @@ Generation follows the FP8 page's four-rank NCCL procedure with this checkpoint 
 - BF16 weights are materialized as FP16 for RTX 2080 Ti. This is a precision-narrowing conversion at load time, not a lossless path, and it is specific to Turing. An accelerator with native BF16 must supply its own dtype policy rather than reusing `qwen_device_dtype`.
 - Resident BF16 weights are 12.8 GiB per rank at TP4, well above the FP8 and NVFP4 checkpoints. Long-context headroom on 22 GiB cards is correspondingly smaller.
 - Text-only: no image or video preprocessing, and the vision tower is never mapped or uploaded.
-- CLI only: Qwen remains rejected by the DeepSeek-V4 OpenAI server path.
+- Native OpenAI-compatible serving is not validated for this checkpoint because full-model CUDA generation is not validated yet.
 - The Ascend backend configures but does not link; no kernels exist yet.
 
 ## Evidence and related notes

--- a/docs/models/qwen3.8-27b-fp8.md
+++ b/docs/models/qwen3.8-27b-fp8.md
@@ -4,7 +4,7 @@
 
 **Validated native C++/CUDA TP4 text runtime.** PocketLLM detects the nested Qwen3.5 text configuration, maps rank-local Safetensors weights, converts BF16 scales/non-FP8 tensors to FP16 for Turing where required, and keeps local FP8 weights resident on each GPU.
 
-The current integration supports text prompt/token-ID smoke and timed greedy generation through `pocketllm_engine`. It does not execute the checkpoint's vision tower and is not connected to the OpenAI-compatible server.
+The current integration supports text prompt/token-ID smoke, timed greedy generation, and native OpenAI-compatible text serving through `pocketllm_engine`. It does not execute the checkpoint's vision tower or accept image/video inputs.
 
 ## Model specification
 
@@ -422,7 +422,7 @@ build/cpp_engine/pocketllm_engine \
 ## Known limitations
 
 - Text-only: no image/video preprocessing or vision-tower execution.
-- CLI/smoke integration only: Qwen is explicitly rejected by the current DeepSeek-V4 OpenAI server path.
+- Text-only serving: the native OpenAI-compatible server is validated for Qwen text requests, while the checkpoint's vision tower and multimodal request formats are not implemented.
 - Greedy generation only in the current Qwen engine API.
 - The model limit is 262,144 positions; with four generated tokens, the longest valid benchmark prompt is 262,140 tokens. This boundary is validated with both the default FP16 KV cache and the explicit FP8 cache mode; FP8 uses less memory but is slower on this RTX 2080 Ti setup.
 - CUDA Graph and a decode megakernel remain future work; neither is included in the reported TPS.

--- a/docs/models/qwen3.8-27b-nvfp4.md
+++ b/docs/models/qwen3.8-27b-nvfp4.md
@@ -6,7 +6,7 @@
 
 RTX 2080 Ti has no native FP4 tensor-core instruction. Nothing here executes Blackwell FP4 MMA. The NVFP4 weights are unpacked in registers to INT8 and consumed by DP4A and INT8 WMMA, which is why NVFP4 buys memory rather than speed on this hardware. Read the performance section before choosing this format.
 
-Like the FP8 page, this covers text prompt/token-ID smoke and timed greedy generation through `pocketllm_engine`. The vision tower is not executed and the OpenAI-compatible server is not wired up.
+Like the FP8 page, this covers text prompt/token-ID smoke and timed greedy generation through `pocketllm_engine`. The shared native server path is text-only; this page does not claim a separate NVFP4 serving benchmark, and the vision tower is not executed.
 
 ## Checkpoint specification
 
@@ -176,7 +176,7 @@ Measure on idle GPUs. Contention from unrelated jobs was repeatedly visible in t
 
 - **Slower than FP8 on SM75.** NVFP4 is a memory-footprint option here (0.73x per rank), not a throughput option. Choose it only when 4 GiB per rank matters more than roughly half the throughput.
 - No native FP4 tensor-core execution. All NVFP4 math is emulated through INT8 DP4A/WMMA after register-level nibble unpacking.
-- Text-only, CLI-only, greedy generation only — the same limits as the FP8 page. The vision tower is skipped, and Qwen is rejected by the OpenAI server path.
+- Text-only and greedy generation only. The shared native OpenAI-compatible text path exists, but this checkpoint has no separate serving benchmark; the vision tower is skipped.
 - The wide tile only engages at 128 rows and above. Decode and very narrow prefill chunks see none of the 2.7–2.8x prefill gain.
 - Validated at 512 and 8,192 on TP2 only. Longer contexts, other TP widths, and FP8 KV cache over NVFP4 weights are not measured here.
 - Layers 56–63 are FP8 in this checkpoint, so any claim about NVFP4 coverage must be read as a per-tensor, not a whole-model, property.

--- a/scripts/run_cpp_serve_tp4.sh
+++ b/scripts/run_cpp_serve_tp4.sh
@@ -9,8 +9,30 @@ PORT="${PORT:-8000}"
 NCCL_ID="${NCCL_ID:-/tmp/pocketllm_cpp_serve_nccl.id}"
 MAX_CONTEXT="${MAX_CONTEXT:-8192}"
 MAX_BATCH_SIZE="${MAX_BATCH_SIZE:-8}"
+PREFILL_TOKEN_BUDGET="${PREFILL_TOKEN_BUDGET:-4096}"
+PREFILL_CHUNK_TOKENS="${PREFILL_CHUNK_TOKENS:-0}"
+REQUEST_TIMEOUT_SECONDS="${REQUEST_TIMEOUT_SECONDS:-900}"
 # 0 means the checkpoint's full depth for every registered architecture.
 SMOKE_LAYERS="${SMOKE_LAYERS:-0}"
+
+if [ "$PREFILL_TOKEN_BUDGET" -lt 0 ]; then
+    echo "PREFILL_TOKEN_BUDGET must not be negative" >&2
+    exit 2
+fi
+if [ "$PREFILL_CHUNK_TOKENS" -lt 0 ]; then
+    echo "PREFILL_CHUNK_TOKENS must not be negative" >&2
+    exit 2
+fi
+if [ "$REQUEST_TIMEOUT_SECONDS" -le 0 ]; then
+    echo "REQUEST_TIMEOUT_SECONDS must be positive" >&2
+    exit 2
+fi
+
+if [ "$PREFILL_CHUNK_TOKENS" -gt 0 ]; then
+    PREFILL_CHUNK_ARG="--prefill-chunk-tokens $PREFILL_CHUNK_TOKENS"
+else
+    PREFILL_CHUNK_ARG=""
+fi
 # Paging is ignored by an engine that does not support it. It is on here so a
 # Qwen server shares one block pool across the requested batch width instead of
 # reserving max_context separately for every slot.
@@ -25,7 +47,7 @@ EXTRA_ARGS="${EXTRA_ARGS:-}"
 
 rm -f "$NCCL_ID"
 
-COMMON="--serve --ckpt $CKPT --tp-world 4 --nccl-id-path $NCCL_ID --smoke-layers $SMOKE_LAYERS --max-context $MAX_CONTEXT --max-batch-size $MAX_BATCH_SIZE --kv-block-size $KV_BLOCK_SIZE --python $PYTHON --sidecar $SIDECAR --port $PORT $EXTRA_ARGS"
+COMMON="--serve --ckpt $CKPT --tp-world 4 --nccl-id-path $NCCL_ID --smoke-layers $SMOKE_LAYERS --max-context $MAX_CONTEXT --max-batch-size $MAX_BATCH_SIZE --prefill-token-budget $PREFILL_TOKEN_BUDGET --request-timeout-seconds $REQUEST_TIMEOUT_SECONDS $PREFILL_CHUNK_ARG --kv-block-size $KV_BLOCK_SIZE --python $PYTHON --sidecar $SIDECAR --port $PORT $EXTRA_ARGS"
 if [ "$KV_PAGED" != "0" ]; then
     COMMON="$COMMON --kv-paged"
 fi

--- a/scripts/verify_cpp_qwen_openai.py
+++ b/scripts/verify_cpp_qwen_openai.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Verify the native Qwen C++ OpenAI-compatible server with real weights.
+
+This is an opt-in integration check rather than a unit test. It starts one native
+process per tensor-parallel rank, exercises the HTTP surface, and tears the group
+down on every exit path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import pathlib
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+import uuid
+from typing import Any
+
+
+class HttpResult:
+    def __init__(self, status: int, body: bytes, headers: Any = None) -> None:
+        self.status = status
+        self.body = body
+        self.headers = headers
+
+    @property
+    def text(self) -> str:
+        return self.body.decode("utf-8", errors="replace")
+
+    def json(self) -> dict[str, Any]:
+        value = json.loads(self.text)
+        if not isinstance(value, dict):
+            raise AssertionError(f"expected JSON object, got {type(value).__name__}")
+        return value
+
+
+def http_request(
+    base_url: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    timeout: float,
+    stream: bool = False,
+) -> HttpResult:
+    data = None
+    headers: dict[str, str] = {}
+    if payload is not None:
+        data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(
+        base_url.rstrip("/") + path,
+        data=data,
+        headers=headers,
+        method="POST" if payload is not None else "GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            # Reading the complete body also makes the server observe the client
+            # reaching a safe completion boundary before the next request.
+            return HttpResult(response.status, response.read(), response.headers)
+    except urllib.error.HTTPError as exc:
+        return HttpResult(exc.code, exc.read(), exc.headers)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def parse_devices(value: str) -> list[str]:
+    devices = [item.strip() for item in value.split(",") if item.strip()]
+    if not devices:
+        raise ValueError("--devices must contain at least one device")
+    return devices
+
+
+def wait_for_health(base_url: str, processes: list[subprocess.Popen[bytes]], timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_error = "no response"
+    while time.monotonic() < deadline:
+        if any(process.poll() is not None for process in processes):
+            exited = [process.returncode for process in processes]
+            raise RuntimeError(f"a TP rank exited before readiness: {exited}")
+        try:
+            result = http_request(base_url, "/health", timeout=2.0)
+            if result.status == 200 and result.json().get("status") == "ok":
+                return
+            last_error = f"HTTP {result.status}: {result.text}"
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            last_error = str(exc)
+        time.sleep(2.0)
+    raise TimeoutError(f"server did not become healthy: {last_error}")
+
+
+def terminate_processes(processes: list[subprocess.Popen[bytes]]) -> None:
+    for process in processes:
+        if process.poll() is None:
+            process.send_signal(signal.SIGTERM)
+    deadline = time.monotonic() + 10.0
+    for process in processes:
+        remaining = max(0.0, deadline - time.monotonic())
+        try:
+            process.wait(timeout=remaining)
+        except subprocess.TimeoutExpired:
+            process.kill()
+    for process in processes:
+        try:
+            process.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+def read_logs(log_dir: pathlib.Path) -> str:
+    chunks: list[str] = []
+    for path in sorted(log_dir.glob("rank*.log")):
+        chunks.append(f"--- {path.name}\n{path.read_text(encoding='utf-8', errors='replace')}")
+    return "\n".join(chunks)
+
+
+def validate_nonstream(result: HttpResult, expected_model: str) -> dict[str, Any]:
+    require(result.status == 200, f"non-stream request failed: HTTP {result.status}: {result.text}")
+    body = result.json()
+    require(body.get("object") == "chat.completion", "wrong non-stream object")
+    require(body.get("model") == expected_model, "wrong non-stream model")
+    choices = body.get("choices")
+    require(isinstance(choices, list) and choices, "non-stream response has no choices")
+    choice = choices[0]
+    require(isinstance(choice, dict), "non-stream choice is not an object")
+    require(choice.get("message", {}).get("role") == "assistant", "missing assistant role")
+    require(isinstance(choice.get("message", {}).get("content"), str), "missing assistant content")
+    require(choice["message"]["content"] != "", "assistant content is empty")
+    require(choice.get("finish_reason") in {"stop", "length"}, "invalid non-stream finish reason")
+    usage = body.get("usage")
+    require(isinstance(usage, dict), "non-stream response has no usage")
+    require(usage.get("prompt_tokens", 0) > 0, "prompt token count is not positive")
+    require(usage.get("completion_tokens", 0) > 0, "completion token count is not positive")
+    require(
+        usage.get("total_tokens") == usage.get("prompt_tokens") + usage.get("completion_tokens"),
+        "usage total does not equal prompt plus completion",
+    )
+    return body
+
+
+def validate_stream(result: HttpResult, expected_model: str) -> list[dict[str, Any]]:
+    require(result.status == 200, f"stream request failed: HTTP {result.status}: {result.text}")
+    events: list[dict[str, Any]] = []
+    saw_done = False
+    for line in result.text.splitlines():
+        if not line.startswith("data: "):
+            continue
+        payload = line[6:]
+        if payload == "[DONE]":
+            saw_done = True
+            continue
+        event = json.loads(payload)
+        require(event.get("object") == "chat.completion.chunk", "wrong stream object")
+        require(event.get("model") == expected_model, "wrong stream model")
+        choices = event.get("choices")
+        require(isinstance(choices, list) and choices, "stream event has no choices")
+        events.append(event)
+    require(saw_done, "stream did not terminate with [DONE]")
+    require(events, "stream contained no JSON events")
+    require(events[0]["choices"][0]["delta"].get("role") == "assistant", "stream lacks role event")
+    content = "".join(
+        event["choices"][0]["delta"].get("content", "")
+        for event in events
+        if isinstance(event.get("choices"), list)
+    )
+    require(content != "", "stream produced no content delta")
+    terminal = events[-1]["choices"][0]
+    require(terminal.get("finish_reason") in {"stop", "length"}, "stream lacks terminal finish reason")
+    return events
+
+
+def chat_payload(text: str, max_tokens: int, *, stream: bool = False) -> dict[str, Any]:
+    return {
+        "messages": [{"role": "user", "content": text}],
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "top_k": 20,
+        "stream": stream,
+    }
+
+
+def run(args: argparse.Namespace) -> int:
+    checkpoint = pathlib.Path(args.ckpt).resolve()
+    binary = pathlib.Path(args.binary).resolve()
+    sidecar = pathlib.Path(args.sidecar).resolve()
+    python_bin = pathlib.Path(args.python).resolve()
+    devices = parse_devices(args.devices)
+    tp_world = len(devices)
+
+    for path, label in (
+        (checkpoint, "checkpoint"),
+        (binary, "native binary"),
+        (sidecar, "sidecar script"),
+        (python_bin, "Python executable"),
+    ):
+        require(path.exists(), f"{label} does not exist: {path}")
+    require((checkpoint / "config.json").exists(), "checkpoint has no config.json")
+    require((checkpoint / "tokenizer.json").exists(), "checkpoint has no tokenizer.json")
+
+    log_dir: pathlib.Path
+    temporary_log_dir: str | None = None
+    if args.log_dir:
+        log_dir = pathlib.Path(args.log_dir).resolve()
+        log_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        temporary_log_dir = tempfile.mkdtemp(prefix="pocketllm-qwen-openai-")
+        log_dir = pathlib.Path(temporary_log_dir)
+
+    rendezvous = log_dir / f"nccl-{uuid.uuid4().hex}.id"
+    processes: list[subprocess.Popen[bytes]] = []
+    base_url = f"http://127.0.0.1:{args.port}"
+    try:
+        common = [
+            str(binary),
+            "--serve",
+            "--ckpt",
+            str(checkpoint),
+            "--tp-world",
+            str(tp_world),
+            "--nccl-id-path",
+            str(rendezvous),
+            "--smoke-layers",
+            str(args.layers),
+            "--max-context",
+            str(args.max_context),
+            "--max-batch-size",
+            str(args.max_batch_size),
+            "--prefill-token-budget",
+            str(args.prefill_token_budget),
+            "--request-timeout-seconds",
+            str(args.request_timeout_seconds),
+            "--python",
+            str(python_bin),
+            "--sidecar",
+            str(sidecar),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(args.port),
+            "--kv-block-size",
+            str(args.kv_block_size),
+        ]
+        if args.prefill_chunk_tokens > 0:
+            common.extend(["--prefill-chunk-tokens", str(args.prefill_chunk_tokens)])
+        if args.kv_paged:
+            common.append("--kv-paged")
+
+        for rank, visible_device in enumerate(devices):
+            log = (log_dir / f"rank{rank}.log").open("wb")
+            environment = os.environ.copy()
+            environment["CUDA_VISIBLE_DEVICES"] = visible_device
+            process = subprocess.Popen(
+                common + ["--tp-rank", str(rank), "--device", "0"],
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                env=environment,
+            )
+            processes.append(process)
+            log.close()
+
+        wait_for_health(base_url, processes, args.startup_timeout)
+
+        health = http_request(base_url, "/health", timeout=5.0)
+        require(health.status == 200 and health.json().get("status") == "ok", "health check failed")
+
+        models = http_request(base_url, "/v1/models", timeout=5.0)
+        require(models.status == 200, f"models endpoint failed: {models.text}")
+        model_body = models.json()
+        model_data = model_body.get("data")
+        require(isinstance(model_data, list) and model_data, "models endpoint has no data")
+        model_name = model_data[0].get("id")
+        require(model_name == "qwen3_5", f"unexpected served model: {model_name!r}")
+
+        nonstream = http_request(
+            base_url,
+            "/v1/chat/completions",
+            chat_payload("Reply with exactly OK.", args.max_tokens),
+            timeout=args.request_timeout_seconds + 30,
+        )
+        validate_nonstream(nonstream, model_name)
+
+        stream = http_request(
+            base_url,
+            "/v1/chat/completions",
+            chat_payload("Reply with exactly OK.", args.max_tokens, stream=True),
+            timeout=args.request_timeout_seconds + 30,
+        )
+        validate_stream(stream, model_name)
+
+        incompatible = http_request(
+            base_url,
+            "/v1/chat/completions",
+            {
+                "messages": [{"role": "user", "content": "This must be rejected."}],
+                "max_tokens": 1,
+                "temperature": 0.5,
+            },
+            timeout=10.0,
+        )
+        require(incompatible.status == 400, "fixed-sampling mismatch was not rejected")
+        require("effective temperature" in incompatible.text, "sampling error did not explain the fixed temperature")
+
+        def concurrent_request(index: int) -> dict[str, Any]:
+            result = http_request(
+                base_url,
+                "/v1/chat/completions",
+                chat_payload(f"Reply briefly to request {index}.", min(args.max_tokens, 2)),
+                timeout=args.request_timeout_seconds + 30,
+            )
+            return validate_nonstream(result, model_name)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            concurrent_results = list(pool.map(concurrent_request, (0, 1)))
+        require(len(concurrent_results) == 2, "concurrent request count mismatch")
+
+        logs = read_logs(log_dir)
+        expected_width = min(args.max_batch_size, 2)
+        require(
+            f"[server] batch width {expected_width}" in logs,
+            "rank-0 log did not report the requested scheduler width",
+        )
+        require(
+            f"prefill budget {args.prefill_token_budget}" in logs,
+            "rank-0 log did not report the configured prefill budget",
+        )
+        print(
+            f"[PASS] native Qwen OpenAI serving: tp={tp_world} model={model_name} "
+            f"log_dir={log_dir} concurrent_requests={len(concurrent_results)}"
+        )
+        return 0
+    except Exception:
+        print("[FAIL] native Qwen OpenAI serving", file=sys.stderr)
+        print(read_logs(log_dir), file=sys.stderr)
+        raise
+    finally:
+        terminate_processes(processes)
+        try:
+            rendezvous.unlink()
+        except FileNotFoundError:
+            pass
+        if temporary_log_dir is not None:
+            shutil.rmtree(temporary_log_dir, ignore_errors=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt", required=True, help="Qwen Safetensors checkpoint directory")
+    parser.add_argument("--binary", default="build/cpp_engine/pocketllm_engine")
+    parser.add_argument("--python", default=sys.executable, help="Python with transformers installed")
+    parser.add_argument("--sidecar", default="src/server/cpp_sidecar.py")
+    parser.add_argument("--devices", default="0,1,2,3", help="Comma-separated CUDA device IDs")
+    parser.add_argument("--port", type=int, default=18080)
+    parser.add_argument("--layers", type=int, default=0, help="0 means complete Qwen depth")
+    parser.add_argument("--max-context", type=int, default=2048)
+    parser.add_argument("--max-batch-size", type=int, default=2)
+    parser.add_argument("--prefill-token-budget", type=int, default=4096)
+    parser.add_argument("--prefill-chunk-tokens", type=int, default=0)
+    parser.add_argument("--request-timeout-seconds", type=int, default=900)
+    parser.add_argument("--kv-block-size", type=int, default=16)
+    parser.add_argument("--kv-paged", action="store_true")
+    parser.add_argument("--max-tokens", type=int, default=4)
+    parser.add_argument("--startup-timeout", type=float, default=600.0)
+    parser.add_argument("--log-dir", default=None, help="Keep rank logs in this directory")
+    return parser
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(run(build_parser().parse_args()))
+    except KeyboardInterrupt:
+        raise SystemExit(130)


### PR DESCRIPTION
## Summary

- Wire model-agnostic native serving controls for prefill budget and request timeout.
- Pass the optional Qwen prefill chunk setting through the registry without widening the engine abstraction with Qwen-only tuning.
- Add a real-checkpoint TP integration harness for native Qwen OpenAI-compatible text serving.
- Synchronize English, Chinese, and model support documentation with the validated text-only server path.

## Implementation details

- `pocketllm_engine --serve` now accepts `--prefill-token-budget` and `--request-timeout-seconds`.
- `EngineOptions::prefill_chunk_tokens` is forwarded only by the Qwen registry factory.
- `scripts/verify_cpp_qwen_openai.py` starts one process per TP rank, validates health and model discovery, checks non-streaming and SSE responses, verifies fixed-sampling rejection, and exercises concurrent scheduler admission.
- Vision and multimodal serving remain explicitly unsupported.

## Testing status

Passed:

- Native binary build for `pocketllm_engine` and focused C++ tests.
- `test_model_registry`.
- `test_scheduler_callbacks`.
- `test_batch_scheduler`.
- `test_qwen_batched_engine_parity`.
- Python syntax check for the integration harness.
- Shell syntax check for `scripts/run_cpp_serve_tp4.sh`.
- `git diff --check`.
- `ldd` confirms CUDA runtime, cuBLAS, and NCCL linkage.
- Real Qwen3.8-27B-FP8 TP4 native serving harness: health, `/v1/models`, non-streaming completion, SSE streaming, fixed-sampling rejection, and two concurrent requests.

The selected Python suite reported 56 passed and 2 existing CLI/supervisor failures; those failures are outside this serving change and are not modified here.

## Performance impact

No performance claim is introduced. The integration proof uses real Qwen weights and TP4 only for correctness and serving behavior.

## Checklist

- [x] Focused implementation and documentation changes.
- [x] Real-checkpoint integration validation.
- [x] Unrelated pre-existing benchmark/kernel files left unstaged.
- [ ] Merge after maintainer approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
