### PR TITLE
Call select_backend before supervisor construction in CLI

### DIFF
--- a/pocketllm/cli.py
+++ b/pocketllm/cli.py
@@ -184,6 +184,13 @@ def main(argv: list[str] | None = None) -> int:
                 "--device cannot be used with automatic TP supervision; "
                 "use --no-tensor-parallel-supervisor for manual rank control"
             )
+        selected = select_backend(engine_args)
+        if selected == "cpp":
+            raise UnsupportedFeatureError(
+                "Python C++ Qwen adapter does not support automatic TP supervision; "
+                "use --no-tensor-parallel-supervisor and launch ranks through the "
+                "native binary instead"
+            )
         supervisor = TensorParallelSupervisor(
             command=[sys.executable, "-m", "pocketllm", *_supervised_command(argv or sys.argv[1:])],
             world_size=world,


### PR DESCRIPTION
## Summary

The supervised parent path in `pocketllm/cli.py` was constructing `TensorParallelSupervisor` without first calling `select_backend`, which broke two contracts:

1. **Ordering:** `select_backend` must run before the supervisor is instantiated so the backend selection result is known before any child processes are spawned.
2. **Early rejection:** When the selected backend is `cpp`, a `UnsupportedFeatureError` must be raised before supervisor construction — not after child ranks start and throw `BackendUnavailableError`.

## Changes

`pocketllm/cli.py`: In the supervised parent branch, insert a `select_backend(engine_args)` call immediately after the `--device` guard, then raise `UnsupportedFeatureError` if the result is `"cpp"` before constructing `TensorParallelSupervisor`.

## Testing

```
58 passed in 3.51s
```

Previously: 56 passed, 2 failed. Both failures were pre-existing regressions:
- `test_supervised_parent_selects_before_construct`
- `test_supervised_parent_rejects_cpp_before_backend_construction`

🤖 Generated with [Claude Code](https://claude.com/claude-code)