### PR TITLE
Remove stale roadmap and limitation entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ The benchmark starts ranks 1–3 as command workers and keeps rank 0 alive for a
 - [x] DeepSeek-V4 FP4/FP8 and GGUF Q2/IQ2/IQ1 generation paths.
 - [x] MiniMax-M2.7 and GLM-5.2 GGUF raw-block generation paths.
 - [x] Qwen3.8-27B-FP8 C++ TP4 text runtime.
-- [ ] Generalize the C++ model dispatch and binary naming without breaking existing scripts.
+- [x] Generalize the C++ model dispatch and binary naming without breaking existing scripts.
 - [x] Qwen OpenAI-compatible text serving adapter.
 - [ ] CUDA Graph and persistent decode dispatch where measured beneficial.
 - [ ] More model-specific benchmark fixtures and automated regression dashboards.

--- a/docs/models/qwen3.8-27b-fp8.md
+++ b/docs/models/qwen3.8-27b-fp8.md
@@ -423,7 +423,7 @@ build/cpp_engine/pocketllm_engine \
 
 - Text-only: no image/video preprocessing or vision-tower execution.
 - Text-only serving: the native OpenAI-compatible server is validated for Qwen text requests, while the checkpoint's vision tower and multimodal request formats are not implemented.
-- Greedy generation only in the current Qwen engine API.
+- Stochastic sampling is available through `--temperature`, `--top-p`, and `--top-k`. The default remains greedy (temperature 0) so existing benchmarks stay reproducible. Per-request sampling overrides are exposed in the batched API and the OpenAI server.
 - The model limit is 262,144 positions; with four generated tokens, the longest valid benchmark prompt is 262,140 tokens. This boundary is validated with both the default FP16 KV cache and the explicit FP8 cache mode; FP8 uses less memory but is slower on this RTX 2080 Ti setup.
 - CUDA Graph and a decode megakernel remain future work; neither is included in the reported TPS.
 - Native MTP is opt-in. Parity-safe high-acceptance cases accelerate decode by 1.67x at 4K, 2.47x at 8K, and 3.21x at 32K; 65–71% acceptance gives only 1.18–1.37x on 512-token varied prompts. Persistent exact-prefix workloads are the intended use case; `--qwen-mtp-adaptive` starts at K=1 and limits but does not eliminate low-acceptance overhead.


### PR DESCRIPTION
## Summary

Two documentation statements were left behind by recent PRs and are no longer accurate.

**README.md** — The roadmap item "Generalize the C++ model dispatch and binary naming without breaking existing scripts" was marked pending but has been complete since PRs #137–#140, which introduced the model registry, `create_engine`, `detect_architecture`, and renamed the binary to `pocketllm_engine`. Marked as done.

**docs/models/qwen3.8-27b-fp8.md** — The known-limitation entry "Greedy generation only in the current Qwen engine API" was accurate before PR #146, which added per-request temperature/top_p/top_k sampling in batched decode. PR #147 wired those fields through model-agnostic CLI flags (`--temperature`, `--top-p`, `--top-k`, `--seed`). Replaced with a description of what is now true: stochastic sampling is available, greedy remains the default, per-request overrides are exposed in the batched API and the server.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)