### PR TITLE
Measure benchmark GPU memory with one shared sampler

### DIFF
--- a/scripts/_gpu_memory_sampler.py
+++ b/scripts/_gpu_memory_sampler.py
@@ -1,0 +1,132 @@
+"""Shared GPU memory sampling for the engine comparison benchmarks.
+
+PocketLLM and vLLM must report memory through the same instrument or the
+comparison column is meaningless. They do not by default: PocketLLM reports
+what its own engine allocated, while vLLM pre-reserves a
+`gpu_memory_utilization` fraction of the card up front, so a single post-run
+`nvidia-smi` reading describes vLLM's reservation rather than what the model
+actually needed. Reading the same external instrument on both sides, and
+keeping the peak rather than one final sample, is what makes the numbers
+comparable.
+
+`nvidia-smi` reports physical device indices and ignores
+CUDA_VISIBLE_DEVICES, so callers pass physical indices here regardless of how
+they masked the child processes.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import threading
+import time
+from typing import Any
+
+MIB = 1024 * 1024
+
+
+def read_used_bytes(devices: list[int]) -> dict[int, int]:
+    """One `nvidia-smi` poll of used memory, in bytes, per requested device."""
+    out = subprocess.run(
+        ["nvidia-smi", "--query-gpu=index,memory.used", "--format=csv,noheader,nounits"],
+        check=True, capture_output=True, text=True,
+    ).stdout
+    used: dict[int, int] = {}
+    for line in out.strip().splitlines():
+        index, value = (item.strip() for item in line.split(","))
+        if int(index) in devices:
+            used[int(index)] = int(value) * MIB
+    return used
+
+
+class GpuMemorySampler:
+    """Polls used memory on a background thread and keeps the per-device peak.
+
+    A single reading after the run misses the peak entirely: prefill at 65K
+    allocates and frees activation workspace long before the process exits. The
+    sampler runs for the whole measured window instead.
+
+    The poll interval is a tradeoff against what it perturbs -- each poll forks
+    `nvidia-smi`, so 250 ms is frequent enough to catch a multi-second prefill
+    peak without adding measurable load to the benchmark itself.
+    """
+
+    def __init__(self, devices: list[int], interval_seconds: float = 0.25) -> None:
+        self.devices = list(devices)
+        self.interval_seconds = interval_seconds
+        self.before: dict[int, int] = {}
+        self.peak: dict[int, int] = {}
+        self.after: dict[int, int] = {}
+        self.samples = 0
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+
+    def _poll_into_peak(self) -> None:
+        try:
+            used = read_used_bytes(self.devices)
+        except Exception:
+            # A transient nvidia-smi failure must not take down the benchmark;
+            # the peak simply misses that sample.
+            return
+        with self._lock:
+            self.samples += 1
+            for device, value in used.items():
+                if value > self.peak.get(device, 0):
+                    self.peak[device] = value
+
+    def start(self) -> "GpuMemorySampler":
+        self.before = read_used_bytes(self.devices)
+        with self._lock:
+            self.peak = dict(self.before)
+
+        def loop() -> None:
+            while not self._stop.wait(self.interval_seconds):
+                self._poll_into_peak()
+
+        self._thread = threading.Thread(target=loop, name="gpu-mem-sampler", daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self) -> "GpuMemorySampler":
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+        # Fold in a final reading so a run shorter than one interval still has
+        # a peak that reflects the run rather than only its starting point.
+        self._poll_into_peak()
+        self.after = read_used_bytes(self.devices)
+        return self
+
+    def __enter__(self) -> "GpuMemorySampler":
+        return self.start()
+
+    def __exit__(self, *_exc: object) -> None:
+        self.stop()
+
+    def report(self) -> dict[str, Any]:
+        """Serializable result. `delta` is peak minus the pre-run baseline.
+
+        `delta` is the figure to compare across engines: it excludes whatever
+        was already resident on the card before the run started. `peak_bytes`
+        is kept alongside it because an absolute ceiling is what tells you
+        whether a configuration fits in 22 GiB at all.
+        """
+        with self._lock:
+            peak = dict(self.peak)
+        delta = {
+            device: max(peak.get(device, 0) - self.before.get(device, 0), 0)
+            for device in self.devices
+        }
+        return {
+            "instrument": "nvidia-smi",
+            "interval_seconds": self.interval_seconds,
+            "samples": self.samples,
+            "devices": self.devices,
+            "before_bytes": dict(self.before),
+            "peak_bytes": peak,
+            "after_bytes": dict(self.after),
+            "delta_bytes": delta,
+            "max_peak_bytes": max(peak.values(), default=None),
+            "max_delta_bytes": max(delta.values(), default=None),
+        }

--- a/scripts/bench_qwen_full_comparison.py
+++ b/scripts/bench_qwen_full_comparison.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Aggregate PocketLLM and vLLM benchmark artifacts into one comparison table.
+
+This script does not run models. It reads the raw JSON summaries produced by
+  * scripts/bench_qwen_long_context.py   (PocketLLM plain long context)
+  * scripts/bench_qwen_mtp.py            (PocketLLM plain/MTP K sweep)
+  * scripts/bench_qwen_drafters.py       (PocketLLM MTP/DSpark/DFlash2)
+  * scripts/bench_qwen_vllm_long_context.py (vLLM plain/MTP)
+and emits comparison.json, comparison.csv and comparison.md.
+
+Keeping aggregation separate from execution means a long matrix can be resumed
+and re-summarized without re-timing anything, and failed cases stay visible
+with their reason instead of being silently dropped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+FIELDS = [
+    "engine", "mode", "mtp_k", "drafter", "workload", "prompt_tokens",
+    "generated_tokens", "prefill_seconds", "prefill_tps", "ttft_seconds",
+    "decode_seconds", "decode_tokens", "decode_tps", "e2e_wall_seconds",
+    "gpu_memory_bytes", "gpu_memory_instrument", "accept_length", "draft_match_rate",
+    "rank_token_parity", "cross_engine_token_parity", "first_divergence",
+    "status", "failure_reason", "provenance",
+]
+
+
+def blank_row() -> dict[str, Any]:
+    return {field: None for field in FIELDS}
+
+
+def load(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def sampled_peak_bytes(case: dict[str, Any]) -> Any:
+    """Externally sampled peak, or None when the run predates the sampler.
+
+    Both runners now record `gpu_memory` from the shared nvidia-smi sampler.
+    Older result files carry only engine self-reports (PocketLLM) or a single
+    post-run reading (vLLM); those are not comparable across engines, so they
+    are reported as absent rather than silently mixed into the same column.
+    """
+    memory = case.get("gpu_memory")
+    if isinstance(memory, dict):
+        return memory.get("max_peak_bytes")
+    return None
+
+
+def memory_instrument(case: dict[str, Any]) -> str:
+    memory = case.get("gpu_memory")
+    if isinstance(memory, dict):
+        return str(memory.get("instrument", "unknown"))
+    return "self-report"
+
+
+def rows_from_pocketllm_long_context(path: Path) -> list[dict[str, Any]]:
+    payload = load(path)
+    provenance = {
+        "git_revision": None,
+        "binary_sha256": None,
+        "source": str(path),
+    }
+    rows: list[dict[str, Any]] = []
+    for case in payload.get("results", payload if isinstance(payload, list) else []):
+        row = blank_row()
+        runtime = case.get("runtime", {})
+        prov = dict(provenance)
+        prov["git_revision"] = case.get("git_revision")
+        prov["binary_sha256"] = (case.get("binary_metadata") or {}).get("binary_sha256")
+        prov["token_fixture_sha256"] = case.get("token_fixture_sha256")
+        row.update({
+            "engine": "pocketllm",
+            "mode": "plain",
+            "mtp_k": 0,
+            "workload": f"ctx{case.get('prompt_tokens')}",
+            "prompt_tokens": case.get("prompt_tokens"),
+            "generated_tokens": case.get("generated_tokens"),
+            "prefill_seconds": runtime.get("prefill_seconds"),
+            "prefill_tps": runtime.get("prefill_tokens_per_s"),
+            "ttft_seconds": runtime.get("prefill_seconds"),
+            "decode_seconds": runtime.get("decode_seconds"),
+            "decode_tokens": runtime.get("decode_token_count"),
+            "decode_tps": runtime.get("decode_tokens_per_s"),
+            "e2e_wall_seconds": runtime.get("wall"),
+            "gpu_memory_bytes": sampled_peak_bytes(case),
+            "gpu_memory_instrument": memory_instrument(case),
+            "rank_token_parity": case.get("rank_token_parity"),
+            "status": "ok",
+            "provenance": prov,
+            "_tokens": case.get("tokens"),
+        })
+        rows.append(row)
+    return rows
+
+
+def rows_from_vllm(path: Path) -> list[dict[str, Any]]:
+    payload = load(path)
+    rows: list[dict[str, Any]] = []
+    for case in payload.get("results", []):
+        row = blank_row()
+        row.update({
+            "engine": "vllm",
+            "mode": case.get("mode", payload.get("mode", "plain")),
+            "mtp_k": case.get("mtp_k", payload.get("mtp_tokens", 0)),
+            "workload": f"ctx{case.get('prompt_tokens')}",
+            "prompt_tokens": case.get("prompt_tokens"),
+            "generated_tokens": case.get("generated_tokens"),
+            "prefill_seconds": case.get("prefill_seconds"),
+            "prefill_tps": case.get("prefill_tps"),
+            "ttft_seconds": case.get("ttft_seconds"),
+            "decode_seconds": case.get("decode_seconds"),
+            "decode_tokens": case.get("decode_tokens"),
+            "decode_tps": case.get("decode_tps"),
+            "e2e_wall_seconds": case.get("e2e_wall_seconds"),
+            "gpu_memory_bytes": sampled_peak_bytes(case),
+            "gpu_memory_instrument": memory_instrument(case),
+            "status": case.get("status", "ok"),
+            "failure_reason": case.get("failure_reason"),
+            "provenance": {
+                "source": str(path),
+                "vllm_python": payload.get("python"),
+                "token_fixture_sha256": case.get("token_fixture_sha256"),
+                "max_num_seqs": payload.get("max_num_seqs"),
+                "gpu_memory_utilization": payload.get("gpu_memory_utilization"),
+            },
+            "_tokens": case.get("tokens"),
+        })
+        rows.append(row)
+    return rows
+
+
+def rows_from_pocketllm_mtp(path: Path) -> list[dict[str, Any]]:
+    payload = load(path)
+    rows: list[dict[str, Any]] = []
+    for group in payload.get("results", []):
+        for case in group.get("cases", []):
+            runtime = case.get("runtime", {})
+            mode = case.get("mode", "plain")
+            row = blank_row()
+            row.update({
+                "engine": "pocketllm",
+                "mode": "plain" if mode == "plain" else "mtp",
+                "mtp_k": int(runtime.get("mtp_tokens") or 0),
+                "workload": f"ctx{group.get('prompt_tokens')}",
+                "prompt_tokens": group.get("prompt_tokens"),
+                "generated_tokens": runtime.get("generated_tokens"),
+                "prefill_seconds": runtime.get("prefill_seconds"),
+                "prefill_tps": runtime.get("prefill_tokens_per_s"),
+                "ttft_seconds": runtime.get("prefill_seconds"),
+                "decode_seconds": runtime.get("decode_seconds"),
+                "decode_tokens": runtime.get("decode_token_count"),
+                "decode_tps": runtime.get("decode_tokens_per_s"),
+                "e2e_wall_seconds": runtime.get("wall"),
+                # This runner reports engine self-accounting, not the shared
+                # sampler, so it is labeled rather than mixed into the
+                # cross-engine memory comparison.
+                "gpu_memory_bytes": case.get("max_gpu_memory_used_bytes"),
+                "gpu_memory_instrument": "self-report",
+                "accept_length": runtime.get("spec_accept_length"),
+                "draft_match_rate": runtime.get("mtp_accept_rate"),
+                "rank_token_parity": case.get("rank_token_parity"),
+                "status": "ok",
+                "provenance": {
+                    "source": str(path),
+                    "binary": payload.get("binary"),
+                    "kv_cache_dtype": payload.get("kv_cache_dtype"),
+                    "prefill_chunk_tokens": payload.get("prefill_chunk_tokens"),
+                    "draft_seconds": runtime.get("mtp_draft_seconds"),
+                    "verify_seconds": runtime.get("mtp_verify_seconds"),
+                    "replay_seconds": runtime.get("mtp_replay_seconds"),
+                    "proposed_drafts": runtime.get("mtp_proposed_drafts"),
+                    "correct_drafts": runtime.get("mtp_correct_drafts"),
+                    "speedup_vs_plain_wall": case.get("speedup_vs_plain_wall"),
+                    "speedup_vs_plain_decode": case.get("speedup_vs_plain_decode"),
+                },
+                "_tokens": case.get("tokens"),
+            })
+            rows.append(row)
+    return rows
+
+
+def rows_from_pocketllm_drafters(path: Path) -> list[dict[str, Any]]:
+    payload = load(path)
+    rows: list[dict[str, Any]] = []
+    for case in payload.get("results", []):
+        row = blank_row()
+        row.update({
+            "engine": "pocketllm",
+            "mode": case.get("mode", "plain"),
+            "drafter": case.get("drafter"),
+            "mtp_k": case.get("mtp_tokens", 0),
+            "workload": case.get("dataset") or case.get("workload"),
+            "prompt_tokens": case.get("mean_prompt_tokens") or case.get("prompt_tokens"),
+            "generated_tokens": case.get("generated_tokens"),
+            "decode_tps": case.get("decode_tps"),
+            "e2e_wall_seconds": case.get("wall") or case.get("e2e_wall_seconds"),
+            "accept_length": case.get("accept_length"),
+            "draft_match_rate": case.get("draft_match_rate"),
+            "rank_token_parity": case.get("rank_token_parity"),
+            "cross_engine_token_parity": case.get("token_parity"),
+            "first_divergence": case.get("first_divergence"),
+            "status": case.get("status", "ok"),
+            "failure_reason": case.get("failure_reason"),
+            "provenance": {"source": str(path)},
+        })
+        rows.append(row)
+    return rows
+
+
+LOADERS = {
+    "pocketllm-long-context": rows_from_pocketllm_long_context,
+    "pocketllm-mtp": rows_from_pocketllm_mtp,
+    "pocketllm-drafters": rows_from_pocketllm_drafters,
+    "vllm": rows_from_vllm,
+}
+
+
+def cross_engine_parity(rows: list[dict[str, Any]]) -> None:
+    """Compare each vLLM row's tokens against the PocketLLM row at the same shape."""
+    baseline: dict[tuple[Any, Any, Any], list[int]] = {}
+    for row in rows:
+        if row["engine"] != "pocketllm":
+            continue
+        tokens = row.get("_tokens")
+        if tokens:
+            baseline[(row["workload"], row["mode"], row["mtp_k"])] = tokens
+    # PocketLLM plain is the reference for every engine at the same prompt.
+    plain = {
+        key[0]: value for key, value in baseline.items() if key[1] == "plain"
+    }
+    for row in rows:
+        tokens = row.get("_tokens")
+        reference = plain.get(row["workload"])
+        if not tokens or not reference:
+            continue
+        limit = min(len(tokens), len(reference))
+        divergence = next(
+            (i for i in range(limit) if tokens[i] != reference[i]), None
+        )
+        if row["engine"] == "pocketllm" and row["mode"] == "plain":
+            row["cross_engine_token_parity"] = True
+            continue
+        row["cross_engine_token_parity"] = divergence is None
+        row["first_divergence"] = divergence
+
+
+def fmt(value: Any, digits: int = 2) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def markdown_table(rows: list[dict[str, Any]], title: str) -> str:
+    header = ("| engine | mode | K | drafter | workload | prompt | gen | "
+              "prefill s | prefill tok/s | decode s | decode tok/s | wall s | "
+              "accept | parity | status |")
+    sep = "|" + "---|" * 15
+    lines = [f"### {title}", "", header, sep]
+    for row in rows:
+        lines.append(
+            f"| {row['engine']} | {row['mode']} | {fmt(row['mtp_k'], 0)} | "
+            f"{row['drafter'] or '-'} | {row['workload']} | "
+            f"{fmt(row['prompt_tokens'], 0)} | {fmt(row['generated_tokens'], 0)} | "
+            f"{fmt(row['prefill_seconds'], 3)} | {fmt(row['prefill_tps'])} | "
+            f"{fmt(row['decode_seconds'], 3)} | {fmt(row['decode_tps'], 3)} | "
+            f"{fmt(row['e2e_wall_seconds'], 3)} | {fmt(row['accept_length'], 3)} | "
+            f"{fmt(row['cross_engine_token_parity'])} | {row['status']} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def ratio_table(rows: list[dict[str, Any]]) -> str:
+    by_key: dict[tuple[Any, Any, Any], dict[str, dict[str, Any]]] = {}
+    for row in rows:
+        key = (row["workload"], row["mode"], row["mtp_k"])
+        by_key.setdefault(key, {})[row["engine"]] = row
+    lines = ["### PocketLLM / vLLM ratios", "",
+             "| workload | mode | K | prefill ratio | decode ratio | wall ratio |",
+             "|---|---|---|---|---|---|"]
+    for (workload, mode, k), engines in sorted(by_key.items(), key=lambda kv: str(kv[0])):
+        pocket, vllm = engines.get("pocketllm"), engines.get("vllm")
+        if not pocket or not vllm:
+            continue
+
+        def div(a: Any, b: Any, invert: bool = False) -> str:
+            if not a or not b:
+                return "n/a"
+            return f"{(b / a) if invert else (a / b):.3f}"
+
+        lines.append(
+            f"| {workload} | {mode} | {fmt(k, 0)} | "
+            f"{div(pocket['prefill_tps'], vllm['prefill_tps'])} | "
+            f"{div(pocket['decode_tps'], vllm['decode_tps'])} | "
+            f"{div(pocket['e2e_wall_seconds'], vllm['e2e_wall_seconds'], invert=True)} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", action="append", default=[], metavar="KIND=PATH",
+                        help=f"one of {sorted(LOADERS)} plus a JSON path")
+    parser.add_argument("--out-dir", type=Path,
+                        default=Path(".scratch/qwen_full_comparison"))
+    args = parser.parse_args()
+
+    rows: list[dict[str, Any]] = []
+    for spec in args.input:
+        kind, _, path = spec.partition("=")
+        if kind not in LOADERS:
+            raise SystemExit(f"unknown input kind: {kind}")
+        target = Path(path)
+        if not target.exists():
+            print(f"[skip] missing {target}")
+            continue
+        loaded = LOADERS[kind](target)
+        print(f"[load] {kind} {target} -> {len(loaded)} rows")
+        rows.extend(loaded)
+
+    cross_engine_parity(rows)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    clean = [{k: v for k, v in row.items() if not k.startswith("_")} for row in rows]
+    (args.out_dir / "comparison.json").write_text(
+        json.dumps(clean, indent=2), encoding="utf-8")
+
+    with (args.out_dir / "comparison.csv").open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=FIELDS, extrasaction="ignore")
+        writer.writeheader()
+        for row in clean:
+            out = dict(row)
+            out["provenance"] = json.dumps(row.get("provenance"))
+            writer.writerow(out)
+
+    plain = [r for r in rows if r["mode"] == "plain" and not r["drafter"]]
+    mtp = [r for r in rows if r["mode"] in ("mtp", "native_mtp") or (r["mtp_k"] or 0) > 0]
+    drafters = [r for r in rows if r["drafter"]]
+
+    doc = ["# PocketLLM vs vLLM TP4 comparison", "",
+           "All rows: TP4 on 4x RTX 2080 Ti, concurrency=1, serial execution,",
+           "same real tokenizer fixture, full 64-layer target, greedy, TG128.", ""]
+    if plain:
+        doc.append(markdown_table(plain, "Table 1 - plain (no speculation)"))
+        doc.append(ratio_table(plain))
+    if mtp:
+        doc.append(markdown_table(mtp, "Table 2 - native MTP K=1/2/3"))
+        doc.append(ratio_table(mtp))
+    if drafters:
+        doc.append(markdown_table(drafters, "Table 3 - MTP / DSpark / DFlash2"))
+    (args.out_dir / "comparison.md").write_text("\n".join(doc), encoding="utf-8")
+    print(f"[done] wrote {args.out_dir}/comparison.{{json,csv,md}} ({len(rows)} rows)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_qwen_long_context.py
+++ b/scripts/bench_qwen_long_context.py
@@ -20,6 +20,9 @@ import time
 from pathlib import Path
 from typing import Any
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _gpu_memory_sampler import GpuMemorySampler  # noqa: E402
+
 
 DEFAULT_TEXT = (
     "Decode context parallelism partitions the key-value history across devices "
@@ -381,6 +384,10 @@ def run_case(
     processes: list[tuple[int, subprocess.Popen[bytes]]] = []
     started = time.monotonic()
     statuses: dict[int, int] = {}
+    # Same instrument as the vLLM comparison bench: engine self-reporting cannot
+    # be compared against an external process's usage.
+    sampler = GpuMemorySampler(devices[:tp_world])
+    sampler.start()
     try:
         for rank in range(tp_world):
             log = (case_dir / f"rank{rank}.log").open("wb")
@@ -450,6 +457,7 @@ def run_case(
             except subprocess.TimeoutExpired:
                 process.kill()
                 statuses[rank] = process.wait(timeout=30)
+        gpu_memory = sampler.stop().report()
 
     ordered_statuses = [(rank, statuses[rank]) for rank in range(tp_world)]
     if any(status != 0 for _, status in ordered_statuses):
@@ -509,6 +517,9 @@ def run_case(
         "rank_gpu_memory_total_bytes": [
             item.get("gpu_memory_total_bytes") for item in rank_runtime
         ],
+        # Externally sampled peak, comparable with the vLLM run. The rank_*
+        # fields above are engine self-reports and are not.
+        "gpu_memory": gpu_memory,
         "rank_phase_summary": [phase_summary(items) for items in rank_phases],
         "phase_leaf_summary": phase_leaf_summary(rank_phases[0]),
         "phase_leaf_share_summary": phase_share_summary(

--- a/scripts/bench_qwen_vllm_long_context.py
+++ b/scripts/bench_qwen_vllm_long_context.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""vLLM TP4 long-context prefill/decode benchmark for the PocketLLM comparison.
+
+Runs one prompt length per process so initialization, JIT, and CUDA-graph
+capture never land inside a measured request. Prompt token IDs come from a
+shared fixture file so vLLM and PocketLLM see the exact same prompt.
+
+Timing model, matched to the PocketLLM side:
+  * prefill/TTFT -- wall time from request submission to the first output token.
+  * decode       -- wall time from the first to the last output token.
+  * decode TPS   -- (generated_tokens - 1) / decode_seconds.
+
+This must run in an environment that has vLLM (the project's `qwen35` env).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _gpu_memory_sampler import GpuMemorySampler, read_used_bytes  # noqa: E402
+
+DEFAULT_CKPT = "/mnt/data2/Qwen3.8-27B-FP8"
+DEFAULT_LENGTHS = "8192,16384,32768,65536,131072,262016"
+MODEL_MAX_CONTEXT = 262144
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", type=Path, default=Path(DEFAULT_CKPT))
+    parser.add_argument("--fixture-dir", type=Path,
+                        default=Path(".scratch/qwen_full_comparison/fixtures"))
+    parser.add_argument("--work-dir", type=Path,
+                        default=Path(".scratch/qwen_full_comparison/vllm"))
+    parser.add_argument("--lengths", default=DEFAULT_LENGTHS)
+    parser.add_argument("--max-new-tokens", type=int, default=128)
+    parser.add_argument("--tp-world", type=int, default=4)
+    parser.add_argument("--devices", default="0,1,2,3")
+    parser.add_argument("--max-num-batched-tokens", type=int, default=8192)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.90)
+    parser.add_argument("--disable-custom-all-reduce", action="store_true")
+    # The benchmark is single-request. vLLM's sampler warmup allocates for
+    # max_num_seqs dummy requests, and the default 256 OOMs on a 2080 Ti.
+    parser.add_argument("--max-num-seqs", type=int, default=1)
+    # vLLM's "auto" picks flashqla_legacy on SM70/SM75, which imports the
+    # separate `flash_qla` package. That package is not installed in this
+    # environment, so auto raises ModuleNotFoundError inside the GDN prefill
+    # call and the whole run fails. Triton/FLA is the working SM75 path.
+    parser.add_argument("--gdn-prefill-backend",
+                        choices=["auto", "triton", "flashqla_legacy", "flashinfer"],
+                        default="triton",
+                        help="GDN prefill kernel (default: triton, the working SM75 path)")
+    parser.add_argument("--mtp-tokens", type=int, default=0,
+                        help="0 runs plain; >0 enables qwen3_5_mtp with that K")
+    parser.add_argument("--result", type=Path, default=None)
+    # Internal: the worker mode for a single length inside a fresh process.
+    parser.add_argument("--worker-spec", default=None, help=argparse.SUPPRESS)
+    return parser.parse_args()
+
+
+def read_fixture(path: Path, length: int) -> list[int]:
+    tokens = [int(item) for item in path.read_text(encoding="ascii").split(",") if item]
+    if len(tokens) != length:
+        raise RuntimeError(f"fixture {path} has {len(tokens)} tokens, expected {length}")
+    return tokens
+
+
+def fixture_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def gpu_memory_bytes(devices: list[int]) -> dict[int, int]:
+    return read_used_bytes(devices)
+
+
+def run_worker(spec_path: str) -> None:
+    spec = json.loads(Path(spec_path).read_text(encoding="utf-8"))
+    from vllm import LLM, SamplingParams
+
+    prompt_tokens = spec["prompt_token_ids"]
+    max_new = spec["max_new_tokens"]
+    prompt_len = len(prompt_tokens)
+    max_len = min(prompt_len + max_new, MODEL_MAX_CONTEXT)
+
+    kwargs: dict[str, Any] = dict(
+        model=spec["checkpoint"],
+        tensor_parallel_size=spec["tp_world"],
+        trust_remote_code=True,
+        max_model_len=max_len,
+        max_num_batched_tokens=spec["max_num_batched_tokens"],
+        gpu_memory_utilization=spec["gpu_memory_utilization"],
+        enforce_eager=False,
+        enable_chunked_prefill=True,
+        enable_prefix_caching=False,
+        max_num_seqs=spec["max_num_seqs"],
+        disable_custom_all_reduce=spec["disable_custom_all_reduce"],
+        # Async scheduling drives the batch-queue path, whose sample_tokens RPC
+        # times out with a single in-flight sequence on this build.
+        async_scheduling=False,
+        additional_config={"gdn_prefill_backend": spec["gdn_prefill_backend"]},
+    )
+    if spec["mtp_tokens"] > 0:
+        kwargs["speculative_config"] = {
+            "method": "qwen3_5_mtp",
+            "num_speculative_tokens": spec["mtp_tokens"],
+        }
+
+    load_start = time.perf_counter()
+    llm = LLM(**kwargs)
+    load_seconds = time.perf_counter() - load_start
+
+    sampling = SamplingParams(temperature=0.0, top_p=1.0, max_tokens=max_new)
+    warm_sampling = SamplingParams(temperature=0.0, top_p=1.0, max_tokens=4)
+
+    request = [{"prompt_token_ids": prompt_tokens}]
+    # Warmup exercises the same shapes so graph capture and Triton JIT happen
+    # outside the measured request.
+    llm.generate(request, warm_sampling)
+
+    # RequestOutput.metrics is empty on this vLLM V1 build, and timing prefill
+    # as a separate max_tokens=1 request is unusable at 128K (prefill noise
+    # exceeds the whole decode window). Drive the engine step loop instead and
+    # timestamp the first emitted token inside the one measured request.
+    from vllm.sampling_params import RequestOutputKind
+
+    step_params = SamplingParams(temperature=0.0, top_p=1.0, max_tokens=max_new)
+    step_params.output_kind = RequestOutputKind.DELTA
+    engine = llm.llm_engine
+    engine.add_request("bench", {"prompt_token_ids": prompt_tokens}, step_params)
+
+    start = time.perf_counter()
+    first_token_ts = None
+    generated: list[int] = []
+    final_out = None
+    while engine.has_unfinished_requests():
+        for out in engine.step():
+            new_ids = list(out.outputs[0].token_ids)
+            if new_ids and first_token_ts is None:
+                first_token_ts = time.perf_counter()
+            generated.extend(new_ids)
+            if out.finished:
+                final_out = out
+    end_ts = time.perf_counter()
+
+    wall = end_ts - start
+    prefill_wall = (first_token_ts - start) if first_token_ts else None
+    decode_seconds = (end_ts - first_token_ts) if first_token_ts else None
+    decode_tokens = max(len(generated) - 1, 0)
+
+    out = final_out
+    metric_fields: dict[str, Any] = {}
+    metrics = getattr(out, "metrics", None) if out is not None else None
+    if metrics is not None:
+        for name in dir(metrics):
+            if name.startswith("_"):
+                continue
+            value = getattr(metrics, name)
+            if isinstance(value, (int, float, type(None))):
+                metric_fields[name] = value
+
+    result = {
+        "engine": "vllm",
+        "mode": "mtp" if spec["mtp_tokens"] > 0 else "plain",
+        "mtp_k": spec["mtp_tokens"],
+        "prompt_tokens": prompt_len,
+        "max_model_len": max_len,
+        "generated_tokens": len(generated),
+        "tokens": generated,
+        "e2e_wall_seconds": wall,
+        "load_seconds": load_seconds,
+        "ttft_seconds": prefill_wall,
+        "prefill_seconds": prefill_wall,
+        "prefill_tps": (prompt_len / prefill_wall) if prefill_wall else None,
+        "decode_seconds": decode_seconds,
+        "decode_tokens": decode_tokens,
+        "decode_tps": (decode_tokens / decode_seconds)
+        if decode_seconds and decode_tokens > 0 else None,
+        "timing_method": "engine_step_loop_first_token",
+        "raw_metrics": metric_fields,
+        "num_cached_tokens": getattr(out, "num_cached_tokens", None) if out else None,
+    }
+    Path(spec["result_path"]).write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print("worker_ok " + json.dumps({k: v for k, v in result.items() if k != "tokens"}))
+
+
+def main() -> int:
+    args = parse_args()
+    if args.worker_spec:
+        run_worker(args.worker_spec)
+        return 0
+
+    lengths = [int(item) for item in args.lengths.split(",") if item]
+    devices = [int(item) for item in args.devices.split(",") if item]
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+
+    tag = "plain" if args.mtp_tokens == 0 else f"mtp{args.mtp_tokens}"
+    results: list[dict[str, Any]] = []
+    for length in lengths:
+        fixture = args.fixture_dir / f"tokens_{length}.txt"
+        prompt_tokens = read_fixture(fixture, length)
+        spec_path = args.work_dir / f"spec_{tag}_{length}.json"
+        result_path = args.work_dir / f"result_{tag}_{length}.json"
+        log_path = args.work_dir / f"log_{tag}_{length}.txt"
+        spec_path.write_text(json.dumps({
+            "checkpoint": str(args.checkpoint),
+            "prompt_token_ids": prompt_tokens,
+            "max_new_tokens": args.max_new_tokens,
+            "tp_world": args.tp_world,
+            "max_num_batched_tokens": args.max_num_batched_tokens,
+            "gpu_memory_utilization": args.gpu_memory_utilization,
+            "max_num_seqs": args.max_num_seqs,
+            "disable_custom_all_reduce": args.disable_custom_all_reduce,
+            "gdn_prefill_backend": args.gdn_prefill_backend,
+            "mtp_tokens": args.mtp_tokens,
+            "result_path": str(result_path),
+        }), encoding="utf-8")
+
+        env = dict(os.environ)
+        env["CUDA_VISIBLE_DEVICES"] = ",".join(str(d) for d in devices)
+        env["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+        env["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+        # The first real forward JITs the Triton gated-delta kernels, which
+        # exceeds the 300 s default execute_model RPC timeout on this GPU.
+        env["VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"] = "3600"
+
+        print(f"[run] vllm {tag} length={length}", flush=True)
+        started = time.perf_counter()
+        with log_path.open("w", encoding="utf-8") as log:
+            # The sampler spans the whole child lifetime, so the peak covers
+            # weight load, KV reservation, and the measured prefill/decode.
+            with GpuMemorySampler(devices) as sampler:
+                completed = subprocess.run(
+                    [sys.executable, str(Path(__file__).resolve()),
+                     "--worker-spec", str(spec_path)],
+                    env=env, stdout=log, stderr=subprocess.STDOUT, text=True,
+                )
+        elapsed = time.perf_counter() - started
+        memory = sampler.report()
+
+        if completed.returncode != 0 or not result_path.exists():
+            tail = log_path.read_text(encoding="utf-8", errors="replace").splitlines()[-25:]
+            results.append({
+                "engine": "vllm", "mode": tag, "mtp_k": args.mtp_tokens,
+                "prompt_tokens": length, "status": "failed",
+                "returncode": completed.returncode,
+                "process_seconds": elapsed,
+                "failure_reason": "\n".join(tail),
+                "gpu_memory": memory,
+                "log": str(log_path),
+            })
+            print(f"[fail] vllm {tag} length={length} rc={completed.returncode}", flush=True)
+            continue
+
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        result.update({
+            "status": "ok",
+            "process_seconds": elapsed,
+            "token_fixture": str(fixture),
+            "token_fixture_sha256": fixture_sha256(fixture),
+            "log": str(log_path),
+            "gpu_memory": memory,
+            "gpu_memory_bytes_after": memory["after_bytes"],
+        })
+        results.append(result)
+        print(f"[ok] vllm {tag} length={length} "
+              f"prefill_tps={result.get('prefill_tps')} "
+              f"decode_tps={result.get('decode_tps')}", flush=True)
+
+    payload = {
+        "engine": "vllm",
+        "checkpoint": str(args.checkpoint),
+        "tp_world": args.tp_world,
+        "devices": devices,
+        "max_new_tokens": args.max_new_tokens,
+        "prefill_chunk_tokens": args.max_num_batched_tokens,
+        "mtp_tokens": args.mtp_tokens,
+        "max_num_seqs": args.max_num_seqs,
+        "gpu_memory_utilization": args.gpu_memory_utilization,
+        "disable_custom_all_reduce": args.disable_custom_all_reduce,
+        "gdn_prefill_backend": args.gdn_prefill_backend,
+        "python": sys.executable,
+        "results": results,
+    }
+    result_path = args.result or (args.work_dir / f"summary_{tag}.json")
+    result_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"[done] wrote {result_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The PocketLLM and vLLM long-context benchmarks measured GPU memory with different instruments, which made the memory column in the comparison meaningless. This lands one shared sampler for both, and fixes the vLLM runner crashing before it produced any result at all.

## Problem

Three separate issues, all in the way memory was measured:

- PocketLLM reported what its own engine allocated. vLLM was read once with `nvidia-smi` after the run, which describes its `gpu_memory_utilization` pre-reservation, not what the model needed. Those two numbers were being placed in the same column.
- Neither side captured a peak. Prefill activation workspace at 65K is allocated and freed long before the process exits, so a single reading missed it.
- The aggregator read two different keys (`rank_gpu_memory_used_bytes` vs `gpu_memory_bytes_after`), so the drift was reproduced at the reporting layer.

Separately, the vLLM runner could not complete a single case. Its GDN prefill backend `auto` selects `flashqla_legacy` on SM70/SM75, which imports the separate `flash_qla` package; that package is not installed in this environment, so `auto` raised `ModuleNotFoundError` inside the GDN prefill call and the whole run failed.

## Implementation

- `scripts/_gpu_memory_sampler.py` — polls `nvidia-smi` on a background thread at 250 ms and keeps the per-device peak alongside the pre-run baseline. `stop()` folds in a final poll so a run shorter than one interval still gets a peak that reflects the run. A transient `nvidia-smi` failure drops that sample rather than taking down the benchmark. Callers pass physical device indices, since `nvidia-smi` ignores `CUDA_VISIBLE_DEVICES`.
- Both runners wrap the whole child-process lifetime in the sampler, so the window covers weight load, KV reservation, and the measured prefill/decode.
- The aggregator reads a single `gpu_memory` key from both engines and records `gpu_memory_instrument` per row. Result files that predate the sampler report the memory column as absent rather than silently mixing self-reports into a cross-engine comparison. `bench_qwen_mtp.py` rows are explicitly labeled `self-report`.
- `--gdn-prefill-backend` added to the vLLM runner, defaulting to `triton`, the working SM75 path.

## Testing

Measured on 4x RTX 2080 Ti, Qwen3.8-27B-FP8, TP4, TG128, concurrency=1, same token fixtures on both sides.

| context | prefill PocketLLM / vLLM | ratio | decode PocketLLM / vLLM | ratio | peak GiB/rank PocketLLM / vLLM |
|---|---|---|---|---|---|
| 4 096 | 1 760 / 1 798 | 0.979x | 46.0 / 41.1 | 1.12x | 8.1 / 19.2 |
| 8 192 | 1 825 / 1 775 | 1.028x | 45.5 / 42.7 | 1.06x | 8.7 / 19.8 |
| 32 768 | 1 679 / 1 666 | 1.008x | 43.3 / 41.1 | 1.05x | 9.1 / 19.8 |
| 65 536 | 1 456 / 1 505 | 0.968x | 40.2 / 37.8 | 1.06x | 9.6 / 19.8 |

Prefill is at parity within +/-3%; decode is 5-12% ahead. Sampled baseline was 0.0 GiB on all four cards before every case, so the peaks are attributable to the run.

The vLLM peak is its 90% upfront reservation of the 22 GiB card rather than actual need, and must be read that way — it is not evidence that vLLM requires 19.8 GiB for these requests. Rank-local token parity passed on every PocketLLM case.

Scripts pass `py_compile` under the `deepseek` env; the sampler was smoke-tested against real GPUs.

## Notes

- No engine or kernel code is touched; this is benchmark harness only.
- `bench_qwen_mtp.py` and `bench_qwen_dspark.py` still feed engine self-accounting into the aggregator. They are now labeled rather than silently mixed; wiring them to the sampler is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)