### PR TITLE
Add opt-in native Python package build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,25 @@
+include README.md
+include README_CN.md
+include LICENSE
+include requirements.txt
+
+# Torch extension sources, needed for an sdist to rebuild ext_modules.
+recursive-include src/csrc *.cpp *.cu *.cuh *.h *.hpp
+
+# C++ engine sources, needed for an sdist to build the optional native module
+# under POCKETLLM_BUILD_CPP=1.
+include cpp_engine/CMakeLists.txt
+recursive-include cpp_engine/cmake *.cmake
+recursive-include cpp_engine/backends *.cpp *.cu *.cuh *.h *.hpp *.txt *.cmake
+recursive-include cpp_engine/core *.cpp *.h *.hpp
+recursive-include cpp_engine/engine *.cpp *.h *.hpp
+recursive-include cpp_engine/include *.h *.hpp
+recursive-include cpp_engine/python *.cpp
+recursive-include cpp_engine/third_party *.cpp *.h *.hpp
+
+# Build trees are environment-specific and are already git-ignored.
+prune cpp_engine/build
+prune cpp_engine/build-python
+prune cpp_engine/build-ascend
+prune cpp_engine/build-cuda
+prune build

--- a/README.md
+++ b/README.md
@@ -63,10 +63,27 @@ The runtime is intentionally model-specific. DeepSeek-V4 uses MLA/indexing and r
 
 ## Quick start
 
-### Build the Python extensions
+### Install the Python package
 
 ```bash
 python -m pip install -r requirements.txt
+python -m pip install --no-build-isolation .
+```
+
+This installs the `pocketllm` package and the `pocketllm` CLI. `--no-build-isolation` keeps the
+build using the active environment's Torch, which must match the CUDA toolkit the extensions
+compile against.
+
+To also build the optional native C++ engine module (`pocketllm_cpp`), which the
+`backend="cpp"` path needs:
+
+```bash
+POCKETLLM_BUILD_CPP=1 python -m pip install --no-build-isolation .
+```
+
+Building the Torch extensions in place, without installing, still works:
+
+```bash
 python setup.py build_ext
 ```
 

--- a/docs/pocketllm_api.md
+++ b/docs/pocketllm_api.md
@@ -145,7 +145,22 @@ Prefer typed `EngineArgs` and explicit CLI options. `EngineArgs.from_env()` exis
 
 ## Native C++ Python module
 
-The native bridge is optional and does not affect CPU-only imports:
+The native bridge is optional and does not affect CPU-only imports. You can build it as part of
+`pip install` (recommended) or manually via CMake.
+
+### Via pip install
+
+```bash
+POCKETLLM_BUILD_CPP=1 pip install --no-build-isolation .
+```
+
+The `--no-build-isolation` flag ensures the active environment's Torch is the one that drives the
+Torch extension build. Without `POCKETLLM_BUILD_CPP=1`, the install skips the native module and
+produces only the Torch runtime.
+
+The native module installs top-level (`import pocketllm_cpp`), so no manual copy is needed.
+
+### Manual CMake build
 
 ```bash
 cmake -S cpp_engine -B cpp_engine/build-python \

--- a/pocketllm/__init__.py
+++ b/pocketllm/__init__.py
@@ -1,5 +1,7 @@
 """PocketLLM: one user-facing API over independent Torch and C++ backends."""
 
+__version__ = "0.1.0"
+
 from .api import (
     BackendCapabilities,
     BackendUnavailableError,
@@ -29,6 +31,7 @@ def __getattr__(name: str):
 
 
 __all__ = [
+    "__version__",
     "AsyncLLM",
     "BackendCapabilities",
     "BackendUnavailableError",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+# Torch is deliberately absent from this list. setup.py imports
+# torch.utils.cpp_extension at module level, and a Torch resolved fresh into an
+# isolated build environment does not necessarily match the CUDA toolkit the host
+# extensions are compiled against. Build with --no-build-isolation so the active
+# environment's Torch is the one that drives the extension build.
+requires = [
+    "setuptools>=68",
+    "wheel",
+    "pybind11>=2.12",
+    "cmake>=3.18",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pocketllm"
+version = "0.1.0"
+description = "Inference engine for large language models on older accelerators"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+dependencies = [
+    "torch>=2.0",
+    "transformers>=4.40",
+    "safetensors>=0.4",
+    "tqdm>=4.66",
+    "setuptools>=68",
+    "ninja>=1.11",
+    "triton>=2.0",
+]
+
+[project.scripts]
+pocketllm = "pocketllm.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/lvyufeng/PocketLLM"
+
+# Packages are resolved in setup.py via find_packages() so the list cannot drift
+# from the tree the way a hand-maintained literal did.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ tqdm>=4.66
 setuptools>=68
 ninja>=1.11
 triton>=2.0
+# Build dependency for the optional native module (POCKETLLM_BUILD_CPP=1).
+pybind11>=2.12

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,71 @@
-from pathlib import Path
+import os
 import shutil
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
 
-from setuptools import Extension, setup
+from setuptools import find_namespace_packages, setup
+from setuptools import Extension
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
 ROOT = Path(__file__).resolve().parent
 CSRC = ROOT / "src" / "csrc"
 EXTENSIONS_DIR = ROOT / "build" / "extensions"
+CPP_ENGINE_DIR = ROOT / "cpp_engine"
+
+
+def _build_native_requested() -> bool:
+    """Whether to build the optional pybind11 module for the C++ engine.
+
+    Off by default: the native build needs pybind11, a CUDA toolkit and NCCL, and
+    takes minutes. A host that only wants the Torch runtimes must still install.
+    """
+    return os.environ.get("POCKETLLM_BUILD_CPP", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _python_cmake_hints() -> list[str]:
+    """Interpreter hints for CMake's FindPython3.
+
+    ``-DPython3_EXECUTABLE`` alone is not enough against a conda environment:
+    FindPython3 reports "missing: Development.Module" even though the headers are
+    installed. Passing the root, include dir and library explicitly resolves it.
+    """
+    hints = [f"-DPython3_EXECUTABLE={sys.executable}"]
+
+    prefix = sysconfig.get_config_var("prefix")
+    if prefix:
+        hints.append(f"-DPython3_ROOT_DIR={prefix}")
+
+    include_dir = sysconfig.get_path("include")
+    if include_dir and Path(include_dir).is_dir():
+        hints.append(f"-DPython3_INCLUDE_DIR={include_dir}")
+
+    # A shared libpython is not guaranteed to exist (static builds are valid), so
+    # only pass the library when it is actually there.
+    libdir = sysconfig.get_config_var("LIBDIR")
+    ldlibrary = sysconfig.get_config_var("LDLIBRARY")
+    if libdir and ldlibrary:
+        candidate = Path(libdir) / ldlibrary
+        if candidate.is_file():
+            hints.append(f"-DPython3_LIBRARY={candidate}")
+
+    return hints
+
+
+def _nccl_cmake_hints() -> list[str]:
+    """Forward NCCL locations when the environment names them.
+
+    A native module built without NCCL loads fine and then fails every TP>1 run
+    with "Qwen TP requires an NCCL-enabled build", so an explicit location is
+    worth forwarding rather than leaving to discovery.
+    """
+    hints = []
+    for variable in ("NCCL_INCLUDE_DIR", "NCCL_LIBRARY", "NCCL_ROOT"):
+        value = os.environ.get(variable)
+        if value:
+            hints.append(f"-D{variable}={value}")
+    return hints
 
 
 class BuildExtensions(BuildExtension):
@@ -17,48 +76,88 @@ class BuildExtensions(BuildExtension):
             built_path = Path(self.get_ext_fullpath(ext.name)).resolve()
             if built_path.exists():
                 shutil.copy2(built_path, EXTENSIONS_DIR / built_path.name)
+        if _build_native_requested():
+            self.build_native_module()
+
+    def build_native_module(self):
+        """Configure and build ``pocketllm_cpp`` through the engine's CMake project.
+
+        Any failure here is fatal. A silently missing native module is worse than a
+        failed install: ``backend="auto"`` would quietly fall back to Torch, and the
+        caller who asked for the C++ engine would get different kernels than
+        requested with no error to explain it.
+        """
+        try:
+            import pybind11
+        except ImportError as exc:  # pragma: no cover - environment dependent
+            raise RuntimeError(
+                "POCKETLLM_BUILD_CPP=1 requires pybind11 (pip install pybind11)"
+            ) from exc
+
+        cmake = shutil.which("cmake")
+        if cmake is None:  # pragma: no cover - environment dependent
+            raise RuntimeError("POCKETLLM_BUILD_CPP=1 requires cmake on PATH")
+
+        backend = os.environ.get("POCKETLLM_BACKEND", "cuda")
+        build_dir = Path(self.build_temp).resolve() / "cpp_engine"
+        build_dir.mkdir(parents=True, exist_ok=True)
+
+        configure = [
+            cmake,
+            "-S", str(CPP_ENGINE_DIR),
+            "-B", str(build_dir),
+            f"-DPOCKET_BACKEND={backend}",
+            "-DPOCKET_BUILD_PYTHON=ON",
+            f"-Dpybind11_DIR={pybind11.get_cmake_dir()}",
+        ]
+        configure.extend(_python_cmake_hints())
+        configure.extend(_nccl_cmake_hints())
+
+        subprocess.check_call(configure)
+        subprocess.check_call([
+            cmake, "--build", str(build_dir),
+            "--target", "pocketllm_cpp",
+            "-j", str(os.cpu_count() or 1),
+        ])
+
+        built = sorted((build_dir / "python").glob("pocketllm_cpp*.so"))
+        if not built:
+            raise RuntimeError(
+                f"pocketllm_cpp built but no shared object was found under {build_dir / 'python'}"
+            )
+
+        # Install top-level, next to the Torch extensions, so `import pocketllm_cpp`
+        # resolves without the manual copy onto sys.path the old flow required.
+        destination_dir = Path(self.build_lib).resolve()
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        for module in built:
+            shutil.copy2(module, destination_dir / module.name)
+            shutil.copy2(module, EXTENSIONS_DIR / module.name)
 
 
 setup(
-    name="pocketllm",
-    packages=[
-        "src",
-        "src.cli",
-        "src.encoding",
-        "src.kernels",
-        "src.loader",
-        "src.loader.gguf",
-        "src.loader.mappings",
-        "src.components",
-        "src.components.moe",
-        "src.models",
-        "src.models.deepseek_v4",
-        "src.models.minimax_m2",
-        "src.runtime",
-        "src.server",
-        "pocketllm",
-        "pocketllm.api",
-        "pocketllm.backends",
-        "pocketllm.protocol",
-        "pocketllm.server",
-    ],
-    entry_points={
-        "console_scripts": [
-            "pocketllm=pocketllm.cli:main",
-        ],
-    },
+    # Resolved from the tree rather than hand-listed; the previous literal had
+    # drifted, omitting src.components.gguf, src.models.glm_dsa and
+    # src.models.qwen4_exp while naming two directories that are not packages.
+    # find_namespace_packages picks up src.components and src.loader.mappings,
+    # which are real namespace packages actively imported but have no __init__.py.
+    packages=find_namespace_packages(
+        include=["pocketllm", "pocketllm.*", "src", "src.*"],
+        # src.csrc holds only C++/CUDA sources; src.gguf and src.moe are stale empty dirs.
+        exclude=["src.csrc", "src.csrc.*", "src.gguf", "src.moe"],
+    ),
     ext_modules=[
         CUDAExtension(
             name="cuda_kernel",
             sources=[
-                str(CSRC / "cuda_kernel.cpp"),
-                str(CSRC / "cuda_kernel_impl.cu"),
-                str(CSRC / "minimax_rope_kernel.cu"),
-                str(CSRC / "llama_mmq" / "gguf_mma_wrapper.cu"),
-                str(CSRC / "qwen4_exp_moe.cu"),
-                str(CSRC / "qwen4_exp_gated_delta.cu"),
-                str(CSRC / "qwen4_exp_qsa.cu"),
-                str(CSRC / "qwen4_exp_hyper_connection.cu"),
+                "src/csrc/cuda_kernel.cpp",
+                "src/csrc/cuda_kernel_impl.cu",
+                "src/csrc/minimax_rope_kernel.cu",
+                "src/csrc/llama_mmq/gguf_mma_wrapper.cu",
+                "src/csrc/qwen4_exp_moe.cu",
+                "src/csrc/qwen4_exp_gated_delta.cu",
+                "src/csrc/qwen4_exp_qsa.cu",
+                "src/csrc/qwen4_exp_hyper_connection.cu",
             ],
             libraries=["cublas"],
             extra_compile_args={
@@ -68,15 +167,15 @@ setup(
         ),
         Extension(
             name="deepseek_cpu_moe_ext",
-            sources=[str(CSRC / "deepseek_cpu_moe_ext.cpp")],
+            sources=["src/csrc/deepseek_cpu_moe_ext.cpp"],
             extra_compile_args=["-O3", "-mavx2", "-mfma", "-fopenmp"],
             extra_link_args=["-fopenmp"],
         ),
         CUDAExtension(
             name="moe_dispatch_cuda_ext",
             sources=[
-                str(CSRC / "moe_dispatch_cuda_ext.cpp"),
-                str(CSRC / "moe_dispatch_cuda_kernel.cu"),
+                "src/csrc/moe_dispatch_cuda_ext.cpp",
+                "src/csrc/moe_dispatch_cuda_kernel.cu",
             ],
             extra_compile_args={
                 "cxx": ["-O3"],


### PR DESCRIPTION
## Summary

Closes #105 by making the existing native bindings and high-level API installable from source as a Python package.

## Implementation

- Add `pyproject.toml` project metadata and `MANIFEST.in` source distribution rules.
- Replace the stale package list with namespace-package discovery.
- Add `POCKETLLM_BUILD_CPP=1` opt-in CMake integration to `setup.py`; the native `pocketllm_cpp` extension is installed top-level without a manual copy.
- Keep the default install Torch-only for CPU/Torch hosts.
- Add `pybind11` build dependency, package version metadata, and installation documentation.

Pre-built manylinux wheels and PyPI publication remain out of scope for this source-install phase.

## Testing

- Source distribution contains `cpp_engine/CMakeLists.txt` and `cpp_engine/python/bindings.cpp`.
- Torch-only wheel built and installed in a clean virtual environment; package imports and CLI work.
- Opt-in native wheel built successfully; `import pocketllm_cpp` reports `backend: cuda`; `ldd` resolves NCCL.
- `tests/test_cpp_binding_smoke.py tests/test_public_api.py tests/test_cpp_backend.py tests/test_supervisor.py`: **68 passed**.

## Related follow-up

TP2 automatic C++ supervision is tracked separately in #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)