### PR TITLE
Fix automatic TP2 tensor-parallel supervision

### DIFF
--- a/pocketllm/backends/cpp_backend.py
+++ b/pocketllm/backends/cpp_backend.py
@@ -169,6 +169,14 @@ class CppBackend(BackendBase):
             self._native = load_native_module()
         else:
             self._native = None
+        if engine is None and args.tensor_parallel_size > 1:
+            nccl_id_path = str(args.backend_options.get("nccl_id_path", ""))
+            if not nccl_id_path:
+                nccl_id_path = os.environ.get("POCKETLLM_NCCL_ID_PATH", "")
+            if not nccl_id_path:
+                raise ConfigurationError(
+                    "C++ tensor-parallel backend requires nccl_id_path"
+                )
         self._tokenizer_error: str | None = None
         self._engine = engine if engine is not None else self._construct_engine()
         # A primitive lock may be released by a different worker thread.  This

--- a/pocketllm/backends/factory.py
+++ b/pocketllm/backends/factory.py
@@ -137,7 +137,7 @@ def create_backend(args: EngineArgs, **injected: Any):
             # Auto-launch supervisor for multi-GPU setup
             from ..supervisor import TensorParallelSupervisor, TensorParallelConfig
 
-            # Build command for worker processes (rank 1, 2, 3, ...)
+            # Build command for worker processes (actual ranks 1, 2, 3, ...)
             worker_command = [
                 sys.executable,
                 "-c",
@@ -161,12 +161,14 @@ def create_backend(args: EngineArgs, **injected: Any):
                 "POCKETLLM_WORKER_ARGS": json.dumps(_worker_arg_overrides(args)),
             }
 
-            # Create supervisor configuration
-            # Supervisor will spawn workers for ranks 1, 2, 3
-            # (it starts from rank 0 in its own numbering, which we map to our rank 1)
+            # Create supervisor configuration. Rank 0 remains in this parent
+            # process, while the supervisor owns the remaining actual TP ranks.
+            # Keep the full world size in child environments so NCCL sees the
+            # same group as rank 0, including the TP2 case with one child.
             config = TensorParallelConfig(
                 command=tuple(worker_command),
-                world_size=args.tensor_parallel_size - 1,  # Spawn N-1 workers (ranks 1..N-1)
+                world_size=args.tensor_parallel_size,
+                child_ranks=tuple(range(1, args.tensor_parallel_size)),
                 env=worker_env,
             )
 
@@ -258,10 +260,10 @@ def _restore_env(name: str, previous: str | None) -> None:
 
 
 def _worker_script() -> str:
-    """Generate Python code for worker processes (ranks 1, 2, 3, ...).
+    """Generate Python code for worker processes (actual TP ranks 1, 2, ...).
 
-    The supervisor spawns world_size-1 processes with TP_RANK 0, 1, 2, ...
-    We map them to actual tensor-parallel ranks 1, 2, 3, ...
+    Rank 0 stays in the parent process. The supervisor assigns each child its
+    actual TP rank, so the worker environment already matches the NCCL group.
     """
     return """
 import os
@@ -269,11 +271,9 @@ import json
 from pocketllm import EngineArgs
 from pocketllm.backends.cpp_backend import CppBackend
 
-# Get configuration from environment
-# TP_RANK is set by supervisor (0, 1, 2, ... for world_size-1 workers)
-# Map to actual TP ranks 1, 2, 3, ... (rank 0 is the main process)
-supervisor_rank = int(os.environ.get("TP_RANK", "0"))
-actual_rank = supervisor_rank + 1
+# Get the actual rank assigned by the supervisor. Rank 0 belongs to the
+# parent process; child TP ranks start at 1.
+actual_rank = int(os.environ.get("TP_RANK", "0"))
 
 tp_size = int(os.environ["POCKETLLM_TP_SIZE"])
 checkpoint = os.environ["POCKETLLM_CHECKPOINT"]

--- a/pocketllm/supervisor.py
+++ b/pocketllm/supervisor.py
@@ -96,6 +96,7 @@ class TensorParallelConfig:
     rendezvous_dir: str | os.PathLike[str] | None = None
     rank_flag: str = "--tensor-parallel-rank"
     forward_output: bool = True
+    child_ranks: tuple[int, ...] | None = None
 
     def __post_init__(self) -> None:
         command = tuple(str(item) for item in self.command)
@@ -104,6 +105,20 @@ class TensorParallelConfig:
             raise ConfigurationError("supervisor command must not be empty")
         if self.world_size < 2:
             raise ConfigurationError("supervisor world_size must be >= 2")
+        if self.child_ranks is not None:
+            try:
+                child_ranks = tuple(int(rank) for rank in self.child_ranks)
+            except (TypeError, ValueError) as exc:
+                raise ConfigurationError("supervisor child_ranks must contain integers") from exc
+            object.__setattr__(self, "child_ranks", child_ranks)
+            if not child_ranks:
+                raise ConfigurationError("supervisor child_ranks must not be empty")
+            if len(set(child_ranks)) != len(child_ranks):
+                raise ConfigurationError("supervisor child_ranks must be unique")
+            if any(rank < 0 or rank >= self.world_size for rank in child_ranks):
+                raise ConfigurationError(
+                    "supervisor child_ranks must be within [0, world_size)"
+                )
         if self.startup_timeout <= 0:
             raise ConfigurationError("supervisor startup_timeout must be positive")
         if self.shutdown_timeout <= 0:
@@ -149,10 +164,13 @@ class RankProcess:
 class TensorParallelSupervisor:
     """Launch and supervise one local rank process per TP rank.
 
-    ``command`` is the common command prefix for every rank.  The supervisor
-    removes an existing ``rank_flag`` pair and appends the rank-specific value,
-    so callers can safely pass a command assembled from user arguments.  A
-    ``command_builder`` can be supplied when a backend needs generated
+    ``command`` is the common command prefix for every supervised rank.  The
+    supervisor removes an existing ``rank_flag`` pair and appends the
+    rank-specific value, so callers can safely pass a command assembled from
+    user arguments.  By default it supervises every rank in ``world_size``;
+    ``child_ranks`` lets a caller keep one or more ranks in its own process
+    while retaining the full distributed world size in every child environment.
+    A ``command_builder`` can be supplied when a backend needs generated
     rendezvous data in argv; it receives ``(rank, child_env)`` after the private
     rendezvous directory has been created.
     """
@@ -172,11 +190,21 @@ class TensorParallelSupervisor:
         rendezvous_dir: str | os.PathLike[str] | None = None,
         rank_flag: str = "--tensor-parallel-rank",
         forward_output: bool = True,
+        child_ranks: Sequence[int] | None = None,
         command_builder: Callable[[int, Mapping[str, str]], Sequence[str]] | None = None,
     ) -> None:
         if config is not None and any(
             value is not None
-            for value in (command, world_size, env, cwd, master_addr, master_port, rendezvous_dir)
+            for value in (
+                command,
+                world_size,
+                env,
+                cwd,
+                master_addr,
+                master_port,
+                rendezvous_dir,
+                child_ranks,
+            )
         ):
             raise TypeError("pass either TensorParallelConfig or supervisor keyword configuration")
         if config is None:
@@ -194,6 +222,7 @@ class TensorParallelSupervisor:
                 rendezvous_dir=rendezvous_dir,
                 rank_flag=rank_flag,
                 forward_output=forward_output,
+                child_ranks=None if child_ranks is None else tuple(child_ranks),
             )
         elif command_builder is not None:
             # A builder is an execution detail and cannot be represented by the
@@ -234,6 +263,14 @@ class TensorParallelSupervisor:
     @property
     def signal_received(self) -> int | None:
         return self._signal_received
+
+    def _child_ranks(self) -> tuple[int, ...]:
+        """Return the ranks this supervisor owns, in launch order."""
+        return (
+            tuple(range(self.config.world_size))
+            if self.config.child_ranks is None
+            else self.config.child_ranks
+        )
 
     def _base_env(self) -> dict[str, str]:
         result = dict(os.environ)
@@ -428,7 +465,7 @@ class TensorParallelSupervisor:
             try:
                 self._prepare_rendezvous()
                 self._prepare_master_port(self._base_env())
-                for rank in range(self.config.world_size):
+                for rank in self._child_ranks():
                     self._spawn(rank)
             except BaseException:
                 self.cleanup()

--- a/tests/test_factory_tp_supervision_reuse.py
+++ b/tests/test_factory_tp_supervision_reuse.py
@@ -68,6 +68,26 @@ def _args(**overrides) -> EngineArgs:
     return EngineArgs(**base)
 
 
+def test_tp2_supervision_keeps_full_world_and_spawns_rank_one(supervised):
+    backend = factory.create_backend(_args(tensor_parallel_size=2))
+
+    assert len(supervised.instances) == 1
+    config = supervised.instances[0].config
+    assert config.world_size == 2
+    assert config.child_ranks == (1,)
+    assert backend.args.tensor_parallel_size == 2
+    assert backend.args.tensor_parallel_rank == 0
+    assert backend.seen_nccl_id_path == supervised.instances[0].nccl_id_path
+    assert "POCKETLLM_NCCL_ID_PATH" not in os.environ
+
+
+def test_worker_script_uses_supervisor_assigned_actual_rank():
+    script = factory._worker_script()
+
+    assert 'actual_rank = int(os.environ.get("TP_RANK", "0"))' in script
+    assert "actual_rank = supervisor_rank + 1" not in script
+
+
 def test_second_backend_still_spawns_workers(supervised):
     """The env var must not make the second backend think it is supervised.
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -37,6 +37,20 @@ print(f"POCKETLLM_RANK_READY rank={rank}", flush=True)
 sys.exit(0)
 """
 
+_CHILD_READY_WITH_ENV = """
+import os
+rank = int(os.environ["RANK"])
+print(f"POCKETLLM_RANK_READY rank={rank}", flush=True)
+print(
+    f"TP_ENV world={os.environ['WORLD_SIZE']} tp_world={os.environ['TP_WORLD']} "
+    f"rank={os.environ['RANK']} tp_rank={os.environ['TP_RANK']}",
+    flush=True,
+)
+import time
+while True:
+    time.sleep(0.1)
+"""
+
 _CHILD_FAIL = """
 import os
 import sys
@@ -64,6 +78,38 @@ def test_supervisor_config_validation() -> None:
         TensorParallelConfig(command=("echo",), world_size=2, master_port=99999)
     with pytest.raises(ConfigurationError, match="rank_flag"):
         TensorParallelConfig(command=("echo",), world_size=2, rank_flag="")
+
+
+def test_supervisor_subset_rank_validation() -> None:
+    config = TensorParallelConfig(command=("echo",), world_size=2, child_ranks=(1,))
+    assert config.child_ranks == (1,)
+
+    with pytest.raises(ConfigurationError, match="child_ranks.*empty"):
+        TensorParallelConfig(command=("echo",), world_size=2, child_ranks=())
+    with pytest.raises(ConfigurationError, match="child_ranks.*unique"):
+        TensorParallelConfig(command=("echo",), world_size=2, child_ranks=(1, 1))
+    with pytest.raises(ConfigurationError, match="child_ranks.*within"):
+        TensorParallelConfig(command=("echo",), world_size=2, child_ranks=(2,))
+
+
+def test_supervisor_subset_rank_launch_keeps_full_world_size() -> None:
+    supervisor = TensorParallelSupervisor(
+        command=[sys.executable, "-c", _CHILD_READY_WITH_ENV],
+        world_size=2,
+        child_ranks=(1,),
+        startup_timeout=5.0,
+        shutdown_timeout=2.0,
+        forward_output=False,
+    )
+    supervisor.start()
+    try:
+        supervisor.wait_ready(timeout=5.0)
+        assert [record.rank for record in supervisor.processes] == [1]
+        assert supervisor.processes[0].ready
+        assert supervisor.processes[0].stdout[0] == "POCKETLLM_RANK_READY rank=1"
+        assert supervisor.processes[0].stdout[1] == "TP_ENV world=2 tp_world=2 rank=1 tp_rank=1"
+    finally:
+        supervisor.cleanup()
 
 
 def test_supervisor_requires_config_or_kwargs() -> None:


### PR DESCRIPTION
## Summary
- Fix automatic C++ tensor-parallel supervision for `tensor_parallel_size=2`.
- Keep rank 0 in the parent process while launching actual child ranks `1..N-1`.
- Preserve the full NCCL process-group world size in every child environment.

## Implementation
- Add optional `child_ranks` support to `TensorParallelConfig` and `TensorParallelSupervisor`.
- Preserve the existing default behavior when `child_ranks` is omitted: supervise ranks `0..world_size-1`.
- Configure automatic C++ TP supervision with `world_size=N` and `child_ranks=(1, ..., N-1)`.
- Remove obsolete worker rank remapping and consume `TP_RANK` as the actual rank.
- Validate that multi-rank C++ backend construction has an NCCL rendezvous path.
- Keep environment restoration and worker cleanup behavior unchanged.

## Validation
- `PYTHONPATH=. pytest -q tests/test_supervisor.py tests/test_supervisor_orphan_guard.py tests/test_factory_tp_supervision_reuse.py tests/test_cpp_backend_tp.py`
- Result: **50 passed**.
- Real Qwen3.8-27B-FP8 TP2 validation on RTX 2080 Ti GPUs 0 and 1:
  - automatic supervisor startup with rank 1 child;
  - three real prompts;
  - offline and streaming generation;
  - token-for-token parity with the native reference;
  - EOS/length finish behavior;
  - worker readiness and cleanup.
  - Result: **6/6 cases passed**.

## Known unrelated limitation
The full Python suite still stops during collection in the unrelated untracked `tests/test_gguf_q2_precision.py` because `src.gguf.reader` is unavailable. That file is outside this fix and was left untouched.

Fixes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
