### PR TITLE
Add non-FP16 batched Qwen KV decode

### DIFF
--- a/cpp_engine/backends/cuda/kernels/qwen_fp8_ops.cu
+++ b/cpp_engine/backends/cuda/kernels/qwen_fp8_ops.cu
@@ -1229,14 +1229,149 @@ __global__ void dequant_fp8_kv_cache_kernel(
         const uint8_t k_code = d_k_cache_fp8[cache_offset + ch];
         const float k_scale = scale_bits_to_float<kFp16Scale>(d_k_scale[scale_offset + scale_idx]);
         const float k_val = fp8_e4m3_to_float(k_code) * k_scale;
-        d_k_dense_fp16[dense_offset + ch] = __float2half_rn(k_val);
+        d_k_dense_fp16[dense_offset + ch] = __half_as_ushort(__float2half_rn(k_val));
 
         // Dequantize V
         const uint8_t v_code = d_v_cache_fp8[cache_offset + ch];
         const float v_scale = scale_bits_to_float<kFp16Scale>(d_v_scale[scale_offset + scale_idx]);
         const float v_val = fp8_e4m3_to_float(v_code) * v_scale;
-        d_v_dense_fp16[dense_offset + ch] = __float2half_rn(v_val);
+        d_v_dense_fp16[dense_offset + ch] = __half_as_ushort(__float2half_rn(v_val));
     }
+}
+
+__global__ void dequant_fp8_kv_cache_paged_kernel(
+    const uint8_t* __restrict__ d_k_cache_fp8,
+    const uint8_t* __restrict__ d_v_cache_fp8,
+    const uint16_t* __restrict__ d_k_scale,
+    const uint16_t* __restrict__ d_v_scale,
+    uint16_t* __restrict__ d_k_dense_fp16,
+    uint16_t* __restrict__ d_v_dense_fp16,
+    int context_len, int kv_heads, int head_dim, int scale_block,
+    const int* __restrict__ block_table, int block_size) {
+    const int position = blockIdx.x;
+    const int kv_head = blockIdx.y;
+    if (position >= context_len || kv_head >= kv_heads) return;
+    const int physical_block = block_table[position / block_size];
+    const size_t cache_offset =
+        (static_cast<size_t>(physical_block) * block_size + position % block_size) *
+        static_cast<size_t>(kv_heads) * head_dim +
+        static_cast<size_t>(kv_head) * head_dim;
+    const size_t scale_offset =
+        (static_cast<size_t>(physical_block) * block_size + position % block_size) *
+        static_cast<size_t>(kv_heads) * (head_dim / scale_block) +
+        static_cast<size_t>(kv_head) * (head_dim / scale_block);
+    const size_t dense_offset =
+        (static_cast<size_t>(position) * kv_heads + kv_head) * head_dim;
+    for (int channel = threadIdx.x; channel < head_dim; channel += blockDim.x) {
+        const int scale_index = channel / scale_block;
+        const float k = fp8_e4m3_to_float(d_k_cache_fp8[cache_offset + channel]) *
+                        scale_bits_to_float<true>(d_k_scale[scale_offset + scale_index]);
+        const float v = fp8_e4m3_to_float(d_v_cache_fp8[cache_offset + channel]) *
+                        scale_bits_to_float<true>(d_v_scale[scale_offset + scale_index]);
+        d_k_dense_fp16[dense_offset + channel] = __half_as_ushort(__float2half_rn(k));
+        d_v_dense_fp16[dense_offset + channel] = __half_as_ushort(__float2half_rn(v));
+    }
+}
+
+bool qwen_fp8_dequant_kv_cache_paged_cuda(
+    const uint8_t* d_k_cache_fp8, const uint8_t* d_v_cache_fp8,
+    const uint16_t* d_k_scale_fp16, const uint16_t* d_v_scale_fp16,
+    uint16_t* d_k_dense_fp16, uint16_t* d_v_dense_fp16,
+    int context_len, int kv_heads, int head_dim, int scale_block,
+    const int* d_block_table, int block_size, void* stream) {
+    if (!d_k_cache_fp8 || !d_v_cache_fp8 || !d_k_scale_fp16 || !d_v_scale_fp16 ||
+        !d_k_dense_fp16 || !d_v_dense_fp16 || !d_block_table || context_len <= 0 ||
+        kv_heads <= 0 || head_dim <= 0 || scale_block <= 0 ||
+        head_dim % scale_block != 0 || block_size <= 0) return false;
+    const dim3 grid(context_len, kv_heads);
+    dequant_fp8_kv_cache_paged_kernel<<<grid, 256, 0,
+        static_cast<cudaStream_t>(stream)>>>(
+        d_k_cache_fp8, d_v_cache_fp8, d_k_scale_fp16, d_v_scale_fp16,
+        d_k_dense_fp16, d_v_dense_fp16, context_len, kv_heads, head_dim,
+        scale_block, d_block_table, block_size);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+template <bool kPaged>
+__global__ void dequant_fp8_kv_cache_batched_kernel(
+    const uint8_t* __restrict__ d_k_cache_fp8,
+    const uint8_t* __restrict__ d_v_cache_fp8,
+    const uint16_t* __restrict__ d_k_scale,
+    const uint16_t* __restrict__ d_v_scale,
+    uint16_t* __restrict__ d_k_dense_fp16,
+    uint16_t* __restrict__ d_v_dense_fp16,
+    const int* __restrict__ d_context_lens, const int* __restrict__ d_slot_ids,
+    int rows, int max_context_len, int kv_heads, int head_dim, int scale_block,
+    size_t kv_slot_stride, const int* __restrict__ d_block_table,
+    int block_size, int max_blocks_per_seq) {
+    const int row = blockIdx.z;
+    const int position = blockIdx.x;
+    const int kv_head = blockIdx.y;
+    if (row >= rows || position >= d_context_lens[row] ||
+        position >= max_context_len || kv_head >= kv_heads) return;
+    const int slot = d_slot_ids != nullptr ? d_slot_ids[row] : row;
+    size_t cache_offset;
+    size_t scale_offset;
+    if constexpr (kPaged) {
+        const int block = d_block_table[static_cast<size_t>(slot) * max_blocks_per_seq +
+                                        position / block_size];
+        cache_offset = (static_cast<size_t>(block) * block_size + position % block_size) *
+                       static_cast<size_t>(kv_heads) * head_dim +
+                       static_cast<size_t>(kv_head) * head_dim;
+        scale_offset = (static_cast<size_t>(block) * block_size + position % block_size) *
+                       static_cast<size_t>(kv_heads) * (head_dim / scale_block) +
+                       static_cast<size_t>(kv_head) * (head_dim / scale_block);
+    } else {
+        cache_offset = static_cast<size_t>(slot) * kv_slot_stride +
+                       (static_cast<size_t>(position) * kv_heads + kv_head) * head_dim;
+        scale_offset = static_cast<size_t>(slot) * (kv_slot_stride / scale_block) +
+                       (static_cast<size_t>(position) * kv_heads + kv_head) *
+                           (head_dim / scale_block);
+    }
+    const size_t dense_offset =
+        (static_cast<size_t>(row) * max_context_len * kv_heads +
+         static_cast<size_t>(position) * kv_heads + kv_head) * head_dim;
+    for (int channel = threadIdx.x; channel < head_dim; channel += blockDim.x) {
+        const int scale_index = channel / scale_block;
+        const float k = fp8_e4m3_to_float(d_k_cache_fp8[cache_offset + channel]) *
+                        scale_bits_to_float<true>(d_k_scale[scale_offset + scale_index]);
+        const float v = fp8_e4m3_to_float(d_v_cache_fp8[cache_offset + channel]) *
+                        scale_bits_to_float<true>(d_v_scale[scale_offset + scale_index]);
+        d_k_dense_fp16[dense_offset + channel] = __half_as_ushort(__float2half_rn(k));
+        d_v_dense_fp16[dense_offset + channel] = __half_as_ushort(__float2half_rn(v));
+    }
+}
+
+bool qwen_fp8_dequant_kv_cache_batched_cuda(
+    const uint8_t* d_k_cache_fp8, const uint8_t* d_v_cache_fp8,
+    const uint16_t* d_k_scale_fp16, const uint16_t* d_v_scale_fp16,
+    uint16_t* d_k_dense_fp16, uint16_t* d_v_dense_fp16,
+    const int* d_context_lens, const int* d_slot_ids, int rows,
+    int max_context_len, int kv_heads, int head_dim, int scale_block,
+    size_t kv_slot_stride, const int* d_block_table, int block_size,
+    int max_blocks_per_seq, void* stream) {
+    if (!d_k_cache_fp8 || !d_v_cache_fp8 || !d_k_scale_fp16 || !d_v_scale_fp16 ||
+        !d_k_dense_fp16 || !d_v_dense_fp16 || !d_context_lens || rows <= 0 ||
+        max_context_len <= 0 || kv_heads <= 0 || head_dim <= 0 || scale_block <= 0 ||
+        head_dim % scale_block != 0) return false;
+    const bool paged = d_block_table != nullptr;
+    if (paged) {
+        if (block_size <= 0 || max_blocks_per_seq <= 0) return false;
+    } else if (kv_slot_stride == 0) {
+        return false;
+    }
+    const dim3 grid(static_cast<unsigned>(max_context_len),
+                    static_cast<unsigned>(kv_heads), static_cast<unsigned>(rows));
+#define POCKET_LAUNCH_DEQUANT(PAGED) \
+    dequant_fp8_kv_cache_batched_kernel<PAGED><<<grid, 256, 0, static_cast<cudaStream_t>(stream)>>>( \
+        d_k_cache_fp8, d_v_cache_fp8, d_k_scale_fp16, d_v_scale_fp16, \
+        d_k_dense_fp16, d_v_dense_fp16, d_context_lens, d_slot_ids, rows, \
+        max_context_len, kv_heads, head_dim, scale_block, kv_slot_stride, \
+        d_block_table, block_size, max_blocks_per_seq)
+    if (paged) POCKET_LAUNCH_DEQUANT(true);
+    else POCKET_LAUNCH_DEQUANT(false);
+#undef POCKET_LAUNCH_DEQUANT
+    return cudaGetLastError() == cudaSuccess;
 }
 
 bool qwen_fp8_dequant_kv_cache_cuda(

--- a/cpp_engine/backends/cuda/kernels/qwen_gqa_optimized.cu
+++ b/cpp_engine/backends/cuda/kernels/qwen_gqa_optimized.cu
@@ -2,6 +2,8 @@
 
 #include <cublas_v2.h>
 #include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <type_traits>
 #include <cuda_runtime.h>
 
 #include <algorithm>
@@ -252,6 +254,23 @@ __device__ __forceinline__ float half_to_float(uint16_t bits) {
 
 __device__ __forceinline__ uint16_t float_to_half(float value) {
     return __half_as_ushort(__float2half_rn(value));
+}
+
+__device__ __forceinline__ float fp8_e4m3_to_float(uint8_t code) {
+    const uint32_t sign = static_cast<uint32_t>(code & 0x80u) << 24;
+    const uint32_t exponent = (code >> 3) & 0xfu;
+    const uint32_t mantissa = code & 0x7u;
+    uint32_t bits;
+    if (exponent != 0) {
+        bits = sign | ((exponent + 120u) << 23) | (mantissa << 20);
+    } else if (mantissa >= 4) {
+        bits = sign | (120u << 23) | ((mantissa - 4u) << 21);
+    } else if (mantissa >= 2) {
+        bits = sign | (119u << 23) | ((mantissa - 2u) << 22);
+    } else {
+        bits = sign | (mantissa == 0 ? 0u : (118u << 23));
+    }
+    return __uint_as_float(bits);
 }
 
 // Butterfly reduction: every lane ends with the full warp total, so a warp that
@@ -1644,11 +1663,12 @@ __global__ void gqa_prefill_tiled_f16_kernel(
 // contiguous per-slot reservation. It is a separate template parameter rather
 // than a runtime null check so the contiguous instantiation keeps its exact
 // register count and address arithmetic.
-template <int kHPG, bool kBatched = false, bool kPaged = false>
+template <int kHPG, bool kBatched = false, bool kPaged = false,
+          bool kFp8 = false>
 __global__ void gqa_decode_split_f16_kernel(
     const uint16_t* __restrict__ q,
-    const uint16_t* __restrict__ k_cache,
-    const uint16_t* __restrict__ v_cache,
+    const std::conditional_t<kFp8, uint8_t, uint16_t>* __restrict__ k_cache,
+    const std::conditional_t<kFp8, uint8_t, uint16_t>* __restrict__ v_cache,
     float* __restrict__ partial_output,
     int q_heads,
     int kv_heads,
@@ -1663,8 +1683,14 @@ __global__ void gqa_decode_split_f16_kernel(
     size_t kv_slot_stride = 0,
     const int* __restrict__ block_table = nullptr,
     int block_size = 0,
-    int max_blocks_per_seq = 0) {
+    int max_blocks_per_seq = 0,
+    // FP8 cache only: one FP16 scale per token, KV head and scale_block-wide
+    // channel group, laid out with the same geometry as the codes it rescales.
+    const uint16_t* __restrict__ k_scale = nullptr,
+    const uint16_t* __restrict__ v_scale = nullptr,
+    int scale_block = 0) {
     const int q_per_kv = q_heads / kv_heads;
+    const int scales_per_head = kFp8 ? head_dim / scale_block : 0;
     const int groups_per_kv = (q_per_kv + kHPG - 1) / kHPG;
     const int grouped = static_cast<int>(blockIdx.x) / splits;
     const int split = static_cast<int>(blockIdx.x) % splits;
@@ -1691,6 +1717,14 @@ __global__ void gqa_decode_split_f16_kernel(
                 static_cast<size_t>(slot_index) * kv_slot_stride;
             k_cache += slot;
             v_cache += slot;
+            if constexpr (kFp8) {
+                // The scale arena carries one entry per scale_block channels,
+                // so its per-slot stride is the code stride divided by that
+                // block width.
+                const size_t scale_slot = slot / scale_block;
+                k_scale += scale_slot;
+                v_scale += scale_slot;
+            }
         }
         q += static_cast<size_t>(row) * q_heads * head_dim;
         partial_output += static_cast<size_t>(row) * q_heads * splits *
@@ -1750,6 +1784,7 @@ __global__ void gqa_decode_split_f16_kernel(
     for (int logical = start; logical < end; ++logical) {
         const int position = ranges.position(logical);
         size_t kv_base;
+        size_t scale_base = 0;
         if constexpr (kPaged) {
             const int block_index = position / block_size;
             if (block_index != cached_block_index) {
@@ -1761,17 +1796,39 @@ __global__ void gqa_decode_split_f16_kernel(
             kv_base = cached_block_base +
                 static_cast<size_t>(position % block_size) * kv_stride +
                 static_cast<size_t>(kv_head) * head_dim;
+            if constexpr (kFp8) {
+                scale_base =
+                    (static_cast<size_t>(slot_blocks[block_index]) * block_size +
+                     position % block_size) * kv_heads * scales_per_head +
+                    static_cast<size_t>(kv_head) * scales_per_head;
+            }
         } else {
             kv_base = static_cast<size_t>(position) * kv_stride +
                 static_cast<size_t>(kv_head) * head_dim;
+            if constexpr (kFp8) {
+                scale_base = static_cast<size_t>(position) * kv_heads *
+                    scales_per_head + static_cast<size_t>(kv_head) * scales_per_head;
+            }
         }
         float key[kValuesPerThread];
         float value[kValuesPerThread];
 #pragma unroll
         for (int i = 0; i < kValuesPerThread; ++i) {
             const int d = tid + i * kThreads;
-            key[i] = d < head_dim ? half_to_float(k_cache[kv_base + d]) : 0.0f;
-            value[i] = d < head_dim ? half_to_float(v_cache[kv_base + d]) : 0.0f;
+            if (d < head_dim) {
+                if constexpr (kFp8) {
+                    key[i] = fp8_e4m3_to_float(k_cache[kv_base + d]) *
+                        half_to_float(k_scale[scale_base + d / scale_block]);
+                    value[i] = fp8_e4m3_to_float(v_cache[kv_base + d]) *
+                        half_to_float(v_scale[scale_base + d / scale_block]);
+                } else {
+                    key[i] = half_to_float(k_cache[kv_base + d]);
+                    value[i] = half_to_float(v_cache[kv_base + d]);
+                }
+            } else {
+                key[i] = 0.0f;
+                value[i] = 0.0f;
+            }
         }
         float dot[kHPG] = {};
 #pragma unroll
@@ -3215,6 +3272,82 @@ bool qwen_gqa_decode_attention_f16_batched_cuda(
     }
 #undef POCKET_LAUNCH_DECODE_SPLIT_BATCHED_WIDTH
 #undef POCKET_LAUNCH_DECODE_SPLIT_BATCHED
+    if (cudaGetLastError() != cudaSuccess) return false;
+    const dim3 merge_grid(static_cast<unsigned>(q_heads),
+                          static_cast<unsigned>(rows), 1);
+    gqa_decode_merge_f16_kernel<<<merge_grid, kThreads, 0, cuda_stream>>>(
+        partial_scratch, output, q_heads, head_dim, splits);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gqa_decode_attention_fp8_batched_cuda(
+    const uint16_t* q, const uint8_t* k_cache, const uint8_t* v_cache,
+    const uint16_t* k_scale, const uint16_t* v_scale, uint16_t* output,
+    float* partial_scratch, const int* context_lens, const int* slot_ids,
+    int rows, int max_context_len, size_t kv_slot_stride, int q_heads,
+    int kv_heads, int head_dim, int scale_block, int max_context,
+    int attention_window, int sink_tokens, const int* block_table,
+    int block_size, int max_blocks_per_seq, void* stream) {
+    if (!q || !k_cache || !v_cache || !k_scale || !v_scale || !output ||
+        !partial_scratch || !context_lens || rows <= 0 || max_context_len <= 0 ||
+        attention_window < 0 || sink_tokens < 0 || scale_block <= 0 ||
+        head_dim % scale_block != 0 || !valid_shape(q_heads, kv_heads, head_dim)) {
+        return false;
+    }
+    const bool paged = block_table != nullptr;
+    if (paged) {
+        if (block_size <= 0 || max_blocks_per_seq <= 0 ||
+            max_context_len > block_size * max_blocks_per_seq) return false;
+    } else if (max_context_len > max_context || kv_slot_stride == 0) {
+        return false;
+    }
+    const SparseRanges ranges =
+        sparse_ranges(max_context_len, attention_window, sink_tokens);
+    const int attended = ranges.total();
+    const int splits = decode_split_count_for_variant(attended, false, 0, kv_heads);
+    if (splits <= 0 || splits > kDecodeSplitCeiling) return false;
+    const int positions_per_split = (attended + splits - 1) / splits;
+    const int group_heads = decode_group_width(q_heads / kv_heads);
+    const int groups_per_kv =
+        (q_heads / kv_heads + group_heads - 1) / group_heads;
+    const cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
+    const dim3 grid(static_cast<unsigned>(kv_heads * groups_per_kv * splits),
+                    static_cast<unsigned>(rows), 1);
+#define POCKET_LAUNCH_FP8_BATCHED(HPG, PAGED) \
+    gqa_decode_split_f16_kernel<HPG, true, PAGED, true> \
+        <<<grid, kThreads, 0, cuda_stream>>>( \
+        q, k_cache, v_cache, partial_scratch, q_heads, kv_heads, head_dim, \
+        max_context_len, splits, positions_per_split, attention_window, \
+        sink_tokens, context_lens, slot_ids, kv_slot_stride, block_table, \
+        block_size, max_blocks_per_seq, k_scale, v_scale, scale_block)
+    switch (group_heads) {
+        case 1:
+            if (paged) POCKET_LAUNCH_FP8_BATCHED(1, true);
+            else POCKET_LAUNCH_FP8_BATCHED(1, false);
+            break;
+        case 2:
+            if (paged) POCKET_LAUNCH_FP8_BATCHED(2, true);
+            else POCKET_LAUNCH_FP8_BATCHED(2, false);
+            break;
+        case 3:
+            if (paged) POCKET_LAUNCH_FP8_BATCHED(3, true);
+            else POCKET_LAUNCH_FP8_BATCHED(3, false);
+            break;
+        case 4:
+            if (paged) POCKET_LAUNCH_FP8_BATCHED(4, true);
+            else POCKET_LAUNCH_FP8_BATCHED(4, false);
+            break;
+        case 5:
+            if (paged) POCKET_LAUNCH_FP8_BATCHED(5, true);
+            else POCKET_LAUNCH_FP8_BATCHED(5, false);
+            break;
+        case 6:
+            if (paged) POCKET_LAUNCH_FP8_BATCHED(6, true);
+            else POCKET_LAUNCH_FP8_BATCHED(6, false);
+            break;
+        default: return false;
+    }
+#undef POCKET_LAUNCH_FP8_BATCHED
     if (cudaGetLastError() != cudaSuccess) return false;
     const dim3 merge_grid(static_cast<unsigned>(q_heads),
                           static_cast<unsigned>(rows), 1);

--- a/cpp_engine/backends/cuda/kernels/qwen_half_ops.cu
+++ b/cpp_engine/backends/cuda/kernels/qwen_half_ops.cu
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <climits>
 #include <cstdlib>
 #include <cstring>
 #include <type_traits>
@@ -2860,7 +2861,7 @@ __global__ void append_kv_fp8_kernel(
     uint8_t* k_cache, uint8_t* v_cache,
     uint16_t* k_scale, uint16_t* v_scale,
     int seq_len, int kv_heads, int head_dim, int scale_block,
-    int start_pos, int max_context) {
+    int start_pos, int max_context, const int* block_table, int block_size) {
     const int block_index = static_cast<int>(blockIdx.x);
     const int blocks_per_head = head_dim / scale_block;
     const int token = block_index / (kv_heads * blocks_per_head);
@@ -2890,12 +2891,29 @@ __global__ void append_kv_fp8_kernel(
     const float ks = reduce_k[0] > 0.0f ? reduce_k[0] / 448.0f : 1.0f;
     const float vs = reduce_v[0] > 0.0f ? reduce_v[0] / 448.0f : 1.0f;
     const int destination_token = start_pos + token;
-    const size_t scale_index = (static_cast<size_t>(destination_token) * kv_heads + head) * blocks_per_head + channel_block;
+    const size_t token_stride = static_cast<size_t>(kv_heads) * head_dim;
+    const size_t scale_stride = static_cast<size_t>(kv_heads) * blocks_per_head;
+    size_t scale_index;
+    size_t destination_base;
+    if (block_table != nullptr) {
+        const int physical_block = block_table[destination_token / block_size];
+        destination_base = (static_cast<size_t>(physical_block) * block_size +
+                           destination_token % block_size) * token_stride +
+                          static_cast<size_t>(head) * head_dim +
+                          static_cast<size_t>(channel_block) * scale_block;
+        scale_index = (static_cast<size_t>(physical_block) * block_size +
+                       destination_token % block_size) * scale_stride +
+                      static_cast<size_t>(head) * blocks_per_head + channel_block;
+    } else {
+        scale_index = (static_cast<size_t>(destination_token) * kv_heads + head) *
+                      blocks_per_head + channel_block;
+        destination_base = (static_cast<size_t>(destination_token) * kv_heads + head) *
+                           head_dim + static_cast<size_t>(channel_block) * scale_block;
+    }
     if (threadIdx.x == 0) {
         k_scale[scale_index] = float_to_half(ks);
         v_scale[scale_index] = float_to_half(vs);
     }
-    const size_t destination_base = (static_cast<size_t>(destination_token) * kv_heads + head) * head_dim + channel_block * scale_block;
     for (int d = threadIdx.x; d < scale_block; d += blockDim.x) {
         k_cache[destination_base + d] = float_to_fp8_e4m3(half_to_float(k_rows[source_base + d]) / ks);
         v_cache[destination_base + d] = float_to_fp8_e4m3(half_to_float(v_rows[source_base + d]) / vs);
@@ -2907,7 +2925,8 @@ __global__ void append_kv_fp8_batched_kernel(
     uint8_t* k_cache, uint8_t* v_cache,
     uint16_t* k_scale, uint16_t* v_scale,
     const int* start_positions, const int* slot_ids, int rows, int kv_heads,
-    int head_dim, int scale_block, int max_context, size_t kv_slot_stride) {
+    int head_dim, int scale_block, int max_context, size_t kv_slot_stride,
+    const int* block_table, int block_size, int max_blocks_per_seq) {
     const int block_index = static_cast<int>(blockIdx.x);
     const int blocks_per_head = head_dim / scale_block;
     const int row = block_index / (kv_heads * blocks_per_head);
@@ -2920,10 +2939,12 @@ __global__ void append_kv_fp8_batched_kernel(
     // Each sequence owns a contiguous cache slot, which is not its batch index;
     // the scale array is strided by the same slot count over the block width.
     const int slot = slot_ids != nullptr ? slot_ids[row] : row;
-    k_cache += static_cast<size_t>(slot) * kv_slot_stride;
-    v_cache += static_cast<size_t>(slot) * kv_slot_stride;
-    k_scale += static_cast<size_t>(slot) * (kv_slot_stride / scale_block);
-    v_scale += static_cast<size_t>(slot) * (kv_slot_stride / scale_block);
+    if (block_table == nullptr) {
+        k_cache += static_cast<size_t>(slot) * kv_slot_stride;
+        v_cache += static_cast<size_t>(slot) * kv_slot_stride;
+        k_scale += static_cast<size_t>(slot) * (kv_slot_stride / scale_block);
+        v_scale += static_cast<size_t>(slot) * (kv_slot_stride / scale_block);
+    }
     const int source_base = (row * kv_heads + head) * head_dim + channel_block * scale_block;
     float k_max = 0.0f;
     float v_max = 0.0f;
@@ -2945,12 +2966,31 @@ __global__ void append_kv_fp8_batched_kernel(
     }
     const float ks = reduce_k[0] > 0.0f ? reduce_k[0] / 448.0f : 1.0f;
     const float vs = reduce_v[0] > 0.0f ? reduce_v[0] / 448.0f : 1.0f;
-    const size_t scale_index = (static_cast<size_t>(destination_token) * kv_heads + head) * blocks_per_head + channel_block;
+    const size_t token_stride = static_cast<size_t>(kv_heads) * head_dim;
+    const size_t scale_stride = static_cast<size_t>(kv_heads) * blocks_per_head;
+    size_t scale_index;
+    size_t destination_base;
+    if (block_table != nullptr) {
+        const int physical_block = block_table[
+            static_cast<size_t>(slot) * max_blocks_per_seq +
+            destination_token / block_size];
+        destination_base = (static_cast<size_t>(physical_block) * block_size +
+                           destination_token % block_size) * token_stride +
+                          static_cast<size_t>(head) * head_dim +
+                          static_cast<size_t>(channel_block) * scale_block;
+        scale_index = (static_cast<size_t>(physical_block) * block_size +
+                       destination_token % block_size) * scale_stride +
+                      static_cast<size_t>(head) * blocks_per_head + channel_block;
+    } else {
+        scale_index = (static_cast<size_t>(destination_token) * kv_heads + head) *
+                      blocks_per_head + channel_block;
+        destination_base = (static_cast<size_t>(destination_token) * kv_heads + head) *
+                           head_dim + static_cast<size_t>(channel_block) * scale_block;
+    }
     if (threadIdx.x == 0) {
         k_scale[scale_index] = float_to_half(ks);
         v_scale[scale_index] = float_to_half(vs);
     }
-    const size_t destination_base = (static_cast<size_t>(destination_token) * kv_heads + head) * head_dim + channel_block * scale_block;
     for (int d = threadIdx.x; d < scale_block; d += blockDim.x) {
         k_cache[destination_base + d] = float_to_fp8_e4m3(half_to_float(k_rows[source_base + d]) / ks);
         v_cache[destination_base + d] = float_to_fp8_e4m3(half_to_float(v_rows[source_base + d]) / vs);
@@ -4432,7 +4472,7 @@ bool qwen_append_kv_cache_fp8_cuda(
     const int blocks = seq_len * kv_heads * (head_dim / scale_block);
     append_kv_fp8_kernel<<<blocks, 128, 0, static_cast<cudaStream_t>(stream)>>>(
         k_rows, v_rows, k_cache, v_cache, k_scale, v_scale, seq_len,
-        kv_heads, head_dim, scale_block, start_pos, max_context);
+        kv_heads, head_dim, scale_block, start_pos, max_context, nullptr, 0);
     return cudaGetLastError() == cudaSuccess;
 }
 
@@ -4441,16 +4481,40 @@ bool qwen_append_kv_cache_fp8_batched_cuda(
     uint8_t* k_cache, uint8_t* v_cache, uint16_t* k_scale,
     uint16_t* v_scale, int rows, int kv_heads, int head_dim,
     int scale_block, const int* start_positions, const int* slot_ids,
-    int max_context, size_t kv_slot_stride, void* stream) {
+    int max_context, size_t kv_slot_stride, const int* block_table,
+    int block_size, int max_blocks_per_seq, void* stream) {
     if (!k_rows || !v_rows || !k_cache || !v_cache || !k_scale || !v_scale ||
         !start_positions || rows <= 0 || kv_heads <= 0 || head_dim <= 0 ||
         scale_block <= 0 || scale_block > 128 || head_dim % scale_block != 0 ||
-        max_context <= 0 || kv_slot_stride == 0) return false;
+        max_context <= 0) return false;
+    if (block_table != nullptr) {
+        if (block_size <= 0 || max_blocks_per_seq <= 0) return false;
+    } else if (kv_slot_stride == 0) {
+        return false;
+    }
     const int blocks = rows * kv_heads * (head_dim / scale_block);
     append_kv_fp8_batched_kernel<<<blocks, 128, 0, static_cast<cudaStream_t>(stream)>>>(
         k_rows, v_rows, k_cache, v_cache, k_scale, v_scale, start_positions,
         slot_ids, rows, kv_heads, head_dim, scale_block, max_context,
-        kv_slot_stride);
+        kv_slot_stride, block_table, block_size, max_blocks_per_seq);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_append_kv_cache_fp8_paged_cuda(
+    const uint16_t* k_rows, const uint16_t* v_rows,
+    uint8_t* k_cache, uint8_t* v_cache, uint16_t* k_scale,
+    uint16_t* v_scale, int seq_len, int kv_heads, int head_dim,
+    int scale_block, int start_pos, const int* block_table, int block_size,
+    void* stream) {
+    if (!k_rows || !k_cache || !v_rows || !v_cache || !k_scale || !v_scale ||
+        !block_table || seq_len <= 0 || kv_heads <= 0 || head_dim <= 0 ||
+        scale_block <= 0 || scale_block > 128 || head_dim % scale_block != 0 ||
+        start_pos < 0 || block_size <= 0) return false;
+    const int blocks = seq_len * kv_heads * (head_dim / scale_block);
+    append_kv_fp8_kernel<<<blocks, 128, 0, static_cast<cudaStream_t>(stream)>>>(
+        k_rows, v_rows, k_cache, v_cache, k_scale, v_scale, seq_len,
+        kv_heads, head_dim, scale_block, start_pos, INT_MAX, block_table,
+        block_size);
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/backends/cuda/kernels/qwen_turboquant_ops.cu
+++ b/cpp_engine/backends/cuda/kernels/qwen_turboquant_ops.cu
@@ -3,6 +3,7 @@
 #include <cuda_fp8.h>
 #include <cuda_runtime.h>
 #include <cstdint>
+#include <climits>
 #include <cstring>
 
 namespace pocket {
@@ -37,7 +38,8 @@ __global__ void append_kv_cache_turboquant_k8v4_kernel(
     const uint16_t* __restrict__ d_k_rows_fp16,
     const uint16_t* __restrict__ d_v_rows_fp16,
     uint8_t* __restrict__ d_combined_cache,
-    int seq_len, int kv_heads, int head_dim, int start_pos, int max_context) {
+    int seq_len, int kv_heads, int head_dim, int start_pos, int max_context,
+    const int* __restrict__ d_block_table, int block_size) {
 
     const int token = blockIdx.x;
     const int head = blockIdx.y;
@@ -51,8 +53,11 @@ __global__ void append_kv_cache_turboquant_k8v4_kernel(
 
     const size_t k_offset = (static_cast<size_t>(token) * kv_heads + head) * head_dim;
     const size_t v_offset = k_offset;
-    const size_t slot_offset =
-        (static_cast<size_t>(cache_pos) * kv_heads + head) * slot_bytes;
+    const size_t slot_offset = d_block_table != nullptr
+        ? (static_cast<size_t>(d_block_table[cache_pos / block_size]) * block_size +
+           cache_pos % block_size) * static_cast<size_t>(kv_heads) * slot_bytes +
+          static_cast<size_t>(head) * slot_bytes
+        : (static_cast<size_t>(cache_pos) * kv_heads + head) * slot_bytes;
 
     uint8_t* slot = d_combined_cache + slot_offset;
 
@@ -135,6 +140,84 @@ __global__ void append_kv_cache_turboquant_k8v4_kernel(
 }
 
 // Decode attention with TurboQuant K8V4 cache.
+__global__ void append_kv_cache_turboquant_k8v4_batched_kernel(
+    const uint16_t* __restrict__ d_k_rows_fp16,
+    const uint16_t* __restrict__ d_v_rows_fp16,
+    uint8_t* __restrict__ d_combined_cache,
+    const int* __restrict__ d_start_positions,
+    const int* __restrict__ d_slot_ids, int rows, int kv_heads, int head_dim,
+    int max_context, size_t slot_stride_bytes, const int* __restrict__ d_block_table,
+    int block_size, int max_blocks_per_seq) {
+    const int row = blockIdx.x;
+    const int head = blockIdx.y;
+    if (row >= rows || head >= kv_heads) return;
+    const int position = d_start_positions[row];
+    if (position < 0 || position >= max_context) return;
+    const int slot_id = d_slot_ids != nullptr ? d_slot_ids[row] : row;
+    const int slot_bytes = slot_bytes_for(head_dim);
+    size_t slot_offset;
+    if (d_block_table != nullptr) {
+        const int block = d_block_table[static_cast<size_t>(slot_id) * max_blocks_per_seq +
+                                        position / block_size];
+        slot_offset = (static_cast<size_t>(block) * block_size + position % block_size) *
+                      static_cast<size_t>(kv_heads) * slot_bytes +
+                      static_cast<size_t>(head) * slot_bytes;
+    } else {
+        slot_offset = static_cast<size_t>(slot_id) * slot_stride_bytes +
+                      (static_cast<size_t>(position) * kv_heads + head) * slot_bytes;
+    }
+    const size_t source = (static_cast<size_t>(row) * kv_heads + head) * head_dim;
+    uint8_t* slot = d_combined_cache + slot_offset;
+    float v_min = INFINITY;
+    float v_max = -INFINITY;
+    for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        const float value = __half2float(__ushort_as_half(d_v_rows_fp16[source + d]));
+        if (isfinite(value)) {
+            v_min = fminf(v_min, value);
+            v_max = fmaxf(v_max, value);
+        }
+    }
+    __shared__ float s_min[kStoreThreads];
+    __shared__ float s_max[kStoreThreads];
+    s_min[threadIdx.x] = v_min;
+    s_max[threadIdx.x] = v_max;
+    __syncthreads();
+    for (int stride = kStoreThreads / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            s_min[threadIdx.x] = fminf(s_min[threadIdx.x], s_min[threadIdx.x + stride]);
+            s_max[threadIdx.x] = fmaxf(s_max[threadIdx.x], s_max[threadIdx.x + stride]);
+        }
+        __syncthreads();
+    }
+    v_min = isfinite(s_min[0]) ? s_min[0] : 0.0f;
+    v_max = isfinite(s_max[0]) ? s_max[0] : 0.0f;
+    const __half min_h = __float2half(v_min);
+    v_min = __half2float(min_h);
+    float scale = fmaxf((v_max - v_min) / 15.0f, 1e-8f);
+    const __half scale_h = __float2half(scale);
+    scale = fmaxf(__half2float(scale_h), 1e-8f);
+    for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        const float key = __half2float(__ushort_as_half(d_k_rows_fp16[source + d]));
+        slot[d] = __nv_cvt_float_to_fp8(key, __NV_SATFINITE, __NV_E5M2);
+    }
+    const int value_bytes = head_dim / 2;
+    for (int byte = threadIdx.x; byte < value_bytes; byte += blockDim.x) {
+        const int d = byte * 2;
+        const uint8_t low = quantize_value_nibble(
+            __half2float(__ushort_as_half(d_v_rows_fp16[source + d])), scale, v_min);
+        const uint8_t high = quantize_value_nibble(
+            __half2float(__ushort_as_half(d_v_rows_fp16[source + d + 1])), scale, v_min);
+        slot[head_dim + byte] = static_cast<uint8_t>(low | (high << 4));
+    }
+    if (threadIdx.x == 0) {
+        uint16_t scale_bits, min_bits;
+        std::memcpy(&scale_bits, &scale_h, 2);
+        std::memcpy(&min_bits, &min_h, 2);
+        std::memcpy(slot + head_dim + value_bytes, &scale_bits, 2);
+        std::memcpy(slot + head_dim + value_bytes + 2, &min_bits, 2);
+    }
+}
+
 __global__ void gqa_decode_attention_turboquant_k8v4_score_kernel(
     const uint16_t* __restrict__ d_q_fp16,
     const uint8_t* __restrict__ d_combined_cache,
@@ -232,14 +315,19 @@ __global__ void dequant_kv_turboquant_k8v4_kernel(
 // One block per query head. Masked-out positions already hold -inf, so they
 // contribute nothing and stay zero after normalization.
 __global__ void softmax_rows_f32_kernel(float* __restrict__ d_scores,
-                                        int row_stride, int valid_cols) {
+                                        int row_stride, int valid_cols,
+                                        const int* __restrict__ row_lengths,
+                                        int heads_per_row) {
     const int row = blockIdx.x;
     float* scores = d_scores + static_cast<size_t>(row) * row_stride;
+    const int sequence = heads_per_row > 0 ? row / heads_per_row : 0;
+    const int row_valid_cols = row_lengths != nullptr
+        ? row_lengths[sequence] : valid_cols;
 
     __shared__ float s_reduce[256];
 
     float local_max = -INFINITY;
-    for (int col = threadIdx.x; col < valid_cols; col += blockDim.x) {
+    for (int col = threadIdx.x; col < row_valid_cols; col += blockDim.x) {
         local_max = fmaxf(local_max, scores[col]);
     }
     s_reduce[threadIdx.x] = local_max;
@@ -255,7 +343,7 @@ __global__ void softmax_rows_f32_kernel(float* __restrict__ d_scores,
     __syncthreads();
 
     float local_sum = 0.0f;
-    for (int col = threadIdx.x; col < valid_cols; col += blockDim.x) {
+    for (int col = threadIdx.x; col < row_valid_cols; col += blockDim.x) {
         const float score = scores[col];
         const float weight = isfinite(score) ? __expf(score - row_max) : 0.0f;
         scores[col] = weight;
@@ -272,7 +360,7 @@ __global__ void softmax_rows_f32_kernel(float* __restrict__ d_scores,
     const float row_sum = s_reduce[0];
     const float inv_sum = row_sum > 0.0f ? 1.0f / row_sum : 0.0f;
 
-    for (int col = threadIdx.x; col < valid_cols; col += blockDim.x) {
+    for (int col = threadIdx.x; col < row_valid_cols; col += blockDim.x) {
         scores[col] *= inv_sum;
     }
 }
@@ -466,7 +554,174 @@ __global__ void gqa_prefill_attention_turboquant_k8v4_kernel(
     d_out_rows_fp16[out_offset] = out_bits;
 }
 
+// Resolves one token's slot inside the combined cache. The contiguous arena
+// gives every sequence its own `slot_stride_bytes` region; the paged arena is
+// shared and the sequence's block-table row names the physical block that holds
+// each position, so only the addressing differs between the two layouts.
+__device__ __forceinline__ const uint8_t* turboquant_k8v4_slot_of(
+    const uint8_t* __restrict__ cache, int slot_id, int position, int kv_head,
+    int kv_heads, int slot_bytes, size_t slot_stride_bytes,
+    const int* __restrict__ block_table, int block_size,
+    int max_blocks_per_seq) {
+    if (block_table != nullptr) {
+        const int block = block_table[static_cast<size_t>(slot_id) * max_blocks_per_seq +
+                                      position / block_size];
+        return cache +
+               (static_cast<size_t>(block) * block_size + position % block_size) *
+                   static_cast<size_t>(kv_heads) * slot_bytes +
+               static_cast<size_t>(kv_head) * slot_bytes;
+    }
+    return cache + static_cast<size_t>(slot_id) * slot_stride_bytes +
+           (static_cast<size_t>(position) * kv_heads + kv_head) * slot_bytes;
+}
+
+__device__ __forceinline__ bool turboquant_k8v4_position_visible(
+    int position, int context_len, int attention_window,
+    int attention_sink_tokens) {
+    if (position >= context_len) return false;
+    if (attention_window <= 0) return true;
+    const int sink_end = attention_sink_tokens;
+    const int window_start = max(sink_end, context_len - attention_window);
+    return position < sink_end || position >= window_start;
+}
+
+// Batched score phase: one thread per (row, query head, position). Rows carry
+// their own context length, so a short row leaves padded columns at -inf while
+// its softmax and output phases consume only the logical history.
+__global__ void gqa_decode_attention_turboquant_k8v4_score_batched_kernel(
+    const uint16_t* __restrict__ d_q_fp16,
+    const uint8_t* __restrict__ d_combined_cache,
+    float* __restrict__ d_scores,
+    const int* __restrict__ d_context_lens,
+    const int* __restrict__ d_slot_ids, int rows, int max_context_len,
+    size_t slot_stride_bytes, int q_heads, int kv_heads, int head_dim,
+    int attention_window, int attention_sink_tokens, float q_scale,
+    const int* __restrict__ d_block_table, int block_size,
+    int max_blocks_per_seq) {
+
+    const int row = static_cast<int>(blockIdx.z);
+    const int head = static_cast<int>(blockIdx.x);
+    const int pos = static_cast<int>(blockIdx.y * blockDim.x + threadIdx.x);
+    if (row >= rows || head >= q_heads || pos >= max_context_len) return;
+
+    const int context_len = d_context_lens[row];
+    const int slot_id = d_slot_ids != nullptr ? d_slot_ids[row] : row;
+    const int kv_head = head / (q_heads / kv_heads);
+
+    float score = -INFINITY;
+    if (turboquant_k8v4_position_visible(pos, context_len, attention_window,
+                                         attention_sink_tokens)) {
+        const uint16_t* q_row = d_q_fp16 +
+            (static_cast<size_t>(row) * q_heads + head) * head_dim;
+        const uint8_t* slot = turboquant_k8v4_slot_of(
+            d_combined_cache, slot_id, pos, kv_head, kv_heads,
+            slot_bytes_for(head_dim), slot_stride_bytes, d_block_table,
+            block_size, max_blocks_per_seq);
+        float dot = 0.0f;
+        for (int d = 0; d < head_dim; ++d) {
+            const float q = __half2float(__ushort_as_half(q_row[d]));
+            const __half key = __nv_cvt_fp8_to_halfraw(slot[d], __NV_E5M2);
+            dot += q * __half2float(key);
+        }
+        score = dot * q_scale;
+    }
+    d_scores[(static_cast<size_t>(row) * q_heads + head) * max_context_len + pos] =
+        score;
+}
+
+__global__ void gqa_decode_attention_turboquant_k8v4_output_batched_kernel(
+    const uint8_t* __restrict__ d_combined_cache,
+    const float* __restrict__ d_probs,
+    uint16_t* __restrict__ d_out_fp16,
+    const int* __restrict__ d_context_lens,
+    const int* __restrict__ d_slot_ids, int rows, int max_context_len,
+    size_t slot_stride_bytes, int q_heads, int kv_heads, int head_dim,
+    int attention_window, int attention_sink_tokens,
+    const int* __restrict__ d_block_table, int block_size,
+    int max_blocks_per_seq) {
+
+    const int row = static_cast<int>(blockIdx.z);
+    const int head = static_cast<int>(blockIdx.x);
+    const int dim = static_cast<int>(blockIdx.y * blockDim.x + threadIdx.x);
+    if (row >= rows || head >= q_heads || dim >= head_dim) return;
+
+    const int context_len = d_context_lens[row];
+    const int slot_id = d_slot_ids != nullptr ? d_slot_ids[row] : row;
+    const int kv_head = head / (q_heads / kv_heads);
+    const int value_bytes = head_dim / 2;
+    const int slot_bytes = slot_bytes_for(head_dim);
+    const float* head_probs = d_probs +
+        (static_cast<size_t>(row) * q_heads + head) * max_context_len;
+
+    float accum = 0.0f;
+    for (int pos = 0; pos < context_len; ++pos) {
+        if (!turboquant_k8v4_position_visible(pos, context_len, attention_window,
+                                              attention_sink_tokens)) {
+            continue;
+        }
+        const uint8_t* slot = turboquant_k8v4_slot_of(
+            d_combined_cache, slot_id, pos, kv_head, kv_heads, slot_bytes,
+            slot_stride_bytes, d_block_table, block_size, max_blocks_per_seq);
+        uint16_t scale_bits, min_bits;
+        std::memcpy(&scale_bits, slot + head_dim + value_bytes, 2);
+        std::memcpy(&min_bits, slot + head_dim + value_bytes + 2, 2);
+        const float scale = __half2float(__ushort_as_half(scale_bits));
+        const float minimum = __half2float(__ushort_as_half(min_bits));
+        const uint8_t packed = slot[head_dim + (dim >> 1)];
+        const uint8_t nibble = (dim & 1) ? (packed >> 4) : (packed & 0x0F);
+        accum += head_probs[pos] *
+                 dequantize_value_nibble(nibble, scale, minimum);
+    }
+
+    const size_t out_offset =
+        (static_cast<size_t>(row) * q_heads + head) * head_dim + dim;
+    __half out_h = __float2half(accum);
+    uint16_t out_bits;
+    std::memcpy(&out_bits, &out_h, 2);
+    d_out_fp16[out_offset] = out_bits;
+}
+
 }  // namespace
+
+bool qwen_append_kv_cache_turboquant_k8v4_batched_cuda(
+    const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
+    uint8_t* d_combined_cache, int rows, int kv_heads, int head_dim,
+    const int* d_start_positions, const int* d_slot_ids, int max_context,
+    size_t slot_stride_bytes, const int* d_block_table, int block_size,
+    int max_blocks_per_seq, void* stream) {
+    if (!d_k_rows_fp16 || !d_v_rows_fp16 || !d_combined_cache ||
+        !d_start_positions || rows <= 0 || kv_heads <= 0 || head_dim <= 0 ||
+        head_dim > kMaxHeadDim || (head_dim % 2) != 0 || max_context <= 0) {
+        return false;
+    }
+    if (d_block_table != nullptr) {
+        if (block_size <= 0 || max_blocks_per_seq <= 0) return false;
+    } else if (slot_stride_bytes == 0) {
+        return false;
+    }
+    append_kv_cache_turboquant_k8v4_batched_kernel<<<
+        dim3(static_cast<unsigned>(rows), static_cast<unsigned>(kv_heads)),
+        kStoreThreads, 0, static_cast<cudaStream_t>(stream)>>>(
+        d_k_rows_fp16, d_v_rows_fp16, d_combined_cache, d_start_positions,
+        d_slot_ids, rows, kv_heads, head_dim, max_context, slot_stride_bytes,
+        d_block_table, block_size, max_blocks_per_seq);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_append_kv_cache_turboquant_k8v4_paged_cuda(
+    const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
+    uint8_t* d_combined_cache, int seq_len, int kv_heads, int head_dim,
+    int start_pos, const int* d_block_table, int block_size, void* stream) {
+    if (!d_k_rows_fp16 || !d_v_rows_fp16 || !d_combined_cache || !d_block_table ||
+        seq_len <= 0 || kv_heads <= 0 || head_dim <= 0 || head_dim > kMaxHeadDim ||
+        (head_dim % 2) != 0 || start_pos < 0 || block_size <= 0) return false;
+    dim3 grid(seq_len, kv_heads);
+    append_kv_cache_turboquant_k8v4_kernel<<<grid, kStoreThreads, 0,
+        static_cast<cudaStream_t>(stream)>>>(
+        d_k_rows_fp16, d_v_rows_fp16, d_combined_cache, seq_len, kv_heads,
+        head_dim, start_pos, INT_MAX, d_block_table, block_size);
+    return cudaGetLastError() == cudaSuccess;
+}
 
 bool qwen_append_kv_cache_turboquant_k8v4_cuda(
     const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
@@ -490,8 +745,59 @@ bool qwen_append_kv_cache_turboquant_k8v4_cuda(
     append_kv_cache_turboquant_k8v4_kernel<<<grid, block, 0,
                                              static_cast<cudaStream_t>(stream)>>>(
         d_k_rows_fp16, d_v_rows_fp16, d_combined_cache, seq_len, kv_heads,
-        head_dim, start_pos, max_context);
+        head_dim, start_pos, max_context, nullptr, 0);
 
+    return cudaGetLastError() == cudaSuccess;
+}
+
+bool qwen_gqa_decode_attention_turboquant_k8v4_batched_cuda(
+    const uint16_t* d_q_fp16, const uint8_t* d_combined_cache,
+    uint16_t* d_out_fp16, float* d_score_scratch, const int* d_context_lens,
+    const int* d_slot_ids, int rows, int max_context_len,
+    size_t slot_stride_bytes, int q_heads, int kv_heads, int head_dim,
+    int attention_window, int attention_sink_tokens, const int* d_block_table,
+    int block_size, int max_blocks_per_seq, void* stream) {
+    if (!d_q_fp16 || !d_combined_cache || !d_out_fp16 || !d_score_scratch ||
+        !d_context_lens || rows <= 0 || max_context_len <= 0 ||
+        q_heads <= 0 || kv_heads <= 0 || head_dim <= 0 ||
+        head_dim > kMaxHeadDim || (head_dim % 2) != 0 || kv_heads > q_heads ||
+        (q_heads % kv_heads) != 0 || attention_window < 0 ||
+        attention_sink_tokens < 0) return false;
+    if (d_block_table != nullptr) {
+        if (block_size <= 0 || max_blocks_per_seq <= 0 ||
+            max_context_len > block_size * max_blocks_per_seq) return false;
+    } else if (slot_stride_bytes == 0) {
+        return false;
+    }
+    const cudaStream_t s = static_cast<cudaStream_t>(stream);
+    const float q_scale = 1.0f / sqrtf(static_cast<float>(head_dim));
+    const dim3 score_grid(static_cast<unsigned>(q_heads),
+                          static_cast<unsigned>((max_context_len + 127) / 128),
+                          static_cast<unsigned>(rows));
+    gqa_decode_attention_turboquant_k8v4_score_batched_kernel<<<
+        score_grid, 128, 0, s>>>(
+        d_q_fp16, d_combined_cache, d_score_scratch, d_context_lens,
+        d_slot_ids, rows, max_context_len, slot_stride_bytes, q_heads, kv_heads,
+        head_dim, attention_window, attention_sink_tokens, q_scale,
+        d_block_table, block_size, max_blocks_per_seq);
+    if (cudaGetLastError() != cudaSuccess) return false;
+    // The score rows are padded to the longest context; all padding is -inf,
+    // allowing one uniform softmax launch while each output row still consumes
+    // only its own context length.
+    const int score_rows = rows * q_heads;
+    softmax_rows_f32_kernel<<<score_rows, 256, 0, s>>>(
+        d_score_scratch, max_context_len, max_context_len, d_context_lens,
+        q_heads);
+    if (cudaGetLastError() != cudaSuccess) return false;
+    const dim3 output_grid(static_cast<unsigned>(q_heads),
+                           static_cast<unsigned>((head_dim + 127) / 128),
+                           static_cast<unsigned>(rows));
+    gqa_decode_attention_turboquant_k8v4_output_batched_kernel<<<
+        output_grid, 128, 0, s>>>(
+        d_combined_cache, d_score_scratch, d_out_fp16, d_context_lens,
+        d_slot_ids, rows, max_context_len, slot_stride_bytes, q_heads, kv_heads,
+        head_dim, attention_window, attention_sink_tokens, d_block_table,
+        block_size, max_blocks_per_seq);
     return cudaGetLastError() == cudaSuccess;
 }
 
@@ -515,12 +821,15 @@ bool qwen_gqa_decode_attention_turboquant_k8v4_cuda(
 
     // Score phase.
     {
-        dim3 grid(q_heads, (max_context + 127) / 128);
+        // The caller sizes scratch for the attended context, not the arena's
+        // maximum reservation. The cache itself is bounded by max_context, but
+        // scores only need one row of context_len entries.
+        dim3 grid(q_heads, (context_len + 127) / 128);
         dim3 block(128);
         gqa_decode_attention_turboquant_k8v4_score_kernel<<<grid, block, 0,
                                                             static_cast<cudaStream_t>(stream)>>>(
             d_q_fp16, d_combined_cache, d_score_scratch, q_heads, kv_heads,
-            head_dim, context_len, max_context, attention_window,
+            head_dim, context_len, context_len, attention_window,
             attention_sink_tokens, q_scale);
     }
 
@@ -530,7 +839,7 @@ bool qwen_gqa_decode_attention_turboquant_k8v4_cuda(
         dim3 block(256);
         softmax_rows_f32_kernel<<<grid, block, 0,
                                   static_cast<cudaStream_t>(stream)>>>(
-            d_score_scratch, max_context, context_len);
+            d_score_scratch, context_len, context_len, nullptr, 0);
     }
 
     // Output phase.
@@ -540,10 +849,56 @@ bool qwen_gqa_decode_attention_turboquant_k8v4_cuda(
         gqa_decode_attention_turboquant_k8v4_output_kernel<<<grid, block, 0,
                                                              static_cast<cudaStream_t>(stream)>>>(
             d_q_fp16, d_combined_cache, d_score_scratch, d_out_fp16, q_heads,
-            kv_heads, head_dim, context_len, max_context, attention_window,
+            kv_heads, head_dim, context_len, context_len, attention_window,
             attention_sink_tokens);
     }
 
+    return cudaGetLastError() == cudaSuccess;
+}
+
+__global__ void dequant_kv_turboquant_k8v4_paged_kernel(
+    const uint8_t* __restrict__ d_combined_cache,
+    uint16_t* __restrict__ d_k_dense_fp16,
+    uint16_t* __restrict__ d_v_dense_fp16,
+    int context_len, int kv_heads, int head_dim, const int* __restrict__ block_table,
+    int block_size) {
+    const int pos = blockIdx.x;
+    const int kv_head = blockIdx.y;
+    const int dim = threadIdx.x;
+    if (pos >= context_len || kv_head >= kv_heads || dim >= head_dim) return;
+    const int block = block_table[pos / block_size];
+    const int value_bytes = head_dim / 2;
+    const int slot_bytes = slot_bytes_for(head_dim);
+    const uint8_t* slot = d_combined_cache +
+        (static_cast<size_t>(block) * block_size + pos % block_size) *
+            static_cast<size_t>(kv_heads) * slot_bytes +
+        static_cast<size_t>(kv_head) * slot_bytes;
+    uint16_t scale_bits, min_bits;
+    std::memcpy(&scale_bits, slot + head_dim + value_bytes, 2);
+    std::memcpy(&min_bits, slot + head_dim + value_bytes + 2, 2);
+    const float scale = __half2float(__ushort_as_half(scale_bits));
+    const float minimum = __half2float(__ushort_as_half(min_bits));
+    const __half key = __nv_cvt_fp8_to_halfraw(slot[dim], __NV_E5M2);
+    const uint8_t packed = slot[head_dim + (dim >> 1)];
+    const uint8_t nibble = (dim & 1) ? packed >> 4 : packed & 0x0F;
+    const __half value = __float2half(dequantize_value_nibble(nibble, scale, minimum));
+    const size_t out = (static_cast<size_t>(pos) * kv_heads + kv_head) * head_dim + dim;
+    d_k_dense_fp16[out] = __half_as_ushort(key);
+    d_v_dense_fp16[out] = __half_as_ushort(value);
+}
+
+bool qwen_turboquant_k8v4_dequant_kv_paged_cuda(
+    const uint8_t* d_combined_cache, uint16_t* d_k_dense_fp16,
+    uint16_t* d_v_dense_fp16, int context_len, int kv_heads, int head_dim,
+    const int* d_block_table, int block_size, void* stream) {
+    if (!d_combined_cache || !d_k_dense_fp16 || !d_v_dense_fp16 || !d_block_table ||
+        context_len <= 0 || kv_heads <= 0 || head_dim <= 0 || head_dim > kMaxHeadDim ||
+        (head_dim % 2) != 0 || block_size <= 0) return false;
+    dequant_kv_turboquant_k8v4_paged_kernel<<<
+        dim3(static_cast<unsigned>(context_len), static_cast<unsigned>(kv_heads)),
+        head_dim, 0, static_cast<cudaStream_t>(stream)>>>(
+        d_combined_cache, d_k_dense_fp16, d_v_dense_fp16, context_len, kv_heads,
+        head_dim, d_block_table, block_size);
     return cudaGetLastError() == cudaSuccess;
 }
 

--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -907,11 +907,20 @@ struct QwenEngine::Impl {
             }
             const size_t elements_per_token =
                 static_cast<size_t>(local_kv_heads) * head_dim;
-            // Bytes one block costs across every full-attention layer, K and V
-            // together. That is the unit the budget divides.
-            const size_t bytes_per_block = static_cast<size_t>(
-                options.kv_block_size) * elements_per_token * sizeof(uint16_t) *
-                2 * full_attention_layers;
+            size_t bytes_per_token = elements_per_token * sizeof(uint16_t) * 2;
+            size_t scale_bytes_per_token = 0;
+            if (options.kv_cache_dtype == QwenKvCacheDType::Fp8) {
+                bytes_per_token = elements_per_token * 2;
+                scale_bytes_per_token = static_cast<size_t>(local_kv_heads) *
+                    (head_dim / kKvScaleBlock) * sizeof(uint16_t) * 2;
+            } else if (options.kv_cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
+                bytes_per_token = static_cast<size_t>(local_kv_heads) *
+                    qwen_turboquant_k8v4_slot_bytes(head_dim);
+            }
+            // Bytes one block costs across every full-attention layer, including
+            // quantized scale/metadata storage, which is the unit the budget divides.
+            const size_t bytes_per_block = static_cast<size_t>(options.kv_block_size) *
+                (bytes_per_token + scale_bytes_per_token) * full_attention_layers;
             if (full_attention_layers == 0 || bytes_per_block == 0) {
                 throw std::runtime_error(
                     "Qwen paged KV cache requires at least one full-attention "
@@ -923,7 +932,7 @@ struct QwenEngine::Impl {
             const uint64_t budget = options.kv_cache_bytes != 0
                 ? options.kv_cache_bytes
                 : static_cast<uint64_t>(options.max_batch_size) * max_context *
-                      elements_per_token * sizeof(uint16_t) * 2 *
+                      (bytes_per_token + scale_bytes_per_token) *
                       full_attention_layers;
             const int num_blocks = static_cast<int>(budget / bytes_per_block);
             // A slot must be able to reach max_context, or a long request would
@@ -1101,26 +1110,54 @@ struct QwenEngine::Impl {
                     static_cast<uint64_t>(head_dim)};
 
                 if (block_pool != nullptr) {
-                    // Paged: one arena of blocks shared by every slot. The
-                    // leading dimension is the block count, not the slot count,
-                    // which is the whole difference: a slot's extent is now what
-                    // it has been handed rather than what it reserved.
-                    // Construction rejects the quantized dtypes, so this branch
-                    // is FP16 by definition.
-                    const size_t paged_elements =
-                        static_cast<size_t>(block_pool->total_blocks()) *
-                        block_pool->block_size() * local_kv_heads * head_dim;
+                    const size_t physical_tokens = static_cast<size_t>(block_pool->total_blocks()) *
+                        block_pool->block_size();
                     const std::vector<uint64_t> paged_shape = {
                         static_cast<uint64_t>(block_pool->total_blocks()),
                         static_cast<uint64_t>(block_pool->block_size()),
                         static_cast<uint64_t>(local_kv_heads),
                         static_cast<uint64_t>(head_dim)};
-                    allocate_half(destination.full.k_cache, paged_elements,
-                                  paged_shape);
-                    allocate_half(destination.full.v_cache, paged_elements,
-                                  paged_shape);
-                    cache_data_bytes += destination.full.k_cache.nbytes +
-                                        destination.full.v_cache.nbytes;
+                    if (options.kv_cache_dtype == QwenKvCacheDType::Fp16) {
+                        const size_t paged_elements = physical_tokens * local_kv_heads * head_dim;
+                        allocate_half(destination.full.k_cache, paged_elements, paged_shape);
+                        allocate_half(destination.full.v_cache, paged_elements, paged_shape);
+                        cache_data_bytes += destination.full.k_cache.nbytes +
+                                            destination.full.v_cache.nbytes;
+                    } else if (options.kv_cache_dtype == QwenKvCacheDType::Fp8) {
+                        const size_t paged_elements = physical_tokens * local_kv_heads * head_dim;
+                        const std::vector<uint64_t> scale_shape = {
+                            static_cast<uint64_t>(block_pool->total_blocks()),
+                            static_cast<uint64_t>(block_pool->block_size()),
+                            static_cast<uint64_t>(local_kv_heads),
+                            static_cast<uint64_t>(head_dim / kKvScaleBlock)};
+                        const size_t scale_elements = physical_tokens * local_kv_heads *
+                            (head_dim / kKvScaleBlock);
+                        allocate_elements(destination.full.k_cache, paged_elements,
+                                          paged_shape, SafeDType::F8_E4M3);
+                        allocate_elements(destination.full.v_cache, paged_elements,
+                                          paged_shape, SafeDType::F8_E4M3);
+                        allocate_half(destination.full.k_scale, scale_elements, scale_shape);
+                        allocate_half(destination.full.v_scale, scale_elements, scale_shape);
+                        cache_data_bytes += destination.full.k_cache.nbytes +
+                                            destination.full.v_cache.nbytes;
+                        cache_scale_bytes += destination.full.k_scale.nbytes +
+                                             destination.full.v_scale.nbytes;
+                    } else if (options.kv_cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
+                        const int slot_bytes = qwen_turboquant_k8v4_slot_bytes(head_dim);
+                        const size_t packed_elements = physical_tokens * local_kv_heads * slot_bytes;
+                        const std::vector<uint64_t> packed_shape = {
+                            static_cast<uint64_t>(block_pool->total_blocks()),
+                            static_cast<uint64_t>(block_pool->block_size()),
+                            static_cast<uint64_t>(local_kv_heads),
+                            static_cast<uint64_t>(slot_bytes)};
+                        allocate_elements(destination.full.turboquant_cache, packed_elements,
+                                          packed_shape, SafeDType::I8);
+                        cache_data_bytes += destination.full.turboquant_cache.nbytes;
+                    } else {
+                        throw std::runtime_error(
+                            std::string("Qwen paged KV cache does not support ") +
+                            qwen_kv_cache_dtype_name(options.kv_cache_dtype));
+                    }
                 } else if (options.kv_cache_dtype == QwenKvCacheDType::Fp16) {
                     allocate_half(destination.full.k_cache, cache_elements, cache_shape);
                     allocate_half(destination.full.v_cache, cache_elements, cache_shape);
@@ -3237,12 +3274,12 @@ struct QwenEngine::Impl {
         throw std::runtime_error(
             "Qwen batched decode has no Ascend kernels yet");
 #else
-        // The batched append and attention kernels are FP16-cache only. A
-        // quantized cache would have the FP16 append write raw halves into
-        // packed codes, so it is refused rather than silently corrupted.
-        if (options.kv_cache_dtype != QwenKvCacheDType::Fp16) {
+        if (options.kv_cache_dtype != QwenKvCacheDType::Fp16 &&
+            options.kv_cache_dtype != QwenKvCacheDType::Fp8 &&
+            options.kv_cache_dtype != QwenKvCacheDType::TurboQuantK8V4) {
             throw std::runtime_error(
-                "Qwen batched decode requires an FP16 KV cache");
+                std::string("Qwen batched decode does not support ") +
+                qwen_kv_cache_dtype_name(options.kv_cache_dtype));
         }
         std::vector<int> context_lens(static_cast<size_t>(rows));
         int max_context_len = 0;
@@ -3388,15 +3425,9 @@ QwenEngine::QwenEngine(const std::string& ckpt_dir,
             "Qwen sparse attention currently requires an FP16 KV cache");
     }
     if (options_.kv_paged) {
-        // FP16 only. The quantized caches carry their own scale and packed-slot
-        // offset arithmetic, and paging them would mean reworking each one's
-        // addressing with no coverage from the batched path, which is FP16
-        // already. Refusing is what keeps the restriction visible instead of
-        // silently degrading to a contiguous cache.
-        if (options_.kv_cache_dtype != QwenKvCacheDType::Fp16) {
+        if (options_.kv_cache_dtype == QwenKvCacheDType::Int8PerTokenHead) {
             throw std::runtime_error(
-                std::string("Qwen paged KV cache requires an FP16 cache; got ") +
-                qwen_kv_cache_dtype_name(options_.kv_cache_dtype));
+                "Qwen paged KV cache does not support int8_per_token_head");
         }
         if (options_.kv_block_size <= 0) {
             throw std::runtime_error(

--- a/cpp_engine/engine/qwen_layer_components.inl
+++ b/cpp_engine/engine/qwen_layer_components.inl
@@ -581,26 +581,70 @@ void GqaAttention::forward(
         kv_heads * head_dim;
 
     if (runtime.batch_rows != nullptr) {
-        // Each row appends its new K/V at its own position in its own slot.
-        // Under paging the slot stride is replaced by the block table, which
-        // the caller has already grown and uploaded for these positions.
-        require_launch(qwen_append_kv_cache_f16_batched_cuda(
-            k_norm.f16_data(), v.f16_data(),
-            layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
-            rows, kv_heads, head_dim, runtime.batch_rows->positions,
-            runtime.batch_rows->slot_ids, runtime.max_context, kv_slot_stride,
-            runtime.block_table_data(), runtime.paged_block_size(),
-            runtime.paged_blocks_per_seq()),
-            "append batched FP16 full KV cache");
+        if (cache_dtype == QwenKvCacheDType::Fp16) {
+            require_launch(qwen_append_kv_cache_f16_batched_cuda(
+                k_norm.f16_data(), v.f16_data(),
+                layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
+                rows, kv_heads, head_dim, runtime.batch_rows->positions,
+                runtime.batch_rows->slot_ids, runtime.max_context, kv_slot_stride,
+                runtime.block_table_data(), runtime.paged_block_size(),
+                runtime.paged_blocks_per_seq()),
+                "append batched FP16 full KV cache");
+        } else if (cache_dtype == QwenKvCacheDType::Fp8) {
+            const size_t slot_offset = static_cast<size_t>(runtime.max_context) *
+                kv_heads * head_dim;
+            require_launch(qwen_append_kv_cache_fp8_batched_cuda(
+                k_norm.f16_data(), v.f16_data(), layer.full.k_cache.fp8_data(),
+                layer.full.v_cache.fp8_data(), layer.full.k_scale.f16_data(),
+                layer.full.v_scale.f16_data(), rows, kv_heads, head_dim,
+                kKvScaleBlock, runtime.batch_rows->positions,
+                runtime.batch_rows->slot_ids, runtime.max_context, slot_offset,
+                runtime.block_table_data(), runtime.paged_block_size(),
+                runtime.paged_blocks_per_seq()),
+                "append batched FP8 full KV cache");
+        } else if (cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
+            const size_t slot_bytes = static_cast<size_t>(qwen_turboquant_k8v4_slot_bytes(head_dim));
+            const size_t slot_stride_bytes = static_cast<size_t>(runtime.max_context) *
+                kv_heads * slot_bytes;
+            require_launch(qwen_append_kv_cache_turboquant_k8v4_batched_cuda(
+                k_norm.f16_data(), v.f16_data(),
+                layer.full.turboquant_cache.byte_data(), rows, kv_heads, head_dim,
+                runtime.batch_rows->positions, runtime.batch_rows->slot_ids,
+                runtime.max_context, slot_stride_bytes, runtime.block_table_data(),
+                runtime.paged_block_size(), runtime.paged_blocks_per_seq()),
+                "append batched TurboQuant K8V4 full KV cache");
+        } else {
+            throw std::runtime_error(
+                std::string("Qwen batched decode does not support ") +
+                qwen_kv_cache_dtype_name(cache_dtype));
+        }
     } else if (runtime.kv_paged()) {
-        // Single-sequence paged append: consecutive positions of one
-        // sequence, scattered across the blocks its row names.
-        require_launch(qwen_append_kv_cache_f16_paged_cuda(
-            k_norm.f16_data(), v.f16_data(),
-            layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
-            rows, kv_heads, head_dim, position_offset,
-            runtime.block_table_row(slot_id), runtime.paged_block_size()),
-            "append paged FP16 full KV cache");
+        if (cache_dtype == QwenKvCacheDType::Fp16) {
+            require_launch(qwen_append_kv_cache_f16_paged_cuda(
+                k_norm.f16_data(), v.f16_data(),
+                layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
+                rows, kv_heads, head_dim, position_offset,
+                runtime.block_table_row(slot_id), runtime.paged_block_size()),
+                "append paged FP16 full KV cache");
+        } else if (cache_dtype == QwenKvCacheDType::Fp8) {
+            require_launch(qwen_append_kv_cache_fp8_paged_cuda(
+                k_norm.f16_data(), v.f16_data(), layer.full.k_cache.fp8_data(),
+                layer.full.v_cache.fp8_data(), layer.full.k_scale.f16_data(),
+                layer.full.v_scale.f16_data(), rows, kv_heads, head_dim,
+                kKvScaleBlock, position_offset, runtime.block_table_row(slot_id),
+                runtime.paged_block_size()), "append paged FP8 full KV cache");
+        } else if (cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
+            require_launch(qwen_append_kv_cache_turboquant_k8v4_paged_cuda(
+                k_norm.f16_data(), v.f16_data(),
+                layer.full.turboquant_cache.byte_data(), rows, kv_heads, head_dim,
+                position_offset, runtime.block_table_row(slot_id),
+                runtime.paged_block_size()),
+                "append paged TurboQuant K8V4 full KV cache");
+        } else {
+            throw std::runtime_error(
+                std::string("Qwen paged KV cache does not support ") +
+                qwen_kv_cache_dtype_name(cache_dtype));
+        }
     } else if (cache_dtype == QwenKvCacheDType::Fp8) {
         require_launch(qwen_append_kv_cache_fp8_cuda(
             k_norm.f16_data(), v.f16_data(),
@@ -657,6 +701,7 @@ void GqaAttention::forward(
         ? layer.full.k_cache.f16_data() + slot_offset : nullptr;
     const uint16_t* v_read = fp16_cache
         ? layer.full.v_cache.f16_data() + slot_offset : nullptr;
+    bool paged_quantized_dense = false;
     if (runtime.kv_paged() && runtime.batch_rows == nullptr) {
         const int context_length = position_offset + rows;
         const std::vector<uint64_t> dense_shape = {
@@ -670,16 +715,37 @@ void GqaAttention::forward(
         QwenDeviceTensor& v_dense =
             runtime.workspace_half(dense_elements, dense_shape);
         typename Runtime::PhaseScope sub(&runtime, "full.kv_gather");
-        require_launch(qwen_gather_kv_cache_f16_paged_cuda(
-            layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
-            k_dense.f16_data(), v_dense.f16_data(), context_length,
-            kv_heads, head_dim, runtime.block_table_row(slot_id),
-            runtime.paged_block_size()), "gather paged FP16 KV cache");
-        k_read = k_dense.f16_data();
-        v_read = v_dense.f16_data();
+        const int* table = runtime.block_table_row(slot_id);
+        if (cache_dtype == QwenKvCacheDType::Fp16) {
+            require_launch(qwen_gather_kv_cache_f16_paged_cuda(
+                layer.full.k_cache.f16_data(), layer.full.v_cache.f16_data(),
+                k_dense.f16_data(), v_dense.f16_data(), context_length,
+                kv_heads, head_dim, table, runtime.paged_block_size()),
+                "gather paged FP16 KV cache");
+            k_read = k_dense.f16_data();
+            v_read = v_dense.f16_data();
+        } else if (cache_dtype == QwenKvCacheDType::Fp8) {
+            require_launch(qwen_fp8_dequant_kv_cache_paged_cuda(
+                layer.full.k_cache.fp8_data(), layer.full.v_cache.fp8_data(),
+                layer.full.k_scale.f16_data(), layer.full.v_scale.f16_data(),
+                k_dense.f16_data(), v_dense.f16_data(), context_length,
+                kv_heads, head_dim, kKvScaleBlock, table,
+                runtime.paged_block_size()), "dequant paged FP8 KV cache");
+            k_read = k_dense.f16_data();
+            v_read = v_dense.f16_data();
+            paged_quantized_dense = true;
+        } else if (cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
+            require_launch(qwen_turboquant_k8v4_dequant_kv_paged_cuda(
+                layer.full.turboquant_cache.byte_data(), k_dense.f16_data(),
+                v_dense.f16_data(), context_length, kv_heads, head_dim, table,
+                runtime.paged_block_size()), "dequant paged TurboQuant KV cache");
+            k_read = k_dense.f16_data();
+            v_read = v_dense.f16_data();
+            paged_quantized_dense = true;
+        }
     }
 
-    if (runtime.batch_rows != nullptr) {
+    if (runtime.batch_rows != nullptr && cache_dtype == QwenKvCacheDType::Fp16) {
         // One launch for the whole batch. The split geometry comes from the
         // longest row, so the scratch is sized from that same query the
         // launcher uses; shorter rows leave their trailing splits empty.
@@ -703,6 +769,50 @@ void GqaAttention::forward(
             attention_window, sink_tokens, runtime.block_table_data(),
             runtime.paged_block_size(), runtime.paged_blocks_per_seq()),
             "batched decode FP16-cache GQA");
+    } else if (runtime.batch_rows != nullptr) {
+        const int context_len = runtime.batch_rows->max_context_len;
+        if (cache_dtype == QwenKvCacheDType::Fp8) {
+            const int splits = qwen_gqa_decode_batched_split_count(
+                context_len, kv_heads, attention_window, sink_tokens);
+            require_launch(splits > 0, "batched FP8 decode split geometry");
+            QwenDeviceTensor& partials = runtime.workspace_float(
+                static_cast<size_t>(rows) * q_heads * splits *
+                    static_cast<size_t>(head_dim + 2),
+                {static_cast<uint64_t>(rows), static_cast<uint64_t>(q_heads),
+                 static_cast<uint64_t>(splits),
+                 static_cast<uint64_t>(head_dim + 2)});
+            require_launch(qwen_gqa_decode_attention_fp8_batched_cuda(
+                q_norm.f16_data(), layer.full.k_cache.fp8_data(),
+                layer.full.v_cache.fp8_data(), layer.full.k_scale.f16_data(),
+                layer.full.v_scale.f16_data(), attention.f16_data(),
+                partials.f32_data(), runtime.batch_rows->context_lens,
+                runtime.batch_rows->slot_ids, rows, context_len, kv_slot_stride,
+                q_heads, kv_heads, head_dim, kKvScaleBlock, runtime.max_context,
+                attention_window, sink_tokens, runtime.block_table_data(),
+                runtime.paged_block_size(), runtime.paged_blocks_per_seq()),
+                "batched decode FP8-cache GQA");
+        } else if (cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
+            const size_t score_elements = static_cast<size_t>(rows) * q_heads * context_len;
+            QwenDeviceTensor& scores = runtime.workspace_float(
+                score_elements, {static_cast<uint64_t>(rows),
+                                 static_cast<uint64_t>(q_heads),
+                                 static_cast<uint64_t>(context_len)});
+            const int slot_bytes = qwen_turboquant_k8v4_slot_bytes(head_dim);
+            const size_t slot_stride_bytes = static_cast<size_t>(runtime.max_context) *
+                kv_heads * slot_bytes;
+            require_launch(qwen_gqa_decode_attention_turboquant_k8v4_batched_cuda(
+                q_norm.f16_data(), layer.full.turboquant_cache.byte_data(),
+                attention.f16_data(), scores.f32_data(),
+                runtime.batch_rows->context_lens, runtime.batch_rows->slot_ids, rows,
+                context_len, slot_stride_bytes, q_heads, kv_heads, head_dim,
+                attention_window, sink_tokens, runtime.block_table_data(),
+                runtime.paged_block_size(), runtime.paged_blocks_per_seq()),
+                "batched decode TurboQuant K8V4 GQA");
+        } else {
+            throw std::runtime_error(
+                std::string("Qwen batched decode attention does not support ") +
+                qwen_kv_cache_dtype_name(cache_dtype));
+        }
     } else if (rows == 1) {
         const int context_length = position_offset + 1;
         const bool optimized_attention =
@@ -740,7 +850,13 @@ void GqaAttention::forward(
                                         static_cast<uint64_t>(head_dim + 2)}
                 : std::vector<uint64_t>{static_cast<uint64_t>(q_heads),
                                          static_cast<uint64_t>(context_length)});
-        if (cache_dtype == QwenKvCacheDType::Fp8) {
+        if (paged_quantized_dense) {
+            require_launch(qwen_gqa_decode_attention_f16(
+                q_norm.f16_data(), k_read, v_read, attention.f16_data(),
+                scores.f32_data(), q_heads, kv_heads, head_dim,
+                context_length, runtime.max_context),
+                "decode paged quantized KV via dense FP16 GQA");
+        } else if (cache_dtype == QwenKvCacheDType::Fp8) {
             require_launch(qwen_gqa_decode_attention_fp8_cuda(
                 q_norm.f16_data(),
                 layer.full.k_cache.fp8_data() + slot_offset,
@@ -792,7 +908,7 @@ void GqaAttention::forward(
                 scores.f32_data(), q_heads, kv_heads, head_dim,
                 context_length, runtime.max_context), "decode FP16-cache GQA");
         }
-    } else if (cache_dtype == QwenKvCacheDType::Fp8) {
+    } else if (cache_dtype == QwenKvCacheDType::Fp8 && !paged_quantized_dense) {
         const int context_length = position_offset + rows;
         // Dequantize the [0, context_length) range once into dense FP16
         // buffers, then call the tensor-core prefill kernel. O(ctx) dequant
@@ -866,7 +982,8 @@ void GqaAttention::forward(
                 position_offset, runtime.max_context),
                 "prefill INT8 via tensor-core exact");
         }
-    } else if (cache_dtype == QwenKvCacheDType::TurboQuantK8V4) {
+    } else if (cache_dtype == QwenKvCacheDType::TurboQuantK8V4 &&
+               !paged_quantized_dense) {
         const int context_length = position_offset + rows;
         // Dequantize the [0, context_length) range once into dense FP16
         // buffers laid out like the FP16 cache, then call the tensor-core
@@ -902,6 +1019,21 @@ void GqaAttention::forward(
                 attention.f16_data(), rows, q_heads, kv_heads, head_dim,
                 position_offset, runtime.max_context),
                 "prefill TurboQuant via tensor-core exact");
+        }
+    } else if (paged_quantized_dense) {
+        // Paged quantized history was dequantized above into the same dense
+        // layout used by the established FP16 prefill kernels.
+        if (runtime.layer_config.gqa_optimized || attention_window > 0) {
+            require_launch(qwen_gqa_prefill_attention_f16_tiled_cuda(
+                q_norm.f16_data(), k_read, v_read, attention.f16_data(), rows,
+                q_heads, kv_heads, head_dim, position_offset, runtime.max_context,
+                attention_window, sink_tokens),
+                "prefill paged quantized via tensor-core tiled");
+        } else {
+            require_launch(qwen_gqa_prefill_attention_f16(
+                q_norm.f16_data(), k_read, v_read, attention.f16_data(), rows,
+                q_heads, kv_heads, head_dim, position_offset, runtime.max_context),
+                "prefill paged quantized via exact FP16 GQA");
         }
     } else if (cache_dtype == QwenKvCacheDType::Fp16 && rows <= 8 && attention_window == 0) {
         const int context_length = position_offset + rows;

--- a/cpp_engine/include/qwen_cuda_ops.hpp
+++ b/cpp_engine/include/qwen_cuda_ops.hpp
@@ -880,7 +880,38 @@ bool qwen_append_kv_cache_fp8_batched_cuda(
     uint16_t* d_k_scale_fp16, uint16_t* d_v_scale_fp16, int rows,
     int kv_heads, int head_dim, int scale_block, const int* d_start_positions,
     const int* d_slot_ids, int max_context, size_t kv_slot_stride,
-    void* stream = nullptr);
+    const int* d_block_table = nullptr, int block_size = 0,
+    int max_blocks_per_seq = 0, void* stream = nullptr);
+bool qwen_append_kv_cache_fp8_paged_cuda(
+    const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
+    uint8_t* d_k_cache_fp8, uint8_t* d_v_cache_fp8,
+    uint16_t* d_k_scale_fp16, uint16_t* d_v_scale_fp16, int seq_len,
+    int kv_heads, int head_dim, int scale_block, int start_pos,
+    const int* d_block_table, int block_size, void* stream = nullptr);
+bool qwen_gqa_decode_attention_fp8_batched_cuda(
+    const uint16_t* d_q_fp16, const uint8_t* d_k_cache_fp8,
+    const uint8_t* d_v_cache_fp8, const uint16_t* d_k_scale_fp16,
+    const uint16_t* d_v_scale_fp16, uint16_t* d_out_fp16,
+    float* d_score_scratch, const int* d_context_lens,
+    const int* d_slot_ids, int rows, int max_context_len,
+    size_t kv_slot_stride, int q_heads, int kv_heads, int head_dim,
+    int scale_block, int max_context, int attention_window = 0,
+    int sink_tokens = 0, const int* d_block_table = nullptr,
+    int block_size = 0, int max_blocks_per_seq = 0, void* stream = nullptr);
+bool qwen_fp8_dequant_kv_cache_paged_cuda(
+    const uint8_t* d_k_cache_fp8, const uint8_t* d_v_cache_fp8,
+    const uint16_t* d_k_scale_fp16, const uint16_t* d_v_scale_fp16,
+    uint16_t* d_k_dense_fp16, uint16_t* d_v_dense_fp16,
+    int context_len, int kv_heads, int head_dim, int scale_block,
+    const int* d_block_table, int block_size, void* stream = nullptr);
+bool qwen_fp8_dequant_kv_cache_batched_cuda(
+    const uint8_t* d_k_cache_fp8, const uint8_t* d_v_cache_fp8,
+    const uint16_t* d_k_scale_fp16, const uint16_t* d_v_scale_fp16,
+    uint16_t* d_k_dense_fp16, uint16_t* d_v_dense_fp16,
+    const int* d_context_lens, const int* d_slot_ids, int rows,
+    int max_context_len, int kv_heads, int head_dim, int scale_block,
+    size_t kv_slot_stride, const int* d_block_table = nullptr,
+    int block_size = 0, int max_blocks_per_seq = 0, void* stream = nullptr);
 bool qwen_gqa_decode_attention_f16_cuda(
     const uint16_t* d_q_fp16, const uint16_t* d_k_cache_fp16,
     const uint16_t* d_v_cache_fp16, uint16_t* d_out_fp16,
@@ -1059,12 +1090,34 @@ bool qwen_append_kv_cache_turboquant_k8v4_cuda(
     const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
     uint8_t* d_combined_cache, int seq_len, int kv_heads, int head_dim,
     int start_pos, int max_context, void* stream = nullptr);
+bool qwen_append_kv_cache_turboquant_k8v4_paged_cuda(
+    const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
+    uint8_t* d_combined_cache, int seq_len, int kv_heads, int head_dim,
+    int start_pos, const int* d_block_table, int block_size,
+    void* stream = nullptr);
+bool qwen_append_kv_cache_turboquant_k8v4_batched_cuda(
+    const uint16_t* d_k_rows_fp16, const uint16_t* d_v_rows_fp16,
+    uint8_t* d_combined_cache, int rows, int kv_heads, int head_dim,
+    const int* d_start_positions, const int* d_slot_ids, int max_context,
+    size_t slot_stride_bytes, const int* d_block_table = nullptr,
+    int block_size = 0, int max_blocks_per_seq = 0, void* stream = nullptr);
 
 bool qwen_gqa_decode_attention_turboquant_k8v4_cuda(
     const uint16_t* d_q_fp16, const uint8_t* d_combined_cache,
     uint16_t* d_out_fp16, float* d_score_scratch, int q_heads, int kv_heads,
     int head_dim, int context_len, int max_context, int attention_window,
     int attention_sink_tokens, void* stream = nullptr);
+bool qwen_gqa_decode_attention_turboquant_k8v4_batched_cuda(
+    const uint16_t* d_q_fp16, const uint8_t* d_combined_cache,
+    uint16_t* d_out_fp16, float* d_score_scratch, const int* d_context_lens,
+    const int* d_slot_ids, int rows, int max_context_len, size_t slot_stride_bytes,
+    int q_heads, int kv_heads, int head_dim, int attention_window,
+    int attention_sink_tokens, const int* d_block_table = nullptr,
+    int block_size = 0, int max_blocks_per_seq = 0, void* stream = nullptr);
+bool qwen_turboquant_k8v4_dequant_kv_paged_cuda(
+    const uint8_t* d_combined_cache, uint16_t* d_k_dense_fp16,
+    uint16_t* d_v_dense_fp16, int context_len, int kv_heads, int head_dim,
+    const int* d_block_table, int block_size, void* stream = nullptr);
 
 bool qwen_gqa_prefill_attention_turboquant_k8v4_cuda(
     const uint16_t* d_q_rows_fp16, const uint8_t* d_combined_cache,

--- a/cpp_engine/tests/test_qwen_batched_decode.cpp
+++ b/cpp_engine/tests/test_qwen_batched_decode.cpp
@@ -618,6 +618,290 @@ bool test_conv_silu_batched() {
     return true;
 }
 
+// Quantized KV append must preserve the packed representation as well as the
+// attention result. Comparing decoded outputs alone can miss a bad scale offset
+// when two rows happen to have similar values.
+bool test_quantized_kv_batched(int head_dim) {
+    constexpr int kRows = 4;
+    constexpr int kKvHeads = 1;
+    constexpr int kQHeads = 6;
+    const int kHeadDim = head_dim;
+    constexpr int kMaxContext = 512;
+    constexpr int kSlots = 7;
+    const int positions[kRows] = {0, 17, 129, 511};
+    const int slots[kRows] = {1, 5, 2, 6};
+    const size_t row_elements = static_cast<size_t>(kKvHeads) * kHeadDim;
+    const size_t slot_stride = static_cast<size_t>(kMaxContext) * row_elements;
+    const size_t scale_stride = slot_stride / 64;
+    const size_t cache_bytes = static_cast<size_t>(kSlots) * slot_stride;
+    const size_t scale_bytes = static_cast<size_t>(kSlots) * scale_stride * sizeof(uint16_t);
+    std::mt19937 rng(246813);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<uint16_t> k_rows(static_cast<size_t>(kRows) * row_elements);
+    std::vector<uint16_t> v_rows(k_rows.size());
+    for (uint16_t& value : k_rows) value = to_half(dist(rng));
+    for (uint16_t& value : v_rows) value = to_half(dist(rng));
+
+    Buffer d_k_rows, d_v_rows, d_positions, d_slots;
+    Buffer fp8_k_seq, fp8_v_seq, fp8_k_batch, fp8_v_batch;
+    Buffer fp8_ks_seq, fp8_vs_seq, fp8_ks_batch, fp8_vs_batch;
+    if (!d_k_rows.allocate(k_rows.size() * sizeof(uint16_t)) ||
+        !d_v_rows.allocate(v_rows.size() * sizeof(uint16_t)) ||
+        !d_positions.allocate(kRows * sizeof(int)) ||
+        !d_slots.allocate(kRows * sizeof(int)) ||
+        !fp8_k_seq.allocate(cache_bytes) || !fp8_v_seq.allocate(cache_bytes) ||
+        !fp8_k_batch.allocate(cache_bytes) || !fp8_v_batch.allocate(cache_bytes) ||
+        !fp8_ks_seq.allocate(scale_bytes) || !fp8_vs_seq.allocate(scale_bytes) ||
+        !fp8_ks_batch.allocate(scale_bytes) || !fp8_vs_batch.allocate(scale_bytes)) {
+        device_ready = false;
+        return false;
+    }
+    if (!d_k_rows.upload(k_rows.data()) || !d_v_rows.upload(v_rows.data()) ||
+        !d_positions.upload(positions) || !d_slots.upload(slots) ||
+        !fp8_k_seq.clear() || !fp8_v_seq.clear() || !fp8_k_batch.clear() ||
+        !fp8_v_batch.clear() || !fp8_ks_seq.clear() || !fp8_vs_seq.clear() ||
+        !fp8_ks_batch.clear() || !fp8_vs_batch.clear()) {
+        device_ready = false;
+        return false;
+    }
+    for (int row = 0; row < kRows; ++row) {
+        if (!qwen_append_kv_cache_fp8_cuda(
+                d_k_rows.as<uint16_t>() + static_cast<size_t>(row) * row_elements,
+                d_v_rows.as<uint16_t>() + static_cast<size_t>(row) * row_elements,
+                fp8_k_seq.as<uint8_t>() + static_cast<size_t>(slots[row]) * slot_stride,
+                fp8_v_seq.as<uint8_t>() + static_cast<size_t>(slots[row]) * slot_stride,
+                fp8_ks_seq.as<uint16_t>() + static_cast<size_t>(slots[row]) * scale_stride,
+                fp8_vs_seq.as<uint16_t>() + static_cast<size_t>(slots[row]) * scale_stride,
+                1, kKvHeads, kHeadDim, 64, positions[row], kMaxContext)) {
+            fail("FP8 sequential append launch failed");
+            return true;
+        }
+    }
+    if (!qwen_append_kv_cache_fp8_batched_cuda(
+            d_k_rows.as<uint16_t>(), d_v_rows.as<uint16_t>(),
+            fp8_k_batch.as<uint8_t>(), fp8_v_batch.as<uint8_t>(),
+            fp8_ks_batch.as<uint16_t>(), fp8_vs_batch.as<uint16_t>(), kRows,
+            kKvHeads, kHeadDim, 64, d_positions.as<int>(), d_slots.as<int>(),
+            kMaxContext, slot_stride)) {
+        fail("FP8 batched append launch failed");
+        return true;
+    }
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP8 batched append sync failed");
+        return true;
+    }
+    std::vector<uint8_t> want_k(cache_bytes), got_k(cache_bytes), want_v(cache_bytes), got_v(cache_bytes);
+    std::vector<uint16_t> want_ks(static_cast<size_t>(kSlots) * scale_stride), got_ks(want_ks.size());
+    std::vector<uint16_t> want_vs(want_ks.size()), got_vs(want_ks.size());
+    if (!fp8_k_seq.download(want_k.data()) || !fp8_k_batch.download(got_k.data()) ||
+        !fp8_v_seq.download(want_v.data()) || !fp8_v_batch.download(got_v.data()) ||
+        !fp8_ks_seq.download(want_ks.data()) || !fp8_ks_batch.download(got_ks.data()) ||
+        !fp8_vs_seq.download(want_vs.data()) || !fp8_vs_batch.download(got_vs.data())) {
+        device_ready = false;
+        return false;
+    }
+    if (want_k != got_k || want_v != got_v || want_ks != got_ks || want_vs != got_vs) {
+        fail("FP8 batched append packed bytes or scales mismatch");
+        return true;
+    }
+    std::printf("  FP8 batched append rows=%d non-identity slots byte-exact\n", kRows);
+
+    // Give every slot a distinct, nonuniform history. Uniform codes and scales
+    // cannot expose a wrong slot, head, position, or scale offset in attention.
+    const size_t history_row_elements = static_cast<size_t>(kMaxContext) * row_elements;
+    std::vector<uint16_t> history_k(static_cast<size_t>(kRows) * history_row_elements);
+    std::vector<uint16_t> history_v(history_k.size());
+    for (int row = 0; row < kRows; ++row) {
+        for (size_t i = 0; i < history_row_elements; ++i) {
+            const size_t at = static_cast<size_t>(row) * history_row_elements + i;
+            history_k[at] = to_half(dist(rng) * (0.5f + row * 0.4f));
+            history_v[at] = to_half(dist(rng) * (0.7f + row * 0.6f));
+        }
+    }
+    Buffer d_history_k, d_history_v;
+    if (!d_history_k.allocate(history_k.size() * sizeof(uint16_t)) ||
+        !d_history_v.allocate(history_v.size() * sizeof(uint16_t)) ||
+        !d_history_k.upload(history_k.data()) || !d_history_v.upload(history_v.data())) {
+        device_ready = false;
+        return false;
+    }
+    for (int row = 0; row < kRows; ++row) {
+        if (!qwen_append_kv_cache_fp8_cuda(
+                d_history_k.as<uint16_t>() + static_cast<size_t>(row) * history_row_elements,
+                d_history_v.as<uint16_t>() + static_cast<size_t>(row) * history_row_elements,
+                fp8_k_seq.as<uint8_t>() + static_cast<size_t>(slots[row]) * slot_stride,
+                fp8_v_seq.as<uint8_t>() + static_cast<size_t>(slots[row]) * slot_stride,
+                fp8_ks_seq.as<uint16_t>() + static_cast<size_t>(slots[row]) * scale_stride,
+                fp8_vs_seq.as<uint16_t>() + static_cast<size_t>(slots[row]) * scale_stride,
+                kMaxContext, kKvHeads, kHeadDim, 64, 0, kMaxContext)) {
+            fail("FP8 history append launch failed");
+            return true;
+        }
+    }
+    const int contexts[kRows] = {64, 127, 256, 511};
+    const size_t q_row = static_cast<size_t>(kQHeads) * kHeadDim;
+    std::vector<uint16_t> q_host(static_cast<size_t>(kRows) * q_row);
+    for (uint16_t& value : q_host) value = to_half(dist(rng));
+    Buffer d_q, d_contexts, out_seq, out_batch, score_seq, partial_batch;
+    if (!d_q.allocate(q_host.size() * sizeof(uint16_t)) ||
+        !d_contexts.allocate(kRows * sizeof(int)) ||
+        !out_seq.allocate(q_host.size() * sizeof(uint16_t)) ||
+        !out_batch.allocate(q_host.size() * sizeof(uint16_t)) ||
+        !score_seq.allocate(static_cast<size_t>(kQHeads) * contexts[kRows - 1] * sizeof(float)) ||
+        !partial_batch.allocate(static_cast<size_t>(kRows) * kQHeads *
+                                qwen_gqa_decode_batched_split_count(contexts[kRows - 1], kKvHeads) *
+                                (kHeadDim + 2) * sizeof(float))) {
+        device_ready = false;
+        return false;
+    }
+    if (!d_q.upload(q_host.data()) || !d_contexts.upload(contexts) ||
+        !out_seq.clear() || !out_batch.clear()) {
+        device_ready = false;
+        return false;
+    }
+    for (int row = 0; row < kRows; ++row) {
+        if (!qwen_gqa_decode_attention_fp8_cuda(
+                d_q.as<uint16_t>() + static_cast<size_t>(row) * q_row,
+                fp8_k_seq.as<uint8_t>() + static_cast<size_t>(slots[row]) * slot_stride,
+                fp8_v_seq.as<uint8_t>() + static_cast<size_t>(slots[row]) * slot_stride,
+                fp8_ks_seq.as<uint16_t>() + static_cast<size_t>(slots[row]) * scale_stride,
+                fp8_vs_seq.as<uint16_t>() + static_cast<size_t>(slots[row]) * scale_stride,
+                out_seq.as<uint16_t>() + static_cast<size_t>(row) * q_row,
+                score_seq.as<float>(), kQHeads, kKvHeads, kHeadDim, 64,
+                contexts[row], kMaxContext)) {
+            fail("FP8 sequential attention launch failed");
+            return true;
+        }
+    }
+    if (!qwen_gqa_decode_attention_fp8_batched_cuda(
+            d_q.as<uint16_t>(), fp8_k_seq.as<uint8_t>(), fp8_v_seq.as<uint8_t>(),
+            fp8_ks_seq.as<uint16_t>(), fp8_vs_seq.as<uint16_t>(), out_batch.as<uint16_t>(),
+            partial_batch.as<float>(), d_contexts.as<int>(), d_slots.as<int>(), kRows,
+            contexts[kRows - 1], slot_stride, kQHeads, kKvHeads, kHeadDim, 64,
+            kMaxContext, 0, 0)) {
+        fail("FP8 batched attention launch failed");
+        return true;
+    }
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        fail("FP8 batched attention sync failed");
+        return true;
+    }
+    std::vector<uint16_t> attention_want(q_host.size()), attention_got(q_host.size());
+    if (!out_seq.download(attention_want.data()) || !out_batch.download(attention_got.data())) {
+        device_ready = false;
+        return false;
+    }
+    const double fp8_worst = worst_difference(attention_want, attention_got);
+    if (fp8_worst > 1.0e-3) {
+        fail("FP8 batched attention worst=" + std::to_string(fp8_worst));
+    } else {
+        std::printf("  FP8 batched attention rows=%d head_dim=%d contexts=%d..%d worst=%.4g PASS\n",
+                    kRows, kHeadDim, contexts[0], contexts[kRows - 1], fp8_worst);
+    }
+    // TurboQuant uses a combined packed slot rather than separate K/V arrays.
+    // Check both the byte-exact store and the batched attention reader with the
+    // same fragmented logical slot assignment.
+    const int tq_slot_bytes = qwen_turboquant_k8v4_slot_bytes(kHeadDim);
+    const size_t tq_slot_stride = static_cast<size_t>(kMaxContext) * kKvHeads *
+        tq_slot_bytes;
+    const size_t tq_cache_bytes = static_cast<size_t>(kSlots) * tq_slot_stride;
+    Buffer tq_seq, tq_batch;
+    if (!tq_seq.allocate(tq_cache_bytes) || !tq_batch.allocate(tq_cache_bytes) ||
+        !tq_seq.clear() || !tq_batch.clear()) {
+        device_ready = false;
+        return false;
+    }
+    for (int row = 0; row < kRows; ++row) {
+        if (!qwen_append_kv_cache_turboquant_k8v4_cuda(
+                d_k_rows.as<uint16_t>() + static_cast<size_t>(row) * row_elements,
+                d_v_rows.as<uint16_t>() + static_cast<size_t>(row) * row_elements,
+                tq_seq.as<uint8_t>() + static_cast<size_t>(slots[row]) * tq_slot_stride,
+                1, kKvHeads, kHeadDim, positions[row], kMaxContext)) {
+            fail("TurboQuant sequential append launch failed");
+            return true;
+        }
+    }
+    if (!qwen_append_kv_cache_turboquant_k8v4_batched_cuda(
+            d_k_rows.as<uint16_t>(), d_v_rows.as<uint16_t>(), tq_batch.as<uint8_t>(),
+            kRows, kKvHeads, kHeadDim, d_positions.as<int>(), d_slots.as<int>(),
+            kMaxContext, tq_slot_stride)) {
+        fail("TurboQuant batched append launch failed");
+        return true;
+    }
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        fail("TurboQuant batched append sync failed");
+        return true;
+    }
+    std::vector<uint8_t> tq_want(tq_cache_bytes), tq_got(tq_cache_bytes);
+    if (!tq_seq.download(tq_want.data()) || !tq_batch.download(tq_got.data())) {
+        device_ready = false;
+        return false;
+    }
+    if (tq_want != tq_got) {
+        fail("TurboQuant batched append packed bytes mismatch");
+        return true;
+    }
+    std::printf("  TurboQuant batched append rows=%d non-identity slots byte-exact\n", kRows);
+    for (int row = 0; row < kRows; ++row) {
+        if (!qwen_append_kv_cache_turboquant_k8v4_cuda(
+                d_history_k.as<uint16_t>() + static_cast<size_t>(row) * history_row_elements,
+                d_history_v.as<uint16_t>() + static_cast<size_t>(row) * history_row_elements,
+                tq_seq.as<uint8_t>() + static_cast<size_t>(slots[row]) * tq_slot_stride,
+                kMaxContext, kKvHeads, kHeadDim, 0, kMaxContext)) {
+            fail("TurboQuant history append launch failed");
+            return true;
+        }
+    }
+
+    const size_t tq_q_elements = q_host.size();
+    Buffer tq_out_seq, tq_out_batch, tq_scores_seq, tq_scores_batch;
+    if (!tq_out_seq.allocate(tq_q_elements * sizeof(uint16_t)) ||
+        !tq_out_batch.allocate(tq_q_elements * sizeof(uint16_t)) ||
+        !tq_scores_seq.allocate(static_cast<size_t>(kQHeads) * contexts[kRows - 1] * sizeof(float)) ||
+        !tq_scores_batch.allocate(static_cast<size_t>(kRows) * kQHeads *
+                                   contexts[kRows - 1] * sizeof(float)) ||
+        !tq_out_seq.clear() || !tq_out_batch.clear()) {
+        device_ready = false;
+        return false;
+    }
+    for (int row = 0; row < kRows; ++row) {
+        if (!qwen_gqa_decode_attention_turboquant_k8v4_cuda(
+                d_q.as<uint16_t>() + static_cast<size_t>(row) * q_row,
+                tq_seq.as<uint8_t>() + static_cast<size_t>(slots[row]) * tq_slot_stride,
+                tq_out_seq.as<uint16_t>() + static_cast<size_t>(row) * q_row,
+                tq_scores_seq.as<float>(), kQHeads, kKvHeads, kHeadDim,
+                contexts[row], kMaxContext, 0, 0)) {
+            fail("TurboQuant sequential attention launch failed");
+            return true;
+        }
+    }
+    if (!qwen_gqa_decode_attention_turboquant_k8v4_batched_cuda(
+            d_q.as<uint16_t>(), tq_seq.as<uint8_t>(), tq_out_batch.as<uint16_t>(),
+            tq_scores_batch.as<float>(), d_contexts.as<int>(), d_slots.as<int>(),
+            kRows, contexts[kRows - 1], tq_slot_stride, kQHeads, kKvHeads,
+            kHeadDim, 0, 0)) {
+        fail("TurboQuant batched attention launch failed");
+        return true;
+    }
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        fail("TurboQuant batched attention sync failed");
+        return true;
+    }
+    if (!tq_out_seq.download(attention_want.data()) ||
+        !tq_out_batch.download(attention_got.data())) {
+        device_ready = false;
+        return false;
+    }
+    const double tq_worst = worst_difference(attention_want, attention_got);
+    if (tq_worst > 1.0e-3) {
+        fail("TurboQuant batched attention worst=" + std::to_string(tq_worst));
+    } else {
+        std::printf("  TurboQuant batched attention rows=%d head_dim=%d contexts=%d..%d worst=%.4g PASS\n",
+                    kRows, kHeadDim, contexts[0], contexts[kRows - 1], tq_worst);
+    }
+    return true;
+}
+
 }  // namespace
 
 int main() {
@@ -628,7 +912,8 @@ int main() {
     }
     const bool completed = test_rope_batched() && test_append_kv_batched() &&
         test_gqa_decode_batched() && test_gated_delta_step_batched() &&
-        test_conv_silu_batched();
+        test_conv_silu_batched() && test_quantized_kv_batched(128) &&
+        test_quantized_kv_batched(256);
     if (!completed && !device_ready) {
         std::printf("[SKIP] device allocation failed\n");
         return 0;

--- a/cpp_engine/tests/test_qwen_batched_engine_parity.cpp
+++ b/cpp_engine/tests/test_qwen_batched_engine_parity.cpp
@@ -87,7 +87,7 @@ void test_batched_decode_parity(const std::string& dir,
     // Batched path: one forward for all sequences
     std::vector<int> batch_tokens(static_cast<size_t>(num_seqs));
     for (int seq = 0; seq < num_seqs; ++seq) {
-        batch_tokens[static_cast<size_t>(seq)] = (seq * 13 + 42) % 128;
+        batch_tokens[static_cast<size_t>(seq)] = (seq * 13 + 42) % 64;
     }
     const std::vector<pocket::ForwardResult> batched_results =
         engine.batch_decode_tokens(batch_tokens, slots);
@@ -133,7 +133,8 @@ int main() {
             "qwen_batched_engine_parity_fixture");
         require(write_fixture(dir), "could not create batched parity fixture");
         test_batched_decode_parity(dir, pocket::QwenKvCacheDType::Fp16);
-        // FP8 and TurboQuant batched decode are not yet implemented
+        test_batched_decode_parity(dir, pocket::QwenKvCacheDType::Fp8);
+        test_batched_decode_parity(dir, pocket::QwenKvCacheDType::TurboQuantK8V4);
         std::cout << "[PASS] test_qwen_batched_engine_parity\n";
         return 0;
     } catch (const std::exception& ex) {

--- a/cpp_engine/tests/test_qwen_paged_engine_parity.cpp
+++ b/cpp_engine/tests/test_qwen_paged_engine_parity.cpp
@@ -34,20 +34,22 @@ constexpr int kMaxContext = 8192;
 constexpr int kSlots = 8;
 constexpr int kBlockSize = 256;
 
-pocket::QwenEngineOptions base_options() {
+pocket::QwenEngineOptions base_options(
+    pocket::QwenKvCacheDType dtype = pocket::QwenKvCacheDType::Fp16) {
     pocket::QwenEngineOptions options;
     options.tp_world = 1;
     options.tp_rank = 0;
     options.device = 0;
     options.prefill_chunk_tokens = 1024;
-    options.kv_cache_dtype = pocket::QwenKvCacheDType::Fp16;
+    options.kv_cache_dtype = dtype;
     options.prefix_cache = false;
     options.max_batch_size = kSlots;
     return options;
 }
 
-pocket::QwenEngineOptions paged_options() {
-    pocket::QwenEngineOptions options = base_options();
+pocket::QwenEngineOptions paged_options(
+    pocket::QwenKvCacheDType dtype = pocket::QwenKvCacheDType::Fp16) {
+    pocket::QwenEngineOptions options = base_options(dtype);
     options.kv_paged = true;
     options.kv_block_size = kBlockSize;
     return options;
@@ -168,12 +170,66 @@ void test_batched_decode_parity(const std::string& dir) {
               << " steps at 4k-7.5k context: token-exact PASS\n";
 }
 
+void test_quantized_paged_parity(const std::string& dir,
+                                 pocket::QwenKvCacheDType dtype) {
+    const std::vector<int> prompt_lens = {63, 257, 513, 769};
+    const std::vector<int> slots = {1, 5, 2, 7};
+    const int steps = 4;
+    pocket::QwenEngine contiguous(dir, base_options(dtype), 2, kMaxContext);
+    contiguous.allocate_batch_slots(kSlots);
+    pocket::QwenEngine paged(dir, paged_options(dtype), 2, kMaxContext);
+    paged.allocate_batch_slots(kSlots);
+
+    for (size_t seq = 0; seq < prompt_lens.size(); ++seq) {
+        const std::vector<int> tokens =
+            prompt_for(static_cast<int>(seq), prompt_lens[seq]);
+        compare(contiguous.prefill(tokens, slots[seq]),
+                paged.prefill(tokens, slots[seq]),
+                std::string("quantized ") +
+                    pocket::qwen_kv_cache_dtype_name(dtype) +
+                    " prefill seq=" + std::to_string(seq));
+    }
+    for (int step = 0; step < steps; ++step) {
+        std::vector<int> tokens(slots.size());
+        for (size_t seq = 0; seq < slots.size(); ++seq) {
+            tokens[seq] = (static_cast<int>(seq) * 11 + step * 5 + 3) % 64;
+        }
+        const std::vector<pocket::ForwardResult> reference =
+            contiguous.batch_decode_tokens(tokens, slots);
+        const std::vector<pocket::ForwardResult> actual =
+            paged.batch_decode_tokens(tokens, slots);
+        require(reference.size() == actual.size(), "quantized batch count mismatch");
+        for (size_t seq = 0; seq < reference.size(); ++seq) {
+            compare(reference[seq], actual[seq],
+                    std::string("quantized ") +
+                        pocket::qwen_kv_cache_dtype_name(dtype) +
+                        " batch step=" + std::to_string(step) +
+                        " seq=" + std::to_string(seq));
+        }
+    }
+    std::cout << "  " << pocket::qwen_kv_cache_dtype_name(dtype)
+              << " paged/contiguous parity across block boundaries: PASS\n";
+}
+
 // ============================================================================
 // Blocks are returned and reused. A long request runs, finishes, and a second
 // request on a different slot then runs on the blocks the first gave back. If
 // free_slot did not release them, the pool here is too small for the
 // second request and reservation fails.
 // ============================================================================
+void test_paged_int8_rejected(const std::string& dir) {
+    bool threw = false;
+    try {
+        pocket::QwenEngine engine(
+            dir, paged_options(pocket::QwenKvCacheDType::Int8PerTokenHead),
+            2, kMaxContext);
+    } catch (const std::exception&) {
+        threw = true;
+    }
+    require(threw, "paged int8_per_token_head was accepted");
+    std::cout << "  unsupported paged int8 cache rejected explicitly: PASS\n";
+}
+
 void test_block_reuse(const std::string& dir) {
     pocket::QwenEngineOptions options = paged_options();
     // Room for roughly one max-context sequence, so the second request can only
@@ -225,18 +281,7 @@ void test_undersized_pool_rejected(const std::string& dir) {
     }
     require(threw, "undersized block pool was accepted");
 
-    // A quantized cache cannot be paged, and saying so beats silently running
-    // contiguous.
-    pocket::QwenEngineOptions fp8 = paged_options();
-    fp8.kv_cache_dtype = pocket::QwenKvCacheDType::Fp8;
-    threw = false;
-    try {
-        pocket::QwenEngine engine(dir, fp8, 2, kMaxContext);
-    } catch (const std::exception&) {
-        threw = true;
-    }
-    require(threw, "paged FP8 cache was accepted");
-    std::cout << "  undersized pool and paged-FP8 both rejected: PASS\n";
+    std::cout << "  undersized pool rejected before allocation: PASS\n";
 }
 
 }  // namespace
@@ -253,6 +298,9 @@ int main() {
                 "could not create paged parity fixture");
         test_prefill_decode_parity(dir);
         test_batched_decode_parity(dir);
+        test_quantized_paged_parity(dir, pocket::QwenKvCacheDType::Fp8);
+        test_quantized_paged_parity(dir, pocket::QwenKvCacheDType::TurboQuantK8V4);
+        test_paged_int8_rejected(dir);
         test_block_reuse(dir);
         test_undersized_pool_rejected(dir);
         std::cout << "[PASS] test_qwen_paged_engine_parity\n";

--- a/cpp_engine/tests/test_qwen_paged_kv_kernels.cpp
+++ b/cpp_engine/tests/test_qwen_paged_kv_kernels.cpp
@@ -34,6 +34,8 @@
 
 namespace {
 
+using namespace pocket;
+
 void check(cudaError_t error, const char* what) {
     if (error != cudaSuccess) {
         throw std::runtime_error(std::string(what) + ": " +
@@ -355,7 +357,145 @@ void test_paged_batched_append(const Geometry& geometry) {
 }
 
 // ============================================================================
-// Test 4: batched decode attention. The same K/V history and the same queries
+// Test 4: quantized paged append and dequantization. The logical dense result
+// must match a contiguous cache even when the target sequence uses a shuffled
+// row in a table interleaved with another sequence.
+// ============================================================================
+void test_paged_fp8_round_trip(const Geometry& geometry) {
+    const int context = 300;
+    const int block_size = geometry.block_size;
+    const int max_blocks = (context + block_size - 1) / block_size;
+    const int scale_channels =
+        (geometry.head_dim + 64 - 1) / 64;
+    const int scale_stride = geometry.kv_heads * scale_channels;
+    const std::vector<int32_t> image =
+        fragmented_table({context, context}, block_size, max_blocks, 51u);
+    const int blocks = total_blocks(image);
+    const size_t kv_elements = static_cast<size_t>(context) * geometry.kv_stride();
+    const size_t paged_elements = static_cast<size_t>(blocks) * block_size *
+                                  geometry.kv_stride();
+    const size_t paged_scales = static_cast<size_t>(blocks) * block_size *
+                                scale_stride;
+    const std::vector<uint16_t> k_host = random_half(kv_elements, 52u);
+    const std::vector<uint16_t> v_host = random_half(kv_elements, 53u);
+
+    DeviceBuffer<uint16_t> k_rows(kv_elements);
+    DeviceBuffer<uint16_t> v_rows(kv_elements);
+    DeviceBuffer<uint8_t> k_contiguous(kv_elements);
+    DeviceBuffer<uint8_t> v_contiguous(kv_elements);
+    DeviceBuffer<uint16_t> k_contiguous_scale(static_cast<size_t>(context) * scale_stride);
+    DeviceBuffer<uint16_t> v_contiguous_scale(static_cast<size_t>(context) * scale_stride);
+    DeviceBuffer<uint8_t> k_paged(paged_elements);
+    DeviceBuffer<uint8_t> v_paged(paged_elements);
+    DeviceBuffer<uint16_t> k_paged_scale(paged_scales);
+    DeviceBuffer<uint16_t> v_paged_scale(paged_scales);
+    DeviceBuffer<uint16_t> k_dense_contiguous(kv_elements);
+    DeviceBuffer<uint16_t> v_dense_contiguous(kv_elements);
+    DeviceBuffer<uint16_t> k_dense_paged(kv_elements);
+    DeviceBuffer<uint16_t> v_dense_paged(kv_elements);
+    DeviceBuffer<int32_t> table(image.size());
+    DeviceBuffer<int32_t> context_lens(1);
+    DeviceBuffer<int32_t> slots(1);
+    k_rows.upload(k_host);
+    v_rows.upload(v_host);
+    table.upload(image);
+    context_lens.upload({context});
+    slots.upload({0});
+
+    require(qwen_append_kv_cache_fp8_cuda(
+                k_rows.get(), v_rows.get(), k_contiguous.get(), v_contiguous.get(),
+                k_contiguous_scale.get(), v_contiguous_scale.get(), context,
+                geometry.kv_heads, geometry.head_dim, 64, 0, context),
+            "contiguous FP8 append launch");
+    require(qwen_append_kv_cache_fp8_paged_cuda(
+                k_rows.get(), v_rows.get(), k_paged.get(), v_paged.get(),
+                k_paged_scale.get(), v_paged_scale.get(), context,
+                geometry.kv_heads, geometry.head_dim, 64, 0,
+                table.get() + max_blocks, block_size),
+            "paged FP8 append launch");
+    require(qwen_fp8_dequant_kv_cache_batched_cuda(
+                k_contiguous.get(), v_contiguous.get(), k_contiguous_scale.get(),
+                v_contiguous_scale.get(), k_dense_contiguous.get(),
+                v_dense_contiguous.get(), context_lens.get(), slots.get(), 1,
+                context, geometry.kv_heads, geometry.head_dim, 64,
+                static_cast<size_t>(context) * geometry.kv_stride()),
+            "contiguous FP8 dequant launch");
+    require(qwen_fp8_dequant_kv_cache_batched_cuda(
+                k_paged.get(), v_paged.get(), k_paged_scale.get(),
+                v_paged_scale.get(), k_dense_paged.get(), v_dense_paged.get(),
+                context_lens.get(), slots.get(), 1, context, geometry.kv_heads,
+                geometry.head_dim, 64, 0, table.get() + max_blocks,
+                block_size, max_blocks),
+            "paged FP8 dequant launch");
+    check(cudaDeviceSynchronize(), "paged FP8 round-trip sync");
+    const std::vector<uint16_t> k_a = k_dense_contiguous.download();
+    const std::vector<uint16_t> v_a = v_dense_contiguous.download();
+    const std::vector<uint16_t> k_b = k_dense_paged.download();
+    const std::vector<uint16_t> v_b = v_dense_paged.download();
+    require(k_a == k_b && v_a == v_b,
+            "paged FP8 dequantization differs from contiguous result");
+    std::cout << "  paged FP8 append/dequant: " << context
+              << " tokens across an interleaved shuffled table PASS\n";
+}
+
+void test_paged_turboquant_round_trip(const Geometry& geometry) {
+    const int context = 300;
+    const int block_size = geometry.block_size;
+    const int max_blocks = (context + block_size - 1) / block_size;
+    const int slot_bytes = qwen_turboquant_k8v4_slot_bytes(geometry.head_dim);
+    const std::vector<int32_t> image =
+        fragmented_table({context, context}, block_size, max_blocks, 61u);
+    const int blocks = total_blocks(image);
+    const size_t contiguous_bytes = static_cast<size_t>(context) *
+                                    geometry.kv_heads * slot_bytes;
+    const size_t paged_bytes = static_cast<size_t>(blocks) * block_size *
+                               geometry.kv_heads * slot_bytes;
+    const size_t kv_elements = static_cast<size_t>(context) * geometry.kv_stride();
+    const std::vector<uint16_t> k_host = random_half(kv_elements, 62u);
+    const std::vector<uint16_t> v_host = random_half(kv_elements, 63u);
+
+    DeviceBuffer<uint16_t> k_rows(kv_elements);
+    DeviceBuffer<uint16_t> v_rows(kv_elements);
+    DeviceBuffer<uint8_t> contiguous(contiguous_bytes);
+    DeviceBuffer<uint8_t> paged(paged_bytes);
+    DeviceBuffer<uint16_t> k_dense_contiguous(kv_elements);
+    DeviceBuffer<uint16_t> v_dense_contiguous(kv_elements);
+    DeviceBuffer<uint16_t> k_dense_paged(kv_elements);
+    DeviceBuffer<uint16_t> v_dense_paged(kv_elements);
+    DeviceBuffer<int32_t> table(image.size());
+    k_rows.upload(k_host);
+    v_rows.upload(v_host);
+    table.upload(image);
+
+    require(qwen_append_kv_cache_turboquant_k8v4_cuda(
+                k_rows.get(), v_rows.get(), contiguous.get(), context,
+                geometry.kv_heads, geometry.head_dim, 0, context),
+            "contiguous TurboQuant append launch");
+    require(qwen_append_kv_cache_turboquant_k8v4_paged_cuda(
+                k_rows.get(), v_rows.get(), paged.get(), context,
+                geometry.kv_heads, geometry.head_dim, 0,
+                table.get() + max_blocks, block_size),
+            "paged TurboQuant append launch");
+    require(qwen_turboquant_k8v4_dequant_kv_cuda(
+                contiguous.get(), k_dense_contiguous.get(),
+                v_dense_contiguous.get(), context, geometry.kv_heads,
+                geometry.head_dim, context),
+            "contiguous TurboQuant dequant launch");
+    require(qwen_turboquant_k8v4_dequant_kv_paged_cuda(
+                paged.get(), k_dense_paged.get(), v_dense_paged.get(), context,
+                geometry.kv_heads, geometry.head_dim, table.get() + max_blocks,
+                block_size),
+            "paged TurboQuant dequant launch");
+    check(cudaDeviceSynchronize(), "paged TurboQuant round-trip sync");
+    require(k_dense_contiguous.download() == k_dense_paged.download() &&
+                v_dense_contiguous.download() == v_dense_paged.download(),
+            "paged TurboQuant dequantization differs from contiguous result");
+    std::cout << "  paged TurboQuant append/dequant: " << context
+              << " tokens across an interleaved shuffled table PASS\n";
+}
+
+// ============================================================================
+// Test 6: batched decode attention. The same K/V history and the same queries
 // are laid out both ways, and the two launches must agree to the bit. This is
 // the load-bearing case: batched decode reads the blocks natively rather than
 // going through the gather.
@@ -512,6 +652,8 @@ int main() {
         test_paged_append(geometry);
         test_paged_gather(geometry);
         test_paged_batched_append(geometry);
+        test_paged_fp8_round_trip(geometry);
+        test_paged_turboquant_round_trip(geometry);
         test_paged_batched_decode(geometry, 0, 0, "dense");
         // Sparse attention keeps its own window and sink ranges; the block
         // translation has to hold for the positions those ranges actually visit.


### PR DESCRIPTION
## Summary

- Add batched KV-cache append and GQA decode for FP8 E4M3 and TurboQuant K8V4.
- Extend paged KV allocation, fragmented block-table addressing, and quantized single-request dequantization.
- Preserve FP16 behavior and explicitly reject unsupported dtype/layout/backend combinations.

## Implementation

- Add CUDA primitives for contiguous and paged FP8/TurboQuant append and attention.
- Add correct paged code/scale/packed-byte accounting and slot-aware engine dispatch.
- Keep packed quantized data out of FP16 attention kernels by materializing dense FP16 workspace where required.
- Add kernel, fixture-engine, and paged-engine parity coverage for non-identity slots, differing contexts, block boundaries, and block reuse.

## Validation

- `cmake --build cpp_engine/build-python -j2` — PASS.
- Focused native tests (`test_qwen_batched_decode`, `test_qwen_batched_engine_parity`, `test_qwen_paged_kv_kernels`, `test_qwen_paged_engine_parity`) — PASS.
- Existing Qwen kernel/engine regressions — PASS.
- Python backend/supervisor regression subset — 82 passed, 2 deselected. The two deselected tests consume `sys.argv[1]` directly and interpret pytest `-q` as a checkpoint.
- Real `/mnt/data2/Qwen3.8-27B-FP8` TP2 checks on physical GPUs 2 and 3 completed with finite outputs and expected throughput/memory accounting. Fixture and direct parity are token-exact; full-model quantized batched runs show occasional top-token differences from changed batched reduction order, so this PR does not claim full-model token-exact parity.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)
