### PR TITLE
Add batched Qwen speculative decoding

### DIFF
--- a/cpp_engine/core/block_table.cpp
+++ b/cpp_engine/core/block_table.cpp
@@ -64,6 +64,21 @@ void BlockTable::release(int slot) {
     dirty_ = true;
 }
 
+void BlockTable::trim_capacity(int slot, int tokens) {
+    validate_slot(slot);
+    if (tokens < 0 || tokens > max_context_) {
+        throw std::runtime_error(
+            "BlockTable::trim_capacity: tokens out of range");
+    }
+    std::vector<int>& row = rows_[static_cast<size_t>(slot)];
+    const int needed = pool_->blocks_for_tokens(tokens);
+    if (needed >= static_cast<int>(row.size())) return;
+    std::vector<int> trailing(row.begin() + needed, row.end());
+    pool_->free(trailing);
+    row.resize(static_cast<size_t>(needed));
+    dirty_ = true;
+}
+
 void BlockTable::release_all() {
     for (int slot = 0; slot < max_slots_; ++slot) release(slot);
 }

--- a/cpp_engine/engine/backend_unimplemented_ascend.cpp
+++ b/cpp_engine/engine/backend_unimplemented_ascend.cpp
@@ -173,15 +173,15 @@ QwenDSparkRuntime::QwenDSparkRuntime(const std::string&,
                                     const QwenDSparkWeightMap&,
                                     const QwenDeviceTensor&,
                                     QwenTargetHeadAdapter, int, int, int,
-                                    std::string, int) {
+                                    std::string, int, int) {
     unimplemented("Qwen DSpark drafter");
 }
 
 QwenDSparkRuntime::~QwenDSparkRuntime() = default;
 
-void QwenDSparkRuntime::reset() { unimplemented("Qwen DSpark drafter"); }
+void QwenDSparkRuntime::reset(int) { unimplemented("Qwen DSpark drafter"); }
 
-int QwenDSparkRuntime::committed_position() const {
+int QwenDSparkRuntime::committed_position(int) const {
     unimplemented("Qwen DSpark drafter");
 }
 
@@ -197,15 +197,15 @@ uint64_t QwenDSparkRuntime::activation_workspace_bytes() const {
     unimplemented("Qwen DSpark drafter");
 }
 
-void QwenDSparkRuntime::append_target_taps(const uint16_t*, int, int) {
+void QwenDSparkRuntime::append_target_taps(const uint16_t*, int, int, int) {
     unimplemented("Qwen DSpark drafter");
 }
 
-void QwenDSparkRuntime::crop_context(int) {
+void QwenDSparkRuntime::crop_context(int, int) {
     unimplemented("Qwen DSpark drafter");
 }
 
-QwenDSparkProposal QwenDSparkRuntime::propose(int) {
+QwenDSparkProposal QwenDSparkRuntime::propose(int, int) {
     unimplemented("Qwen DSpark drafter");
 }
 
@@ -216,15 +216,15 @@ QwenDFlash2Runtime::QwenDFlash2Runtime(const std::string&,
                                       const QwenDFlash2WeightMap&,
                                       const QwenDeviceTensor&,
                                       QwenTargetHeadAdapter, int, int, int,
-                                      std::string, int) {
+                                      std::string, int, int) {
     unimplemented("Qwen DFlash2 drafter");
 }
 
 QwenDFlash2Runtime::~QwenDFlash2Runtime() = default;
 
-void QwenDFlash2Runtime::reset() { unimplemented("Qwen DFlash2 drafter"); }
+void QwenDFlash2Runtime::reset(int) { unimplemented("Qwen DFlash2 drafter"); }
 
-int QwenDFlash2Runtime::committed_position() const {
+int QwenDFlash2Runtime::committed_position(int) const {
     unimplemented("Qwen DFlash2 drafter");
 }
 
@@ -245,24 +245,24 @@ void QwenDFlash2Runtime::set_debug_callback(QwenDFlash2DebugCallback) {
 }
 
 void QwenDFlash2Runtime::debug_load_target_taps(
-    const std::vector<uint16_t>&, int, int) {
-    unimplemented("Qwen DFlash2 drafter");
-}
-
-QwenDFlash2Proposal QwenDFlash2Runtime::debug_propose_from_host(
     const std::vector<uint16_t>&, int, int, int) {
     unimplemented("Qwen DFlash2 drafter");
 }
 
-void QwenDFlash2Runtime::append_target_taps(const uint16_t*, int, int) {
+QwenDFlash2Proposal QwenDFlash2Runtime::debug_propose_from_host(
+    const std::vector<uint16_t>&, int, int, int, int) {
     unimplemented("Qwen DFlash2 drafter");
 }
 
-void QwenDFlash2Runtime::crop_context(int) {
+void QwenDFlash2Runtime::append_target_taps(const uint16_t*, int, int, int) {
     unimplemented("Qwen DFlash2 drafter");
 }
 
-QwenDFlash2Proposal QwenDFlash2Runtime::propose(int) {
+void QwenDFlash2Runtime::crop_context(int, int) {
+    unimplemented("Qwen DFlash2 drafter");
+}
+
+QwenDFlash2Proposal QwenDFlash2Runtime::propose(int, int) {
     unimplemented("Qwen DFlash2 drafter");
 }
 

--- a/cpp_engine/engine/batch_scheduler.cpp
+++ b/cpp_engine/engine/batch_scheduler.cpp
@@ -455,6 +455,7 @@ bool BatchScheduler::run_decode_batch() {
                 batch_req->slot_id = req->slot_id;
                 batch_req->seq_len = req->seq_len;
                 batch_req->last_token = req->last_token;
+                batch_req->generated_tokens = req->generated_tokens;
                 batch_req->sampling = req->sampling;
 
                 decode_batch.push_back(batch_req);
@@ -482,43 +483,123 @@ bool BatchScheduler::run_decode_batch() {
                 " stop flags for " + std::to_string(decode_batch.size()) +
                 " requests");
         }
+        const bool has_row_metadata = !result.emitted_tokens.empty() ||
+            !result.position_advances.empty() ||
+            !result.proposed_drafts.empty() ||
+            !result.accepted_drafts.empty() ||
+            !result.used_speculative.empty() ||
+            !result.rolled_back.empty();
+        if (has_row_metadata &&
+            (result.emitted_tokens.size() != decode_batch.size() ||
+             result.position_advances.size() != decode_batch.size() ||
+             result.proposed_drafts.size() != decode_batch.size() ||
+             result.accepted_drafts.size() != decode_batch.size() ||
+             result.used_speculative.size() != decode_batch.size() ||
+             result.rolled_back.size() != decode_batch.size())) {
+            throw std::runtime_error(
+                "batch_decode_step returned malformed speculative row metadata");
+        }
 
-        // Update request states
+        // Update request states. A speculative row may emit several accepted
+        // drafts and one bonus token while consuming the same number of target
+        // KV positions, so the scheduler must not assume one token per call.
         {
             std::lock_guard<std::mutex> lock(queue_mutex_);
             for (size_t i = 0; i < decode_batch.size(); ++i) {
                 auto* req = decode_requests[i];
-                if (i < result.next_tokens.size()) {
-                    req->last_token = result.next_tokens[i];
-                    req->generated_tokens.push_back(req->last_token);
-                    req->seq_len++;
+                if (i >= result.next_tokens.size()) continue;
+                std::vector<int> row_tokens = has_row_metadata
+                    ? result.emitted_tokens[i]
+                    : std::vector<int>{result.next_tokens[i]};
+                const int position_advance = has_row_metadata
+                    ? result.position_advances[i]
+                    : 1;
+                if (row_tokens.empty() || position_advance <= 0) {
+                    throw std::runtime_error(
+                        "batch_decode_step returned an empty speculative row");
+                }
+                // The engine normally applies this bound before launching a
+                // forward, but keep the generic scheduler safe for engines that
+                // return more output tokens than the request can accept. Target
+                // state may already have consumed the full reported advance; only
+                // the externally visible/generated suffix is truncated here.
+                const size_t remaining = req->generated_tokens.size() >=
+                        static_cast<size_t>(std::max(0, req->sampling.max_new_tokens))
+                    ? 0
+                    : static_cast<size_t>(req->sampling.max_new_tokens) -
+                          req->generated_tokens.size();
+                const bool row_truncated = row_tokens.size() > remaining;
+                if (row_truncated) row_tokens.resize(remaining);
+                if (row_tokens.empty()) {
+                    req->finished = true;
+                    req->seq_len += position_advance;
+                    if (has_row_metadata) {
+                        req->proposed_drafts += result.proposed_drafts[i];
+                        req->accepted_drafts += result.accepted_drafts[i];
+                        if (result.used_speculative[i]) ++req->speculative_steps;
+                        if (result.rolled_back[i]) ++req->rollback_steps;
+                    }
+                    continue;
+                }
 
-                    // Record TTFT for first decode token (if prefill didn't set it)
-                    if (req->first_token_time == std::chrono::steady_clock::time_point{} &&
-                        req->generated_tokens.size() == 1) {
-                        req->first_token_time = std::chrono::steady_clock::now();
+                bool stopped = false;
+                const bool row_stopped =
+                    !row_truncated && i < result.hit_stop_token.size() &&
+                    result.hit_stop_token[i];
+                for (size_t token_index = 0; token_index < row_tokens.size();
+                     ++token_index) {
+                    const int token = row_tokens[token_index];
+                    // A stop token is retained in the request sequence so the
+                    // request agrees with the engine's committed state, but no
+                    // token at or after it is streamed to the caller. The
+                    // row-level flag is authoritative for checkpoint EOS, which
+                    // the scheduler cannot identify without the model config.
+                    const bool token_stops =
+                        !req->sampling.ignore_eos &&
+                        !req->sampling.stop_token_ids.empty() &&
+                        std::find(req->sampling.stop_token_ids.begin(),
+                                  req->sampling.stop_token_ids.end(), token) !=
+                            req->sampling.stop_token_ids.end();
+                    req->generated_tokens.push_back(token);
+                    req->last_token = token;
+                    if (token_stops) {
+                        stopped = true;
+                        break;
                     }
+                    const bool checkpoint_stop_at_row_end =
+                        row_stopped && token_index + 1 == row_tokens.size();
+                    if (req->token_callback && !checkpoint_stop_at_row_end) {
+                        emitted.emplace_back(req, token);
+                    }
+                }
+                req->seq_len += position_advance;
+                if (has_row_metadata) {
+                    req->proposed_drafts += result.proposed_drafts[i];
+                    req->accepted_drafts += result.accepted_drafts[i];
+                    if (result.used_speculative[i]) ++req->speculative_steps;
+                    if (result.rolled_back[i]) ++req->rollback_steps;
+                }
 
-                    // Check if finished. A stop token remains in the scheduler's
-                    // sequence so it agrees with the engine's KV state, but it is
-                    // not delivered to a streaming caller.
-                    const bool stopped =
-                        i < result.hit_stop_token.size() && result.hit_stop_token[i];
-                    if (i < result.finished.size() && result.finished[i]) {
-                        req->finished = true;
-                    }
-                    if (stopped) {
-                        req->stopped_on_token = true;
-                    }
-                    if (req->token_callback && !stopped) {
-                        emitted.emplace_back(req, req->last_token);
-                    }
+                // The engine already applies checkpoint EOS when the request
+                // leaves stop_token_ids empty. In that case its row-level flag is
+                // authoritative; explicit per-request stop IDs are checked above
+                // so the streamed suffix can be truncated at the exact token.
+                if (i < result.finished.size() && result.finished[i]) {
+                    req->finished = true;
+                }
+                if (stopped || (i < result.hit_stop_token.size() &&
+                                result.hit_stop_token[i])) {
+                    req->finished = true;
+                    req->stopped_on_token = true;
+                }
 
-                    // Check max_new_tokens
-                    if (req->generated_tokens.size() >=
-                        static_cast<size_t>(req->sampling.max_new_tokens)) {
-                        req->finished = true;
-                    }
+                if (req->first_token_time == std::chrono::steady_clock::time_point{} &&
+                    !req->generated_tokens.empty()) {
+                    req->first_token_time = std::chrono::steady_clock::now();
+                }
+                if (req->generated_tokens.size() >=
+                    static_cast<size_t>(req->sampling.max_new_tokens)) {
+                    req->finished = true;
                 }
             }
         }
@@ -653,6 +734,10 @@ void BatchScheduler::notify_result(SchedulerRequest* req) {
     }
     result.prompt_tokens = static_cast<int>(req->prompt_tokens.size());
     result.completion_tokens = static_cast<int>(req->generated_tokens.size());
+    result.proposed_drafts = req->proposed_drafts;
+    result.accepted_drafts = req->accepted_drafts;
+    result.speculative_steps = req->speculative_steps;
+    result.rollback_steps = req->rollback_steps;
 
     // Calculate timings
     auto submit = req->submit_time;

--- a/cpp_engine/engine/qwen_dflash2.cpp
+++ b/cpp_engine/engine/qwen_dflash2.cpp
@@ -494,10 +494,11 @@ struct QwenDFlash2Runtime::Impl {
     int device = 0;
     std::string nccl_id_path;
     int max_context = 0;
-    int committed = 0;
+    int max_slots = 1;
+    std::vector<int> committed;
+    std::vector<int> prepared_context;
     // Raw target taps can be appended while target prefill/verification runs;
     // projection and DFlash2 K/V preparation are flushed once before drafting.
-    int prepared_context = 0;
     uint64_t weight_bytes = 0;
     uint64_t cache_bytes = 0;
     std::vector<DeviceLayer> layers;
@@ -580,20 +581,22 @@ struct QwenDFlash2Runtime::Impl {
     Impl(const std::string& checkpoint_dir_, const QwenDFlash2Config& config_,
          const QwenDFlash2WeightMap& weights_, const QwenDeviceTensor& embedding,
          QwenTargetHeadAdapter target_head_, int world, int rank, int device_,
-         std::string id_path, int max_context_)
+         std::string id_path, int max_context_, int max_slots_)
         : checkpoint_dir(checkpoint_dir_), config(config_), weight_map(weights_),
           index(SafeTensorsIndex::from_single_file(checkpoint_dir_)),
           target_embedding(embedding), target_head(target_head_),
           tp_world(world), tp_rank(rank), device(device_),
           nccl_id_path(std::move(id_path)), max_context(max_context_),
-          profiler(device_, rank) {
-        if (device < 0 || max_context <= 0 ||
+          max_slots(max_slots_), profiler(device_, rank) {
+        if (device < 0 || max_context <= 0 || max_slots <= 0 ||
             target_embedding.device_dtype != SafeDType::F16 ||
             target_embedding.shape.size() != 2 ||
             target_embedding.shape[1] != static_cast<uint64_t>(config.hidden_size) ||
             !target_head.valid() || target_head.hidden_size != config.hidden_size) {
             throw std::runtime_error("invalid Qwen DFlash2 runtime target tensors");
         }
+        committed.assign(static_cast<size_t>(max_slots), 0);
+        prepared_context.assign(static_cast<size_t>(max_slots), 0);
         check_device(device_set(device), "select Qwen DFlash2 device");
         grouped_attention = env_enabled("POCKETLLM_DFLASH2_GROUPED_ATTN");
         fused_swiglu = env_enabled("POCKETLLM_DFLASH2_FUSED_SWIGLU");
@@ -636,10 +639,17 @@ struct QwenDFlash2Runtime::Impl {
         successor = qwen_upload_tensor(index, weight_map.successor_codebook());
         selector_projection = qwen_upload_tensor(index, weight_map.selector_projection());
         weight_bytes = weight_map.local_device_bytes();
-        const size_t tap_elements = static_cast<size_t>(max_context) * config.hidden_size * config.target_layer_ids.size();
-        allocate_half(context_taps, tap_elements, {static_cast<uint64_t>(max_context), static_cast<uint64_t>(config.hidden_size * config.target_layer_ids.size())});
+        const size_t tap_elements = static_cast<size_t>(max_slots) *
+            static_cast<size_t>(max_context) * config.hidden_size *
+            config.target_layer_ids.size();
+        allocate_half(context_taps, tap_elements,
+                      {static_cast<uint64_t>(max_slots),
+                       static_cast<uint64_t>(max_context),
+                       static_cast<uint64_t>(config.hidden_size *
+                                             config.target_layer_ids.size())});
         layers.reserve(weight_map.layers().size());
-        const size_t context_elements = static_cast<size_t>(max_context) * local_kv_dim;
+        const size_t context_elements = static_cast<size_t>(max_slots) *
+            static_cast<size_t>(max_context) * local_kv_dim;
         for (const QwenDFlash2LayerWeights& source : weight_map.layers()) {
             DeviceLayer layer;
             layer.input_norm = qwen_upload_tensor(index, source.input_layernorm);
@@ -657,7 +667,11 @@ struct QwenDFlash2Runtime::Impl {
             layer.attention_conv.projection.weight = qwen_upload_tensor(index, source.attention_conv.kernel_projection.weight);
             layer.mlp_conv.base = qwen_upload_tensor(index, source.mlp_conv.base_kernel);
             layer.mlp_conv.projection.weight = qwen_upload_tensor(index, source.mlp_conv.kernel_projection.weight);
-            allocate_half(layer.context_k, context_elements, {static_cast<uint64_t>(max_context), static_cast<uint64_t>(local_kv_heads), static_cast<uint64_t>(config.head_dim)});
+            allocate_half(layer.context_k, context_elements,
+                          {static_cast<uint64_t>(max_slots),
+                           static_cast<uint64_t>(max_context),
+                           static_cast<uint64_t>(local_kv_heads),
+                           static_cast<uint64_t>(config.head_dim)});
             allocate_half(layer.context_v, context_elements, layer.context_k.shape);
             cache_bytes += layer.context_k.nbytes + layer.context_v.nbytes;
             layers.push_back(std::move(layer));
@@ -767,29 +781,53 @@ struct QwenDFlash2Runtime::Impl {
             columns), "DFlash2 projection");
     }
 
-    void append_target_taps(const uint16_t* taps, int rows, int position_offset) {
-        if (!taps || rows <= 0 || position_offset != committed || position_offset + rows > max_context) throw std::runtime_error("invalid Qwen DFlash2 target tap append");
+    int position_for(int slot_id) const {
+        if (slot_id < 0 || slot_id >= max_slots) {
+            throw std::runtime_error("Qwen DFlash2 slot is out of range");
+        }
+        return committed[static_cast<size_t>(slot_id)];
+    }
+
+    size_t tap_offset(int slot_id, int position) const {
+        const size_t width = static_cast<size_t>(config.hidden_size) *
+            config.target_layer_ids.size();
+        (void)position_for(slot_id);
+        return (static_cast<size_t>(slot_id) * max_context + position) * width;
+    }
+
+    size_t context_offset(int slot_id, int position, int kv_dim) const {
+        (void)position_for(slot_id);
+        return (static_cast<size_t>(slot_id) * max_context + position) *
+               static_cast<size_t>(kv_dim);
+    }
+
+    void append_target_taps(const uint16_t* taps, int rows, int position_offset,
+                            int slot_id) {
+        if (!taps || rows <= 0 || position_offset != position_for(slot_id) ||
+            position_offset + rows > max_context) throw std::runtime_error("invalid Qwen DFlash2 target tap append");
         const int width = config.hidden_size * static_cast<int>(config.target_layer_ids.size());
         const std::vector<uint64_t> tap_shape = {
             static_cast<uint64_t>(rows), static_cast<uint64_t>(width)};
         profiler.begin("context_append");
-        check_device(memcpy_d2d(context_taps.f16_data() + static_cast<size_t>(position_offset) * width,
+        check_device(memcpy_d2d(context_taps.f16_data() + tap_offset(slot_id, position_offset),
                                 taps, static_cast<size_t>(rows) * width * sizeof(uint16_t)), "append DFlash2 target taps");
         profiler.end();
         dump_half("target_taps", taps, tap_shape);
-        committed += rows;
+        committed[static_cast<size_t>(slot_id)] += rows;
     }
 
-    void prepare_context() {
-        if (prepared_context == committed) return;
-        if (prepared_context < 0 || prepared_context > committed) {
+    void prepare_context(int slot_id) {
+        const int committed_position = position_for(slot_id);
+        int& prepared = prepared_context[static_cast<size_t>(slot_id)];
+        if (prepared == committed_position) return;
+        if (prepared < 0 || prepared > committed_position) {
             throw std::runtime_error("invalid Qwen DFlash2 prepared context");
         }
-        const int position_offset = prepared_context;
-        const int rows = committed - prepared_context;
+        const int position_offset = prepared;
+        const int rows = committed_position - prepared;
         const int width = config.hidden_size * static_cast<int>(config.target_layer_ids.size());
         const uint16_t* taps = context_taps.f16_data() +
-            static_cast<size_t>(position_offset) * width;
+            tap_offset(slot_id, position_offset);
         const std::vector<uint64_t> tap_shape = {
             static_cast<uint64_t>(rows), static_cast<uint64_t>(width)};
         dump_half("context.pending_target_taps", taps, tap_shape);
@@ -824,21 +862,25 @@ struct QwenDFlash2Runtime::Impl {
             dump_half_sharded(prefix + "k_norm", knorm.f16_data(), knorm.shape);
             require_launch(qwen_dflash2_rope_k_rows_f16_cuda(knorm.f16_data(), rows, local_kv_heads, config.head_dim, position_offset, static_cast<float>(config.rope_theta)), "DFlash2 context K RoPE");
             dump_half_sharded(prefix + "k_rope", knorm.f16_data(), knorm.shape);
-            check_device(memcpy_d2d(layer.context_k.f16_data() + static_cast<size_t>(position_offset) * kv_dim,
+            const size_t cache_offset = context_offset(
+                slot_id, position_offset, kv_dim);
+            check_device(memcpy_d2d(layer.context_k.f16_data() + cache_offset,
                                     knorm.f16_data(), k.nbytes), "append DFlash2 context K");
-            check_device(memcpy_d2d(layer.context_v.f16_data() + static_cast<size_t>(position_offset) * kv_dim,
+            check_device(memcpy_d2d(layer.context_v.f16_data() + cache_offset,
                                     v.f16_data(), v.nbytes), "append DFlash2 context V");
         }
         profiler.end();
         profiler.flush("prepare_context");
-        prepared_context = committed;
+        prepared = committed_position;
     }
 
     // One denoising pass over the block. `host_tokens` supplies the row inputs:
     // row 0 is the committed anchor and the remaining rows are either mask tokens
     // (first pass) or the previous pass's drafts (refinement passes). The selected
     // path is left in `path` on the device.
-    void denoise_pass(int anchor_token, const std::vector<int>& host_tokens) {
+    void denoise_pass(int anchor_token, const std::vector<int>& host_tokens,
+                      int slot_id) {
+        const int committed_position = position_for(slot_id);
         const int rows = config.block_size;
         const int hidden = config.hidden_size;
         const int q_dim = local_q_dim;
@@ -928,7 +970,7 @@ struct QwenDFlash2Runtime::Impl {
             dump_half_sharded(prefix + "attention.k_norm", k.f16_data(), k.shape);
             require_launch(qwen_dflash2_rope_rows_f16_cuda(
                 q.f16_data(), k.f16_data(), rows, local_q_heads,
-                local_kv_heads, config.head_dim, committed,
+                local_kv_heads, config.head_dim, committed_position,
                 static_cast<float>(config.rope_theta)), "DFlash2 noise RoPE");
             profiler.end();
             dump_half_sharded(prefix + "attention.q_rope", q.f16_data(), q.shape);
@@ -938,16 +980,20 @@ struct QwenDFlash2Runtime::Impl {
             const bool grouped = use_grouped_attention();
             const bool attention_ok = grouped
                 ? qwen_dflash2_attention_grouped_f16_cuda(
-                    q.f16_data(), layer.context_k.f16_data(),
-                    layer.context_v.f16_data(), k.f16_data(), v.f16_data(),
+                    q.f16_data(), layer.context_k.f16_data() +
+                        context_offset(slot_id, 0, local_kv_dim),
+                    layer.context_v.f16_data() +
+                        context_offset(slot_id, 0, local_kv_dim), k.f16_data(), v.f16_data(),
                     attention.f16_data(), rows, local_q_heads,
-                    local_kv_heads, config.head_dim, committed,
+                    local_kv_heads, config.head_dim, committed_position,
                     max_context, config.sliding_window)
                 : qwen_dflash2_attention_f16_cuda(
-                    q.f16_data(), layer.context_k.f16_data(),
-                    layer.context_v.f16_data(), k.f16_data(), v.f16_data(),
+                    q.f16_data(), layer.context_k.f16_data() +
+                        context_offset(slot_id, 0, local_kv_dim),
+                    layer.context_v.f16_data() +
+                        context_offset(slot_id, 0, local_kv_dim), k.f16_data(), v.f16_data(),
                     attention.f16_data(), rows, local_q_heads,
-                    local_kv_heads, config.head_dim, committed,
+                    local_kv_heads, config.head_dim, committed_position,
                     max_context, config.sliding_window);
             require_launch(attention_ok, grouped
                 ? "DFlash2 grouped attention" : "DFlash2 attention");
@@ -1195,18 +1241,19 @@ struct QwenDFlash2Runtime::Impl {
         dump_i32("selector.path", static_cast<const int*>(path.data), path.shape);
     }
 
-    QwenDFlash2Proposal propose(int anchor_token) {
+    QwenDFlash2Proposal propose(int anchor_token, int slot_id) {
+        const int committed_position = position_for(slot_id);
         if (anchor_token < 0 || anchor_token >= config.vocab_size ||
-            committed >= max_context) {
+            committed_position >= max_context) {
             throw std::runtime_error("invalid Qwen DFlash2 proposal anchor");
         }
-        prepare_context();
+        prepare_context(slot_id);
         const int rows = config.block_size;
         const int draft_rows = rows - 1;
         std::vector<int> host_tokens(static_cast<size_t>(rows),
                                     config.mask_token_id);
         host_tokens[0] = anchor_token;
-        denoise_pass(anchor_token, host_tokens);
+        denoise_pass(anchor_token, host_tokens, slot_id);
         // Block diffusion denoises iteratively. The first pass conditions every
         // row on mask tokens, so late rows predict from an all-mask left context
         // and are the weakest drafts; feeding the pass's own tokens back in place
@@ -1224,7 +1271,7 @@ struct QwenDFlash2Runtime::Impl {
             }
             if (next == host_tokens) break;
             host_tokens = next;
-            denoise_pass(anchor_token, host_tokens);
+            denoise_pass(anchor_token, host_tokens, slot_id);
         }
         QwenDFlash2Proposal proposal;
         proposal.tokens.resize(static_cast<size_t>(draft_rows));
@@ -1262,23 +1309,28 @@ QwenDFlash2Runtime::QwenDFlash2Runtime(
     const QwenDFlash2WeightMap& weights,
     const QwenDeviceTensor& target_embedding,
     QwenTargetHeadAdapter target_head, int tp_world, int tp_rank, int device,
-    std::string nccl_id_path, int max_context)
+    std::string nccl_id_path, int max_context, int max_slots)
     : impl_(std::make_unique<Impl>(
           checkpoint_dir, config, weights, target_embedding, target_head,
-          tp_world, tp_rank, device, std::move(nccl_id_path), max_context)) {}
+          tp_world, tp_rank, device, std::move(nccl_id_path), max_context,
+          max_slots)) {}
 
 QwenDFlash2Runtime::~QwenDFlash2Runtime() = default;
-void QwenDFlash2Runtime::reset() {
-    impl_->committed = 0;
-    impl_->prepared_context = 0;
+void QwenDFlash2Runtime::reset(int slot_id) {
+    (void)impl_->position_for(slot_id);
+    impl_->committed[static_cast<size_t>(slot_id)] = 0;
+    impl_->prepared_context[static_cast<size_t>(slot_id)] = 0;
 }
-int QwenDFlash2Runtime::committed_position() const { return impl_->committed; }
+int QwenDFlash2Runtime::committed_position(int slot_id) const {
+    return impl_->position_for(slot_id);
+}
 void QwenDFlash2Runtime::set_debug_callback(
     QwenDFlash2DebugCallback callback) {
     impl_->debug_callback = std::move(callback);
 }
 void QwenDFlash2Runtime::debug_load_target_taps(
-    const std::vector<uint16_t>& taps, int rows, int position_offset) {
+    const std::vector<uint16_t>& taps, int rows, int position_offset,
+    int slot_id) {
     const size_t width = static_cast<size_t>(impl_->config.hidden_size) *
         impl_->config.target_layer_ids.size();
     if (rows <= 0 || position_offset < 0 ||
@@ -1290,31 +1342,40 @@ void QwenDFlash2Runtime::debug_load_target_taps(
                   {static_cast<uint64_t>(rows), static_cast<uint64_t>(width)});
     check_device(memcpy_h2d(device_taps.data, taps.data(), taps.size() * sizeof(uint16_t)),
                  "upload host Qwen DFlash2 target taps");
-    impl_->append_target_taps(device_taps.f16_data(), rows, position_offset);
+    impl_->append_target_taps(device_taps.f16_data(), rows, position_offset,
+                              slot_id);
 }
 QwenDFlash2Proposal QwenDFlash2Runtime::debug_propose_from_host(
     const std::vector<uint16_t>& taps, int context_rows, int position_offset,
-    int anchor_token) {
-    if (impl_->committed != position_offset) {
-        if (position_offset <= impl_->committed) {
-            impl_->committed = position_offset;
-            impl_->prepared_context = std::min(impl_->prepared_context, position_offset);
+    int anchor_token, int slot_id) {
+    const int committed_position = impl_->position_for(slot_id);
+    if (committed_position != position_offset) {
+        if (position_offset <= committed_position) {
+            impl_->committed[static_cast<size_t>(slot_id)] = position_offset;
+            impl_->prepared_context[static_cast<size_t>(slot_id)] = std::min(
+                impl_->prepared_context[static_cast<size_t>(slot_id)], position_offset);
         } else {
             throw std::runtime_error("host Qwen DFlash2 fixture has a context gap");
         }
     }
-    debug_load_target_taps(taps, context_rows, position_offset);
-    return impl_->propose(anchor_token);
+    debug_load_target_taps(taps, context_rows, position_offset, slot_id);
+    return impl_->propose(anchor_token, slot_id);
 }
 uint64_t QwenDFlash2Runtime::resident_weight_bytes() const { return impl_->weight_bytes; }
 uint64_t QwenDFlash2Runtime::context_cache_bytes() const { return impl_->cache_bytes; }
 uint64_t QwenDFlash2Runtime::activation_workspace_bytes() const { return impl_->activation_workspace_bytes(); }
-void QwenDFlash2Runtime::append_target_taps(const uint16_t* taps, int rows, int position_offset) { impl_->append_target_taps(taps, rows, position_offset); }
-void QwenDFlash2Runtime::crop_context(int position) {
-    if (position < 0 || position > impl_->committed) throw std::runtime_error("invalid Qwen DFlash2 context crop");
-    impl_->committed = position;
-    impl_->prepared_context = std::min(impl_->prepared_context, position);
+void QwenDFlash2Runtime::append_target_taps(const uint16_t* taps, int rows,
+                                            int position_offset, int slot_id) {
+    impl_->append_target_taps(taps, rows, position_offset, slot_id);
 }
-QwenDFlash2Proposal QwenDFlash2Runtime::propose(int anchor_token) { return impl_->propose(anchor_token); }
+void QwenDFlash2Runtime::crop_context(int position, int slot_id) {
+    if (position < 0 || position > impl_->position_for(slot_id)) throw std::runtime_error("invalid Qwen DFlash2 context crop");
+    impl_->committed[static_cast<size_t>(slot_id)] = position;
+    impl_->prepared_context[static_cast<size_t>(slot_id)] = std::min(
+        impl_->prepared_context[static_cast<size_t>(slot_id)], position);
+}
+QwenDFlash2Proposal QwenDFlash2Runtime::propose(int anchor_token, int slot_id) {
+    return impl_->propose(anchor_token, slot_id);
+}
 
 }  // namespace pocket

--- a/cpp_engine/engine/qwen_dspark.cpp
+++ b/cpp_engine/engine/qwen_dspark.cpp
@@ -431,7 +431,8 @@ struct QwenDSparkRuntime::Impl {
     int device = 0;
     std::string nccl_id_path;
     int max_context = 0;
-    int committed = 0;
+    int max_slots = 1;
+    std::vector<int> committed;
     uint64_t weight_bytes = 0;
     uint64_t cache_bytes = 0;
 
@@ -469,20 +470,22 @@ struct QwenDSparkRuntime::Impl {
          const QwenDSparkWeightMap& weights_,
          const QwenDeviceTensor& target_embedding_,
          QwenTargetHeadAdapter target_head_, int tp_world_, int tp_rank_,
-         int device_, std::string nccl_id_path_, int max_context_)
+         int device_, std::string nccl_id_path_, int max_context_, int max_slots_)
         : checkpoint_dir(checkpoint_dir_), config(config_), weight_map(weights_),
           index(SafeTensorsIndex::from_single_file(checkpoint_dir_)),
           target_embedding(target_embedding_), target_head(target_head_),
           tp_world(tp_world_), tp_rank(tp_rank_), device(device_),
-          nccl_id_path(std::move(nccl_id_path_)), max_context(max_context_) {
+          nccl_id_path(std::move(nccl_id_path_)), max_context(max_context_),
+          max_slots(max_slots_) {
         if (tp_world <= 0 || tp_rank < 0 || tp_rank >= tp_world ||
-            device < 0 || max_context <= 0 ||
+            device < 0 || max_context <= 0 || max_slots <= 0 ||
             target_embedding.device_dtype != SafeDType::F16 ||
             target_embedding.shape.size() != 2 ||
             target_embedding.shape[1] != static_cast<uint64_t>(config.hidden_size) ||
             !target_head.valid() || target_head.hidden_size != config.hidden_size) {
             throw std::runtime_error("invalid Qwen DSpark runtime target tensors");
         }
+        committed.assign(static_cast<size_t>(max_slots), 0);
         check_device(device_set(device), "select Qwen DSpark device");
         projector = qwen_upload_tensor(index, weight_map.projector());
         hidden_norm = qwen_upload_tensor(index, weight_map.hidden_norm());
@@ -503,11 +506,11 @@ struct QwenDSparkRuntime::Impl {
 
         const int kv_heads = config.num_key_value_heads;
         const int head_dim = config.head_dim;
-        const size_t context_elements = static_cast<size_t>(max_context) *
-            kv_heads * head_dim;
+        const size_t context_elements = static_cast<size_t>(max_slots) *
+            static_cast<size_t>(max_context) * kv_heads * head_dim;
         const std::vector<uint64_t> context_shape = {
-            static_cast<uint64_t>(max_context), static_cast<uint64_t>(kv_heads),
-            static_cast<uint64_t>(head_dim)};
+            static_cast<uint64_t>(max_slots), static_cast<uint64_t>(max_context),
+            static_cast<uint64_t>(kv_heads), static_cast<uint64_t>(head_dim)};
         layers.reserve(weight_map.layers().size());
         for (const QwenDSparkLayerWeights& source : weight_map.layers()) {
             DSparkDeviceLayer layer;
@@ -600,10 +603,24 @@ struct QwenDSparkRuntime::Impl {
             "full YaRN RoPE");
     }
 
+    int position_for(int slot_id) const {
+        if (slot_id < 0 || slot_id >= max_slots) {
+            throw std::runtime_error("Qwen DSpark slot is out of range");
+        }
+        return committed[static_cast<size_t>(slot_id)];
+    }
+
+    size_t context_slot_offset(int slot_id, int kv_dim) const {
+        (void)position_for(slot_id);
+        return static_cast<size_t>(slot_id) * static_cast<size_t>(max_context) *
+               static_cast<size_t>(kv_dim);
+    }
+
     void append_target_taps(const uint16_t* target_taps, int rows,
-                            int position_offset) {
+                            int position_offset, int slot_id) {
         if (target_taps == nullptr || rows <= 0 || position_offset < 0 ||
-            position_offset != committed || position_offset + rows > max_context) {
+            position_offset != position_for(slot_id) ||
+            position_offset + rows > max_context) {
             throw std::runtime_error("invalid Qwen DSpark target tap append");
         }
         const int hidden = config.hidden_size;
@@ -631,7 +648,8 @@ struct QwenDSparkRuntime::Impl {
             head_norm(layer.k_norm, block_k.f16_data(), normalized.f16_data(),
                       rows, kv_heads);
             apply_rope(normalized.f16_data(), rows, kv_heads, position_offset);
-            const size_t offset = static_cast<size_t>(position_offset) * kv_dim;
+            const size_t offset = context_slot_offset(slot_id, kv_dim) +
+                static_cast<size_t>(position_offset) * kv_dim;
             check_device(memcpy_d2d(
                 layer.context_k.f16_data() + offset, normalized.f16_data(),
                 kv_elements * sizeof(uint16_t)),
@@ -641,7 +659,7 @@ struct QwenDSparkRuntime::Impl {
                 kv_elements * sizeof(uint16_t)),
                 "append Qwen DSpark context V");
         }
-        committed += rows;
+        committed[static_cast<size_t>(slot_id)] += rows;
     }
 
     std::pair<int, float> global_top1(float* local_logits, int local_vocab) {
@@ -686,9 +704,10 @@ struct QwenDSparkRuntime::Impl {
             confidence.capacity;
     }
 
-    QwenDSparkProposal propose(int anchor_token) {
+    QwenDSparkProposal propose(int anchor_token, int slot_id) {
+        const int committed_position = position_for(slot_id);
         if (anchor_token < 0 || anchor_token >= config.vocab_size ||
-            committed >= max_context) {
+            committed_position >= max_context) {
             throw std::runtime_error("invalid Qwen DSpark proposal anchor");
         }
         const int rows = config.block_size;
@@ -735,15 +754,17 @@ struct QwenDSparkRuntime::Impl {
             projection(layer.v, normalized.f16_data(), block_v.f16_data(), rows);
             allocate_half(attention, static_cast<size_t>(rows) * q_dim, q.shape);
             head_norm(layer.q_norm, q.f16_data(), attention.f16_data(), rows, q_heads);
-            apply_rope(attention.f16_data(), rows, q_heads, committed);
+            apply_rope(attention.f16_data(), rows, q_heads, committed_position);
             head_norm(layer.k_norm, block_k.f16_data(), normalized.f16_data(),
                       rows, kv_heads);
-            apply_rope(normalized.f16_data(), rows, kv_heads, committed);
+            apply_rope(normalized.f16_data(), rows, kv_heads, committed_position);
+            const size_t context_offset = context_slot_offset(
+                slot_id, kv_dim);
             require_launch(qwen_dspark_dual_source_gqa_f16_cuda(
-                attention.f16_data(), layer.context_k.f16_data(),
-                layer.context_v.f16_data(), normalized.f16_data(),
+                attention.f16_data(), layer.context_k.f16_data() + context_offset,
+                layer.context_v.f16_data() + context_offset, normalized.f16_data(),
                 block_v.f16_data(), q.f16_data(), rows, q_heads, kv_heads,
-                config.head_dim, committed, max_context),
+                config.head_dim, committed_position, max_context),
                 "dual-source GQA");
             projection(layer.out, q.f16_data(), output, rows);
             require_launch(qwen_add_inplace_f16(
@@ -839,16 +860,22 @@ QwenDSparkRuntime::QwenDSparkRuntime(
     const QwenDSparkWeightMap& weights,
     const QwenDeviceTensor& target_embedding,
     QwenTargetHeadAdapter target_head, int tp_world, int tp_rank, int device,
-    std::string nccl_id_path, int max_context)
+    std::string nccl_id_path, int max_context, int max_slots)
     : impl_(std::make_unique<Impl>(
           checkpoint_dir, config, weights, target_embedding, target_head,
-          tp_world, tp_rank, device, std::move(nccl_id_path), max_context)) {}
+          tp_world, tp_rank, device, std::move(nccl_id_path), max_context,
+          max_slots)) {}
 
 QwenDSparkRuntime::~QwenDSparkRuntime() = default;
 
-void QwenDSparkRuntime::reset() { impl_->committed = 0; }
+void QwenDSparkRuntime::reset(int slot_id) {
+    (void)impl_->position_for(slot_id);
+    impl_->committed[static_cast<size_t>(slot_id)] = 0;
+}
 
-int QwenDSparkRuntime::committed_position() const { return impl_->committed; }
+int QwenDSparkRuntime::committed_position(int slot_id) const {
+    return impl_->position_for(slot_id);
+}
 
 uint64_t QwenDSparkRuntime::resident_weight_bytes() const {
     return impl_->weight_bytes;
@@ -863,19 +890,19 @@ uint64_t QwenDSparkRuntime::activation_workspace_bytes() const {
 }
 
 void QwenDSparkRuntime::append_target_taps(
-    const uint16_t* target_taps, int rows, int position_offset) {
-    impl_->append_target_taps(target_taps, rows, position_offset);
+    const uint16_t* target_taps, int rows, int position_offset, int slot_id) {
+    impl_->append_target_taps(target_taps, rows, position_offset, slot_id);
 }
 
-void QwenDSparkRuntime::crop_context(int position) {
-    if (position < 0 || position > impl_->committed) {
+void QwenDSparkRuntime::crop_context(int position, int slot_id) {
+    if (position < 0 || position > impl_->position_for(slot_id)) {
         throw std::runtime_error("invalid Qwen DSpark context crop");
     }
-    impl_->committed = position;
+    impl_->committed[static_cast<size_t>(slot_id)] = position;
 }
 
-QwenDSparkProposal QwenDSparkRuntime::propose(int anchor_token) {
-    return impl_->propose(anchor_token);
+QwenDSparkProposal QwenDSparkRuntime::propose(int anchor_token, int slot_id) {
+    return impl_->propose(anchor_token, slot_id);
 }
 
 std::vector<float> qwen_dspark_yarn_inv_freqs(

--- a/cpp_engine/engine/qwen_engine.cpp
+++ b/cpp_engine/engine/qwen_engine.cpp
@@ -450,6 +450,9 @@ struct QwenEngine::Impl {
     QwenDeviceTensor mtp_norm;
     DeviceLayer mtp_layer;
     QwenDeviceTensor target_hidden_rows;
+    // MTP side-channel state is indexed by request slot. The activation tensors
+    // remain shared scratch because speculative rows are drafted serially per
+    // slot, while the committed seed hidden must survive interleaved requests.
     QwenDeviceTensor target_last_hidden;
     QwenDeviceTensor mtp_seed_hidden;
     QwenDeviceTensor mtp_embedding;
@@ -459,13 +462,13 @@ struct QwenEngine::Impl {
     QwenDeviceTensor mtp_fused;
     QwenDeviceTensor mtp_next_hidden;
     QwenDeviceTensor mtp_normalized_output;
-    int mtp_position = 0;
-    int mtp_seed_input_token = 0;
-    int mtp_next_token = 0;
-    float mtp_next_logit = 0.0f;
-    float mtp_next_checksum = 0.0f;
-    bool has_target_last_hidden = false;
-    bool mtp_seed_ready = false;
+    std::vector<int> mtp_position;
+    std::vector<int> mtp_seed_input_token;
+    std::vector<int> mtp_next_token;
+    std::vector<float> mtp_next_logit;
+    std::vector<float> mtp_next_checksum;
+    std::vector<bool> has_target_last_hidden;
+    std::vector<bool> mtp_seed_ready;
     std::vector<int> local_tokens;
     QwenDeviceTensor d_tokens;
     QwenDeviceTensor hidden_a;
@@ -581,8 +584,7 @@ struct QwenEngine::Impl {
     // non-batch code paths and telemetry still read position_.
     void set_slot_position(int slot_id, int position, int& engine_position) {
         engine_position = position;
-        if (batch_mode_enabled && slot_id >= 0 &&
-            slot_id < static_cast<int>(slot_positions.size())) {
+        if (slot_id >= 0 && slot_id < static_cast<int>(slot_positions.size())) {
             slot_positions[static_cast<size_t>(slot_id)] = position;
         }
     }
@@ -642,6 +644,12 @@ struct QwenEngine::Impl {
                      "Qwen block table upload");
     }
 
+    void trim_paged_slot(int slot_id, int tokens) {
+        if (!kv_paged()) return;
+        block_table->trim_capacity(slot_id, tokens);
+        sync_block_table();
+    }
+
     const int* block_table_data() const {
         return kv_paged()
             ? static_cast<const int*>(block_table_device.data) : nullptr;
@@ -669,17 +677,17 @@ struct QwenEngine::Impl {
         block_table->release(slot_id);
     }
 
-    // Tears down one slot's paged state as a unit: returns its blocks to the
-    // pool, uploads the table, and clears the reuse state that described KV no
-    // longer backed by those blocks. Rank 0's free_slot and the worker loop's
-    // FreeSlot command both call this, so a slot ends up in exactly the same
-    // state on every rank. A stale cached_prompt on a worker would otherwise let
-    // an exact-repeat prompt hit the previous request's logits while rank 0
-    // recomputes, silently desynchronizing the two.
+    // Tears down one slot's state as a unit. Paging additionally returns its
+    // blocks to the pool and uploads the table; contiguous storage only needs
+    // the state reset. Rank 0's free_slot and every worker's FreeSlot command
+    // call this, so a reused slot starts with no recurrent, predictor, or prefix
+    // state on any rank.
     void release_slot_paged_state(int slot_id, int& engine_position) {
-        if (!kv_paged()) return;
-        release_paged_slot(slot_id);
-        sync_block_table();
+        if (kv_paged()) {
+            release_paged_slot(slot_id);
+            sync_block_table();
+        }
+        zero_recurrent_state(slot_id);
         SlotPrefixState& prefix = prefix_for(slot_id);
         prefix.cached_prompt.clear();
         prefix.snapshots.clear();
@@ -801,6 +809,13 @@ struct QwenEngine::Impl {
         max_batch_size = options_.max_batch_size;
         batch_mode_enabled = (max_batch_size > 1);
         slot_positions.resize(max_batch_size, 0);  // Phase 3.4: per-slot positions
+        mtp_position.resize(static_cast<size_t>(max_batch_size), 0);
+        mtp_seed_input_token.resize(static_cast<size_t>(max_batch_size), 0);
+        mtp_next_token.resize(static_cast<size_t>(max_batch_size), 0);
+        mtp_next_logit.resize(static_cast<size_t>(max_batch_size), 0.0f);
+        mtp_next_checksum.resize(static_cast<size_t>(max_batch_size), 0.0f);
+        has_target_last_hidden.resize(static_cast<size_t>(max_batch_size), false);
+        mtp_seed_ready.resize(static_cast<size_t>(max_batch_size), false);
         // One prefix-reuse record per slot, sized with the KV arena.
         slot_prefix.resize(static_cast<size_t>(max_batch_size));
         // Phase 3.4: The KV arena is sized here, so the free list must be
@@ -1315,7 +1330,8 @@ struct QwenEngine::Impl {
             dspark = std::make_unique<QwenDSparkRuntime>(
                 options.dspark_checkpoint, *dspark_config, *dspark_weights,
                 embed, target_head, options.tp_world, options.tp_rank,
-                options.device, options.nccl_id_path, max_context);
+                options.device, options.nccl_id_path, max_context,
+                options.max_batch_size);
             dspark_enabled = true;
             uploaded_weight_bytes += dspark->resident_weight_bytes();
             cache_data_bytes += dspark->context_cache_bytes();
@@ -1344,7 +1360,8 @@ struct QwenEngine::Impl {
             dflash2 = std::make_unique<QwenDFlash2Runtime>(
                 options.dflash2_checkpoint, *dflash2_config, *dflash2_weights,
                 embed, target_head, options.tp_world, options.tp_rank,
-                options.device, options.nccl_id_path, max_context);
+                options.device, options.nccl_id_path, max_context,
+                options.max_batch_size);
             dflash2_enabled = true;
             uploaded_weight_bytes += dflash2->resident_weight_bytes();
             cache_data_bytes += dflash2->context_cache_bytes();
@@ -1403,9 +1420,10 @@ struct QwenEngine::Impl {
                 count_mtp_linear(*linear);
                 count_active_linear(linear->kind);
             }
-            const size_t mtp_cache_elements = static_cast<size_t>(max_context) *
-                local_kv_heads * head_dim;
+            const size_t mtp_cache_elements = static_cast<size_t>(max_batch_size) *
+                static_cast<size_t>(max_context) * local_kv_heads * head_dim;
             const std::vector<uint64_t> mtp_cache_shape = {
+                static_cast<uint64_t>(max_batch_size),
                 static_cast<uint64_t>(max_context),
                 static_cast<uint64_t>(local_kv_heads),
                 static_cast<uint64_t>(head_dim)};
@@ -1421,9 +1439,11 @@ struct QwenEngine::Impl {
                                   mtp_cache_shape, SafeDType::F8_E4M3);
                 allocate_elements(mtp_layer.full.v_cache, mtp_cache_elements,
                                   mtp_cache_shape, SafeDType::F8_E4M3);
-                const size_t scale_elements = static_cast<size_t>(max_context) *
-                    local_kv_heads * (head_dim / kKvScaleBlock);
+                const size_t scale_elements = static_cast<size_t>(max_batch_size) *
+                    static_cast<size_t>(max_context) * local_kv_heads *
+                    (head_dim / kKvScaleBlock);
                 const std::vector<uint64_t> scale_shape = {
+                    static_cast<uint64_t>(max_batch_size),
                     static_cast<uint64_t>(max_context),
                     static_cast<uint64_t>(local_kv_heads),
                     static_cast<uint64_t>(head_dim / kKvScaleBlock)};
@@ -1437,9 +1457,10 @@ struct QwenEngine::Impl {
                 // TurboQuantK8V4: one combined slot per token/head, sized
                 // from head_dim (196 bytes at 128, 388 at 256).
                 const int slot_bytes = qwen_turboquant_k8v4_slot_bytes(head_dim);
-                const size_t slot_elements = static_cast<size_t>(max_context) *
-                    local_kv_heads * slot_bytes;
+                const size_t slot_elements = static_cast<size_t>(max_batch_size) *
+                    static_cast<size_t>(max_context) * local_kv_heads * slot_bytes;
                 const std::vector<uint64_t> slot_shape = {
+                    static_cast<uint64_t>(max_batch_size),
                     static_cast<uint64_t>(max_context),
                     static_cast<uint64_t>(local_kv_heads),
                     static_cast<uint64_t>(slot_bytes)};
@@ -1457,24 +1478,26 @@ struct QwenEngine::Impl {
         return false;
     }
 
-    // Phase 3.4: Clears one slot's recurrent state. The MTP and drafter fields
-    // below are still single-session, so slot != 0 only resets the arena rows
-    // it owns; see the shared-state limits in the Phase 3.4 notes.
+    // Clears one slot's recurrent and speculative state without disturbing any
+    // other request in the batch.
     void zero_recurrent_state(int slot_id = 0) {
+        if (slot_id < 0 || slot_id >= max_batch_size) {
+            throw std::runtime_error("Qwen recurrent state slot is out of range");
+        }
         for (DeviceLayer& layer : layers) {
             if (layer.linear.state.data == nullptr) continue;
             zero_slot_region(layer.linear.state, slot_id);
             zero_slot_region(layer.linear.conv_tail, slot_id);
         }
-        if (dspark_enabled) dspark->reset();
-        if (dflash2_enabled) dflash2->reset();
-        has_target_last_hidden = false;
-        mtp_seed_ready = false;
-        mtp_position = 0;
-        mtp_seed_input_token = 0;
-        mtp_next_token = 0;
-        mtp_next_logit = 0.0f;
-        mtp_next_checksum = 0.0f;
+        if (dspark_enabled) dspark->reset(slot_id);
+        if (dflash2_enabled) dflash2->reset(slot_id);
+        has_target_last_hidden[static_cast<size_t>(slot_id)] = false;
+        mtp_seed_ready[static_cast<size_t>(slot_id)] = false;
+        mtp_position[static_cast<size_t>(slot_id)] = 0;
+        mtp_seed_input_token[static_cast<size_t>(slot_id)] = 0;
+        mtp_next_token[static_cast<size_t>(slot_id)] = 0;
+        mtp_next_logit[static_cast<size_t>(slot_id)] = 0.0f;
+        mtp_next_checksum[static_cast<size_t>(slot_id)] = 0.0f;
     }
 
     void append_transaction_region(void* data, uint64_t bytes,
@@ -1497,30 +1520,87 @@ struct QwenEngine::Impl {
         packed_offset += bytes;
     }
 
-    void initialize_packed_transaction_state() {
-        if (!host_transaction_regions.empty()) return;
+    void set_transaction_slot(int slot_id) {
+        if (slot_id < 0 || slot_id >= max_batch_size) {
+            throw std::runtime_error("Qwen transaction slot is out of range");
+        }
+        size_t region_index = 0;
+        for (DeviceLayer& layer : layers) {
+            if (layer.linear.state.data == nullptr ||
+                layer.linear.state.nbytes == 0) {
+                continue;
+            }
+            if (region_index >= host_transaction_regions.size()) {
+                throw std::runtime_error("Qwen transaction descriptor mismatch");
+            }
+            host_transaction_regions[region_index++].device_address =
+                reinterpret_cast<uint64_t>(layer.linear.state.data) +
+                recurrent_slot_offset(layer.linear.state, slot_id);
+            if (layer.linear.conv_tail.data != nullptr &&
+                layer.linear.conv_tail.nbytes != 0) {
+                if (region_index >= host_transaction_regions.size()) {
+                    throw std::runtime_error(
+                        "Qwen transaction descriptor mismatch");
+                }
+                host_transaction_regions[region_index++].device_address =
+                    reinterpret_cast<uint64_t>(layer.linear.conv_tail.data) +
+                    recurrent_slot_offset(layer.linear.conv_tail, slot_id);
+            }
+        }
+        if (mtp_enabled) {
+            if (region_index >= host_transaction_regions.size()) {
+                throw std::runtime_error("Qwen MTP transaction descriptor mismatch");
+            }
+            host_transaction_regions[region_index++].device_address =
+                reinterpret_cast<uint64_t>(target_last_hidden.data) +
+                recurrent_slot_offset(target_last_hidden, slot_id);
+        }
+        if (region_index != host_transaction_regions.size()) {
+            throw std::runtime_error("Qwen transaction descriptor count mismatch");
+        }
+        check_device(memcpy_h2d(transaction_regions.data,
+                                host_transaction_regions.data(),
+                                host_transaction_regions.size() *
+                                    sizeof(QwenCopyRegion)),
+                     "Qwen transaction descriptor update");
+    }
+
+    void initialize_packed_transaction_state(int slot_id = 0) {
+        if (!host_transaction_regions.empty()) {
+            set_transaction_slot(slot_id);
+            return;
+        }
         uint64_t packed_bytes = 0;
         transaction_total_blocks = 0;
         host_transaction_regions.reserve(layers.size() * 2 +
                                          (mtp_enabled ? 1 : 0));
         for (DeviceLayer& layer : layers) {
-            if (layer.linear.state.data == nullptr) continue;
-            // Phase 3.4: MTP rollback is single-session, so the transaction
-            // covers slot 0's rows only rather than the whole arena.
-            append_transaction_region(layer.linear.state.data,
-                                      recurrent_slot_bytes(layer.linear.state),
-                                      packed_bytes);
-            append_transaction_region(layer.linear.conv_tail.data,
-                                      recurrent_slot_bytes(layer.linear.conv_tail),
-                                      packed_bytes);
+            if (layer.linear.state.data == nullptr ||
+                layer.linear.state.nbytes == 0) continue;
+            // Snapshot one slot's recurrent rows. The descriptor addresses are
+            // rebound before every transaction so slots can interleave without
+            // copying the entire recurrent arena.
+            append_transaction_region(
+                static_cast<uint8_t*>(layer.linear.state.data) +
+                    recurrent_slot_offset(layer.linear.state, slot_id),
+                recurrent_slot_bytes(layer.linear.state), packed_bytes);
+            if (layer.linear.conv_tail.data != nullptr &&
+                layer.linear.conv_tail.nbytes != 0) {
+                append_transaction_region(
+                    static_cast<uint8_t*>(layer.linear.conv_tail.data) +
+                        recurrent_slot_offset(layer.linear.conv_tail, slot_id),
+                    recurrent_slot_bytes(layer.linear.conv_tail), packed_bytes);
+            }
         }
         if (mtp_enabled) {
-            if (!has_target_last_hidden || target_last_hidden.data == nullptr) {
+            if (!has_target_last_hidden[static_cast<size_t>(slot_id)] ||
+                target_last_hidden.data == nullptr) {
                 throw std::runtime_error(
                     "Qwen MTP transaction requires the committed target hidden");
             }
             append_transaction_region(
-                target_last_hidden.data,
+                static_cast<uint8_t*>(target_last_hidden.data) +
+                    recurrent_slot_offset(target_last_hidden, slot_id),
                 static_cast<uint64_t>(config.hidden_size) * sizeof(uint16_t),
                 packed_bytes);
         }
@@ -1542,9 +1622,9 @@ struct QwenEngine::Impl {
     // Copies the recurrent half of the network to device-resident snapshots.
     // Only the 48 DeltaNet layers carry order-dependent state; full attention
     // is skipped because its KV cache is addressed by absolute position.
-    void prepare_transaction_state() {
+    void prepare_transaction_state(int slot_id) {
         PhaseScope scope(this, "transaction_snapshot");
-        initialize_packed_transaction_state();
+        initialize_packed_transaction_state(slot_id);
         require_launch(qwen_gather_copy_regions(
             static_cast<const QwenCopyRegion*>(transaction_regions.data),
             static_cast<int>(host_transaction_regions.size()),
@@ -1553,13 +1633,14 @@ struct QwenEngine::Impl {
             "Qwen packed transaction snapshot");
     }
 
-    void restore_transaction_state(int position) {
+    void restore_transaction_state(int position, int slot_id) {
         PhaseScope scope(this, "transaction_restore");
         if (host_transaction_regions.empty() ||
             transaction_regions.data == nullptr ||
             transaction_packed.data == nullptr) {
             throw std::runtime_error("Qwen transaction state is unavailable");
         }
+        set_transaction_slot(slot_id);
         require_launch(qwen_scatter_copy_regions(
             static_cast<const QwenCopyRegion*>(transaction_regions.data),
             static_cast<int>(host_transaction_regions.size()),
@@ -1567,12 +1648,12 @@ struct QwenEngine::Impl {
             transaction_total_blocks),
             "Qwen packed transaction restore");
         if (mtp_enabled) {
-            has_target_last_hidden = true;
-            mtp_seed_ready = false;
-            mtp_position = position;
+            has_target_last_hidden[static_cast<size_t>(slot_id)] = true;
+            mtp_seed_ready[static_cast<size_t>(slot_id)] = false;
+            mtp_position[static_cast<size_t>(slot_id)] = position;
         }
-        if (dspark_enabled) dspark->crop_context(position);
-        if (dflash2_enabled) dflash2->crop_context(position);
+        if (dspark_enabled) dspark->crop_context(position, slot_id);
+        if (dflash2_enabled) dflash2->crop_context(position, slot_id);
     }
 
     QwenRecurrentSnapshot capture_recurrent_state(
@@ -1603,15 +1684,19 @@ struct QwenEngine::Impl {
                      {tail_bytes / sizeof(uint16_t)}, SafeDType::F16);
         }
         if (mtp_enabled && position > 0) {
-            if (!has_target_last_hidden || target_last_hidden.data == nullptr) {
+            if (!has_target_last_hidden[static_cast<size_t>(slot_id)] ||
+                target_last_hidden.data == nullptr) {
                 throw std::runtime_error(
                     "Qwen MTP snapshot requires the committed target hidden");
             }
             const size_t hidden_elements = static_cast<size_t>(config.hidden_size);
             allocate_half(snapshot.target_hidden, hidden_elements,
                           {config.hidden_size});
-            check_device(memcpy_d2d(snapshot.target_hidden.data, target_last_hidden.data,
-                                    hidden_elements * sizeof(uint16_t)),
+            check_device(memcpy_d2d(
+                snapshot.target_hidden.data,
+                static_cast<const uint8_t*>(target_last_hidden.data) +
+                    recurrent_slot_offset(target_last_hidden, slot_id),
+                hidden_elements * sizeof(uint16_t)),
                          "Qwen target hidden snapshot copy");
         }
         size_t state_offset = 0;
@@ -1659,32 +1744,35 @@ struct QwenEngine::Impl {
                 throw std::runtime_error(
                     "Qwen MTP snapshot target hidden extent mismatch");
             }
-            allocate_half(target_last_hidden, config.hidden_size,
-                          {config.hidden_size});
-            check_device(memcpy_d2d(target_last_hidden.data, snapshot.target_hidden.data,
-                                    hidden_bytes),
-                         "Qwen target hidden snapshot restore");
-            has_target_last_hidden = true;
-            mtp_seed_ready = false;
-            mtp_position = snapshot.position;
+            allocate_half(target_last_hidden,
+                          static_cast<size_t>(max_batch_size) * config.hidden_size,
+                          {static_cast<uint64_t>(max_batch_size), config.hidden_size});
+            check_device(memcpy_d2d(
+                static_cast<uint8_t*>(target_last_hidden.data) +
+                    recurrent_slot_offset(target_last_hidden, slot_id),
+                snapshot.target_hidden.data, hidden_bytes),
+                "Qwen target hidden snapshot restore");
+            has_target_last_hidden[static_cast<size_t>(slot_id)] = true;
+            mtp_seed_ready[static_cast<size_t>(slot_id)] = false;
+            mtp_position[static_cast<size_t>(slot_id)] = snapshot.position;
         } else if (snapshot.position == 0) {
-            has_target_last_hidden = false;
-            mtp_seed_ready = false;
-            mtp_position = 0;
+            has_target_last_hidden[static_cast<size_t>(slot_id)] = false;
+            mtp_seed_ready[static_cast<size_t>(slot_id)] = false;
+            mtp_position[static_cast<size_t>(slot_id)] = 0;
         }
         if (dspark_enabled) {
             // DSpark K/V is position-indexed like target GQA. Cropping only moves
             // the logical committed boundary; replay overwrites the suffix.
-            if (snapshot.position <= dspark->committed_position()) {
-                dspark->crop_context(snapshot.position);
+            if (snapshot.position <= dspark->committed_position(slot_id)) {
+                dspark->crop_context(snapshot.position, slot_id);
             } else {
                 throw std::runtime_error(
                     "Qwen DSpark snapshot exceeds committed context");
             }
         }
         if (dflash2_enabled) {
-            if (snapshot.position <= dflash2->committed_position()) {
-                dflash2->crop_context(snapshot.position);
+            if (snapshot.position <= dflash2->committed_position(slot_id)) {
+                dflash2->crop_context(snapshot.position, slot_id);
             } else {
                 throw std::runtime_error(
                     "Qwen DFlash2 snapshot exceeds committed context");
@@ -2624,9 +2712,13 @@ struct QwenEngine::Impl {
     }
 
     ForwardResult mtp_forward_rows(const std::vector<int>& tokens,
-                                       const uint16_t* hidden, int position) {
+                                       const uint16_t* hidden, int position,
+                                       int slot_id = 0) {
         if (!mtp_enabled) {
             throw std::runtime_error("Qwen MTP rows requested while disabled");
+        }
+        if (slot_id < 0 || slot_id >= max_batch_size) {
+            throw std::runtime_error("Qwen MTP slot is out of range");
         }
         const int rows = static_cast<int>(tokens.size());
         if (hidden == nullptr || rows <= 0 || position < 0 ||
@@ -2671,7 +2763,7 @@ struct QwenEngine::Impl {
         allocate_half(mtp_next_hidden, hidden_elements, hidden_shape);
         decoder_layer_component.forward(
             *this, mtp_layer, mtp_fused.f16_data(),
-            mtp_next_hidden.f16_data(), rows, position, 0);  // slot_id=0 for MTP
+            mtp_next_hidden.f16_data(), rows, position, slot_id);
         allocate_half(mtp_normalized_output, hidden_elements, hidden_shape);
         rms_norm_component.forward(
             *this, mtp_norm, mtp_next_hidden.f16_data(),
@@ -2679,28 +2771,32 @@ struct QwenEngine::Impl {
         const uint16_t* last_hidden = mtp_normalized_output.f16_data() +
             static_cast<size_t>(rows - 1) * hidden_size;
         ForwardResult result = mtp_logits_for(last_hidden, position + rows);
-        allocate_half(mtp_seed_hidden, hidden_size, {config.hidden_size});
+        allocate_half(mtp_seed_hidden,
+                       static_cast<size_t>(max_batch_size) * hidden_size,
+                       {static_cast<uint64_t>(max_batch_size), config.hidden_size});
         // Recursive Qwen3.5 MTP consumes the prior predictor's returned hidden,
         // and that return is after mtp.norm in both vLLM and SGLang.
-        check_device(memcpy_d2d(mtp_seed_hidden.data, last_hidden,
-                                static_cast<size_t>(hidden_size) * sizeof(uint16_t)),
-                     "Qwen MTP seed hidden copy");
-        mtp_position = position + rows;
-        mtp_seed_input_token = tokens.back();
-        mtp_next_token = result.top_token;
-        mtp_next_logit = result.top_logit;
-        mtp_next_checksum = result.checksum;
-        mtp_seed_ready = true;
+        check_device(memcpy_d2d(
+            static_cast<uint8_t*>(mtp_seed_hidden.data) +
+                recurrent_slot_offset(mtp_seed_hidden, slot_id),
+            last_hidden, static_cast<size_t>(hidden_size) * sizeof(uint16_t)),
+            "Qwen MTP seed hidden copy");
+        mtp_position[static_cast<size_t>(slot_id)] = position + rows;
+        mtp_seed_input_token[static_cast<size_t>(slot_id)] = tokens.back();
+        mtp_next_token[static_cast<size_t>(slot_id)] = result.top_token;
+        mtp_next_logit[static_cast<size_t>(slot_id)] = result.top_logit;
+        mtp_next_checksum[static_cast<size_t>(slot_id)] = result.checksum;
+        mtp_seed_ready[static_cast<size_t>(slot_id)] = true;
         return result;
     }
 
     ForwardResult mtp_forward_row(int token, const uint16_t* hidden,
-                                      int position) {
-        return mtp_forward_rows({token}, hidden, position);
+                                      int position, int slot_id = 0) {
+        return mtp_forward_rows({token}, hidden, position, slot_id);
     }
 
     ForwardResult prime_target_mtp(const std::vector<int>& shifted_tokens,
-                                       int position) {
+                                       int position, int slot_id = 0) {
         const int rows = static_cast<int>(shifted_tokens.size());
         const int hidden_size = static_cast<int>(config.hidden_size);
         if (rows <= 0 || target_hidden_rows.data == nullptr ||
@@ -2710,44 +2806,56 @@ struct QwenEngine::Impl {
                 "Qwen MTP target prime requires matching target hidden rows");
         }
         return mtp_forward_rows(shifted_tokens, target_hidden_rows.f16_data(),
-                                position);
+                                position, slot_id);
     }
 
-    ForwardResult seed_mtp(int input_token) {
-        if (!has_target_last_hidden) {
+    ForwardResult seed_mtp(int input_token, int slot_id = 0) {
+        if (!has_target_last_hidden[static_cast<size_t>(slot_id)]) {
             throw std::runtime_error(
                 "Qwen MTP seed requires a committed target hidden");
         }
-        return mtp_forward_row(input_token, target_last_hidden.f16_data(),
-                               mtp_position - 1);
+        const uint16_t* seed = reinterpret_cast<const uint16_t*>(
+            static_cast<const uint8_t*>(target_last_hidden.data) +
+            recurrent_slot_offset(target_last_hidden, slot_id));
+        return mtp_forward_row(input_token, seed,
+                               mtp_position[static_cast<size_t>(slot_id)] - 1,
+                               slot_id);
     }
 
-    void rewrite_mtp_boundary(int input_token, int position) {
-        if (!has_target_last_hidden || position < 0 || position >= max_context) {
+    void rewrite_mtp_boundary(int input_token, int position, int slot_id = 0) {
+        if (!has_target_last_hidden[static_cast<size_t>(slot_id)] ||
+            position < 0 || position >= max_context) {
             throw std::runtime_error(
                 "Qwen MTP boundary rewrite requires a committed target hidden");
         }
-        (void)mtp_forward_row(input_token, target_last_hidden.f16_data(), position);
+        const uint16_t* seed = reinterpret_cast<const uint16_t*>(
+            static_cast<const uint8_t*>(target_last_hidden.data) +
+            recurrent_slot_offset(target_last_hidden, slot_id));
+        (void)mtp_forward_row(input_token, seed, position, slot_id);
     }
 
     std::vector<int> draft_tokens(int count, int input_token,
-                                  QwenMtpStats* stats) {
+                                  QwenMtpStats* stats, int slot_id = 0) {
         if (count <= 0) return {};
         const auto started = std::chrono::steady_clock::now();
         ForwardResult next;
-        if (mtp_seed_ready && mtp_seed_input_token == input_token) {
-            next.top_token = mtp_next_token;
-            next.top_logit = mtp_next_logit;
-            next.checksum = mtp_next_checksum;
+        const size_t slot = static_cast<size_t>(slot_id);
+        if (mtp_seed_ready[slot] && mtp_seed_input_token[slot] == input_token) {
+            next.top_token = mtp_next_token[slot];
+            next.top_logit = mtp_next_logit[slot];
+            next.checksum = mtp_next_checksum[slot];
         } else {
-            next = seed_mtp(input_token);
+            next = seed_mtp(input_token, slot_id);
         }
         std::vector<int> drafts;
         drafts.reserve(static_cast<size_t>(count));
         drafts.push_back(next.top_token);
         while (static_cast<int>(drafts.size()) < count) {
+            const uint16_t* seed = reinterpret_cast<const uint16_t*>(
+                static_cast<const uint8_t*>(mtp_seed_hidden.data) +
+                recurrent_slot_offset(mtp_seed_hidden, slot_id));
             next = mtp_forward_row(
-                drafts.back(), mtp_seed_hidden.f16_data(), mtp_position);
+                drafts.back(), seed, mtp_position[slot], slot_id);
             drafts.push_back(next.top_token);
         }
         if (stats != nullptr) {
@@ -2759,14 +2867,15 @@ struct QwenEngine::Impl {
     }
 
     ForwardResult dflash2_speculative_step(int input_token,
-                                               QwenMtpStats* stats) {
+                                               QwenMtpStats* stats,
+                                               int slot_id = 0) {
         if (!dflash2_enabled) {
             throw std::runtime_error("Qwen DFlash2 speculative step is disabled");
         }
-        const int committed_position = dflash2->committed_position();
-        prepare_transaction_state();
+        const int committed_position = dflash2->committed_position(slot_id);
+        prepare_transaction_state(slot_id);
         const auto draft_started = std::chrono::steady_clock::now();
-        const QwenDFlash2Proposal proposal = dflash2->propose(input_token);
+        const QwenDFlash2Proposal proposal = dflash2->propose(input_token, slot_id);
         // The 48 gated-delta layers recur sequentially across verify rows, so a
         // verify block costs close to linearly in its width. When acceptance runs
         // well below the full seven drafts the tail rows are paid for and then
@@ -2800,7 +2909,8 @@ struct QwenEngine::Impl {
         QwenVerifyBatch verify;
         const auto verify_started = std::chrono::steady_clock::now();
         (void)run_chunk(verify_inputs, committed_position,
-                        static_cast<int>(layers.size()), false, &verify);
+                        static_cast<int>(layers.size()), false, &verify,
+                        nullptr, slot_id);
         if (stats != nullptr) {
             stats->verify_seconds += std::chrono::duration<double>(
                 std::chrono::steady_clock::now() - verify_started).count();
@@ -2838,11 +2948,12 @@ struct QwenEngine::Impl {
                 stats->replay_tokens += static_cast<uint64_t>(correct + 1);
             }
             const auto replay_started = std::chrono::steady_clock::now();
-            restore_transaction_state(committed_position);
+            restore_transaction_state(committed_position, slot_id);
             std::vector<int> replay(verify_inputs.begin(),
                                     verify_inputs.begin() + correct + 1);
             (void)run_chunk(replay, committed_position,
-                            static_cast<int>(layers.size()), false);
+                            static_cast<int>(layers.size()), false, nullptr,
+                            nullptr, slot_id);
             if (stats != nullptr) {
                 stats->replay_seconds += std::chrono::duration<double>(
                     std::chrono::steady_clock::now() - replay_started).count();
@@ -2852,6 +2963,8 @@ struct QwenEngine::Impl {
         result.top_token = bonus;
         result.bonus_token = bonus;
         result.correct_drafts = correct;
+        result.proposed_drafts = static_cast<int>(draft_tokens_used.size());
+        result.rolled_back = correct != static_cast<int>(draft_tokens_used.size());
         result.accept_tokens.assign(draft_tokens_used.begin(),
                                     draft_tokens_used.begin() + correct);
         result.accept_logits.assign(verify.top_logits.begin(),
@@ -2863,22 +2976,23 @@ struct QwenEngine::Impl {
         result.logits = static_cast<int>(config.vocab_size);
         result.top_logit = bonus_logit;
         result.checksum = bonus_checksum;
-        result.position = dflash2->committed_position();
+        result.position = dflash2->committed_position(slot_id);
         return result;
     }
 
     ForwardResult dspark_speculative_step(int input_token,
-                                              QwenMtpStats* stats) {
+                                              QwenMtpStats* stats,
+                                              int slot_id = 0) {
         if (!dspark_enabled) {
             throw std::runtime_error("Qwen DSpark speculative step is disabled");
         }
-        const int committed_position = dspark->committed_position();
-        prepare_transaction_state();
+        const int committed_position = dspark->committed_position(slot_id);
+        prepare_transaction_state(slot_id);
         const auto draft_started = std::chrono::steady_clock::now();
         QwenDSparkProposal proposal;
         {
             RangeScope scope("qwen.dspark.draft");
-            proposal = dspark->propose(input_token);
+            proposal = dspark->propose(input_token, slot_id);
         }
         if (stats != nullptr) {
             stats->draft_seconds += std::chrono::duration<double>(
@@ -2912,7 +3026,8 @@ struct QwenEngine::Impl {
         {
             RangeScope scope("qwen.target.verify");
             (void)run_chunk(verify_inputs, committed_position,
-                            static_cast<int>(layers.size()), false, &verify);
+                            static_cast<int>(layers.size()), false, &verify,
+                            nullptr, slot_id);
         }
         if (stats != nullptr) {
             stats->verify_seconds += std::chrono::duration<double>(
@@ -2936,11 +3051,12 @@ struct QwenEngine::Impl {
                 stats->replay_tokens += static_cast<uint64_t>(correct + 1);
             }
             const auto replay_started = std::chrono::steady_clock::now();
-            restore_transaction_state(committed_position);
+            restore_transaction_state(committed_position, slot_id);
             std::vector<int> replay(verify_inputs.begin(),
                                     verify_inputs.begin() + correct + 1);
             (void)run_chunk(replay, committed_position,
-                            static_cast<int>(layers.size()), false);
+                            static_cast<int>(layers.size()), false, nullptr,
+                            nullptr, slot_id);
             if (stats != nullptr) {
                 stats->replay_seconds += std::chrono::duration<double>(
                     std::chrono::steady_clock::now() - replay_started).count();
@@ -2950,6 +3066,8 @@ struct QwenEngine::Impl {
         result.top_token = bonus;
         result.bonus_token = bonus;
         result.correct_drafts = correct;
+        result.proposed_drafts = static_cast<int>(proposal.tokens.size());
+        result.rolled_back = correct != static_cast<int>(proposal.tokens.size());
         result.accept_tokens.assign(proposal.tokens.begin(),
                                     proposal.tokens.begin() + correct);
         result.accept_logits.assign(verify.top_logits.begin(),
@@ -2961,19 +3079,22 @@ struct QwenEngine::Impl {
         result.logits = static_cast<int>(config.vocab_size);
         result.top_logit = bonus_logit;
         result.checksum = bonus_checksum;
-        result.position = dspark->committed_position();
+        result.position = dspark->committed_position(slot_id);
         return result;
     }
 
     ForwardResult speculative_step(int input_token, int draft_count,
-                                       QwenMtpStats* stats) {
+                                       QwenMtpStats* stats, int slot_id = 0) {
         if (!mtp_enabled || draft_count <= 0) {
-            return run_chunk({input_token}, mtp_position,
-                             static_cast<int>(layers.size()), true);
+            return run_chunk({input_token},
+                             mtp_position[static_cast<size_t>(slot_id)],
+                             static_cast<int>(layers.size()), true, nullptr,
+                             nullptr, slot_id);
         }
-        const int committed_position = mtp_position;
-        prepare_transaction_state();
-        const std::vector<int> drafts = draft_tokens(draft_count, input_token, stats);
+        const int committed_position = mtp_position[static_cast<size_t>(slot_id)];
+        prepare_transaction_state(slot_id);
+        const std::vector<int> drafts = draft_tokens(draft_count, input_token, stats,
+                                                     slot_id);
         std::vector<int> verify_inputs;
         verify_inputs.reserve(drafts.size() + 1);
         verify_inputs.push_back(input_token);
@@ -2981,7 +3102,8 @@ struct QwenEngine::Impl {
         QwenVerifyBatch verify;
         const auto verify_started = std::chrono::steady_clock::now();
         (void)run_chunk(verify_inputs, committed_position,
-                        static_cast<int>(layers.size()), false, &verify);
+                        static_cast<int>(layers.size()), false, &verify,
+                        nullptr, slot_id);
         if (stats != nullptr) {
             stats->verify_seconds += std::chrono::duration<double>(
                 std::chrono::steady_clock::now() - verify_started).count();
@@ -3007,11 +3129,12 @@ struct QwenEngine::Impl {
                 stats->replay_tokens += static_cast<uint64_t>(correct + 1);
             }
             const auto replay_started = std::chrono::steady_clock::now();
-            restore_transaction_state(committed_position);
+            restore_transaction_state(committed_position, slot_id);
             std::vector<int> replay(verify_inputs.begin(),
                                     verify_inputs.begin() + correct + 1);
             (void)run_chunk(replay, committed_position,
-                            static_cast<int>(layers.size()), false);
+                            static_cast<int>(layers.size()), false, nullptr,
+                            nullptr, slot_id);
             if (stats != nullptr) {
                 stats->replay_seconds += std::chrono::duration<double>(
                     std::chrono::steady_clock::now() - replay_started).count();
@@ -3021,7 +3144,7 @@ struct QwenEngine::Impl {
         // this fills the one row beyond the recursively proposed drafts; on
         // rejection it overwrites the stale speculative suffix after replay.
         const auto seed_started = std::chrono::steady_clock::now();
-        rewrite_mtp_boundary(bonus, committed_position + correct);
+        rewrite_mtp_boundary(bonus, committed_position + correct, slot_id);
         if (stats != nullptr) {
             stats->draft_seconds += std::chrono::duration<double>(
                 std::chrono::steady_clock::now() - seed_started).count();
@@ -3033,6 +3156,8 @@ struct QwenEngine::Impl {
         result.top_token = bonus;
         result.bonus_token = bonus;
         result.correct_drafts = correct;
+        result.proposed_drafts = draft_count;
+        result.rolled_back = !full_accept;
         result.accept_tokens.assign(drafts.begin(), drafts.begin() + correct);
         result.accept_logits.assign(verify.top_logits.begin(),
                                     verify.top_logits.begin() + correct);
@@ -3043,8 +3168,124 @@ struct QwenEngine::Impl {
         result.logits = static_cast<int>(config.vocab_size);
         result.top_logit = bonus_logit;
         result.checksum = bonus_checksum;
-        result.position = mtp_position;
+        result.position = mtp_position[static_cast<size_t>(slot_id)];
         return result;
+    }
+
+    std::vector<ForwardResult> batch_speculative_tokens(
+        const std::vector<int>& tokens, const std::vector<int>& slot_ids,
+        const std::vector<int>& draft_counts, QwenMtpStats* stats) {
+        if (tokens.empty() || tokens.size() != slot_ids.size() ||
+            tokens.size() != draft_counts.size()) {
+            throw std::runtime_error(
+                "Qwen batched speculative row metadata has mismatched extents");
+        }
+        // Validate the complete batch before reserving any paged blocks or
+        // mutating recurrent state. A malformed later row must fail atomically
+        // with respect to the earlier rows.
+        for (size_t row = 0; row < tokens.size(); ++row) {
+            const int slot_id = slot_ids[row];
+            if (slot_id < 0 || slot_id >= max_batch_size) {
+                throw std::runtime_error(
+                    "Qwen batched speculative slot is out of range");
+            }
+            for (size_t earlier = 0; earlier < row; ++earlier) {
+                if (slot_ids[earlier] == slot_id) {
+                    throw std::runtime_error(
+                        "Qwen batched speculative slot appears twice in one batch");
+                }
+            }
+            const int draft_count = draft_counts[row];
+            if (draft_count < 0) {
+                throw std::runtime_error(
+                    "Qwen batched speculative draft count is negative");
+            }
+            if (draft_count > 0 && !options.mtp && !dspark_enabled &&
+                !dflash2_enabled) {
+                throw std::runtime_error(
+                    "Qwen batched speculative decode is disabled");
+            }
+            const int position = slot_position(
+                slot_id, slot_positions[static_cast<size_t>(slot_id)]);
+            const int proposal_width = draft_count > 0
+                ? (options.mtp
+                       ? draft_count
+                       : dspark_enabled
+                             ? dspark_config->block_size
+                             : dflash2_config->draft_tokens())
+                : 0;
+            if (position < 0 || position + 1 + proposal_width > max_context) {
+                throw std::runtime_error(
+                    "Qwen batched speculative context length exceeded");
+            }
+        }
+
+        std::vector<ForwardResult> results;
+        results.reserve(tokens.size());
+        for (size_t row = 0; row < tokens.size(); ++row) {
+            const int slot_id = slot_ids[row];
+            if (slot_id < 0 || slot_id >= max_batch_size) {
+                throw std::runtime_error(
+                    "Qwen batched speculative slot is out of range");
+            }
+            for (size_t earlier = 0; earlier < row; ++earlier) {
+                if (slot_ids[earlier] == slot_id) {
+                    throw std::runtime_error(
+                        "Qwen batched speculative slot appears twice in one batch");
+                }
+            }
+            const int draft_count = draft_counts[row];
+            if (draft_count < 0) {
+                throw std::runtime_error(
+                    "Qwen batched speculative draft count is negative");
+            }
+            if (draft_count > 0 && !options.mtp && !dspark_enabled &&
+                !dflash2_enabled) {
+                throw std::runtime_error(
+                    "Qwen batched speculative decode is disabled");
+            }
+            const int position = slot_position(
+                slot_id, slot_positions[static_cast<size_t>(slot_id)]);
+            const int proposal_width = draft_count > 0
+                ? (options.mtp
+                       ? draft_count
+                       : dspark_enabled
+                             ? dspark_config->block_size
+                             : dflash2_config->draft_tokens())
+                : 0;
+            if (position < 0 || position + 1 + proposal_width > max_context) {
+                throw std::runtime_error(
+                    "Qwen batched speculative context length exceeded");
+            }
+            reserve_paged_slot(slot_id, position + 1 + proposal_width);
+            sync_block_table();
+            ForwardResult forward;
+            if (draft_count <= 0) {
+                forward = run_chunk(
+                    {tokens[row]}, position, static_cast<int>(layers.size()),
+                    true, nullptr, nullptr, slot_id);
+            } else if (options.mtp) {
+                forward = speculative_step(
+                    tokens[row], draft_count, stats, slot_id);
+            } else if (dspark_enabled) {
+                forward = dspark_speculative_step(
+                    tokens[row], stats, slot_id);
+            } else if (dflash2_enabled) {
+                forward = dflash2_speculative_step(
+                    tokens[row], stats, slot_id);
+            } else {
+                throw std::runtime_error(
+                    "Qwen batched speculative decode is disabled");
+            }
+            if (forward.position <= position || forward.position > max_context) {
+                throw std::runtime_error(
+                    "Qwen batched speculative step returned an invalid position");
+            }
+            trim_paged_slot(slot_id, forward.position);
+            slot_positions[static_cast<size_t>(slot_id)] = forward.position;
+            results.push_back(std::move(forward));
+        }
+        return results;
     }
 
     uint64_t weights_vocab_start() const {
@@ -3147,32 +3388,32 @@ struct QwenEngine::Impl {
             if (dspark_tap_index != dspark_tap_count) {
                 throw std::runtime_error("Qwen DSpark target taps were not captured");
             }
-            if (dspark->committed_position() != position_offset) {
-                if (position_offset <= dspark->committed_position()) {
-                    dspark->crop_context(position_offset);
+            if (dspark->committed_position(slot_id) != position_offset) {
+                if (position_offset <= dspark->committed_position(slot_id)) {
+                    dspark->crop_context(position_offset, slot_id);
                 } else {
                     throw std::runtime_error(
                         "Qwen DSpark target context has a position gap");
                 }
             }
             dspark->append_target_taps(dspark_target_taps.f16_data(), rows,
-                                       position_offset);
+                                       position_offset, slot_id);
         }
         if (dflash2_tap_layers != nullptr) {
             if (dflash2_tap_index != dflash2_tap_count) {
                 throw std::runtime_error("Qwen DFlash2 target taps were not captured");
             }
             if (dflash2_enabled) {
-                if (dflash2->committed_position() != position_offset) {
-                    if (position_offset <= dflash2->committed_position()) {
-                        dflash2->crop_context(position_offset);
+                if (dflash2->committed_position(slot_id) != position_offset) {
+                    if (position_offset <= dflash2->committed_position(slot_id)) {
+                        dflash2->crop_context(position_offset, slot_id);
                     } else {
                         throw std::runtime_error(
                             "Qwen DFlash2 target context has a position gap");
                     }
                 }
                 dflash2->append_target_taps(dflash2_target_taps.f16_data(), rows,
-                                            position_offset);
+                                            position_offset, slot_id);
             } else if (dflash2_target_debug_callback) {
                 QwenDFlash2DebugTensor tensor;
                 tensor.name = "target_taps";
@@ -3192,21 +3433,26 @@ struct QwenEngine::Impl {
             rms_norm_component.forward(
                 *this, final_norm, hidden, target_hidden_rows.f16_data(), rows,
                 hidden_size);
-            allocate_half(target_last_hidden, hidden_size,
-                          {config.hidden_size});
-            check_device(memcpy_d2d(target_last_hidden.data,
-                                    target_hidden_rows.f16_data() + static_cast<size_t>(rows - 1) * hidden_size,
-                                    static_cast<size_t>(hidden_size) * sizeof(uint16_t)),
-                         "Qwen target last hidden copy");
-            has_target_last_hidden = true;
-            mtp_seed_ready = false;
-            mtp_position = position_offset + rows;
+            allocate_half(target_last_hidden,
+                          static_cast<size_t>(max_batch_size) * hidden_size,
+                          {static_cast<uint64_t>(max_batch_size), config.hidden_size});
+            check_device(memcpy_d2d(
+                static_cast<uint8_t*>(target_last_hidden.data) +
+                    recurrent_slot_offset(target_last_hidden, slot_id),
+                target_hidden_rows.f16_data() +
+                    static_cast<size_t>(rows - 1) * hidden_size,
+                static_cast<size_t>(hidden_size) * sizeof(uint16_t)),
+                "Qwen target last hidden copy");
+            has_target_last_hidden[static_cast<size_t>(slot_id)] = true;
+            mtp_seed_ready[static_cast<size_t>(slot_id)] = false;
+            mtp_position[static_cast<size_t>(slot_id)] = position_offset + rows;
             if (mtp_shifted_tokens != nullptr) {
                 if (mtp_shifted_tokens->size() != token_ids.size()) {
                     throw std::runtime_error(
                         "Qwen MTP shifted-token extent does not match target rows");
                 }
-                (void)prime_target_mtp(*mtp_shifted_tokens, position_offset);
+                (void)prime_target_mtp(*mtp_shifted_tokens, position_offset,
+                                        slot_id);
             }
         }
         if (verify_batch != nullptr) {
@@ -3412,6 +3658,9 @@ QwenEngine::QwenEngine(const std::string& ckpt_dir,
     if (options_.prefill_chunk_tokens <= 0) {
         throw std::runtime_error("Qwen prefill chunk size must be positive");
     }
+    if (options_.max_batch_size <= 0) {
+        throw std::runtime_error("Qwen max batch size must be positive");
+    }
     if (options_.attention_window < 0 || options_.attention_sink_tokens < 0) {
         throw std::runtime_error("Qwen attention window and sink must not be negative");
     }
@@ -3425,6 +3674,10 @@ QwenEngine::QwenEngine(const std::string& ckpt_dir,
             "Qwen sparse attention currently requires an FP16 KV cache");
     }
     if (options_.kv_paged) {
+        if (options_.mtp) {
+            throw std::runtime_error(
+                "Qwen paged KV cache is not supported with native MTP");
+        }
         if (options_.kv_cache_dtype == QwenKvCacheDType::Int8PerTokenHead) {
             throw std::runtime_error(
                 "Qwen paged KV cache does not support int8_per_token_head");
@@ -3598,12 +3851,15 @@ Capabilities QwenEngine::caps() const {
     // batch_prefill honours its token budget on every configuration.
     c.chunked_prefill = true;
     c.max_slots = options_.max_batch_size;
-    // Per-request sampling is supported: each BatchedRequest carries its own
-    // BatchSamplingParams and batch_decode_step extracts them before the
-    // sampler runs. Rows with matching params take the fast batched path;
-    // rows that differ are sampled one at a time (rows=1 per kernel call).
-    c.per_request_sampling = true;
-    c.per_request_top_k = true;
+    // Plain batched decode applies each row's sampling parameters in a
+    // single-process engine. Under TP, all ranks must enter the same sampler
+    // collectives; the worker command therefore carries no sampling metadata,
+    // so rows must use the engine-wide values there.
+    const bool speculative = options_.mtp ||
+        !options_.dspark_checkpoint.empty() ||
+        !options_.dflash2_checkpoint.empty();
+    c.per_request_sampling = !speculative && options_.tp_world <= 1;
+    c.per_request_top_k = !speculative && options_.tp_world <= 1;
     c.fixed_temperature = options_.temperature;
     c.fixed_top_p = options_.top_p;
     c.fixed_top_k = options_.top_k;
@@ -3703,10 +3959,9 @@ void QwenEngine::free_slot(uint64_t request_id) {
     // capacity dynamic: the next request draws from a pool the finished one has
     // already given back, rather than inheriting a fixed reservation.
     //
-    // Under TP the workers hold their own copies of the block table, so they
-    // have to release the same slot too or their pools leak one row per freed
-    // slot and eventually run out. The command is a no-op unless a channel
-    // exists and paging is on, which keeps the contiguous path unchanged.
+    // Under TP the workers hold their own recurrent and cache state, so they
+    // have to clear the same slot too. Paging additionally requires releasing
+    // the worker's block-table row or its pool leaks one row per freed slot.
     impl_->release_slot_paged_state(slot_id, position_);
     worker_command_free_slot(slot_id);
 }
@@ -3728,12 +3983,22 @@ BatchPrefillResult QwenEngine::batch_prefill(
     result.total_tokens = 0;
 
     auto start = std::chrono::steady_clock::now();
-
-    for (BatchedRequest* req : requests) {
+    std::vector<int> seen_slots;
+    seen_slots.reserve(requests.size());
+    for (const BatchedRequest* req : requests) {
         if (!req || req->prompt_tokens.empty()) {
             throw std::runtime_error("QwenEngine::batch_prefill: invalid request");
         }
+        if (req->slot_id < 0 || req->slot_id >= impl_->max_batch_size ||
+            std::find(seen_slots.begin(), seen_slots.end(), req->slot_id) !=
+                seen_slots.end()) {
+            throw std::runtime_error(
+                "QwenEngine::batch_prefill: slots must be distinct and in range");
+        }
+        seen_slots.push_back(req->slot_id);
+    }
 
+    for (BatchedRequest* req : requests) {
         // Under TP the workers sit in run_worker_loop() waiting to be told which
         // collective to join; rank 0 must announce the op before running it, or
         // the group deadlocks with rank 0 computing alone.  No-op at world size 1.
@@ -3793,6 +4058,10 @@ std::vector<ForwardResult> QwenEngine::batch_decode_tokens(
     std::vector<int> positions(static_cast<size_t>(rows));
     for (int row = 0; row < rows; ++row) {
         const int slot = slot_ids[static_cast<size_t>(row)];
+        if (slot < 0 || slot >= impl_->max_batch_size) {
+            throw std::runtime_error(
+                "QwenEngine::batch_decode_tokens: slot is out of range");
+        }
         for (int earlier = 0; earlier < row; ++earlier) {
             if (slot_ids[static_cast<size_t>(earlier)] == slot) {
                 throw std::runtime_error(
@@ -3848,6 +4117,37 @@ std::vector<ForwardResult> QwenEngine::batch_decode_tokens(
     return results;
 }
 
+std::vector<ForwardResult> QwenEngine::batch_speculative_tokens(
+    const std::vector<int>& tokens, const std::vector<int>& slot_ids,
+    const std::vector<int>& draft_counts) {
+    if (tokens.size() != slot_ids.size() ||
+        tokens.size() != draft_counts.size()) {
+        throw std::runtime_error(
+            "QwenEngine::batch_speculative_tokens: row extents differ");
+    }
+    if (tokens.empty()) return {};
+    std::vector<ForwardResult> results = impl_->batch_speculative_tokens(
+        tokens, slot_ids, draft_counts, &mtp_stats_);
+    for (size_t index = 0; index < results.size(); ++index) {
+        const int slot = slot_ids[index];
+        impl_->set_slot_position(slot, results[index].position, position_);
+        if (options_.prefix_cache) {
+            Impl::SlotPrefixState& prefix = impl_->prefix_for(slot);
+            prefix.cached_prompt.push_back(tokens[index]);
+            prefix.cached_prompt.insert(prefix.cached_prompt.end(),
+                                        results[index].accept_tokens.begin(),
+                                        results[index].accept_tokens.end());
+            prefix.cached_result = results[index];
+            prefix.has_cached_result = true;
+            if (impl_->is_periodic_snapshot_position(results[index].position)) {
+                impl_->record_snapshot(results[index].position, &results[index],
+                                       true, slot);
+            }
+        }
+    }
+    return results;
+}
+
 bool QwenEngine::is_stop_token(const BatchSamplingParams& sampling,
                                int token) const {
     if (sampling.ignore_eos) return false;
@@ -3879,24 +4179,135 @@ BatchDecodeResult QwenEngine::batch_decode_step(
         if (!req) {
             throw std::runtime_error("QwenEngine::batch_decode_step: null request");
         }
+        if (req->slot_id < 0 || req->slot_id >= impl_->max_batch_size) {
+            throw std::runtime_error(
+                "QwenEngine::batch_decode_step: slot is out of range");
+        }
+        if (std::find(slots.begin(), slots.end(), req->slot_id) != slots.end()) {
+            throw std::runtime_error(
+                "QwenEngine::batch_decode_step: slot appears twice in one batch");
+        }
         tokens.push_back(req->last_token);
         slots.push_back(req->slot_id);
     }
+
+    const bool speculative = options_.mtp ||
+        !options_.dspark_checkpoint.empty() ||
+        !options_.dflash2_checkpoint.empty();
+    if (speculative) {
+        // The current speculative verifier is greedy: acceptance compares each
+        // draft with target argmax and the bonus is also an argmax. Do not
+        // silently ignore per-request sampling parameters until a sampled
+        // speculative verifier exists.
+        for (const BatchedRequest* req : requests) {
+            if (std::abs(req->sampling.temperature - options_.temperature) >
+                    1.0e-5f ||
+                std::abs(req->sampling.top_p - options_.top_p) > 1.0e-5f ||
+                req->sampling.top_k != options_.top_k ||
+                req->sampling.seed != options_.sampling_seed) {
+                throw std::runtime_error(
+                    "Qwen speculative batch decode does not support per-request "
+                    "sampling parameters");
+            }
+        }
+        std::vector<int> draft_counts;
+        draft_counts.reserve(requests.size());
+        for (const BatchedRequest* req : requests) {
+            const int remaining = req->sampling.max_new_tokens -
+                static_cast<int>(req->generated_tokens.size());
+            int count = 0;
+            if (remaining > 1) {
+                if (options_.mtp) {
+                    count = std::min(std::max(1, options_.mtp_speculative_tokens),
+                                     remaining - 1);
+                } else if (remaining >= 8) {
+                    // External Qwen drafters are trained for their fixed block;
+                    // use plain decode for the short tail rather than consuming
+                    // a block that would exceed the request's length cap.
+                    count = 1;
+                }
+            }
+            draft_counts.push_back(count);
+        }
+        worker_command_batch_speculative(tokens, slots, draft_counts);
+        std::vector<ForwardResult> forwards = batch_speculative_tokens(
+            tokens, slots, draft_counts);
+        for (size_t index = 0; index < requests.size(); ++index) {
+            BatchedRequest* req = requests[index];
+            ForwardResult& forward = forwards[index];
+            std::vector<int> emitted;
+            if (forward.proposed_drafts > 0) {
+                emitted = forward.accept_tokens;
+                emitted.push_back(forward.bonus_token);
+            } else {
+                emitted.push_back(forward.top_token);
+            }
+            bool stopped = false;
+            for (size_t token_index = 0; token_index < emitted.size();
+                 ++token_index) {
+                if (is_stop_token(req->sampling, emitted[token_index])) {
+                    emitted.resize(token_index + 1);
+                    stopped = true;
+                    break;
+                }
+            }
+            req->last_token = emitted.back();
+            req->last_result = forward;
+            req->seq_len += forward.proposed_drafts > 0
+                ? 1 + forward.correct_drafts : 1;
+            req->generated_tokens.insert(req->generated_tokens.end(),
+                                         emitted.begin(), emitted.end());
+            const bool capped = static_cast<int>(req->generated_tokens.size()) >=
+                                req->sampling.max_new_tokens;
+            req->finished = stopped || capped;
+            result.next_tokens.push_back(req->last_token);
+            result.finished.push_back(req->finished);
+            result.hit_stop_token.push_back(stopped);
+            result.emitted_tokens.push_back(std::move(emitted));
+            result.position_advances.push_back(
+                forward.proposed_drafts > 0 ? 1 + forward.correct_drafts : 1);
+            result.proposed_drafts.push_back(forward.proposed_drafts);
+            result.accepted_drafts.push_back(forward.correct_drafts);
+            result.used_speculative.push_back(forward.proposed_drafts > 0);
+            result.rolled_back.push_back(forward.rolled_back);
+        }
+        result.seconds = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - start).count();
+        return result;
+    }
+
+    // Collect per-request sampling params before announcing the operation. In a
+    // TP run, workers receive only the batch tokens and slots and therefore use
+    // the engine-wide sampler settings. Passing a non-null row-parameter pointer
+    // on rank 0 would take the sampling collective path while workers took the
+    // greedy top-1 path, leaving the ranks permanently out of step even when
+    // every request used the same greedy settings.
+    std::vector<BatchSamplingParams> row_params;
+    row_params.reserve(requests.size());
+    bool rows_differ_from_engine = false;
+    for (const BatchedRequest* req : requests) {
+        row_params.push_back(req->sampling);
+        rows_differ_from_engine |=
+            std::abs(req->sampling.temperature - options_.temperature) > 1.0e-5f ||
+            std::abs(req->sampling.top_p - options_.top_p) > 1.0e-5f ||
+            req->sampling.top_k != options_.top_k ||
+            req->sampling.seed != options_.sampling_seed;
+    }
+    if (options_.tp_world > 1 && rows_differ_from_engine) {
+        throw std::runtime_error(
+            "Qwen TP batched decode requires per-request sampling to match "
+            "the engine options");
+    }
+    const std::vector<BatchSamplingParams>* decode_params =
+        options_.tp_world > 1 ? nullptr : &row_params;
 
     // One forward for the whole batch. Under TP the workers sit in
     // run_worker_loop() waiting to be told which collective to join, so rank 0
     // announces the batch before running it or the group deadlocks with rank 0
     // computing alone. No-op at world size 1.
     worker_command_batch_decode(tokens, slots);
-    // Collect per-request sampling params so the sampler can honour each
-    // request's own temperature/top_k/top_p rather than the engine default.
-    std::vector<BatchSamplingParams> row_params;
-    row_params.reserve(requests.size());
-    for (const BatchedRequest* req : requests) {
-        row_params.push_back(req->sampling);
-    }
-    std::vector<ForwardResult> forwards = batch_decode_tokens(tokens, slots,
-                                                              &row_params);
+    std::vector<ForwardResult> forwards = batch_decode_tokens(
+        tokens, slots, decode_params);
 
     for (size_t index = 0; index < requests.size(); ++index) {
         BatchedRequest* req = requests[index];
@@ -4054,7 +4465,7 @@ PartialPrefillResult QwenEngine::prefill_bounded(
         // new suffix so every predictor row observes target h[S-1] + new x[S].
         impl_->rewrite_mtp_boundary(
             token_ids[static_cast<size_t>(start_position)],
-            start_position - 1);
+            start_position - 1, slot_id);
     }
     ForwardResult result;
     // A budget both caps how far this call advances and shrinks the chunk, since
@@ -4113,7 +4524,7 @@ PartialPrefillResult QwenEngine::prefill_bounded(
                 result = impl_->run_chunk(chunk, offset, active_layers_, true,
                                           nullptr, nullptr, slot_id);
                 shifted.back() = result.top_token;
-                (void)impl_->prime_target_mtp(shifted, offset);
+                (void)impl_->prime_target_mtp(shifted, offset, slot_id);
             } else {
                 result = impl_->run_chunk(chunk, offset, active_layers_,
                                           snapshot_result, nullptr, &shifted, slot_id);
@@ -4418,6 +4829,28 @@ void QwenEngine::run_worker_loop() {
                 (void)batch_decode_tokens(batch_tokens, batch_slots);
                 break;
             }
+            case WorkerCommand::BatchSpeculativeStep: {
+                const int batch_rows = static_cast<int>(header[1]);
+                if (batch_rows <= 0 ||
+                    tokens.size() != static_cast<size_t>(batch_rows) * 3) {
+                    throw std::runtime_error(
+                        "run_worker_loop: malformed batched speculative payload");
+                }
+                std::vector<int> batch_tokens(static_cast<size_t>(batch_rows));
+                std::vector<int> batch_slots(static_cast<size_t>(batch_rows));
+                std::vector<int> draft_counts(static_cast<size_t>(batch_rows));
+                for (int row = 0; row < batch_rows; ++row) {
+                    batch_tokens[static_cast<size_t>(row)] =
+                        tokens[static_cast<size_t>(row) * 3];
+                    batch_slots[static_cast<size_t>(row)] =
+                        tokens[static_cast<size_t>(row) * 3 + 1];
+                    draft_counts[static_cast<size_t>(row)] =
+                        tokens[static_cast<size_t>(row) * 3 + 2];
+                }
+                (void)batch_speculative_tokens(
+                    batch_tokens, batch_slots, draft_counts);
+                break;
+            }
             case WorkerCommand::Reset:
                 reset();
                 break;
@@ -4513,6 +4946,45 @@ void QwenEngine::worker_command_batch_decode(
     impl_->cmd->send_to_workers(payload.data(), payload.size());
 }
 
+void QwenEngine::worker_command_batch_speculative(
+    const std::vector<int>& tokens, const std::vector<int>& slot_ids,
+    const std::vector<int>& draft_counts) {
+    if (options_.tp_world <= 1) return;
+    if (options_.tp_rank != 0) {
+        throw std::runtime_error(
+            "worker_command_batch_speculative: rank 0 only");
+    }
+    if (!impl_->cmd) {
+        throw std::runtime_error(
+            "worker_command_batch_speculative: command channel not initialized "
+            "(call warmup_tp first)");
+    }
+    if (tokens.size() != slot_ids.size() ||
+        tokens.size() != draft_counts.size()) {
+        throw std::runtime_error(
+            "worker_command_batch_speculative: row extents differ");
+    }
+    if (tokens.empty()) return;
+
+    const int32_t rows = static_cast<int32_t>(tokens.size());
+    int32_t header[4] = {
+        static_cast<int32_t>(WorkerCommand::BatchSpeculativeStep),
+        rows,
+        0,
+        rows * 3
+    };
+    impl_->cmd->send_to_workers(header, 4);
+
+    std::vector<int32_t> payload(static_cast<size_t>(rows) * 3);
+    for (int32_t row = 0; row < rows; ++row) {
+        const size_t offset = static_cast<size_t>(row) * 3;
+        payload[offset] = tokens[static_cast<size_t>(row)];
+        payload[offset + 1] = slot_ids[static_cast<size_t>(row)];
+        payload[offset + 2] = draft_counts[static_cast<size_t>(row)];
+    }
+    impl_->cmd->send_to_workers(payload.data(), payload.size());
+}
+
 void QwenEngine::worker_command_reset() {
     if (options_.tp_world <= 1) return;
     if (options_.tp_rank != 0) {
@@ -4556,11 +5028,8 @@ void QwenEngine::worker_command_free_slot(int32_t slot_id) {
     if (options_.tp_rank != 0) {
         throw std::runtime_error("worker_command_free_slot: rank 0 only");
     }
-    // Contiguous arena: a slot already owns max_context implicitly, so there is
-    // no per-slot block state for a worker to release. A worker's position and
-    // prefix state are re-derived at the next prefill on that slot, so leaving
-    // the command unsent keeps the non-paged path byte-for-byte unchanged.
-    if (!impl_->kv_paged()) return;
+    // The command also clears recurrent, predictor, and prefix state for a
+    // contiguous slot; paging additionally returns its blocks to the pool.
     if (!impl_->cmd) {
         throw std::runtime_error("worker_command_free_slot: command channel not initialized (call warmup_tp first)");
     }

--- a/cpp_engine/include/batch_scheduler.hpp
+++ b/cpp_engine/include/batch_scheduler.hpp
@@ -26,6 +26,13 @@ struct SchedulerGenerationResult {
     std::string finish_reason;  // "stop" or "length"
     int prompt_tokens = 0;
     int completion_tokens = 0;
+    // Aggregate speculative work performed for this request. These remain zero
+    // for plain decoding and make row-local engine metadata visible after the
+    // temporary BatchedRequest is destroyed.
+    int proposed_drafts = 0;
+    int accepted_drafts = 0;
+    int speculative_steps = 0;
+    int rollback_steps = 0;
     double total_seconds = 0.0;
     double ttft_seconds = 0.0;  // Time to first token
     // Non-empty when the engine rejected or failed a forward. The old direct
@@ -72,6 +79,10 @@ struct SchedulerRequest {
     std::string error;
     int last_token = 0;
     std::vector<int> generated_tokens;
+    int proposed_drafts = 0;
+    int accepted_drafts = 0;
+    int speculative_steps = 0;
+    int rollback_steps = 0;
 
     // Timing
     std::chrono::steady_clock::time_point submit_time;

--- a/cpp_engine/include/block_table.hpp
+++ b/cpp_engine/include/block_table.hpp
@@ -26,12 +26,17 @@ public:
     // Ensures `slot` is backed to at least `tokens` logical positions, taking
     // blocks from the pool as needed. Returns false without changing anything
     // when the pool cannot cover the growth, so the caller can leave the request
-    // waiting instead of failing it. Shrinking is not supported: a sequence only
-    // ever grows until it is released.
+    // waiting instead of failing it. Ordinary request growth is monotonic; the
+    // explicit trim_capacity() operation is used only after over-reserving a
+    // speculative step.
     bool ensure_capacity(int slot, int tokens);
 
     // Returns every block held by `slot` to the pool and clears the row.
     void release(int slot);
+
+    // Releases trailing blocks that are no longer needed for `tokens` logical
+    // positions. The logical position itself is not changed.
+    void trim_capacity(int slot, int tokens);
 
     void release_all();
 

--- a/cpp_engine/include/inference_engine.hpp
+++ b/cpp_engine/include/inference_engine.hpp
@@ -59,7 +59,9 @@ struct ForwardResult {
     int top_token = 0;
     // Filled by native MTP speculative steps; plain forwards leave these zero.
     int correct_drafts = 0;
+    int proposed_drafts = 0;
     int bonus_token = 0;
+    bool rolled_back = false;
     std::vector<int> accept_tokens;
     std::vector<float> accept_logits;
     std::vector<float> accept_checksums;
@@ -126,6 +128,20 @@ struct BatchDecodeResult {
     // to `next_tokens`. Callers need the distinction to report finish_reason,
     // which cannot be recovered from `finished` alone.
     std::vector<bool> hit_stop_token;
+    // Tokens produced by one row in this iteration. Plain decoding has one
+    // entry, while speculative decoding has the accepted draft suffix followed
+    // by the target bonus token. Keeping this separate from next_tokens lets
+    // the scheduler advance each request by its actual accepted length.
+    std::vector<std::vector<int>> emitted_tokens;
+    // Number of target KV positions consumed by each row. This can differ from
+    // one when a speculative block accepts multiple drafts.
+    std::vector<int> position_advances;
+    // Draft accounting parallel to the rows. These fields are zero for plain
+    // decode and are intentionally row-local so telemetry cannot cross slots.
+    std::vector<int> proposed_drafts;
+    std::vector<int> accepted_drafts;
+    std::vector<bool> used_speculative;
+    std::vector<bool> rolled_back;
     double seconds = 0.0;
 };
 
@@ -195,8 +211,10 @@ public:
     virtual BatchPrefillResult batch_prefill(
         const std::vector<BatchedRequest*>& requests, int token_budget) = 0;
 
-    // Advance every request one token. Requests may sit at different positions
-    // but must occupy distinct slots.
+    // Advance every request by one or more output tokens. Plain rows consume one
+    // target position; speculative rows report their accepted span through the
+    // returned row metadata. Requests may sit at different positions but must
+    // occupy distinct slots.
     virtual BatchDecodeResult batch_decode_step(
         const std::vector<BatchedRequest*>& requests) = 0;
 

--- a/cpp_engine/include/qwen_dflash2.hpp
+++ b/cpp_engine/include/qwen_dflash2.hpp
@@ -107,28 +107,30 @@ public:
                        const QwenDeviceTensor& target_embedding,
                        QwenTargetHeadAdapter target_head,
                        int tp_world, int tp_rank, int device,
-                       std::string nccl_id_path, int max_context);
+                       std::string nccl_id_path, int max_context,
+                       int max_slots = 1);
     ~QwenDFlash2Runtime();
 
     QwenDFlash2Runtime(const QwenDFlash2Runtime&) = delete;
     QwenDFlash2Runtime& operator=(const QwenDFlash2Runtime&) = delete;
 
-    void reset();
-    int committed_position() const;
+    void reset(int slot_id = 0);
+    int committed_position(int slot_id = 0) const;
     uint64_t resident_weight_bytes() const;
     uint64_t context_cache_bytes() const;
     uint64_t activation_workspace_bytes() const;
 
     void set_debug_callback(QwenDFlash2DebugCallback callback);
     void debug_load_target_taps(const std::vector<uint16_t>& target_taps,
-                                int rows, int position_offset);
+                                int rows, int position_offset,
+                                int slot_id = 0);
     QwenDFlash2Proposal debug_propose_from_host(
         const std::vector<uint16_t>& target_taps, int context_rows,
-        int position_offset, int anchor_token);
+        int position_offset, int anchor_token, int slot_id = 0);
     void append_target_taps(const uint16_t* target_taps, int rows,
-                            int position_offset);
-    void crop_context(int position);
-    QwenDFlash2Proposal propose(int anchor_token);
+                            int position_offset, int slot_id = 0);
+    void crop_context(int position, int slot_id = 0);
+    QwenDFlash2Proposal propose(int anchor_token, int slot_id = 0);
 
 private:
     struct Impl;

--- a/cpp_engine/include/qwen_dspark.hpp
+++ b/cpp_engine/include/qwen_dspark.hpp
@@ -84,14 +84,15 @@ public:
                       const QwenDeviceTensor& target_embedding,
                       QwenTargetHeadAdapter target_head,
                       int tp_world, int tp_rank, int device,
-                      std::string nccl_id_path, int max_context);
+                      std::string nccl_id_path, int max_context,
+                      int max_slots = 1);
     ~QwenDSparkRuntime();
 
     QwenDSparkRuntime(const QwenDSparkRuntime&) = delete;
     QwenDSparkRuntime& operator=(const QwenDSparkRuntime&) = delete;
 
-    void reset();
-    int committed_position() const;
+    void reset(int slot_id = 0);
+    int committed_position(int slot_id = 0) const;
     uint64_t resident_weight_bytes() const;
     uint64_t context_cache_bytes() const;
     uint64_t activation_workspace_bytes() const;
@@ -99,9 +100,9 @@ public:
     // target_taps is [rows, target_layer_ids.size() * hidden_size], containing
     // raw target post-layer hidden states in target_layer_ids order.
     void append_target_taps(const uint16_t* target_taps, int rows,
-                            int position_offset);
-    void crop_context(int position);
-    QwenDSparkProposal propose(int anchor_token);
+                            int position_offset, int slot_id = 0);
+    void crop_context(int position, int slot_id = 0);
+    QwenDSparkProposal propose(int anchor_token, int slot_id = 0);
 
 private:
     struct Impl;

--- a/cpp_engine/include/qwen_engine.hpp
+++ b/cpp_engine/include/qwen_engine.hpp
@@ -112,11 +112,9 @@ struct QwenEngineOptions {
     // fixed-size blocks handed out as tokens arrive, so batch size scales with
     // what the requests actually hold.
     //
-    // FP16 only: batched decode already routes to the FP16 kernels before the
-    // dtype branches are reached, so paging FP16 covers all of batched decode
-    // while the quantized caches keep their validated scale and packed-slot
-    // arithmetic untouched. Construction rejects the other dtypes rather than
-    // silently falling back.
+    // CUDA FP16, FP8, and TurboQuant paging use their matching cache address
+    // arithmetic. Native MTP keeps a separate predictor cache and is rejected
+    // with paging until that cache has a page-table-aware allocation.
     bool kv_paged = false;
     // Tokens per block. 16 follows vLLM; at kv_heads * head_dim = 1024 FP16
     // elements that is 32 KiB of contiguity per block, so reads stay coalesced
@@ -338,6 +336,14 @@ public:
         const std::vector<int>& tokens, const std::vector<int>& slot_ids,
         const std::vector<BatchSamplingParams>* per_row_params = nullptr);
 
+    // One speculative transaction per row. The reference implementation is
+    // serialized because each drafter owns reusable activation scratch and the
+    // recurrent verifier must preserve order within each slot. It preserves
+    // slot isolation and TP ordering but does not claim cross-request speedup.
+    std::vector<ForwardResult> batch_speculative_tokens(
+        const std::vector<int>& tokens, const std::vector<int>& slot_ids,
+        const std::vector<int>& draft_counts);
+
     // Check if batched API is supported (depends on build config)
     bool supports_batching() const;
 
@@ -356,9 +362,10 @@ public:
         Reset = 2,
         Shutdown = 3,
         BatchDecodeStep = 4,
-        // Releases one slot's paged blocks on every rank. Under the contiguous
-        // arena a slot owns max_context implicitly, so there is nothing to
-        // broadcast and this command is only sent when paging is on.
+        BatchSpeculativeStep = 6,
+        // Releases one slot's state on every rank. Paging additionally returns
+        // its blocks to the pool; contiguous storage still needs the recurrent,
+        // predictor, and prefix state reset.
         FreeSlot = 5,
     };
     // slot_id selects the KV cache slot the workers must use, so it has to match
@@ -371,6 +378,9 @@ public:
     // tokens and their slots travel together as one interleaved payload.
     void worker_command_batch_decode(const std::vector<int>& tokens,
                                      const std::vector<int>& slot_ids);
+    void worker_command_batch_speculative(
+        const std::vector<int>& tokens, const std::vector<int>& slot_ids,
+        const std::vector<int>& draft_counts);
     void worker_command_reset();
     void worker_command_shutdown();
     void worker_command_free_slot(int32_t slot_id);

--- a/cpp_engine/python/bindings.cpp
+++ b/cpp_engine/python/bindings.cpp
@@ -31,7 +31,9 @@ py::dict forward_result_dict(const ForwardResult& result) {
     out["logits"] = result.logits;
     out["top_token"] = result.top_token;
     out["correct_drafts"] = result.correct_drafts;
+    out["proposed_drafts"] = result.proposed_drafts;
     out["bonus_token"] = result.bonus_token;
+    out["rolled_back"] = result.rolled_back;
     out["accept_tokens"] = result.accept_tokens;
     out["accept_logits"] = result.accept_logits;
     out["accept_checksums"] = result.accept_checksums;
@@ -246,7 +248,9 @@ PYBIND11_MODULE(pocketllm_cpp, module) {
         .def_readwrite("logits", &ForwardResult::logits)
         .def_readwrite("top_token", &ForwardResult::top_token)
         .def_readwrite("correct_drafts", &ForwardResult::correct_drafts)
+        .def_readwrite("proposed_drafts", &ForwardResult::proposed_drafts)
         .def_readwrite("bonus_token", &ForwardResult::bonus_token)
+        .def_readwrite("rolled_back", &ForwardResult::rolled_back)
         .def_readwrite("accept_tokens", &ForwardResult::accept_tokens)
         .def_readwrite("accept_logits", &ForwardResult::accept_logits)
         .def_readwrite("accept_checksums", &ForwardResult::accept_checksums)
@@ -442,6 +446,10 @@ PYBIND11_MODULE(pocketllm_cpp, module) {
         .def_readwrite("finish_reason", &SchedulerGenerationResult::finish_reason)
         .def_readwrite("prompt_tokens", &SchedulerGenerationResult::prompt_tokens)
         .def_readwrite("completion_tokens", &SchedulerGenerationResult::completion_tokens)
+        .def_readwrite("proposed_drafts", &SchedulerGenerationResult::proposed_drafts)
+        .def_readwrite("accepted_drafts", &SchedulerGenerationResult::accepted_drafts)
+        .def_readwrite("speculative_steps", &SchedulerGenerationResult::speculative_steps)
+        .def_readwrite("rollback_steps", &SchedulerGenerationResult::rollback_steps)
         .def_readwrite("total_seconds", &SchedulerGenerationResult::total_seconds)
         .def_readwrite("ttft_seconds", &SchedulerGenerationResult::ttft_seconds)
         .def_readwrite("error", &SchedulerGenerationResult::error);

--- a/cpp_engine/tests/test_block_pool.cpp
+++ b/cpp_engine/tests/test_block_pool.cpp
@@ -124,6 +124,14 @@ void test_table_growth() {
     check(table.capacity_tokens(0) == 32, "the row is now two blocks");
     check(pool.free_blocks() == 14, "the boundary took one more block");
 
+    table.trim_capacity(0, 16);
+    check(table.capacity_tokens(0) == 16,
+          "trimming releases an unused trailing block");
+    check(pool.free_blocks() == 15, "trim returns the trailing block");
+    check(table.ensure_capacity(0, 17), "trimmed row can grow again");
+    check(table.capacity_tokens(0) == 32, "regrowth restores two blocks");
+    check(pool.free_blocks() == 14, "regrowth takes one block");
+
     table.release(0);
     check(table.capacity_tokens(0) == 0, "release empties the row");
     check(pool.free_blocks() == 16, "release returns every block");

--- a/cpp_engine/tests/test_qwen_engine.cpp
+++ b/cpp_engine/tests/test_qwen_engine.cpp
@@ -554,6 +554,63 @@ void exercise_cache_lifecycle(const std::string& dir,
 
 // Phase 3.4: Verify that independent prompts in different slots produce
 // different results, proving the recurrent state and KV cache are isolated.
+void exercise_batch_speculative_mtp(const std::string& dir) {
+    pocket::QwenEngineOptions options;
+    options.tp_world = 1;
+    options.tp_rank = 0;
+    options.device = 0;
+    options.prefill_chunk_tokens = 8;
+    options.prefix_cache = false;
+    options.mtp = true;
+    options.mtp_speculative_tokens = 2;
+    options.max_batch_size = 2;
+
+    pocket::QwenEngine engine(dir, options, 2, 16);
+    pocket::BatchedRequest first;
+    first.request_id = 1;
+    first.slot_id = 0;
+    first.prompt_tokens = {1, 2, 3};
+    first.sampling.max_new_tokens = 8;
+    pocket::BatchedRequest second;
+    second.request_id = 2;
+    second.slot_id = 1;
+    second.prompt_tokens = {4, 5};
+    second.sampling.max_new_tokens = 8;
+
+    const std::vector<pocket::BatchedRequest*> requests = {&first, &second};
+    const pocket::BatchPrefillResult prefill = engine.batch_prefill(requests, 0);
+    require(prefill.results.size() == 2 && prefill.incomplete.size() == 2,
+            "batched MTP prefill rows");
+    require(!prefill.incomplete[0] && !prefill.incomplete[1],
+            "batched MTP prefill completion");
+    first.last_token = prefill.results[0].top_token;
+    second.last_token = prefill.results[1].top_token;
+    first.seq_len = prefill.results[0].position;
+    second.seq_len = prefill.results[1].position;
+
+    pocket::BatchDecodeResult decoded = engine.batch_decode_step(requests);
+    require(decoded.next_tokens.size() == 2 && decoded.finished.size() == 2,
+            "batched MTP decode rows");
+    require(decoded.emitted_tokens.size() == 2 &&
+                decoded.position_advances.size() == 2,
+            "batched MTP row metadata");
+    for (size_t row = 0; row < 2; ++row) {
+        require(!decoded.emitted_tokens[row].empty(),
+                "batched MTP emitted tokens");
+        require(decoded.position_advances[row] >= 1,
+                "batched MTP position advance");
+        require(decoded.used_speculative[row], "batched MTP speculative marker");
+    }
+
+    // Drive both slots again. This catches stale slot-0 MTP hidden state and
+    // verifies that each row's position advances independently.
+    decoded = engine.batch_decode_step(requests);
+    require(decoded.next_tokens.size() == 2 &&
+                decoded.position_advances[0] >= 1 &&
+                decoded.position_advances[1] >= 1,
+            "batched MTP second decode");
+}
+
 void exercise_batch_isolation(const std::string& dir,
                                pocket::QwenKvCacheDType cache_dtype) {
     pocket::QwenEngineOptions options;
@@ -613,6 +670,7 @@ int main() {
         exercise_mtp_prefix_cache(dir, pocket::QwenKvCacheDType::Fp16);
         exercise_mtp_prefix_cache(dir, pocket::QwenKvCacheDType::Fp8);
         exercise_mtp_prefix_cache(dir, pocket::QwenKvCacheDType::TurboQuantK8V4);
+        exercise_batch_speculative_mtp(dir);
         exercise_batch_isolation(dir, pocket::QwenKvCacheDType::Fp16);
         exercise_batch_isolation(dir, pocket::QwenKvCacheDType::Fp8);
         exercise_batch_isolation(dir, pocket::QwenKvCacheDType::TurboQuantK8V4);

--- a/cpp_engine/tests/test_scheduler_callbacks.cpp
+++ b/cpp_engine/tests/test_scheduler_callbacks.cpp
@@ -101,10 +101,24 @@ public:
         pocket::BatchDecodeResult out;
         for (pocket::BatchedRequest* req : requests) {
             const int token = req->last_token + 1;
-            const bool stopped = is_stop(req->sampling, token);
-            out.next_tokens.push_back(token);
-            out.finished.push_back(stopped);
-            out.hit_stop_token.push_back(stopped);
+            if (emit_multi_token) {
+                // Deliberately overproduce one token so the scheduler must apply
+                // the request's remaining output budget to a multi-token row.
+                out.next_tokens.push_back(token + 1);
+                out.finished.push_back(false);
+                out.hit_stop_token.push_back(false);
+                out.emitted_tokens.push_back({token, token + 1});
+                out.position_advances.push_back(2);
+                out.proposed_drafts.push_back(2);
+                out.accepted_drafts.push_back(1);
+                out.used_speculative.push_back(true);
+                out.rolled_back.push_back(true);
+            } else {
+                const bool stopped = is_stop(req->sampling, token);
+                out.next_tokens.push_back(token);
+                out.finished.push_back(stopped);
+                out.hit_stop_token.push_back(stopped);
+            }
         }
         return out;
     }
@@ -113,6 +127,7 @@ public:
     std::atomic<int> decode_calls{0};
     bool fail_prefill = false;
     bool fail_decode = false;
+    bool emit_multi_token = false;
 
 private:
     std::vector<uint64_t> slots_;
@@ -225,6 +240,36 @@ void test_poll_result_without_callback() {
     scheduler.stop();
 }
 
+void test_multi_token_row_respects_budget_and_reports_stats() {
+    std::cout << "multi-token rows respect the remaining budget and report telemetry\n";
+    CountingEngine engine;
+    engine.emit_multi_token = true;
+    pocket::BatchScheduler scheduler(&engine, 1);
+
+    pocket::BatchSamplingParams sampling;
+    sampling.max_new_tokens = 2;
+    CallbackState state;
+    const uint64_t id = submit_with_callbacks(scheduler, sampling, state);
+
+    check(id != 0, "multi-token request is accepted");
+    check(wait_done(state), "multi-token request completes");
+    check(state.result.generated_tokens == std::vector<int>({10, 11}),
+          "scheduler truncates emitted row at max_new_tokens");
+    check(state.tokens == std::vector<int>({10, 11}),
+          "truncated row streams only visible tokens");
+    check(state.result.proposed_drafts == 2,
+          "proposed draft telemetry is retained");
+    check(state.result.accepted_drafts == 1,
+          "accepted draft telemetry is retained");
+    check(state.result.speculative_steps == 1,
+          "speculative step telemetry is retained");
+    check(state.result.rollback_steps == 1,
+          "rollback telemetry is retained");
+    check(state.result.finish_reason == "length",
+          "truncated multi-token row finishes by length");
+    scheduler.stop();
+}
+
 void test_engine_failure_is_terminal() {
     std::cout << "engine failures complete the request instead of retrying forever\n";
     CountingEngine engine;
@@ -255,6 +300,7 @@ int main() {
     test_prefill_token_counts_toward_limit();
     test_stop_token_is_not_streamed();
     test_poll_result_without_callback();
+    test_multi_token_row_respects_budget_and_reports_stats();
     test_engine_failure_is_terminal();
 
     if (failures != 0) {


### PR DESCRIPTION
## Summary

- Add slot-indexed native Qwen MTP, DSpark, and DFlash2 speculative decoding.
- Integrate multi-token row outputs, position advances, and speculative telemetry into `BatchScheduler`.
- Add TP worker commands, slot reset/reuse handling, recurrent/KV/predictor state isolation, and paged block-capacity trimming.
- Preserve plain Qwen batched decode through the existing cross-request batched target path.

## Implementation notes

- Native MTP and external drafter transactions are serialized per request row because the current recurrent verifier and drafter activation workspaces are single-transaction resources. This provides correct slot isolation and TP ordering; it does not claim a cross-request speculative throughput improvement.
- Plain TP batched decode now keeps rank 0 and worker ranks on the same sampler collective path. TP batched requests must use the engine-wide temperature, top-p, top-k, and seed settings.
- Native MTP remains incompatible with paged KV because its predictor cache is not page-aware.
- Speculative verification remains greedy; sampled speculative acceptance is rejected explicitly.

## Validation

Focused native tests passed:

- `test_qwen_engine`
- `test_scheduler_callbacks`
- `test_qwen_batched_decode`
- `test_qwen_batched_engine_parity`
- `test_qwen_paged_kv_kernels`
- `test_qwen_paged_engine_parity`

Real-model TP4 validation passed on `/mnt/data2/Qwen3.8-27B-FP8` with fresh rank processes and tokenizer-generated prompts:

- Full 64-layer plain decode and native MTP K=1/2/4 at 512 and 32768 prompt tokens: TP-rank parity and plain-vs-MTP token parity passed; draft acceptance was 100% in the fixture.
- Two-request scheduler batching: plain, MTP K=1/2/4, DSpark, and DFlash2 all completed without rank deadlock.
- Two-request plain and native MTP rows matched standalone per-request TP4 token streams.
- External DSpark and DFlash2 single-request and two-request runs completed with 100% acceptance on the validation fixture.
- A prior two-request TP4 scheduler hang was reproduced and fixed; the root cause was rank 0 entering the per-row sampler path while workers entered the greedy path.

Performance observations:

- Native MTP decode throughput at 512 prompt tokens: K=1 1.47x, K=2 1.93x, K=4 2.69x versus plain decode.
- Native MTP decode throughput at 32768 prompt tokens: K=1 1.15x, K=2 1.36x, K=4 1.76x versus plain decode. Full-request wall time remains prefill-dominated at this context length.

Closes #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
